### PR TITLE
Ensure the link to the Terraform documentation is correct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,5 +20,6 @@ CHANGELOG
 * Require explict C# namespaces.
 * Add option to control if only asynchronous data sources should be generated in JS/TS.
 * Ensure Terraform deprecations are represented in Pulumi schema
+* Ensure links to Terraform documentation pages are valid
 
 ---


### PR DESCRIPTION
Fixes: https://github.com/pulumi/docs/issues/2020

By default, we always assumed the documentation ended in
`.html.markdown` we now check to ensure we have the correct link by checking
that the documentation exists first. The potential file names are:

* .html.markdown
* .html.md
* .markdown

We check for the file in the same way we do when we want to parse the doc contents

Sample diff

```
     ///
-    /// &gt; This content is derived from https://github.com/terraform-providers/terraform-provider-vault/blob/master/website/docs/r/approle_auth_backend_login.html.markdown.
+    /// &gt; This content is derived from https://github.com/terraform-providers/terraform-provider-vault/blob/master/website/docs/r/approle_auth_backend_login.html.md.
     /// </summary>

```