### PR TITLE
Centralise the logic for AutoNaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,6 @@ CHANGELOG
 * Remove the need for Pandoc in generating Python SDK readme files.
 * Allow a schema variable to be overridden as being `Computed`
 * Allow passing a License Type for the upstream Terraform provider.
+* Centralise the work for Autonaming in providers.
 
 ---

--- a/pkg/tfgen/generate_csharp.go
+++ b/pkg/tfgen/generate_csharp.go
@@ -748,7 +748,8 @@ func (rg *csharpResourceGenerator) generateResourceClass() {
 
 	rg.w.Writefmtln("        public %s(string name, %s args%s, %s? options = null)",
 		className, argsType, argsDefault, optionsType)
-	rg.w.Writefmtln("            : base(\"%s\", name, args ?? ResourceArgs.Empty, MakeResourceOptions(options, \"\"))", rg.res.info.Tok)
+	rg.w.Writefmtln("            : base(\"%s\", name, args ?? ResourceArgs.Empty, MakeResourceOptions(options, \"\"))",
+		rg.res.info.Tok)
 	rg.w.Writefmtln("        {")
 	rg.w.Writefmtln("        }")
 


### PR DESCRIPTION
AWS and Azure have their own custom implementation for AutoNaming
therefore, we are going to centralize this logic into 3 main functions

1. AutoName
This just allows you to pass the name and the maxLength

2. AutoNameTransform
This allows you to pass the name, maxLength and a transform

3. AutoNameWithCustomOptions
This allows setting different combinations for sizes of random values,
different separators and transforms

This centralizes all of the custom logic that we have scattered for
AutoNaming.


**EDIT**
as expected, this is the failure we are receiving

```
BUILD:
go install -ldflags "-X github.com/pulumi/pulumi-aws/pkg/version.Version=v1.10.0-alpha.1574075843+g059ff10d" github.com/pulumi/pulumi-aws/cmd/pulumi-resource-aws
# github.com/pulumi/pulumi-aws
##[error]./resources.go:1710:31: too many arguments in call to tfbridge.FromName
	have (bool, number, nil)
	want (tfbridge.AutoNameOptions)
##[error]Makefile:29: recipe for target 'provider' failed
```
