### PR TITLE
 Fix version generation. 

### DIFF
--- a/pkg/tfgen/generate_csharp.go
+++ b/pkg/tfgen/generate_csharp.go
@@ -28,7 +28,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/blang/semver"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/diag"
@@ -231,19 +230,10 @@ func (g *csharpGenerator) emitProjectFile() error {
 	}
 	defer contract.IgnoreClose(w)
 
-	version, err := semver.ParseTolerant(g.info.Version)
-	if err != nil {
-		return errors.Wrap(err, "could not parse version when emitting project file")
-	}
-
-	// Omit build metadata for .NET.
-	version.Build = nil
-
 	var buf bytes.Buffer
 	err = csharpProjectFileTemplate.Execute(&buf, csharpProjectFileTemplateContext{
-		XMLDoc:  fmt.Sprintf(`.\%s.xml`, assemblyName),
-		Info:    g.info,
-		Version: version.String(),
+		XMLDoc: fmt.Sprintf(`.\%s.xml`, assemblyName),
+		Info:   g.info,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Versions cannot be embedded statically in the generated files because
dev versions contain timestamps and commit hashes.