### PR TITLE
Avoid setting conflicting default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,5 +11,6 @@ CHANGELOG
 * Allow passing a License Type for the upstream Terraform provider.
 * Warn when config with default values are not reflected in providers.
 * Centralise the work for Autonaming in providers.
+* Avoid setting conflicting default values ([91](https://github.com/pulumi/pulumi-terraform-bridge/pull/91)).
 
 ---

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -227,11 +227,19 @@ func MakeTerraformInputs(res *PulumiResource, olds, news resource.PropertyMap,
 					glog.V(9).Infof("Created Terraform input: %v = %v (from %s)", name, defaultValue, source)
 					result[name] = defaultValue
 					newDefaults = append(newDefaults, key)
+
+					// Expand the conflicts map
+					if sch != nil {
+						for _, conflictingName := range sch.ConflictsWith {
+							conflictsWith[conflictingName] = struct{}{}
+						}
+					}
 				}
 			}
 		}
 
 		// Next, populate defaults from the Terraform schema.
+	fields:
 		for name, sch := range tfs {
 			if sch.Removed != "" {
 				continue
@@ -241,6 +249,14 @@ func MakeTerraformInputs(res *PulumiResource, olds, news resource.PropertyMap,
 			}
 			if _, conflicts := conflictsWith[name]; conflicts {
 				continue
+			}
+
+			// If a conflicting field has a default value, don't set the default for the current field
+			for _, conflictingName := range sch.ConflictsWith {
+				dv, _ := tfs[conflictingName].DefaultValue()
+				if dv != nil {
+					continue fields
+				}
 			}
 
 			if _, has := result[name]; !has {

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -824,6 +824,10 @@ func TestDefaults(t *testing.T) {
 		"ll2": {Type: schema.TypeString, Default: "TL2"},
 		"mmm": {Type: schema.TypeString},
 		"mm2": {Type: schema.TypeString},
+		"nnn": {Type: schema.TypeString, ConflictsWith: []string{"nn2"}, Default: "NNN"},
+		"nn2": {Type: schema.TypeString, ConflictsWith: []string{"nnn"}, Default: "NN2"},
+		"ooo": {Type: schema.TypeString, ConflictsWith: []string{"oo2"}, Default: "OOO"},
+		"oo2": {Type: schema.TypeString, ConflictsWith: []string{"ooo"}},
 		"sss": {Type: schema.TypeString, Removed: "removed"},
 		"ttt": {Type: schema.TypeString, Removed: "removed", Default: "TFD"},
 		"uuu": {Type: schema.TypeString},
@@ -843,6 +847,7 @@ func TestDefaults(t *testing.T) {
 		"iii": {Default: &DefaultInfo{Value: "PSI"}},
 		"mmm": {Default: &DefaultInfo{Value: "PSM"}},
 		"mm2": {Default: &DefaultInfo{Value: "PM2"}},
+		"oo2": {Default: &DefaultInfo{Value: "PO2"}},
 		"sss": {Default: &DefaultInfo{Value: "PSS"}},
 		"uuu": {Default: &DefaultInfo{Value: "PSU", EnvVars: []string{"PTFU", "PTFU2"}}},
 		"vvv": {Default: &DefaultInfo{Value: 42, EnvVars: []string{"PTFV", "PTFV2"}}},
@@ -879,7 +884,7 @@ func TestDefaults(t *testing.T) {
 	sortDefaultsList(outputs)
 	assert.Equal(t, resource.NewPropertyMapFromMap(map[string]interface{}{
 		defaultsKey: []interface{}{
-			"cc2", "ccc", "ee2", "eee", "ggg", "iii", "ll2", "lll", "mm2", "mmm", "uuu", "vvv", "www",
+			"cc2", "ccc", "ee2", "eee", "ggg", "iii", "ll2", "lll", "mm2", "mmm", "oo2", "uuu", "vvv", "www",
 		},
 		"bbb": "BBB",
 		"ccc": "CCC",
@@ -897,6 +902,7 @@ func TestDefaults(t *testing.T) {
 		"ll2": "TL2",
 		"mmm": "OLM",
 		"mm2": "PM2",
+		"oo2": "PO2",
 		"uuu": "PSU",
 		"vvv": 1337,
 		"www": "OLW",
@@ -915,7 +921,7 @@ func TestDefaults(t *testing.T) {
 	sortDefaultsList(outputs)
 	assert.Equal(t, resource.NewPropertyMapFromMap(map[string]interface{}{
 		defaultsKey: []interface{}{
-			"cc2", "ccc", "ee2", "eee", "ggg", "iii", "ll2", "lll", "mm2", "mmm", "uuu", "vvv", "www",
+			"cc2", "ccc", "ee2", "eee", "ggg", "iii", "ll2", "lll", "mm2", "mmm", "oo2", "uuu", "vvv", "www",
 		},
 		"bbb": "BBB",
 		"ccc": "CCC",
@@ -933,6 +939,9 @@ func TestDefaults(t *testing.T) {
 		"ll2": "OL2",
 		"mmm": "OLM",
 		"mm2": "OM2",
+		// nnn/nn2 are NOT set as they conflict to each other
+		// ooo is NOT set as it conflicts to oo2
+		"oo2": "PO2",
 		"uuu": "PSU",
 		"vvv": 1337,
 		"www": "OLW",

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -939,8 +939,8 @@ func TestDefaults(t *testing.T) {
 		"ll2": "OL2",
 		"mmm": "OLM",
 		"mm2": "OM2",
-		// nnn/nn2 are NOT set as they conflict to each other
-		// ooo is NOT set as it conflicts to oo2
+		// nnn/nn2 are NOT set as they conflict with each other
+		// ooo is NOT set as it conflicts with oo2
 		"oo2": "PO2",
 		"uuu": "PSU",
 		"vvv": 1337,


### PR DESCRIPTION
Changes to fix https://github.com/pulumi/pulumi/issues/3621

The problem is that TF schema can have two fields that conflict with each other and both have default values. In this case, the old code sets defaults for both fields, and TF complains about the conflict.

I exclude both conflicting values, as setting just one might lead to non-deterministic behavior (we don't order the iteration of fields).

My solution is probably not bullet-proof: there are some logic branches that would lead to conflicting values (e.g. something with old values). The full solution might involve another stage when we first collect all possible defaults and conflicting fields, and then calculate all conflicts and exclude them, but this sounds complicated.