### PR TITLE
Fix paths in Node.js generation in Windows

### DIFF
--- a/pkg/tfgen/generate_nodejs.go
+++ b/pkg/tfgen/generate_nodejs.go
@@ -1269,7 +1269,8 @@ func (g *nodeJSGenerator) emitTypeScriptProjectFile(pack *pkg, files []string) e
 		if err != nil {
 			return err
 		}
-		w.Writefmtln("        \"%s\"%s", relfile, suffix)
+		nodePath := filepath.ToSlash(relfile)
+		w.Writefmtln("        \"%s\"%s", nodePath, suffix)
 	}
 	w.Writefmtln(`    ]
 }
@@ -1288,7 +1289,8 @@ func (g *nodeJSGenerator) relModule(mod *module, path string) (string, error) {
 	if !strings.HasPrefix(file, ".") {
 		file = "./" + file
 	}
-	return removeExtension(file, ".ts"), nil
+	nodePath := filepath.ToSlash(file)
+	return removeExtension(nodePath, ".ts"), nil
 }
 
 // removeExtension removes the file extension, if any.
@@ -1367,7 +1369,7 @@ func (g *nodeJSGenerator) gatherCustomImports(mod *module, info *tfbridge.Schema
 				}
 				modname := ct.Module().Name()
 				modfile := filepath.Join(g.outDir,
-					strings.Replace(string(modname), tokens.TokenDelimiter, string(filepath.Separator), -1))
+					strings.Replace(string(modname), tokens.TokenDelimiter, string("/"), -1))
 				relmod, err := g.relModule(mod, modfile)
 				if err != nil {
 					return err

--- a/pkg/tfgen/generate_nodejs.go
+++ b/pkg/tfgen/generate_nodejs.go
@@ -1369,7 +1369,7 @@ func (g *nodeJSGenerator) gatherCustomImports(mod *module, info *tfbridge.Schema
 				}
 				modname := ct.Module().Name()
 				modfile := filepath.Join(g.outDir,
-					strings.Replace(string(modname), tokens.TokenDelimiter, string("/"), -1))
+					strings.Replace(string(modname), tokens.TokenDelimiter, string(filepath.Separator), -1))
 				relmod, err := g.relModule(mod, modfile)
 				if err != nil {
 					return err


### PR DESCRIPTION
Currently, tfgen on Windows generates some relative paths in `.ts` files with backslashes. (I think it's the first time I ran a tfgen on AWS).

This PR changes relative paths to slashes even on Windows.