### PR TITLE
tfgen: Allow the ability to attribute another GHOrg

### DIFF
--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -169,13 +169,13 @@ var (
 
 	attributeBulletRegexp = regexp.MustCompile("\\*\\s+`([a-zA-z0-9_]*)`\\s+[–-]?\\s+(.*)")
 
-	docsBaseURL    = "https://github.com/terraform-providers/terraform-provider-%s/blob/master/website/docs"
+	docsBaseURL    = "https://github.com/%s/terraform-provider-%s/blob/master/website/docs"
 	docsDetailsURL = docsBaseURL + "/%s/%s.html.markdown"
 
-	standardDocReadme = `> This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-%[2]s)
+	standardDocReadme = `> This provider is a derived work of the [Terraform Provider](https://github.com/%[3]s/terraform-provider-%[2]s)
 > distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,
 > first check the [` + "`pulumi/pulumi-%[1]s`" + ` repo](https://github.com/pulumi/pulumi-%[1]s/issues); however, if that doesn't turn up anything,
-> please consult the source [` + "`terraform-providers/terraform-provider-%[2]s`" + ` repo](https://github.com/terraform-providers/terraform-provider-%[2]s/issues).`
+> please consult the source [` + "`%[3]s/terraform-provider-%[2]s`" + ` repo](https://github.com/%[3]s/terraform-provider-%[2]s/issues).`
 )
 
 // groupLines groups a collection of strings, a, by a given separator, sep.
@@ -206,8 +206,8 @@ func getDocsBaseURL(p string) string {
 }
 
 // getDocsDetailsURL gets the detailed resource or data source documentation source.
-func getDocsDetailsURL(p, kind, name string) string {
-	return fmt.Sprintf(docsDetailsURL, p, kind, name)
+func getDocsDetailsURL(org, p, kind, name string) string {
+	return fmt.Sprintf(docsDetailsURL, org, p, kind, name)
 }
 
 // getDocsIndexURL gets the given provider's documentation index page's source URL.
@@ -223,7 +223,8 @@ func parseTFMarkdown(g *generator, info tfbridge.ResourceOrDataSourceInfo, kind 
 	ret := parsedDoc{
 		Arguments:  make(map[string]string),
 		Attributes: make(map[string]string),
-		URL:        getDocsDetailsURL(resourcePrefix, string(kind), withoutPackageName(resourcePrefix, rawname)),
+		URL: getDocsDetailsURL(g.info.GitHubOrg, resourcePrefix, string(kind),
+			withoutPackageName(resourcePrefix, rawname)),
 	}
 
 	// Replace any Windows-style newlines.

--- a/pkg/tfgen/generate_go.go
+++ b/pkg/tfgen/generate_go.go
@@ -222,7 +222,7 @@ func (g *goGenerator) ensurePackageComment(mod *module, dir string) error {
 	w.Writefmtln("// Package %[1]s exports types, functions, subpackages for provisioning %[1]s resources.", pkg)
 	w.Writefmtln("//")
 
-	readme := fmt.Sprintf(standardDocReadme, g.pkg, g.info.Name)
+	readme := fmt.Sprintf(standardDocReadme, g.pkg, g.info.Name, g.info.GitHubOrg)
 	for _, line := range strings.Split(readme, "\n") {
 		w.Writefmtln("// %s", line)
 	}

--- a/pkg/tfgen/generate_nodejs.go
+++ b/pkg/tfgen/generate_nodejs.go
@@ -475,7 +475,7 @@ func (g *nodeJSGenerator) ensureReadme(dir string) error {
 	}
 	defer contract.IgnoreClose(w)
 
-	w.Writefmtln(standardDocReadme, g.pkg, g.info.Name)
+	w.Writefmtln(standardDocReadme, g.pkg, g.info.Name, g.info.GitHubOrg)
 	return nil
 }
 

--- a/pkg/tfgen/generate_python.go
+++ b/pkg/tfgen/generate_python.go
@@ -255,7 +255,7 @@ func (g *pythonGenerator) ensureReadme(dir string) error {
 	}
 	defer contract.IgnoreClose(w)
 
-	w.Writefmtln(standardDocReadme, g.pkg, g.info.Name)
+	w.Writefmtln(standardDocReadme, g.pkg, g.info.Name, g.info.GitHubOrg)
 	return nil
 }
 


### PR DESCRIPTION
We hardcoded `terraform-providers` as the GH org name. When we
converted TF Providers outside of that org, we were still attributing
that org. This passes the org name to the attribution messages