### PR TITLE
Search for go.mod in the provider folder as well

### DIFF
--- a/pkg/tfgen/gomod.go
+++ b/pkg/tfgen/gomod.go
@@ -35,7 +35,7 @@ func LoadGoMod() (*modfile.File, error) {
 	if moduleRoot == "" {
 		// Some provider repos have a "provider" module, rather than a
 		// module at the root of the repo.
-		moduleRoot = findModuleRoot(exePath + "provider")
+		moduleRoot = findModuleRoot(exePath + "/provider")
 		if moduleRoot == "" {
 			return nil, errors.New("cannot find module root")
 		}

--- a/pkg/tfgen/gomod.go
+++ b/pkg/tfgen/gomod.go
@@ -33,7 +33,12 @@ func LoadGoMod() (*modfile.File, error) {
 
 	moduleRoot := findModuleRoot(exePath)
 	if moduleRoot == "" {
-		return nil, errors.New("cannot find module root")
+		// Some provider repos have a "provider" module, rather than a
+		// module at the root of the repo.
+		moduleRoot = findModuleRoot(exePath + "provider")
+		if moduleRoot == "" {
+			return nil, errors.New("cannot find module root")
+		}
 	}
 
 	gomodContent, err := ioutil.ReadFile(filepath.Join(moduleRoot, "go.mod"))

--- a/pkg/tfgen/gomod.go
+++ b/pkg/tfgen/gomod.go
@@ -35,7 +35,7 @@ func LoadGoMod() (*modfile.File, error) {
 	if moduleRoot == "" {
 		// Some provider repos have a "provider" module, rather than a
 		// module at the root of the repo.
-		moduleRoot = findModuleRoot(exePath + "/provider")
+		moduleRoot = findModuleRoot(filepath.Join(exePath, "provider"))
 		if moduleRoot == "" {
 			return nil, errors.New("cannot find module root")
 		}


### PR DESCRIPTION
I think this is needed for the new module structure in the provider repos to work.