### PR TITLE
Warn on <elided> document comments

### DIFF
--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -55,6 +55,7 @@ func TestURLRewrite(t *testing.T) {
 	assert.NoError(t, err)
 
 	for _, test := range tests {
-		assert.Equal(t, test.Expected, cleanupText(g, nil, test.Input))
+		text, _ := cleanupText(g, nil, test.Input)
+		assert.Equal(t, test.Expected, text)
 	}
 }


### PR DESCRIPTION
Related: https://github.com/pulumi/home/issues/642

Output from AWS gives us this

```
warning: Resource aws_api_gateway_rest_api contains an <elided> doc reference that needs update
warning: Resource aws_batch_compute_environment contains an <elided> doc reference that needs update
warning: Resource aws_dx_hosted_transit_virtual_interface_accepter contains an <elided> doc reference that needs update
warning: Resource aws_ecr_lifecycle_policy contains an <elided> doc reference that needs update
warning: Resource aws_ecr_repository_policy contains an <elided> doc reference that needs update
warning: Resource aws_ecs_capacity_provider contains an <elided> doc reference that needs update
warning: Resource aws_eks_cluster contains an <elided> doc reference that needs update
warning: Resource aws_eks_node_group contains an <elided> doc reference that needs update
warning: Resource aws_elasticsearch_domain contains an <elided> doc reference that needs update
warning: Resource aws_iam_group_policy contains an <elided> doc reference that needs update
warning: Resource aws_iam_policy contains an <elided> doc reference that needs update
......
```