### PR TITLE
Ability to pass TF Provider Version in tfbridge.ProviderInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 ## HEAD (Unreleased)
 * Update Terraform bridge to be based on v1.0.0 of the Terraform Plugin SDK
 * Add support to specify a custom package name for NodeJS package
+* Add ability to pass the TF provider version that the pulumi provider was generated against
 
 ---
 

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -24,22 +24,23 @@ import (
 // ProviderInfo contains information about a Terraform provider plugin that we will use to generate the Pulumi
 // metadata.  It primarily contains a pointer to the Terraform schema, but can also contain specific name translations.
 type ProviderInfo struct {
-	P              *schema.Provider           // the TF provider/schema.
-	Name           string                     // the TF provider name (e.g. terraform-provider-XXXX).
-	ResourcePrefix string                     // the prefix on resources the provider exposes, if different to `Name`.
-	GitHubOrg      string                     // the GitHub org of the provider. Defaults to `terraform-providers`.
-	Description    string                     // an optional descriptive overview of the package (a default will be given).
-	Keywords       []string                   // an optional list of keywords to help discovery of this package.
-	License        string                     // the license, if any, the resulting package has (default is none).
-	Homepage       string                     // the URL to the project homepage.
-	Repository     string                     // the URL to the project source code repository.
-	Config         map[string]*SchemaInfo     // a map of TF name to config schema overrides.
-	ExtraConfig    map[string]*ConfigInfo     // a list of Pulumi-only configuration variables.
-	Resources      map[string]*ResourceInfo   // a map of TF name to Pulumi name; standard mangling occurs if no entry.
-	DataSources    map[string]*DataSourceInfo // a map of TF name to Pulumi resource info.
-	JavaScript     *JavaScriptInfo            // optional overlay information for augmented JavaScript code-generation.
-	Python         *PythonInfo                // optional overlay information for augmented Python code-generation.
-	Golang         *GolangInfo                // optional overlay information for augmented Golang code-generation.
+	P                 *schema.Provider           // the TF provider/schema.
+	Name              string                     // the TF provider name (e.g. terraform-provider-XXXX).
+	ResourcePrefix    string                     // the prefix on resources the provider exposes, if different to `Name`.
+	GitHubOrg         string                     // the GitHub org of the provider. Defaults to `terraform-providers`.
+	Description       string                     // an optional descriptive overview of the package (a default supplied).
+	Keywords          []string                   // an optional list of keywords to help discovery of this package.
+	License           string                     // the license, if any, the resulting package has (default is none).
+	Homepage          string                     // the URL to the project homepage.
+	Repository        string                     // the URL to the project source code repository.
+	Config            map[string]*SchemaInfo     // a map of TF name to config schema overrides.
+	ExtraConfig       map[string]*ConfigInfo     // a list of Pulumi-only configuration variables.
+	Resources         map[string]*ResourceInfo   // a map of TF name to Pulumi name; standard mangling occurs if no entry.
+	DataSources       map[string]*DataSourceInfo // a map of TF name to Pulumi resource info.
+	JavaScript        *JavaScriptInfo            // optional overlay information for augmented JavaScript code-generation.
+	Python            *PythonInfo                // optional overlay information for augmented Python code-generation.
+	Golang            *GolangInfo                // optional overlay information for augmented Golang code-generation.
+	TFProviderVersion string                     // the version of the TF provider on which this was based
 
 	PreConfigureCallback PreConfigureCallback // a provider-specific callback to invoke prior to TF Configure
 }
@@ -546,10 +547,11 @@ func (m *MarshallableDataSourceInfo) Unmarshal() *DataSourceInfo {
 
 // MarshallableProviderInfo is the JSON-marshallable form of a Pulumi ProviderInfo value.
 type MarshallableProviderInfo struct {
-	Provider    *MarshallableProvider                  `json:"provider"`
-	Config      map[string]*MarshallableSchemaInfo     `json:"config,omitempty"`
-	Resources   map[string]*MarshallableResourceInfo   `json:"resources,omitempty"`
-	DataSources map[string]*MarshallableDataSourceInfo `json:"dataSources,omitempty"`
+	Provider          *MarshallableProvider                  `json:"provider"`
+	Config            map[string]*MarshallableSchemaInfo     `json:"config,omitempty"`
+	Resources         map[string]*MarshallableResourceInfo   `json:"resources,omitempty"`
+	DataSources       map[string]*MarshallableDataSourceInfo `json:"dataSources,omitempty"`
+	TFProviderVersion string                                 `json:"tfProviderVersion,omitempty"`
 }
 
 // MarshalProviderInfo converts a Pulumi ProviderInfo value into a MarshallableProviderInfo value.
@@ -567,12 +569,15 @@ func MarshalProviderInfo(p *ProviderInfo) *MarshallableProviderInfo {
 		dataSources[k] = MarshalDataSourceInfo(v)
 	}
 
-	return &MarshallableProviderInfo{
-		Provider:    MarshalProvider(p.P),
-		Config:      config,
-		Resources:   resources,
-		DataSources: dataSources,
+	info := MarshallableProviderInfo{
+		Provider:          MarshalProvider(p.P),
+		Config:            config,
+		Resources:         resources,
+		DataSources:       dataSources,
+		TFProviderVersion: p.TFProviderVersion,
 	}
+
+	return &info
 }
 
 // Unmarshal creates a mostly-=initialized Pulumi ProviderInfo value from the given MarshallableProviderInfo.
@@ -590,10 +595,13 @@ func (m *MarshallableProviderInfo) Unmarshal() *ProviderInfo {
 		dataSources[k] = v.Unmarshal()
 	}
 
-	return &ProviderInfo{
-		P:           m.Provider.Unmarshal(),
-		Config:      config,
-		Resources:   resources,
-		DataSources: dataSources,
+	info := ProviderInfo{
+		P:                 m.Provider.Unmarshal(),
+		Config:            config,
+		Resources:         resources,
+		DataSources:       dataSources,
+		TFProviderVersion: m.TFProviderVersion,
 	}
+
+	return &info
 }

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -977,3 +977,12 @@ func upperFirst(s string) string {
 	c, rest := utf8.DecodeRuneInString(s)
 	return string(unicode.ToUpper(c)) + s[rest:]
 }
+
+func generateManifestDescription(info tfbridge.ProviderInfo) string {
+	if info.TFProviderVersion == "" {
+		return info.Description
+	}
+
+	return fmt.Sprintf("%s. Based on terraform-provider-%s: version v%s", info.Description, info.Name,
+		info.TFProviderVersion)
+}

--- a/pkg/tfgen/generate_nodejs.go
+++ b/pkg/tfgen/generate_nodejs.go
@@ -1156,7 +1156,7 @@ func (g *nodeJSGenerator) emitNPMPackageMetadata(pack *pkg) error {
 	npminfo := npmPackage{
 		Name:        packageName,
 		Version:     "${VERSION}",
-		Description: g.info.Description,
+		Description: generateManifestDescription(g.info),
 		Keywords:    g.info.Keywords,
 		Homepage:    g.info.Homepage,
 		Repository:  g.info.Repository,

--- a/pkg/tfgen/generate_python.go
+++ b/pkg/tfgen/generate_python.go
@@ -838,7 +838,7 @@ func (g *pythonGenerator) emitPackageMetadata(pack *pkg) error {
 	w.Writefmtln("setup(name='%s',", pyPack(pack.name))
 	w.Writefmtln("      version='${VERSION}',")
 	if g.info.Description != "" {
-		w.Writefmtln("      description='%s',", g.info.Description)
+		w.Writefmtln("      description='%s',", generateManifestDescription(g.info))
 	}
 	w.Writefmtln("      long_description=readme(),")
 	w.Writefmtln("      cmdclass={")


### PR DESCRIPTION
This will allow us to inform the user which version of the TF provider
that the current pulumi provider was generated against

It will format in the package metadata as:

```
A Pulumi package for creating and managing Microsoft Azure cloud resources.
Based on terraform-provider-azurerm: version v1.3.5
```

Related to https://github.com/pulumi/pulumi-azure/issues/377