### PR TITLE
Make generated schema.json human readable

### DIFF
--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -52,7 +52,7 @@ func newSchemaGenerator(pkg, version string, info tfbridge.ProviderInfo, outDir 
 }
 
 func (g *schemaGenerator) emitPackage(pack *pkg) error {
-	schema, err := json.Marshal(g.genPackageSpec(pack))
+	schema, err := json.MarshalIndent(g.genPackageSpec(pack), "", "    ")
 	if err != nil {
 		return errors.Wrap(err, "marshaling Pulumi schema")
 	}


### PR DESCRIPTION
Since we are checking this file in, and it has the most direct representation of the changes in any provider update, we should have it be human readable and meaningfully diffable.