### PR TITLE
Take better advantage of the new type system.

### DIFF
--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -274,6 +274,8 @@ func makePropertyType(sch *schema.Schema, info *tfbridge.SchemaInfo, out bool,
 	}
 
 	switch elem := sch.Elem.(type) {
+	case schema.ValueType:
+		t.element = makePropertyType(&schema.Schema{Type: elem}, elemInfo, out, parsedDocs)
 	case *schema.Schema:
 		t.element = makePropertyType(elem, elemInfo, out, parsedDocs)
 	case *schema.Resource:

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -287,8 +287,10 @@ func makePropertyType(sch *schema.Schema, info *tfbridge.SchemaInfo, out bool,
 		}
 	case kindMap:
 		// If this map has a "resource" element type, just use the generated element type. This works around a bug in
-		// TF that effectively forces this behavior.
-		if t.element != nil && t.element.kind == kindObject {
+		// TF that effectively forces this behavior. If this map has _no_ element type, use type string.
+		if t.element == nil {
+			t.element = &propertyType{kind: kindString}
+		} else if t.element.kind == kindObject {
 			t = t.element
 		}
 	}

--- a/pkg/tfgen/generate_python.go
+++ b/pkg/tfgen/generate_python.go
@@ -580,7 +580,7 @@ func (g *pythonGenerator) emitResourceType(mod *module, res *resourceType) (stri
 		//
 		// Note the use of the `json` package here - we must import it at the top of the file so
 		// that we can use it.
-		if res.IsProvider() && prop.schema != nil && prop.schema.Type != schema.TypeString {
+		if res.IsProvider() && prop.typ.kind != kindString {
 			arg = fmt.Sprintf("pulumi.Output.from_input(%s).apply(json.dumps) if %s is not None else None", arg, arg)
 		}
 		w.Writefmtln("            __props__['%s'] = %s", pname, arg)
@@ -1298,12 +1298,12 @@ func pyDefaultValue(v *variable) string {
 
 	if len(defaults.EnvVars) > 0 {
 		envFunc := "utilities.get_env"
-		switch v.schema.Type {
-		case schema.TypeBool:
+		switch v.typ.kind {
+		case kindBool:
 			envFunc = "utilities.get_env_bool"
-		case schema.TypeInt:
+		case kindInt:
 			envFunc = "utilities.get_env_int"
-		case schema.TypeFloat:
+		case kindFloat:
 			envFunc = "utilities.get_env_float"
 		}
 

--- a/pkg/tfgen/generate_test.go
+++ b/pkg/tfgen/generate_test.go
@@ -76,6 +76,7 @@ func Test_NodeDefaults(t *testing.T) {
 			schema: &dvt.schema,
 			info:   &tfbridge.SchemaInfo{Default: &dvt.info},
 		}
+		v.typ = makePropertyType(v.schema, v.info, false, parsedDoc{})
 
 		actual := tsDefaultValue(v)
 		assert.Equal(t, dvt.expectedNode, actual)
@@ -163,6 +164,7 @@ func Test_PythonDefaults(t *testing.T) {
 			schema: &dvt.schema,
 			info:   &tfbridge.SchemaInfo{Default: &dvt.info},
 		}
+		v.typ = makePropertyType(v.schema, v.info, false, parsedDoc{})
 
 		actual := pyDefaultValue(v)
 		assert.Equal(t, dvt.expectedPython, actual)


### PR DESCRIPTION
Replace uses of TF and Pulumi schema info with the info embedded in the
types.