### PR TITLE
Fixup the generation of the docs url when using a default GitHubOrg name

### DIFF
--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -201,8 +201,8 @@ func splitGroupLines(s, sep string) [][]string {
 }
 
 // getDocsBaseURL gets the base URL for a given provider's documentation source.
-func getDocsBaseURL(p string) string {
-	return fmt.Sprintf(docsBaseURL, p)
+func getDocsBaseURL(org, p string) string {
+	return fmt.Sprintf(docsBaseURL, org, p)
 }
 
 // getDocsDetailsURL gets the detailed resource or data source documentation source.
@@ -211,8 +211,8 @@ func getDocsDetailsURL(org, p, kind, name string) string {
 }
 
 // getDocsIndexURL gets the given provider's documentation index page's source URL.
-func getDocsIndexURL(p string) string {
-	return getDocsBaseURL(p) + "/index.html.markdown"
+func getDocsIndexURL(org, p string) string {
+	return getDocsBaseURL(org, p) + "/index.html.markdown"
 }
 
 // parseTFMarkdown takes a TF website markdown doc and extracts a structured representation for use in
@@ -223,7 +223,7 @@ func parseTFMarkdown(g *generator, info tfbridge.ResourceOrDataSourceInfo, kind 
 	ret := parsedDoc{
 		Arguments:  make(map[string]string),
 		Attributes: make(map[string]string),
-		URL: getDocsDetailsURL(g.info.GitHubOrg, resourcePrefix, string(kind),
+		URL: getDocsDetailsURL(g.info.GetGitHubOrg(), resourcePrefix, string(kind),
 			withoutPackageName(resourcePrefix, rawname)),
 	}
 

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -449,7 +449,7 @@ func (g *generator) gatherConfig() *module {
 	for _, key := range cfgkeys {
 		// Generate a name and type to use for this key.
 		sch := cfg[key]
-		docURL := getDocsIndexURL(g.info.Name)
+		docURL := getDocsIndexURL(g.info.GetGitHubOrg(), g.info.Name)
 		if prop := propertyVariable(key, sch, custom[key], "", sch.Description, docURL, true /*out*/); prop != nil {
 			prop.config = true
 			config.addMember(prop)
@@ -563,7 +563,7 @@ func (g *generator) gatherResource(rawname string,
 				"construction to achieve fine-grained programmatic control over provider settings. See the\n"+
 				"[documentation](https://www.pulumi.com/docs/reference/programming-model/#providers) for more information.",
 			g.info.Name)
-		parsedDocs.URL = getDocsIndexURL(g.info.Name)
+		parsedDocs.URL = getDocsIndexURL(g.info.GetGitHubOrg(), g.info.Name)
 	}
 
 	// Create an empty module and associated resource type.

--- a/pkg/tfgen/generate_go.go
+++ b/pkg/tfgen/generate_go.go
@@ -222,7 +222,7 @@ func (g *goGenerator) ensurePackageComment(mod *module, dir string) error {
 	w.Writefmtln("// Package %[1]s exports types, functions, subpackages for provisioning %[1]s resources.", pkg)
 	w.Writefmtln("//")
 
-	readme := fmt.Sprintf(standardDocReadme, g.pkg, g.info.Name, g.info.GitHubOrg)
+	readme := fmt.Sprintf(standardDocReadme, g.pkg, g.info.Name, g.info.GetGitHubOrg())
 	for _, line := range strings.Split(readme, "\n") {
 		w.Writefmtln("// %s", line)
 	}

--- a/pkg/tfgen/generate_nodejs.go
+++ b/pkg/tfgen/generate_nodejs.go
@@ -475,7 +475,7 @@ func (g *nodeJSGenerator) ensureReadme(dir string) error {
 	}
 	defer contract.IgnoreClose(w)
 
-	w.Writefmtln(standardDocReadme, g.pkg, g.info.Name, g.info.GitHubOrg)
+	w.Writefmtln(standardDocReadme, g.pkg, g.info.Name, g.info.GetGitHubOrg())
 	return nil
 }
 

--- a/pkg/tfgen/generate_python.go
+++ b/pkg/tfgen/generate_python.go
@@ -255,7 +255,7 @@ func (g *pythonGenerator) ensureReadme(dir string) error {
 	}
 	defer contract.IgnoreClose(w)
 
-	w.Writefmtln(standardDocReadme, g.pkg, g.info.Name, g.info.GitHubOrg)
+	w.Writefmtln(standardDocReadme, g.pkg, g.info.Name, g.info.GetGitHubOrg())
 	return nil
 }
 


### PR DESCRIPTION
Fixes a small bug introduced in #39 