### PR TITLE
Support CSharpName on resource type level

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -115,6 +115,7 @@ type ResourceInfo struct {
 	DeleteBeforeReplace bool                   // if true, Pulumi will delete before creating new replacement resources.
 	Aliases             []AliasInfo            // aliases for this resources, if any.
 	DeprecationMessage  string                 // message to use in deprecation warning
+	CSharpName          string                 // .NET-specific name
 }
 
 func (info *ResourceInfo) GetTok() tokens.Token              { return tokens.Token(info.Tok) }

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -65,10 +65,12 @@ const (
 
 var allLanguages = []language{golang, nodeJS, python, csharp}
 
-// langGenerator is the interfact for language-specific logic and formatting.
+// langGenerator is the interface for language-specific logic and formatting.
 type langGenerator interface {
 	// emitPackage emits an entire package pack into the configured output directory with the configured settings.
 	emitPackage(pack *pkg) error
+	// typeName returns a type name for a given resource type.
+	typeName(rt *resourceType) string
 }
 
 // pkg is a directory containing one or more modules.
@@ -743,10 +745,12 @@ func (g *generator) gatherResource(rawname string,
 		stateVars = append(stateVars, stateVar)
 	}
 
+	className := g.lg.typeName(res)
+
 	// Generate a state type for looking up instances of this resource.
 	res.statet = &propertyType{
 		kind:       kindObject,
-		name:       fmt.Sprintf("%sState", res.name),
+		name:       fmt.Sprintf("%sState", className),
 		doc:        fmt.Sprintf("Input properties used for looking up and filtering %s resources.", res.name),
 		properties: stateVars,
 	}
@@ -754,7 +758,7 @@ func (g *generator) gatherResource(rawname string,
 	// Next, generate the args interface for this class, and add it first to the list (since the res type uses it).
 	res.argst = &propertyType{
 		kind:       kindObject,
-		name:       fmt.Sprintf("%sArgs", res.name),
+		name:       fmt.Sprintf("%sArgs", className),
 		doc:        fmt.Sprintf("The set of arguments for constructing a %s resource.", name),
 		properties: res.inprops,
 	}

--- a/pkg/tfgen/generate_csharp.go
+++ b/pkg/tfgen/generate_csharp.go
@@ -216,6 +216,14 @@ func (g *csharpGenerator) openWriter(mod *module, name string) (
 	return w, file, nil
 }
 
+// typeName returns a type name for a given resource type.
+func (g *csharpGenerator) typeName(r *resourceType) string {
+	if r.info != nil && r.info.CSharpName != "" {
+		return r.info.CSharpName
+	}
+	return r.name
+}
+
 // emitPackage emits an entire package pack into the configured output directory with the configured settings.
 func (g *csharpGenerator) emitPackage(pack *pkg) error {
 	// Ensure that we have a root module.
@@ -660,7 +668,7 @@ func newCSharpResourceGenerator(g *csharpGenerator, mod *module, res *resourceTy
 		mod:    mod,
 		res:    res,
 		nested: nested.getDeclaredTypes(res),
-		name:   res.name,
+		name:   g.typeName(res),
 	}
 }
 

--- a/pkg/tfgen/generate_go.go
+++ b/pkg/tfgen/generate_go.go
@@ -125,6 +125,11 @@ func (g *goGenerator) emitImports(w *tools.GenWriter, ims imports) {
 	}
 }
 
+// typeName returns a type name for a given resource type.
+func (g *goGenerator) typeName(r *resourceType) string {
+	return r.name
+}
+
 // emitPackage emits an entire package pack into the configured output directory with the configured settings.
 func (g *goGenerator) emitPackage(pack *pkg) error {
 	// Generate individual modules and their contents as packages.

--- a/pkg/tfgen/generate_nodejs.go
+++ b/pkg/tfgen/generate_nodejs.go
@@ -135,6 +135,11 @@ func (g *nodeJSGenerator) emitSDKImport(mod *module, w *tools.GenWriter, needsIn
 	w.Writefmtln("")
 }
 
+// typeName returns a type name for a given resource type.
+func (g *nodeJSGenerator) typeName(r *resourceType) string {
+	return r.name
+}
+
 // emitPackage emits an entire package pack into the configured output directory with the configured settings.
 func (g *nodeJSGenerator) emitPackage(pack *pkg) error {
 	// Return an error if the provider has its own `types` module, which is reserved for now.
@@ -1398,6 +1403,8 @@ func (g *nodeJSGenerator) gatherCustomImports(mod *module, info *tfbridge.Schema
 
 	return nil
 }
+
+
 
 // getCustomImportTypeName returns the import name to use for custom types.
 func getCustomImportTypeName(typeName string) string {

--- a/pkg/tfgen/generate_nodejs.go
+++ b/pkg/tfgen/generate_nodejs.go
@@ -1404,8 +1404,6 @@ func (g *nodeJSGenerator) gatherCustomImports(mod *module, info *tfbridge.Schema
 	return nil
 }
 
-
-
 // getCustomImportTypeName returns the import name to use for custom types.
 func getCustomImportTypeName(typeName string) string {
 	// We allow types to have a `[]` suffix to indicate an array.

--- a/pkg/tfgen/generate_python.go
+++ b/pkg/tfgen/generate_python.go
@@ -116,6 +116,11 @@ func (g *pythonGenerator) emitSDKImport(mod *module, w *tools.GenWriter) {
 	w.Writefmtln("")
 }
 
+// typeName returns a type name for a given resource type.
+func (g *pythonGenerator) typeName(r *resourceType) string {
+	return r.name
+}
+
 // emitPackage emits an entire package pack into the configured output directory with the configured settings.
 func (g *pythonGenerator) emitPackage(pack *pkg) error {
 	// First, generate the individual modules and their contents.


### PR DESCRIPTION
Docker provider has a resource called `Config` which conflicts with our `Config` static configuration class. I'm adding the ability to specify `CSharpName` for resources and will rename the resource to `ServiceConfig`.