### PR TITLE
Fix the initializer of C# config value types

### DIFF
--- a/pkg/tfgen/generate_csharp.go
+++ b/pkg/tfgen/generate_csharp.go
@@ -489,7 +489,7 @@ func (g *csharpGenerator) emitConfigVariableType(w *tools.GenWriter, typ *proper
 		propertyType := csharpPropertyType(prop, false /*wrapInput*/)
 
 		initializer := ""
-		if !prop.optional() {
+		if !prop.optional() && !isValueType(propertyType) {
 			initializer = " = null!;"
 		}
 


### PR DESCRIPTION
Fixes the issue of `pulumi-azure` generation for the latest SDK