### PR TITLE
Extend type information in tfgen.

### DIFF
--- a/pkg/tfbridge/names.go
+++ b/pkg/tfbridge/names.go
@@ -63,7 +63,8 @@ func TerraformToPulumiName(name string, sch *schema.Schema, upper bool) string {
 	if sch != nil && sch.MaxItems != 1 && (sch.Type == schema.TypeList || sch.Type == schema.TypeSet) {
 		contract.Assertf(
 			inflector.Pluralize(name) == name || inflector.Singularize(inflector.Pluralize(name)) == name,
-			"expected to be able to safely pluralize name: %s", name)
+			"expected to be able to safely pluralize name: %s (%s, %s)", name, inflector.Pluralize(name),
+			inflector.Singularize(inflector.Pluralize(name)))
 		name = inflector.Pluralize(name)
 	}
 

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -234,6 +234,21 @@ type propertyType struct {
 
 func makePropertyType(sch *schema.Schema, info *tfbridge.SchemaInfo, out bool, parsedDocs parsedDoc) *propertyType {
 	t := &propertyType{}
+
+	var elemInfo *tfbridge.SchemaInfo
+	if info != nil {
+		t.typ = info.Type
+		t.nestedType = info.NestedType
+		t.altTypes = info.AltTypes
+		t.asset = info.Asset
+		elemInfo = info.Elem
+	}
+
+	if sch == nil {
+		contract.Assert(info != nil)
+		return t
+	}
+
 	switch sch.Type {
 	case schema.TypeBool:
 		t.kind = kindBool
@@ -251,17 +266,6 @@ func makePropertyType(sch *schema.Schema, info *tfbridge.SchemaInfo, out bool, p
 		t.kind = kindSet
 	}
 
-	if info != nil {
-		t.typ = info.Type
-		t.nestedType = info.NestedType
-		t.altTypes = info.AltTypes
-		t.asset = info.Asset
-	}
-
-	var elemInfo *tfbridge.SchemaInfo
-	if info != nil {
-		elemInfo = info.Elem
-	}
 	switch elem := sch.Elem.(type) {
 	case *schema.Schema:
 		t.element = makePropertyType(elem, elemInfo, out, parsedDocs)

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -201,6 +201,125 @@ type moduleMember interface {
 	Doc() string
 }
 
+type typeKind int
+
+const (
+	kindInvalid = iota
+	kindBool
+	kindInt
+	kindFloat
+	kindString
+	kindList
+	kindMap
+	kindSet
+	kindObject
+)
+
+// propertyType represents a non-resource, non-datasource type. Property types may be simple
+type propertyType struct {
+	name       string
+	doc        string
+	kind       typeKind
+	element    *propertyType
+	properties []*variable
+
+	typ        tokens.Type
+	nestedType tokens.Type
+	altTypes   []tokens.Type
+	asset      *tfbridge.AssetTranslation
+}
+
+func makePropertyType(sch *schema.Schema, info *tfbridge.SchemaInfo, out bool, parsedDocs parsedDoc) *propertyType {
+	t := &propertyType{}
+	switch sch.Type {
+	case schema.TypeBool:
+		t.kind = kindBool
+	case schema.TypeInt:
+		t.kind = kindInt
+	case schema.TypeFloat:
+		t.kind = kindFloat
+	case schema.TypeString:
+		t.kind = kindString
+	case schema.TypeList:
+		t.kind = kindList
+	case schema.TypeMap:
+		t.kind = kindMap
+	case schema.TypeSet:
+		t.kind = kindSet
+	}
+
+	if info != nil {
+		t.typ = info.Type
+		t.nestedType = info.NestedType
+		t.altTypes = info.AltTypes
+		t.asset = info.Asset
+	}
+
+	var elemInfo *tfbridge.SchemaInfo
+	if info != nil {
+		elemInfo = info.Elem
+	}
+	switch elem := sch.Elem.(type) {
+	case *schema.Schema:
+		t.element = makePropertyType(elem, elemInfo, out, parsedDocs)
+	case *schema.Resource:
+		t.element = makeObjectPropertyType(elem, elemInfo, out, parsedDocs)
+	}
+
+	switch t.kind {
+	case kindList, kindSet:
+		if tfbridge.IsMaxItemsOne(sch, info) {
+			t = t.element
+		}
+	case kindMap:
+		// If this map has a "resource" element type, just use the generated element type. This works around a bug in
+		// TF that effectively forces this behavior.
+		if t.element != nil && t.element.kind == kindObject {
+			t = t.element
+		}
+	}
+
+	return t
+}
+
+func makeObjectPropertyType(res *schema.Resource, info *tfbridge.SchemaInfo, out bool, parsedDocs parsedDoc) *propertyType {
+	t := &propertyType{
+		kind: kindObject,
+	}
+
+	if info != nil {
+		t.typ = info.Type
+		t.nestedType = info.NestedType
+		t.altTypes = info.AltTypes
+		t.asset = info.Asset
+	}
+
+	var propertyInfos map[string]*tfbridge.SchemaInfo
+	if info != nil {
+		propertyInfos = info.Fields
+	}
+
+	for _, key := range stableSchemas(res.Schema) {
+		propertySchema := res.Schema[key]
+
+		var propertyInfo *tfbridge.SchemaInfo
+		if propertyInfos != nil {
+			propertyInfo = propertyInfos[key]
+		}
+
+		doc := parsedDocs.Arguments[key]
+		if doc == "" {
+			doc = parsedDocs.Attributes[key]
+		}
+
+		if v := propertyVariable(key, propertySchema, propertyInfo, doc, "", "", out, parsedDocs); v != nil {
+			t.properties = append(t.properties, v)
+		}
+	}
+
+	return t
+}
+
 // variable is a schematized variable, property, argument, or return type.
 type variable struct {
 	name   string
@@ -209,9 +328,12 @@ type variable struct {
 	config bool // config is true if this variable represents a Pulumi config value.
 	doc    string
 	rawdoc string
+	docURL string
+
 	schema *schema.Schema
 	info   *tfbridge.SchemaInfo
-	docURL string
+
+	typ *propertyType
 }
 
 func (v *variable) Name() string { return v.name }
@@ -219,20 +341,18 @@ func (v *variable) Doc() string  { return v.doc }
 
 // optional checks whether the given property is optional, either due to Terraform or an overlay.
 func (v *variable) optional() bool {
-	return v.opt || optionalComplex(v.schema, v.info, v.out, v.config)
-}
+	if v.opt {
+		return true
+	}
 
-// optionalComplex takes the constituent parts of a variable, rather than a variable itself, and returns whether it is
-// optional based on the Terraform or custom overlay properties.
-func optionalComplex(sch *schema.Schema, info *tfbridge.SchemaInfo, out, config bool) bool {
 	// If we're checking a property used in an output position, it isn't optional if it's computed.
 	//
 	// Note that config values with custom defaults are _not_ considered optional unless they are marked as such.
-	customDefault := !config && info != nil && info.HasDefault()
-	if out {
-		return sch != nil && sch.Optional && !sch.Computed && !customDefault
+	customDefault := !v.config && v.info != nil && v.info.HasDefault()
+	if v.out {
+		return v.schema != nil && v.schema.Optional && !v.schema.Computed && !customDefault
 	}
-	return (sch != nil && sch.Optional || sch.Computed) || customDefault
+	return (v.schema != nil && v.schema.Optional || v.schema.Computed) || customDefault
 }
 
 // resourceType is a generated resource type that represents a Pulumi CustomResource definition.
@@ -243,8 +363,8 @@ type resourceType struct {
 	inprops    []*variable
 	outprops   []*variable
 	reqprops   map[string]bool
-	argst      *plainOldType // input properties.
-	statet     *plainOldType // output properties (all optional).
+	argst      *propertyType // input properties.
+	statet     *propertyType // output properties (all optional).
 	schema     *schema.Resource
 	info       *tfbridge.ResourceInfo
 	docURL     string
@@ -279,8 +399,8 @@ type resourceFunc struct {
 	args       []*variable
 	rets       []*variable
 	reqargs    map[string]bool
-	argst      *plainOldType
-	retst      *plainOldType
+	argst      *propertyType
+	retst      *propertyType
 	schema     *schema.Resource
 	info       *tfbridge.DataSourceInfo
 	docURL     string
@@ -299,14 +419,6 @@ type overlayFile struct {
 func (of *overlayFile) Name() string { return of.name }
 func (of *overlayFile) Doc() string  { return "" }
 func (of *overlayFile) Copy() bool   { return of.src != "" }
-
-// plainOldType is any simple type definition that doesn't correspond to Pulumi CustomResources.  Note that this is not
-// a legal top-level module definition; instead, this type is embedded within others (see resourceType and Func).
-type plainOldType struct {
-	name  string
-	doc   string
-	props []*variable
-}
 
 // newGenerator returns a code-generator for the given language runtime and package info.
 func newGenerator(pkg, version string, language language, info tfbridge.ProviderInfo,
@@ -450,7 +562,7 @@ func (g *generator) gatherConfig() *module {
 		// Generate a name and type to use for this key.
 		sch := cfg[key]
 		docURL := getDocsIndexURL(g.info.GetGitHubOrg(), g.info.Name)
-		if prop := propertyVariable(key, sch, custom[key], "", sch.Description, docURL, true /*out*/); prop != nil {
+		if prop := propertyVariable(key, sch, custom[key], "", sch.Description, docURL, true /*out*/, parsedDoc{}); prop != nil {
 			prop.config = true
 			config.addMember(prop)
 		}
@@ -466,7 +578,7 @@ func (g *generator) gatherConfig() *module {
 
 	// Now, if there are any extra config variables, that are Pulumi-only, add them.
 	for key, val := range g.info.ExtraConfig {
-		if prop := propertyVariable(key, val.Schema, val.Info, "", "", "", true /*out*/); prop != nil {
+		if prop := propertyVariable(key, val.Schema, val.Info, "", "", "", true /*out*/, parsedDoc{}); prop != nil {
 			prop.config = true
 			config.addMember(prop)
 		}
@@ -589,7 +701,7 @@ func (g *generator) gatherResource(rawname string,
 		if !isProvider {
 			// For all properties, generate the output property metadata. Note that this may differ slightly
 			// from the input in that the types may differ.
-			outprop := propertyVariable(key, propschema, propinfo, doc, rawdoc, "", true /*out*/)
+			outprop := propertyVariable(key, propschema, propinfo, doc, rawdoc, "", true /*out*/, parsedDocs)
 			if outprop != nil {
 				res.outprops = append(res.outprops, outprop)
 			}
@@ -597,7 +709,7 @@ func (g *generator) gatherResource(rawname string,
 
 		// If an input, generate the input property metadata.
 		if input(propschema, propinfo) {
-			inprop := propertyVariable(key, propschema, propinfo, doc, rawdoc, "", false /*out*/)
+			inprop := propertyVariable(key, propschema, propinfo, doc, rawdoc, "", false /*out*/, parsedDocs)
 			if inprop != nil {
 				res.inprops = append(res.inprops, inprop)
 				if !inprop.optional() {
@@ -607,23 +719,23 @@ func (g *generator) gatherResource(rawname string,
 		}
 
 		// Make a state variable.  This is always optional and simply lets callers perform lookups.
-		stateVar := propertyVariable(key, propschema, propinfo, doc, rawdoc, "", false /*out*/)
+		stateVar := propertyVariable(key, propschema, propinfo, doc, rawdoc, "", false /*out*/, parsedDocs)
 		stateVar.opt = true
 		stateVars = append(stateVars, stateVar)
 	}
 
 	// Generate a state type for looking up instances of this resource.
-	res.statet = &plainOldType{
-		name:  fmt.Sprintf("%sState", res.name),
-		doc:   fmt.Sprintf("Input properties used for looking up and filtering %s resources.", res.name),
-		props: stateVars,
+	res.statet = &propertyType{
+		name:       fmt.Sprintf("%sState", res.name),
+		doc:        fmt.Sprintf("Input properties used for looking up and filtering %s resources.", res.name),
+		properties: stateVars,
 	}
 
 	// Next, generate the args interface for this class, and add it first to the list (since the res type uses it).
-	res.argst = &plainOldType{
-		name:  fmt.Sprintf("%sArgs", res.name),
-		doc:   fmt.Sprintf("The set of arguments for constructing a %s resource.", name),
-		props: res.inprops,
+	res.argst = &propertyType{
+		name:       fmt.Sprintf("%sArgs", res.name),
+		doc:        fmt.Sprintf("The set of arguments for constructing a %s resource.", name),
+		properties: res.inprops,
 	}
 
 	// Ensure there weren't any custom fields that were unrecognized.
@@ -735,7 +847,7 @@ func (g *generator) gatherDataSource(rawname string,
 
 		// Remember detailed information for every input arg (we will use it below).
 		if input(args[arg], cust) {
-			argvar := propertyVariable(arg, sch, cust, parsedDocs.Arguments[arg], "", "", false /*out*/)
+			argvar := propertyVariable(arg, sch, cust, parsedDocs.Arguments[arg], "", "", false /*out*/, parsedDocs)
 			fun.args = append(fun.args, argvar)
 			if !argvar.optional() {
 				fun.reqargs[argvar.name] = true
@@ -745,7 +857,7 @@ func (g *generator) gatherDataSource(rawname string,
 		// Also remember properties for the resulting return data structure.
 		// Emit documentation for the property if available
 		fun.rets = append(fun.rets,
-			propertyVariable(arg, sch, cust, parsedDocs.Attributes[arg], "", "", true /*out*/))
+			propertyVariable(arg, sch, cust, parsedDocs.Attributes[arg], "", "", true /*out*/, parsedDocs))
 	}
 
 	// If the data source's schema doesn't expose an id property, make one up since we'd like to expose it for data
@@ -758,22 +870,22 @@ func (g *generator) gatherDataSource(rawname string,
 		cust := &tfbridge.SchemaInfo{}
 		rawdoc := "id is the provider-assigned unique ID for this managed resource."
 		fun.rets = append(fun.rets,
-			propertyVariable("id", sch, cust, "", rawdoc, "", true /*out*/))
+			propertyVariable("id", sch, cust, "", rawdoc, "", true /*out*/, parsedDocs))
 	}
 
 	// Produce the args/return types, if needed.
 	if len(fun.args) > 0 {
-		fun.argst = &plainOldType{
-			name:  fmt.Sprintf("%sArgs", upperFirst(name)),
-			doc:   fmt.Sprintf("A collection of arguments for invoking %s.", name),
-			props: fun.args,
+		fun.argst = &propertyType{
+			name:       fmt.Sprintf("%sArgs", upperFirst(name)),
+			doc:        fmt.Sprintf("A collection of arguments for invoking %s.", name),
+			properties: fun.args,
 		}
 	}
 	if len(fun.rets) > 0 {
-		fun.retst = &plainOldType{
-			name:  fmt.Sprintf("%sResult", upperFirst(name)),
-			doc:   fmt.Sprintf("A collection of values returned by %s.", name),
-			props: fun.rets,
+		fun.retst = &propertyType{
+			name:       fmt.Sprintf("%sResult", upperFirst(name)),
+			doc:        fmt.Sprintf("A collection of values returned by %s.", name),
+			properties: fun.rets,
 		}
 	}
 
@@ -886,7 +998,7 @@ func propertyName(key string, sch *schema.Schema, custom *tfbridge.SchemaInfo) s
 
 // propertyVariable creates a new property, with the Pulumi name, out of the given components.
 func propertyVariable(key string, sch *schema.Schema, info *tfbridge.SchemaInfo,
-	doc string, rawdoc string, docURL string, out bool) *variable {
+	doc string, rawdoc string, docURL string, out bool, parsedDocs parsedDoc) *variable {
 	if name := propertyName(key, sch, info); name != "" {
 		return &variable{
 			name:   name,
@@ -896,6 +1008,7 @@ func propertyVariable(key string, sch *schema.Schema, info *tfbridge.SchemaInfo,
 			schema: sch,
 			info:   info,
 			docURL: docURL,
+			typ:    makePropertyType(sch, info, out, parsedDocs),
 		}
 	}
 	return nil

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -215,6 +215,9 @@ const (
 	kindObject
 )
 
+// Avoid an unused warning from varcheck.
+var _ = kindInvalid
+
 // propertyType represents a non-resource, non-datasource type. Property types may be simple
 type propertyType struct {
 	name       string
@@ -282,7 +285,9 @@ func makePropertyType(sch *schema.Schema, info *tfbridge.SchemaInfo, out bool, p
 	return t
 }
 
-func makeObjectPropertyType(res *schema.Resource, info *tfbridge.SchemaInfo, out bool, parsedDocs parsedDoc) *propertyType {
+func makeObjectPropertyType(res *schema.Resource, info *tfbridge.SchemaInfo, out bool,
+	parsedDocs parsedDoc) *propertyType {
+
 	t := &propertyType{
 		kind: kindObject,
 	}
@@ -562,7 +567,8 @@ func (g *generator) gatherConfig() *module {
 		// Generate a name and type to use for this key.
 		sch := cfg[key]
 		docURL := getDocsIndexURL(g.info.GetGitHubOrg(), g.info.Name)
-		if prop := propertyVariable(key, sch, custom[key], "", sch.Description, docURL, true /*out*/, parsedDoc{}); prop != nil {
+		prop := propertyVariable(key, sch, custom[key], "", sch.Description, docURL, true /*out*/, parsedDoc{})
+		if prop != nil {
 			prop.config = true
 			config.addMember(prop)
 		}

--- a/pkg/tfgen/generate_go.go
+++ b/pkg/tfgen/generate_go.go
@@ -392,12 +392,12 @@ func (g *goGenerator) emitRawDocComment(w *tools.GenWriter, comment, prefix stri
 	}
 }
 
-func (g *goGenerator) emitPlainOldType(w *tools.GenWriter, pot *plainOldType) {
+func (g *goGenerator) emitPlainOldType(w *tools.GenWriter, pot *propertyType) {
 	if pot.doc != "" {
 		g.emitDocComment(w, pot.doc, "", "")
 	}
 	w.Writefmtln("type %s struct {", pot.name)
-	for _, prop := range pot.props {
+	for _, prop := range pot.properties {
 		if prop.doc != "" && prop.doc != elidedDocComment {
 			g.emitDocComment(w, prop.doc, prop.docURL, "\t")
 		} else if prop.rawdoc != "" {

--- a/pkg/tfgen/generate_nodejs_test.go
+++ b/pkg/tfgen/generate_nodejs_test.go
@@ -154,6 +154,7 @@ func Test_TsTypes(t *testing.T) {
 			schema: test.schema,
 			info:   test.info,
 			opt:    true,
+			typ:    makePropertyType(test.schema, test.info, false, parsedDoc{}),
 		}
 
 		// Output
@@ -177,12 +178,14 @@ func Test_Issue130(t *testing.T) {
 		name:   "condition",
 		schema: schema,
 		out:    true,
+		typ:    makePropertyType(schema, nil, true, parsedDoc{}),
 	}, nil, nil, false, false, false))
 
 	assert.Equal(t, "pulumi.Input<string>", tsType("", "", &variable{
 		name:   "condition",
 		schema: schema,
 		out:    false,
+		typ:    makePropertyType(schema, nil, false, parsedDoc{}),
 	}, nil, nil, false, true, false))
 }
 

--- a/pkg/tfgen/generate_nodejs_test.go
+++ b/pkg/tfgen/generate_nodejs_test.go
@@ -158,11 +158,11 @@ func Test_TsTypes(t *testing.T) {
 
 		// Output
 		v.out = true
-		assert.Equal(t, test.expectedOutput, tsType("", "", v, parsedDoc{}, nil, nil, false, false, false))
+		assert.Equal(t, test.expectedOutput, tsType("", "", v, nil, nil, false, false, false))
 
 		// Input
 		v.out = false
-		assert.Equal(t, test.expectedInput, tsType("", "", v, parsedDoc{}, nil, nil, false, true, false))
+		assert.Equal(t, test.expectedInput, tsType("", "", v, nil, nil, false, true, false))
 	}
 }
 
@@ -177,13 +177,13 @@ func Test_Issue130(t *testing.T) {
 		name:   "condition",
 		schema: schema,
 		out:    true,
-	}, parsedDoc{}, nil, nil, false, false, false))
+	}, nil, nil, false, false, false))
 
 	assert.Equal(t, "pulumi.Input<string>", tsType("", "", &variable{
 		name:   "condition",
 		schema: schema,
 		out:    false,
-	}, parsedDoc{}, nil, nil, false, true, false))
+	}, nil, nil, false, true, false))
 }
 
 func Test_GatherCustomImports_ComplexArrayAltType(t *testing.T) {

--- a/pkg/tfgen/generate_python.go
+++ b/pkg/tfgen/generate_python.go
@@ -434,7 +434,7 @@ func (g *pythonGenerator) emitRawDocComment(w *tools.GenWriter, comment, prefix 
 	}
 }
 
-func (g *pythonGenerator) emitAwaitableType(w *tools.GenWriter, pot *plainOldType) string {
+func (g *pythonGenerator) emitAwaitableType(w *tools.GenWriter, pot *propertyType) string {
 	baseName := pyClassName(pot.name)
 
 	// Produce a class definition with optional """ comment.
@@ -445,11 +445,11 @@ func (g *pythonGenerator) emitAwaitableType(w *tools.GenWriter, pot *plainOldTyp
 
 	// Now generate an initializer with properties for all inputs.
 	w.Writefmt("    def __init__(__self__")
-	for _, prop := range pot.props {
+	for _, prop := range pot.properties {
 		w.Writefmt(", %s=None", pycodegen.PyName(prop.name))
 	}
 	w.Writefmtln("):")
-	for _, prop := range pot.props {
+	for _, prop := range pot.properties {
 		// Check that required arguments are present.  Also check that types are as expected.
 		pname := pycodegen.PyName(prop.name)
 		ptype := pyType(prop)
@@ -482,7 +482,7 @@ func (g *pythonGenerator) emitAwaitableType(w *tools.GenWriter, pot *plainOldTyp
 	w.Writefmtln("        if False:")
 	w.Writefmtln("            yield self")
 	w.Writefmtln("        return %s(", baseName)
-	for i, prop := range pot.props {
+	for i, prop := range pot.properties {
 		if i > 0 {
 			w.Writefmtln(",")
 		}
@@ -1278,7 +1278,7 @@ func elemNestedStructure(elem interface{}, info *tfbridge.SchemaInfo, parsedDocs
 			if doc == "" {
 				doc = parsedDocs.Attributes[s]
 			}
-			prop := propertyVariable(propName, sch, fldinfo, doc, "", "", false)
+			prop := propertyVariable(propName, sch, fldinfo, doc, "", "", false, parsedDocs)
 			nested = append(nested, &nestedVariable{
 				prop:   prop,
 				nested: nestedStructureFromSchema(sch, fldinfo, parsedDocs),

--- a/pkg/tfgen/generate_python.go
+++ b/pkg/tfgen/generate_python.go
@@ -192,10 +192,10 @@ func (g *pythonGenerator) emitModule(mod *module, submods []string) error {
 	for _, member := range mod.members {
 		if res, ok := member.(*resourceType); ok {
 			for _, prop := range res.inprops {
-				g.recordProperty(prop.name, prop.schema, prop.info)
+				g.recordProperty(prop)
 			}
 			for _, prop := range res.outprops {
-				g.recordProperty(prop.name, prop.schema, prop.info)
+				g.recordProperty(prop)
 			}
 		}
 	}
@@ -717,7 +717,7 @@ func (g *pythonGenerator) emitResourceFunc(mod *module, fun *resourceFunc) (stri
 	}
 
 	// Nested structures are typed as `dict` so we include some extra documentation for these structures.
-	g.emitNestedStructuresDocstring(&buf, fun.args, fun.parsedDocs, false /*wrapInput*/)
+	g.emitNestedStructuresDocstring(&buf, fun.args, false /*wrapInput*/)
 
 	g.emitDocComment(w, buf.String(), fun.docURL, "    ")
 
@@ -980,55 +980,17 @@ func (g *pythonGenerator) emitPropertyConversionTables(tableModule *module) erro
 //
 // Once all resources have been emitted, the table is written out to a format usable for implementations of
 // translate_input_property and translate_output_property.
-func (g *pythonGenerator) recordProperty(name string, sch *schema.Schema, info *tfbridge.SchemaInfo) {
-	snakeCaseName := pycodegen.PyName(name)
-	g.snakeCaseToCamelCase[snakeCaseName] = name
-	g.camelCaseToSnakeCase[name] = snakeCaseName
-	g.recordPropertyRec(sch, info)
-}
+func (g *pythonGenerator) recordProperty(prop *variable) {
+	snakeCaseName := pycodegen.PyName(prop.name)
+	g.snakeCaseToCamelCase[snakeCaseName] = prop.name
+	g.camelCaseToSnakeCase[prop.name] = snakeCaseName
 
-// recordPropertyRec recurses through a property's schema and recursively records any properties contained within it.
-func (g *pythonGenerator) recordPropertyRec(sch *schema.Schema, info *tfbridge.SchemaInfo) {
-	switch sch.Type {
-	case schema.TypeList, schema.TypeSet:
-		// If this property that we are recursing on is a list or a set, we do not need to record any properties at this
-		// step but we do need to recurse into the element schema of the list or set.
-		if elem, ok := sch.Elem.(*schema.Schema); ok {
-			var schInfo *tfbridge.SchemaInfo
-			if info != nil {
-				schInfo = info.Elem
-			}
-
-			g.recordPropertyRec(elem, schInfo)
-			return
+	// Due to bugs in earlier versions of the bride, we only recurse on properties with TypeMap and an object-typed
+	// element. This is consistent with the earlier behavior.
+	if prop.schema.Type == schema.TypeMap && prop.typ.kind == kindObject {
+		for _, p := range prop.typ.properties {
+			g.recordProperty(p)
 		}
-
-		// If this list or set doesn't have an element schema, it does not need to be recorded.
-	case schema.TypeMap:
-		// If this property that we are recursing on is a map, and that map has associated with it a Resource schema,
-		// this is a map with well-known keys that we will need to record in our table.
-		if res, ok := sch.Elem.(*schema.Resource); ok {
-			for _, prop := range stableSchemas(res.Schema) {
-				// If this field was overridden in SchemaInfo, keep track of that here.
-				var fldinfo *tfbridge.SchemaInfo
-				if info != nil {
-					fldinfo = info.Fields[prop]
-				}
-
-				childSchema := res.Schema[prop]
-				// If this field has a non-empty property name, record it.
-				if name := propertyName(prop, childSchema, fldinfo); name != "" {
-					// Note: recordProperty recurses into childSchema so there is no need to invoke recordPropertyRec
-					// to do so.
-					g.recordProperty(name, childSchema, fldinfo)
-				}
-			}
-		}
-
-		// If this map isn't a resource, there's no need to recurse any further.
-	default:
-		// Primitives do not need to be recorded.
-		return
 	}
 }
 
@@ -1041,7 +1003,7 @@ func (g *pythonGenerator) emitMembers(w *tools.GenWriter, mod *module, res *reso
 		if prop.doc != "" {
 			doc := prop.doc
 
-			nested := nestedStructure(prop, res.parsedDocs)
+			nested := nestedStructure(prop)
 			if len(nested) > 0 {
 				doc = fmt.Sprintf("%s\n\n", doc)
 
@@ -1093,7 +1055,7 @@ func (g *pythonGenerator) emitInitDocstring(w *tools.GenWriter, mod *module, res
 	}
 
 	// Nested structures are typed as `dict` so we include some extra documentation for these structures.
-	g.emitNestedStructuresDocstring(&buf, res.inprops, res.parsedDocs, true /*wrapInput*/)
+	g.emitNestedStructuresDocstring(&buf, res.inprops, true /*wrapInput*/)
 
 	// emitDocComment handles the prefix and triple quotes.
 	g.emitDocComment(w, buf.String(), res.docURL, "        ")
@@ -1115,7 +1077,7 @@ func (g *pythonGenerator) emitGetDocstring(w *tools.GenWriter, mod *module, res 
 	}
 
 	// Nested structures are typed as `dict` so we include some extra documentation for these structures.
-	g.emitNestedStructuresDocstring(&buf, res.outprops, res.parsedDocs, true /*wrapInput*/)
+	g.emitNestedStructuresDocstring(&buf, res.outprops, true /*wrapInput*/)
 
 	// emitDocComment handles the prefix and triple quotes.
 	g.emitDocComment(w, buf.String(), res.docURL, "        ")
@@ -1151,13 +1113,11 @@ func (g *pythonGenerator) emitPropDocstring(buf io.Writer, prop *variable, wrapI
 	}
 }
 
-func (g *pythonGenerator) emitNestedStructuresDocstring(buf io.Writer, props []*variable, parsedDocs parsedDoc,
-	wrapInput bool) {
-
+func (g *pythonGenerator) emitNestedStructuresDocstring(buf io.Writer, props []*variable, wrapInput bool) {
 	var names []string
 	nestedMap := make(map[string][]*nestedVariable)
 	for _, prop := range props {
-		nested := nestedStructure(prop, parsedDocs)
+		nested := nestedStructure(prop)
 		if len(nested) > 0 {
 			nestedMap[prop.Name()] = nested
 			names = append(names, prop.Name())
@@ -1230,101 +1190,55 @@ type nestedVariable struct {
 	nested []*nestedVariable
 }
 
-func nestedStructure(v *variable, parsedDocs parsedDoc) []*nestedVariable {
-	return nestedStructureFromSchema(v.schema, v.info, parsedDocs)
+func nestedStructure(v *variable) []*nestedVariable {
+	return nestedStructureFromPropertyType(v.typ)
 }
 
-func nestedStructureFromSchema(sch *schema.Schema, info *tfbridge.SchemaInfo, parsedDocs parsedDoc) []*nestedVariable {
-	var elem *tfbridge.SchemaInfo
-	if info != nil {
-		elem = info.Elem
-	}
-
-	switch sch.Type {
-	case schema.TypeSet, schema.TypeList:
-		return elemNestedStructure(sch.Elem, elem, parsedDocs)
-
-	case schema.TypeMap:
-		// If this map has a "resource" element type, just use the generated element type. This works around a bug in
-		// TF that effectively forces this behavior.
-		if _, hasResourceElem := sch.Elem.(*schema.Resource); hasResourceElem {
-			return elemNestedStructure(sch.Elem, elem, parsedDocs)
-		}
+func nestedStructureFromPropertyType(typ *propertyType) []*nestedVariable {
+	if typ == nil {
 		return nil
 	}
 
-	return nil
-}
-
-func elemNestedStructure(elem interface{}, info *tfbridge.SchemaInfo, parsedDocs parsedDoc) []*nestedVariable {
-	if elem == nil {
-		return nil
-	}
-
-	e, isResource := elem.(*schema.Resource)
-	if !isResource {
-		return nil
-	}
-
-	var nested []*nestedVariable
-	for _, s := range stableSchemas(e.Schema) {
-		var fldinfo *tfbridge.SchemaInfo
-		if info != nil {
-			fldinfo = info.Fields[s]
-		}
-		sch := e.Schema[s]
-		if propName := propertyName(s, sch, fldinfo); propName != "" {
-			doc := parsedDocs.Arguments[s]
-			if doc == "" {
-				doc = parsedDocs.Attributes[s]
+	switch typ.kind {
+	case kindSet, kindList:
+		return nestedStructureFromPropertyType(typ.element)
+	case kindObject:
+		nested := make([]*nestedVariable, len(typ.properties))
+		for i, p := range typ.properties {
+			nested[i] = &nestedVariable{
+				prop:   p,
+				nested: nestedStructure(p),
 			}
-			prop := propertyVariable(propName, sch, fldinfo, doc, "", "", false, parsedDocs)
-			nested = append(nested, &nestedVariable{
-				prop:   prop,
-				nested: nestedStructureFromSchema(sch, fldinfo, parsedDocs),
-			})
 		}
+		return nested
+	default:
+		return nil
 	}
-
-	return nested
 }
 
 // pyType returns the expected runtime type for the given variable.  Of course, being a dynamic language, this
 // check is not exhaustive, but it should be good enough to catch 80% of the cases early on.
 func pyType(v *variable) string {
-	return pyTypeFromSchema(v.schema, v.info)
+	return pyTypeFromPropertyType(v.typ)
 }
 
-func pyTypeFromSchema(sch *schema.Schema, info *tfbridge.SchemaInfo) string {
+func pyTypeFromPropertyType(typ *propertyType) string {
 	// If this is an asset or archive type, return the proper Pulumi SDK type name.
-	if info != nil && info.Asset != nil {
-		if info.Asset.IsArchive() {
-			return "pulumi." + info.Asset.Type()
+	if typ.asset != nil {
+		if typ.asset.IsArchive() {
+			return "pulumi." + typ.asset.Type()
 		}
 		return "Union[pulumi.Asset, pulumi.Archive]"
 	}
 
-	switch sch.Type {
-	case schema.TypeBool:
+	switch typ.kind {
+	case kindBool:
 		return "bool"
-	case schema.TypeInt, schema.TypeFloat:
+	case kindInt, kindFloat:
 		return "float"
-	case schema.TypeString:
+	case kindString:
 		return "str"
-	case schema.TypeSet, schema.TypeList:
-		if tfbridge.IsMaxItemsOne(sch, info) {
-			// This isn't supposed to be projected as a list; project it as a scalar.
-			if elem, ok := sch.Elem.(*schema.Schema); ok {
-				var schInfo *tfbridge.SchemaInfo
-				if info != nil {
-					schInfo = info.Elem
-				}
-				// If the elem is a schema type, see if we can do better than just "dict".
-				return pyTypeFromSchema(elem, schInfo)
-			}
-			// Otherwise, return "dict".
-			return "dict"
-		}
+	case kindSet, kindList:
 		return "list"
 	default:
 		return "dict"


### PR DESCRIPTION
Create rich type information during the gather phase. This type
information can then be used to drive code generation with fewer special
cases.