### PR TITLE
Make resource path separator always use '/'

### DIFF
--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -94,7 +94,7 @@ func extractModuleName(name string) string {
 	// TODO[pulumi/pulumi-terraform#107]: for now, while we migrate to the new structure, just ignore sub-modules.
 	//     After we are sure our customers have upgraded to the new bits, we can remove this logic.  In fact, in the
 	//     end we may actually want to support this structure, but probably in a different way, and not right now.
-	sepix := strings.IndexRune(name, filepath.Separator)
+	sepix := strings.IndexRune(name, '/')
 	if sepix != -1 {
 		name = name[:sepix] // temporarily whack everything after the /.
 	}


### PR DESCRIPTION
This fixes generation tests on Windows, where filepath.Separator is '\' instead of '/'.