### PR TITLE
Custom resource options for provider

### DIFF
--- a/pkg/tfgen/generate_csharp.go
+++ b/pkg/tfgen/generate_csharp.go
@@ -816,9 +816,6 @@ func (rg *csharpResourceGenerator) generateResourceClass() {
 	}
 
 	optionsType := "CustomResourceOptions"
-	if rg.res.IsProvider() {
-		optionsType = "ResourceOptions"
-	}
 
 	// Write a comment prior to the constructor.
 	rg.w.Writefmtln("        /// <summary>")


### PR DESCRIPTION
`ResourceOptions` becomes an abstract class in https://github.com/pulumi/pulumi/issues/3857.
Pass `CustomResourceOptions` to providers too.