### PR TITLE
Respond to post-hoc feedback on C# codegen.

### DIFF
--- a/pkg/tfgen/generate_csharp_templates.go
+++ b/pkg/tfgen/generate_csharp_templates.go
@@ -48,38 +48,9 @@ namespace {{.Namespace}}
             return null;
         }
 
-        public static int? GetEnvInt32(params string[] names)
-        {
-            var s = GetEnv(names);
-            if (s != null)
-            {
-                try
-                {
-                    return int.Parse(s);
-                }
-                catch (Exception)
-                {
-                }
-            }
-            return null;
-        }
+        public static int? GetEnvInt32(params string[] names) => int.TryParse(GetEnv(names), out int v) ? (int?)v : null;
 
-        public static double? GetEnvDouble(params string[] names)
-        {
-            var s = GetEnv(names);
-            if (s != null)
-            {
-                try
-                {
-                    return double.Parse(s);
-                }
-                catch (Exception)
-                {
-                }
-            }
-            return null;
-
-        }
+        public static double? GetEnvDouble(params string[] names) => double.TryParse(GetEnv(names), out double v) ? (double?)v : null;
 
         public static InvokeOptions WithVersion(this InvokeOptions? options)
         {


### PR DESCRIPTION
- Elide empty nested namespaces
- Fix some whitespace issues
- Eliminate a cast
- Align `Id` behavior with other SDKs