### PR TITLE
Add generation for Python PEP 561 type defs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.6.9
+          python-version: 3.6.10
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@releases/v1
       - name: Install tf2pulumi
@@ -75,7 +75,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.6.9
+          python-version: 3.6.10
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@releases/v1
       - name: Install tf2pulumi
@@ -110,7 +110,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.6.9
+          python-version: 3.6.10
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@releases/v1
       - name: Install tf2pulumi
@@ -145,7 +145,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.6.9
+          python-version: 3.6.10
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@releases/v1
       - name: Install tf2pulumi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
+* Add support for PEP 561 Python type specs ([100](https://github.com/pulumi/pulumi-terraform-bridge/pull/100)).
 * Add support for generating a .NET SDK.
 * Update Terraform bridge to be based on v1.0.0 of the Terraform Plugin SDK
 * Add support to specify a custom package name for NodeJS package

--- a/pkg/tfgen/generate_csharp.go
+++ b/pkg/tfgen/generate_csharp.go
@@ -294,7 +294,7 @@ func (g *csharpGenerator) emitLogo() error {
 	}
 
 	// Get the data.
-	resp, err := http.Get(url)
+	resp, err := http.Get(url) // #nosec
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
See this PR for pulumi/pulumi https://github.com/pulumi/pulumi/pull/3704/files

We did some work to clean up and enable mypy in pulumi/pulumi in https://github.com/pulumi/pulumi/pull/#3758, and then merged the PR to publish the type spec files. 

This PR generates the same `py.typed` files and required config in `setup.py`. I tested this on the `pulumi-aws` package locally. Mypy runs clean on the examples repo, and I was able to solicit some mypy errors:

```py
from pulumi_aws import s33
```
```
Evans-MBP:aws-py-s3-folder evanboyle$ mypy __main__.py 
__main__.py:6: error: Module 'pulumi_aws' has no attribute 's33'
__main__.py:8: error: Name 's3' is not defined
__main__.py:16: error: Name 's3' is not defined
__main__.py:37: error: Name 's3' is not defined
Found 4 errors in 1 file (checked 1 source file)
```
