### PR TITLE
Prevent panic when getting named Schema from the SchemaMap

### DIFF
--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -253,8 +253,8 @@ func MakeTerraformInputs(res *PulumiResource, olds, news resource.PropertyMap,
 
 			// If a conflicting field has a default value, don't set the default for the current field
 			for _, conflictingName := range sch.ConflictsWith {
-				if otherSch, exists := tfs[conflictingName]; exists {
-					dv, _ := otherSch.DefaultValue()
+				if conflictingSchema, exists := tfs[conflictingName]; exists {
+					dv, _ := conflictingSchema.DefaultValue()
 					if dv != nil {
 						continue fields
 					}

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -253,9 +253,11 @@ func MakeTerraformInputs(res *PulumiResource, olds, news resource.PropertyMap,
 
 			// If a conflicting field has a default value, don't set the default for the current field
 			for _, conflictingName := range sch.ConflictsWith {
-				dv, _ := tfs[conflictingName].DefaultValue()
-				if dv != nil {
-					continue fields
+				if otherSch, exists := tfs[conflictingName]; exists {
+					dv, _ := otherSch.DefaultValue()
+					if dv != nil {
+						continue fields
+					}
 				}
 			}
 

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -828,6 +828,7 @@ func TestDefaults(t *testing.T) {
 		"nn2": {Type: schema.TypeString, ConflictsWith: []string{"nnn"}, Default: "NN2"},
 		"ooo": {Type: schema.TypeString, ConflictsWith: []string{"oo2"}, Default: "OOO"},
 		"oo2": {Type: schema.TypeString, ConflictsWith: []string{"ooo"}},
+		"oo3": {Type: schema.TypeString, ConflictsWith: []string{"nonexisting"}},
 		"sss": {Type: schema.TypeString, Removed: "removed"},
 		"ttt": {Type: schema.TypeString, Removed: "removed", Default: "TFD"},
 		"uuu": {Type: schema.TypeString},


### PR DESCRIPTION
When the name was an empty string, this was causing a panic