### PR TITLE
Export TerraformUnknownVariableValue to consumers

### DIFF
--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -34,11 +34,11 @@ import (
 	"github.com/pulumi/pulumi/pkg/util/contract"
 )
 
-// terraformUnknownVariableValue is the sentinal defined in github.com/hashicorp/terraform/configs/hcl2shim,
+// TerraformUnknownVariableValue is the sentinal defined in github.com/hashicorp/terraform/configs/hcl2shim,
 // representing a variable whose value is not known at some particular time. The value is duplicated here in
 // order to prevent an additional dependency - it is unlikely to ever change upstream since that would break
 // rather a lot of things.
-const terraformUnknownVariableValue = "74D93920-ED26-11E3-AC10-0800200C9A66"
+const TerraformUnknownVariableValue = "74D93920-ED26-11E3-AC10-0800200C9A66"
 
 // defaultsKey is the name of the input property that is used to track which property keys were populated using
 // default values from the resource's schema. This information is used to inform which input properties should be
@@ -295,7 +295,7 @@ func MakeTerraformInputs(res *PulumiResource, olds, news resource.PropertyMap,
 func makeTerraformUnknownElement(elem interface{}) interface{} {
 	// If we have no element schema, just return a simple unknown.
 	if elem == nil {
-		return terraformUnknownVariableValue
+		return TerraformUnknownVariableValue
 	}
 
 	switch e := elem.(type) {
@@ -312,7 +312,7 @@ func makeTerraformUnknownElement(elem interface{}) interface{} {
 		}
 		return res
 	default:
-		return terraformUnknownVariableValue
+		return TerraformUnknownVariableValue
 	}
 }
 
@@ -322,7 +322,7 @@ func makeTerraformUnknownElement(elem interface{}) interface{} {
 // e.g. TF does not play nicely with unknown lists, instead expecting a list of unknowns.
 func makeTerraformUnknown(tfs *schema.Schema) interface{} {
 	if tfs == nil {
-		return terraformUnknownVariableValue
+		return TerraformUnknownVariableValue
 	}
 
 	switch tfs.Type {
@@ -338,7 +338,7 @@ func makeTerraformUnknown(tfs *schema.Schema) interface{} {
 		}
 		return arr
 	default:
-		return terraformUnknownVariableValue
+		return TerraformUnknownVariableValue
 	}
 }
 
@@ -618,7 +618,7 @@ func MakeTerraformOutput(v interface{},
 			// If the string is the special unknown property sentinel, reflect back an unknown computed property.  Note that
 			// Terraform doesn't carry the types along with it, so the best we can do is give back a computed string.
 			t := val.String()
-			if t == terraformUnknownVariableValue {
+			if t == TerraformUnknownVariableValue {
 				return resource.NewComputedProperty(
 					resource.Computed{Element: resource.NewStringProperty("")})
 			}

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -184,10 +184,10 @@ func TestTerraformInputs(t *testing.T) {
 		"float_property_value":  99.6767932,
 		"string_property_value": "ognirts",
 		"array_property_value":  []interface{}{"an array"},
-		"unknown_array_value":   []interface{}{terraformUnknownVariableValue},
+		"unknown_array_value":   []interface{}{TerraformUnknownVariableValue},
 		"unknown_array_value2": []interface{}{
 			map[string]interface{}{
-				"required_property": terraformUnknownVariableValue,
+				"required_property": TerraformUnknownVariableValue,
 			},
 		},
 		"object_property_value": map[string]interface{}{
@@ -950,7 +950,7 @@ func TestComputedAsset(t *testing.T) {
 	}
 	olds := resource.PropertyMap{}
 	props := resource.PropertyMap{
-		"zzz": resource.NewStringProperty(terraformUnknownVariableValue),
+		"zzz": resource.NewStringProperty(TerraformUnknownVariableValue),
 	}
 	inputs, err := MakeTerraformInputs(nil, olds, props, tfs, ps, assets, nil, false, false)
 	assert.NoError(t, err)
@@ -1041,13 +1041,13 @@ func TestCustomTransforms(t *testing.T) {
 		nil, "v", resource.PropertyValue{}, resource.NewObjectProperty(resource.NewPropertyMapFromMap(doc)),
 		tfs, psi, nil, nil, false, false)
 	assert.NoError(t, err)
-	assert.Equal(t, terraformUnknownVariableValue, v3)
+	assert.Equal(t, TerraformUnknownVariableValue, v3)
 
 	v4, err := MakeTerraformInput(
 		nil, "v", resource.PropertyValue{}, resource.MakeComputed(resource.NewStringProperty("")),
 		tfs, psi, nil, nil, false, false)
 	assert.NoError(t, err)
-	assert.Equal(t, terraformUnknownVariableValue, v4)
+	assert.Equal(t, TerraformUnknownVariableValue, v4)
 }
 
 func TestImporterOnRead(t *testing.T) {


### PR DESCRIPTION
This allows us to use the unknown variable value without pulling in the entire Terraform dependency tree.