### PR TITLE
Return errors instead of panics where upstream provider errors may occur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,5 +21,6 @@ CHANGELOG
 * Add option to control if only asynchronous data sources should be generated in JS/TS.
 * Ensure Terraform deprecations are represented in Pulumi schema
 * Ensure links to Terraform documentation pages are valid
+* Prefer errors over panics for potential upstream error catches
 
 ---

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -644,11 +644,15 @@ func (p *Provider) Create(ctx context.Context, req *pulumirpc.CreateRequest) (*p
 
 	newstate, err := p.tf.Apply(info, state, diff)
 	if newstate == nil {
-		contract.Assertf(err != nil, "Expected non-nil error with nil state during Create of %s", urn)
+		if err == nil {
+			return nil, fmt.Errorf("expected non-nil error with nil state during Create of %s", urn)
+		}
 		return nil, err
 	}
 
-	contract.Assertf(newstate.ID != "", "Expected non-empty ID for new state during Create of %s", urn)
+	if newstate.ID == "" {
+		return nil, fmt.Errorf("expected non-empty ID for new state during Create of %s", urn)
+	}
 	reasons := make([]string, 0)
 	if err != nil {
 		reasons = append(reasons, errors.Wrapf(err, "creating %s", urn).Error())
@@ -822,7 +826,9 @@ func (p *Provider) Update(ctx context.Context, req *pulumirpc.UpdateRequest) (*p
 			"fixed by running `pulumi refresh` before updating.", urn)
 	}
 
-	contract.Assertf(newstate.ID != "", "Expected non-empty ID for new state during Update of %s", urn)
+	if newstate.ID == "" {
+		return nil, fmt.Errorf("expected non-empty ID for new state during Update of %s", urn)
+	}
 	reasons := make([]string, 0)
 	if err != nil {
 		reasons = append(reasons, errors.Wrapf(err, "updating %s", urn).Error())


### PR DESCRIPTION
Fixes: #114

This will prevent panics being returned to the user and will return
a more accurate description of what has happened