### PR TITLE
Allow passing a TF Provider LicenseType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,5 +7,6 @@ CHANGELOG
 * Add ability to pass the TF provider version that the pulumi provider was generated against
 * Remove the need for Pandoc in generating Python SDK readme files.
 * Allow a schema variable to be overridden as being `Computed`
+* Allow passing a License Type for the upstream Terraform provider.
 
 ---

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -21,6 +21,12 @@ import (
 	"github.com/pulumi/pulumi/pkg/tokens"
 )
 
+const (
+	MPL20LicenseType    TFProviderLicense = "MPL 2.0"
+	MITLicenseType      TFProviderLicense = "MIT"
+	Apache20LicenseType TFProviderLicense = "Apache 2.0"
+)
+
 // ProviderInfo contains information about a Terraform provider plugin that we will use to generate the Pulumi
 // metadata.  It primarily contains a pointer to the Terraform schema, but can also contain specific name translations.
 type ProviderInfo struct {
@@ -41,9 +47,13 @@ type ProviderInfo struct {
 	Python            *PythonInfo                // optional overlay information for augmented Python code-generation.
 	Golang            *GolangInfo                // optional overlay information for augmented Golang code-generation.
 	TFProviderVersion string                     // the version of the TF provider on which this was based
+	TFProviderLicense *TFProviderLicense         // license that the TF provider is distributed under. Default `MPL 2.0`.
 
 	PreConfigureCallback PreConfigureCallback // a provider-specific callback to invoke prior to TF Configure
 }
+
+// TFProviderLicense is a way to be able to pass a license type for the upstream Terraform provider.
+type TFProviderLicense string
 
 // GetResourcePrefix returns the resource prefix for the provider: info.ResourcePrefix
 // if that is set, or info.Name if not. This is to avoid unexpected behaviour with providers
@@ -62,6 +72,14 @@ func (info ProviderInfo) GetGitHubOrg() string {
 	}
 
 	return info.GitHubOrg
+}
+
+func (info ProviderInfo) GetTFProviderLicense() TFProviderLicense {
+	if info.TFProviderLicense == nil {
+		return MPL20LicenseType
+	}
+
+	return *info.TFProviderLicense
 }
 
 // AliasInfo is a partial description of prior named used for a resource. It can be processed in the

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -173,7 +173,7 @@ var (
 	docsDetailsURL = docsBaseURL + "/%s/%s.html.markdown"
 
 	standardDocReadme = `> This provider is a derived work of the [Terraform Provider](https://github.com/%[3]s/terraform-provider-%[2]s)
-> distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,
+> distributed under [%[4]s](%[5]s). If you encounter a bug or missing feature,
 > first check the [` + "`pulumi/pulumi-%[1]s`" + ` repo](https://github.com/pulumi/pulumi-%[1]s/issues); however, if that doesn't turn up anything,
 > please consult the source [` + "`%[3]s/terraform-provider-%[2]s`" + ` repo](https://github.com/%[3]s/terraform-provider-%[2]s/issues).`
 )

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -986,3 +986,17 @@ func generateManifestDescription(info tfbridge.ProviderInfo) string {
 	return fmt.Sprintf("%s. Based on terraform-provider-%s: version v%s", info.Description, info.Name,
 		info.TFProviderVersion)
 }
+
+func getLicenseTypeURL(license tfbridge.TFProviderLicense) string {
+	switch license {
+	case tfbridge.MITLicenseType:
+		return "https://mit-license.org/"
+	case tfbridge.MPL20LicenseType:
+		return "https://www.mozilla.org/en-US/MPL/2.0/"
+	case tfbridge.Apache20LicenseType:
+		return "https://www.apache.org/licenses/LICENSE-2.0.html"
+	default:
+		contract.Failf("Unrecognized license: %v", license)
+		return ""
+	}
+}

--- a/pkg/tfgen/generate_go.go
+++ b/pkg/tfgen/generate_go.go
@@ -222,7 +222,9 @@ func (g *goGenerator) ensurePackageComment(mod *module, dir string) error {
 	w.Writefmtln("// Package %[1]s exports types, functions, subpackages for provisioning %[1]s resources.", pkg)
 	w.Writefmtln("//")
 
-	readme := fmt.Sprintf(standardDocReadme, g.pkg, g.info.Name, g.info.GetGitHubOrg())
+	downstreamLicense := g.info.GetTFProviderLicense()
+	licenseTypeURL := getLicenseTypeURL(downstreamLicense)
+	readme := fmt.Sprintf(standardDocReadme, g.pkg, g.info.Name, g.info.GetGitHubOrg(), downstreamLicense, licenseTypeURL)
 	for _, line := range strings.Split(readme, "\n") {
 		w.Writefmtln("// %s", line)
 	}

--- a/pkg/tfgen/generate_nodejs.go
+++ b/pkg/tfgen/generate_nodejs.go
@@ -475,7 +475,9 @@ func (g *nodeJSGenerator) ensureReadme(dir string) error {
 	}
 	defer contract.IgnoreClose(w)
 
-	w.Writefmtln(standardDocReadme, g.pkg, g.info.Name, g.info.GetGitHubOrg())
+	downstreamLicense := g.info.GetTFProviderLicense()
+	licenseTypeURL := getLicenseTypeURL(downstreamLicense)
+	w.Writefmtln(standardDocReadme, g.pkg, g.info.Name, g.info.GetGitHubOrg(), downstreamLicense, licenseTypeURL)
 	return nil
 }
 

--- a/pkg/tfgen/generate_python.go
+++ b/pkg/tfgen/generate_python.go
@@ -255,7 +255,9 @@ func (g *pythonGenerator) ensureReadme(dir string) error {
 	}
 	defer contract.IgnoreClose(w)
 
-	w.Writefmtln(standardDocReadme, g.pkg, g.info.Name, g.info.GetGitHubOrg())
+	downstreamLicense := g.info.GetTFProviderLicense()
+	licenseTypeURL := getLicenseTypeURL(downstreamLicense)
+	w.Writefmtln(standardDocReadme, g.pkg, g.info.Name, g.info.GetGitHubOrg(), downstreamLicense, licenseTypeURL)
 	return nil
 }
 


### PR DESCRIPTION
This will allow us to tailor our docs to not always assume MPL 2.0
We can now pass a License Type and the docs will be updated accordingly

The default will still be MPL 2.0