### PR TITLE
Require explicit namespace names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,5 +12,6 @@ CHANGELOG
 * Warn when config with default values are not reflected in providers.
 * Centralise the work for Autonaming in providers.
 * Avoid setting conflicting default values ([91](https://github.com/pulumi/pulumi-terraform-bridge/pull/91)).
+* Require explict C# namespaces.
 
 ---


### PR DESCRIPTION
I opened PRs for all provider repositories to define explicit names for C# namespaces. Now we can enforce having them on tfgen level instead of falling back to upper-casing the first character.