### PR TITLE
Ensuring that schema deprecations in TF are accounted for in Pulumi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,5 +18,6 @@ CHANGELOG
 * Avoid setting conflicting default values ([91](https://github.com/pulumi/pulumi-terraform-bridge/pull/91)).
 * Require explict C# namespaces.
 * Add option to control if only asynchronous data sources should be generated in JS/TS.
+* Ensure Terraform deprecations are represented in Pulumi schema
 
 ---

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -177,6 +177,9 @@ type SchemaInfo struct {
 
 	// this will make the parameter as computed and not allow the user to set it
 	MarkAsComputedOnly *bool
+
+	// the deprecation message for the property
+	DeprecationMessage string
 }
 
 // ConfigInfo represents a synthetic configuration variable that is Pulumi-only, and not passed to Terraform.
@@ -276,29 +279,31 @@ type PreConfigureCallback func(vars resource.PropertyMap, config *terraform.Reso
 
 // MarshallableSchema is the JSON-marshallable form of a Terraform schema.
 type MarshallableSchema struct {
-	Type          schema.ValueType  `json:"type"`
-	Optional      bool              `json:"optional,omitempty"`
-	Required      bool              `json:"required,omitempty"`
-	Computed      bool              `json:"computed,omitempty"`
-	ForceNew      bool              `json:"forceNew,omitempty"`
-	Elem          *MarshallableElem `json:"element,omitempty"`
-	MaxItems      int               `json:"maxItems,omitempty"`
-	MinItems      int               `json:"minItems,omitempty"`
-	PromoteSingle bool              `json:"promoteSingle,omitempty"`
+	Type               schema.ValueType  `json:"type"`
+	Optional           bool              `json:"optional,omitempty"`
+	Required           bool              `json:"required,omitempty"`
+	Computed           bool              `json:"computed,omitempty"`
+	ForceNew           bool              `json:"forceNew,omitempty"`
+	Elem               *MarshallableElem `json:"element,omitempty"`
+	MaxItems           int               `json:"maxItems,omitempty"`
+	MinItems           int               `json:"minItems,omitempty"`
+	PromoteSingle      bool              `json:"promoteSingle,omitempty"`
+	DeprecationMessage string            `json:"deprecated,omitempty"`
 }
 
 // MarshalSchema converts a Terraform schema into a MarshallableSchema.
 func MarshalSchema(s *schema.Schema) *MarshallableSchema {
 	return &MarshallableSchema{
-		Type:          s.Type,
-		Optional:      s.Optional,
-		Required:      s.Required,
-		Computed:      s.Computed,
-		ForceNew:      s.ForceNew,
-		Elem:          MarshalElem(s.Elem),
-		MaxItems:      s.MaxItems,
-		MinItems:      s.MinItems,
-		PromoteSingle: s.PromoteSingle,
+		Type:               s.Type,
+		Optional:           s.Optional,
+		Required:           s.Required,
+		Computed:           s.Computed,
+		ForceNew:           s.ForceNew,
+		Elem:               MarshalElem(s.Elem),
+		MaxItems:           s.MaxItems,
+		MinItems:           s.MinItems,
+		PromoteSingle:      s.PromoteSingle,
+		DeprecationMessage: s.Deprecated,
 	}
 }
 
@@ -314,6 +319,7 @@ func (m *MarshallableSchema) Unmarshal() *schema.Schema {
 		MaxItems:      m.MaxItems,
 		MinItems:      m.MinItems,
 		PromoteSingle: m.PromoteSingle,
+		Deprecated:    m.DeprecationMessage,
 	}
 }
 
@@ -430,6 +436,7 @@ type MarshallableSchemaInfo struct {
 	Asset       *AssetTranslation                  `json:"asset,omitempty"`
 	Default     *MarshallableDefaultInfo           `json:"default,omitempty"`
 	MaxItemsOne *bool                              `json:"maxItemsOne,omitempty"`
+	Deprecated  string                             `json:"deprecated,omitempty"`
 }
 
 // MarshalSchemaInfo converts a Pulumi SchemaInfo value into a MarshallableSchemaInfo value.
@@ -452,6 +459,7 @@ func MarshalSchemaInfo(s *SchemaInfo) *MarshallableSchemaInfo {
 		Asset:       s.Asset,
 		Default:     MarshalDefaultInfo(s.Default),
 		MaxItemsOne: s.MaxItemsOne,
+		Deprecated:  s.DeprecationMessage,
 	}
 }
 
@@ -466,15 +474,16 @@ func (m *MarshallableSchemaInfo) Unmarshal() *SchemaInfo {
 		fields[k] = v.Unmarshal()
 	}
 	return &SchemaInfo{
-		Name:        m.Name,
-		CSharpName:  m.CSharpName,
-		Type:        m.Type,
-		AltTypes:    m.AltTypes,
-		Elem:        m.Elem.Unmarshal(),
-		Fields:      fields,
-		Asset:       m.Asset,
-		Default:     m.Default.Unmarshal(),
-		MaxItemsOne: m.MaxItemsOne,
+		Name:               m.Name,
+		CSharpName:         m.CSharpName,
+		Type:               m.Type,
+		AltTypes:           m.AltTypes,
+		Elem:               m.Elem.Unmarshal(),
+		Fields:             fields,
+		Asset:              m.Asset,
+		Default:            m.Default.Unmarshal(),
+		MaxItemsOne:        m.MaxItemsOne,
+		DeprecationMessage: m.Deprecated,
 	}
 }
 

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -275,6 +275,11 @@ func makePropertyType(sch *schema.Schema, info *tfbridge.SchemaInfo, out bool,
 		t.kind = kindSet
 	}
 
+	// We should carry across any of the deprecation messages, to Pulumi, as per Terraform schema
+	if sch.Deprecated != "" && elemInfo != nil {
+		elemInfo.DeprecationMessage = sch.Deprecated
+	}
+
 	switch elem := sch.Elem.(type) {
 	case *schema.Schema:
 		t.element = makePropertyType(elem, elemInfo, out, parsedDocs)
@@ -356,6 +361,18 @@ type variable struct {
 
 func (v *variable) Name() string { return v.name }
 func (v *variable) Doc() string  { return v.doc }
+
+func (v *variable) deprecationMessage() string {
+	if v.schema != nil && v.schema.Deprecated != "" {
+		return v.schema.Deprecated
+	}
+
+	if v.info != nil && v.info.DeprecationMessage != "" {
+		return v.info.DeprecationMessage
+	}
+
+	return ""
+}
 
 // optional checks whether the given property is optional, either due to Terraform or an overlay.
 func (v *variable) optional() bool {

--- a/pkg/tfgen/generate_csharp.go
+++ b/pkg/tfgen/generate_csharp.go
@@ -751,6 +751,7 @@ func (rg *csharpResourceGenerator) openNamespace() error {
 		return err
 	}
 
+	rg.w.Writefmtln("using System;")
 	rg.w.Writefmtln("using System.Collections.Generic;")
 	rg.w.Writefmtln("using System.Collections.Immutable;")
 	rg.w.Writefmtln("using System.Threading.Tasks;")
@@ -1020,6 +1021,10 @@ func (rg *csharpResourceGenerator) generateInputProperty(prop *variable, nested 
 			rg.w.Writefmtln("")
 		}
 		emitCSharpPropertyDocComment(rg.w, prop, "        ")
+
+		if prop.deprecationMessage() != "" {
+			rg.w.Writefmtln("        [Obsolete(@\"%s\")]", strings.Replace(prop.deprecationMessage(), "\"", "\"\"", -1))
+		}
 
 		// Note that we use the backing field type--which is just the property type without any nullable annotation--to
 		// ensure that the user does not see warnings when initializing these properties using object or collection

--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -313,11 +313,12 @@ func (g *schemaGenerator) genProperty(mod string, prop *variable, pyMapCase bool
 	}
 
 	return pschema.PropertySpec{
-		TypeSpec:    g.schemaType(mod, prop.typ, prop.out),
-		Description: description,
-		Default:     defaultValue,
-		DefaultInfo: defaultInfo,
-		Language:    language,
+		TypeSpec:           g.schemaType(mod, prop.typ, prop.out),
+		Description:        description,
+		Default:            defaultValue,
+		DefaultInfo:        defaultInfo,
+		DeprecationMessage: prop.deprecationMessage(),
+		Language:           language,
 	}
 }
 

--- a/pkg/tfgen/generate_test.go
+++ b/pkg/tfgen/generate_test.go
@@ -88,3 +88,13 @@ func Test_NodeDefaults(t *testing.T) {
 		assert.Equal(t, multiEnv, actual)
 	}
 }
+
+func Test_DeprecationFromTFSchema(t *testing.T) {
+	v := &variable{
+		name:   "v",
+		schema: &schema.Schema{Type: schema.TypeString, Deprecated: "This is deprecated"},
+	}
+
+	deprecationMessage := v.deprecationMessage()
+	assert.Equal(t, "This is deprecated", deprecationMessage)
+}


### PR DESCRIPTION
Fixes: #86

We can do this easily for TypeScript and DotNet.

It's not easy in any way to deprecate parameters in Python. We would
need to write our own decorator for that and that would seriously slow
down the performance of our python implementation

FYI, the output of this will change the providers to have something like
this:

```
diff --git a/sdk/nodejs/listChart.ts b/sdk/nodejs/listChart.ts
index e6f38b3..3a20209 100644
--- a/sdk/nodejs/listChart.ts
+++ b/sdk/nodejs/listChart.ts
@@ -244,6 +244,7 @@ export interface ListChartState {
     /**
      * List of properties that should not be displayed in the chart legend (i.e. dimension names). All the properties are visible by default. Deprecated, please use `legendOptionsFields`.
      */
+    /** @deprecated Please use legend_options_fields */
     readonly legendFieldsToHides?: pulumi.Input<pulumi.Input<string>[]>;
     /**
```