### PR TITLE
Do not json-stringify properties that are part of nested types used in providers

### DIFF
--- a/pkg/tfgen/generate_csharp.go
+++ b/pkg/tfgen/generate_csharp.go
@@ -1001,7 +1001,7 @@ func (rg *csharpResourceGenerator) generateInputProperty(prop *variable, nested 
 	if !prop.optional() {
 		attributeArgs = ", required: true"
 	}
-	if rg.res != nil && rg.res.IsProvider() && prop.typ.kind != kindString {
+	if rg.res != nil && rg.res.IsProvider() && prop.typ.kind != kindString && !nested {
 		attributeArgs += ", json: true"
 	}
 


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/3746

The problem here is that the generator generates:

```c#
    public sealed class ProviderArgs : Pulumi.ResourceArgs
    {
        [Input("authLogins", json: true)]
        private InputList<Inputs.ProviderAuthLoginsArgs>? _authLogins;
        public InputList<Inputs.ProviderAuthLoginsArgs> AuthLogins
        {
            get => _authLogins ?? (_authLogins = new InputList<Inputs.ProviderAuthLoginsArgs>());
            set => _authLogins = value;
        }
    }

    namespace Inputs
    {
    public sealed class ProviderAuthLoginsArgs : Pulumi.ResourceArgs
    {
        [Input("parameters", json: true)]
        private InputMap<string>? _parameters;
        public InputMap<string> Parameters
        {
            get => _parameters ?? (_parameters = new InputMap<string>());
            set => _parameters = value;
        }
```

Note how both `_authLogins` and `_parameters` are marked with `json: true`.  This causes the serializer in the core `Pulumi.dll` to double jsonify these values. in other words, instead of producing somethin like:

`'[ { "parameters": { "A": "B" } } ]'` for `authLogins` it instead produces
`'[ { "parameters": "{ \"A\": \"B\" }" } ]'`

Now, i could have fixed this in the serializer by having it ignore hte `json: true` when recursing downwards.  But that felt like a hack to me.  It's really just non-sensible that there's any nested json-ifying even being marked.  Only the true outer value to the *provider itself* is what should be json-ified.  This matches how things work in TS and seems the most sensible to me. 


