### PR TITLE
Restore old autoname maxlen behavior.

### DIFF
--- a/pkg/tfbridge/names.go
+++ b/pkg/tfbridge/names.go
@@ -171,9 +171,6 @@ func FromName(options AutoNameOptions) func(res *PulumiResource) (interface{}, e
 
 			return uniqueHex, nil
 		}
-		if len(vs) > options.Maxlen {
-			return "", errors.Errorf("name '%s' is longer than maximum length %d", vs, options.Maxlen)
-		}
 		return vs, nil
 	}
 }


### PR DESCRIPTION
The prior logic did not check the actual length of the name against its
max length. Performing this check breaks back-compat, especially for
Maxlen=0 (the default).