### PR TITLE
Remove the need for `pandoc` during the build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 * Update Terraform bridge to be based on v1.0.0 of the Terraform Plugin SDK
 * Add support to specify a custom package name for NodeJS package
 * Add ability to pass the TF provider version that the pulumi provider was generated against
+* Remove the need for Pandoc in generating Python SDK readme files.
 
 ---
 

--- a/pkg/tfgen/generate_python.go
+++ b/pkg/tfgen/generate_python.go
@@ -830,7 +830,7 @@ func (g *pythonGenerator) emitPackageMetadata(pack *pkg) error {
 	// Generate a readme method which will load README.rst, we use this to fill out the
 	// long_description field in the setup call.
 	w.Writefmtln("def readme():")
-	w.Writefmtln("    with open('README.rst') as f:")
+	w.Writefmtln("    with open('README.md', encoding='utf-8') as f:")
 	w.Writefmtln("        return f.read()")
 	w.Writefmtln("")
 
@@ -841,6 +841,7 @@ func (g *pythonGenerator) emitPackageMetadata(pack *pkg) error {
 		w.Writefmtln("      description='%s',", generateManifestDescription(g.info))
 	}
 	w.Writefmtln("      long_description=readme(),")
+	w.Writefmtln("      long_description_content_type='text/markdown',")
 	w.Writefmtln("      cmdclass={")
 	w.Writefmtln("          'install': InstallPluginCommand,")
 	w.Writefmtln("      },")


### PR DESCRIPTION
Continues the work from pulumi/pulumi#3195
for the pulumi-providers based on TF