### PR TITLE
Ensure SchemaInfo is checked for MaxItemsOne before naming params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,5 +21,6 @@ CHANGELOG
 * Ensure Terraform deprecations are represented in Pulumi schema
 * Ensure links to Terraform documentation pages are valid
 * Prefer errors over panics for potential upstream error catches
+* Ensure Pulumi SchemaInfo is taken into consideration when pluralizing parameters
 
 ---

--- a/pkg/tfbridge/names_test.go
+++ b/pkg/tfbridge/names_test.go
@@ -22,26 +22,67 @@ import (
 )
 
 func TestPulumiToTerraformName(t *testing.T) {
-	assert.Equal(t, "", PulumiToTerraformName("", nil))
-	assert.Equal(t, "test", PulumiToTerraformName("test", nil))
-	assert.Equal(t, "test_name", PulumiToTerraformName("testName", nil))
-	assert.Equal(t, "test_name_pascal", PulumiToTerraformName("TestNamePascal", nil))
-	assert.Equal(t, "test_name", PulumiToTerraformName("test_name", nil))
-	assert.Equal(t, "test_name_", PulumiToTerraformName("testName_", nil))
-	assert.Equal(t, "t_e_s_t_n_a_m_e", PulumiToTerraformName("TESTNAME", nil))
+	assert.Equal(t, "", PulumiToTerraformName("", nil, nil))
+	assert.Equal(t, "test", PulumiToTerraformName("test", nil, nil))
+	assert.Equal(t, "test_name", PulumiToTerraformName("testName", nil, nil))
+	assert.Equal(t, "test_name_pascal", PulumiToTerraformName("TestNamePascal", nil, nil))
+	assert.Equal(t, "test_name", PulumiToTerraformName("test_name", nil, nil))
+	assert.Equal(t, "test_name_", PulumiToTerraformName("testName_", nil, nil))
+	assert.Equal(t, "t_e_s_t_n_a_m_e", PulumiToTerraformName("TESTNAME", nil, nil))
 }
 
 func TestTerraformToPulumiName(t *testing.T) {
-	assert.Equal(t, "", TerraformToPulumiName("", nil, false))
-	assert.Equal(t, "test", TerraformToPulumiName("test", nil, false))
-	assert.Equal(t, "testName", TerraformToPulumiName("test_name", nil, false))
-	assert.Equal(t, "testName_", TerraformToPulumiName("testName_", nil, false))
-	assert.Equal(t, "tESTNAME", TerraformToPulumiName("t_e_s_t_n_a_m_e", nil, false))
-	assert.Equal(t, "", TerraformToPulumiName("", nil, true))
-	assert.Equal(t, "Test", TerraformToPulumiName("test", nil, true))
-	assert.Equal(t, "TestName", TerraformToPulumiName("test_name", nil, true))
-	assert.Equal(t, "TestName_", TerraformToPulumiName("testName_", nil, true))
-	assert.Equal(t, "TESTNAME", TerraformToPulumiName("t_e_s_t_n_a_m_e", nil, true))
+	assert.Equal(t, "", TerraformToPulumiName("", nil, nil, false))
+	assert.Equal(t, "test", TerraformToPulumiName("test", nil, nil, false))
+	assert.Equal(t, "testName", TerraformToPulumiName("test_name", nil, nil, false))
+	assert.Equal(t, "testName_", TerraformToPulumiName("testName_", nil, nil, false))
+	assert.Equal(t, "tESTNAME", TerraformToPulumiName("t_e_s_t_n_a_m_e", nil, nil, false))
+	assert.Equal(t, "", TerraformToPulumiName("", nil, nil, true))
+	assert.Equal(t, "Test", TerraformToPulumiName("test", nil, nil, true))
+	assert.Equal(t, "TestName", TerraformToPulumiName("test_name", nil, nil, true))
+	assert.Equal(t, "TestName_", TerraformToPulumiName("testName_", nil, nil, true))
+	assert.Equal(t, "TESTNAME", TerraformToPulumiName("t_e_s_t_n_a_m_e", nil, nil, true))
+}
+
+func TestTerraformToPulumiNameWithSchemaInfoOverride(t *testing.T) {
+	tfs := map[string]*schema.Schema{
+		"list_property": {
+			Type: schema.TypeList,
+		},
+	}
+
+	// Override the List from the TF Schema with our own SchemaInfo overrides
+	maxItemsOne := true
+	ps := map[string]*SchemaInfo{
+		"list_property": {
+			MaxItemsOne: &maxItemsOne,
+		},
+	}
+
+	name := TerraformToPulumiName("list_property", tfs["list_property"], ps["list_property"], false)
+	if name != "listProperty" {
+		t.Errorf("Expected `listProperty`, got %s", name)
+	}
+}
+
+func TestPulumiToTerraformNameWithSchemaInfoOverride(t *testing.T) {
+	tfs := map[string]*schema.Schema{
+		"list_property": {
+			Type: schema.TypeList,
+		},
+	}
+
+	maxItemsOne := true
+	ps := map[string]*SchemaInfo{
+		"list_property": {
+			MaxItemsOne: &maxItemsOne,
+		},
+	}
+
+	name := PulumiToTerraformName("listProperty", tfs, ps)
+	if name != "list_property" {
+		t.Errorf("Expected `list_property`, got %s", name)
+	}
 }
 
 func TestPluralize(t *testing.T) {
@@ -57,11 +98,11 @@ func TestPluralize(t *testing.T) {
 			Type: schema.TypeSet,
 		},
 	}
-	assert.Equal(t, "someThings", TerraformToPulumiName("some_thing", tfs["some_thing"], false))
-	assert.Equal(t, "someOtherThing", TerraformToPulumiName("some_other_thing", tfs["some_other_thing"], false))
-	assert.Equal(t, "allThings", TerraformToPulumiName("all_things", tfs["all_things"], false))
+	assert.Equal(t, "someThings", TerraformToPulumiName("some_thing", tfs["some_thing"], nil, false))
+	assert.Equal(t, "someOtherThing", TerraformToPulumiName("some_other_thing", tfs["some_other_thing"], nil, false))
+	assert.Equal(t, "allThings", TerraformToPulumiName("all_things", tfs["all_things"], nil, false))
 
-	assert.Equal(t, "some_thing", PulumiToTerraformName("someThings", tfs))
-	assert.Equal(t, "some_other_things", PulumiToTerraformName("someOtherThings", tfs))
-	assert.Equal(t, "all_things", PulumiToTerraformName("allThings", tfs))
+	assert.Equal(t, "some_thing", PulumiToTerraformName("someThings", tfs, nil))
+	assert.Equal(t, "some_other_things", PulumiToTerraformName("someOtherThings", tfs, nil))
+	assert.Equal(t, "all_things", PulumiToTerraformName("allThings", tfs, nil))
 }

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -263,7 +263,8 @@ func (p *Provider) camelPascalPulumiName(name string) (string, string) {
 	contract.Assertf(strings.HasPrefix(name, prefix),
 		"Expected all Terraform resources in this module to have a '%v' prefix", prefix)
 	name = name[len(prefix):]
-	return TerraformToPulumiName(name, nil, false), TerraformToPulumiName(name, nil, true)
+	return TerraformToPulumiName(name, nil, nil, false),
+		TerraformToPulumiName(name, nil, nil, true)
 }
 
 func convertStringToPropertyValue(s string, typ schema.ValueType) (resource.PropertyValue, error) {
@@ -379,7 +380,7 @@ func (p *Provider) Configure(ctx context.Context,
 	var missingKeys []*pulumirpc.ConfigureErrorMissingKeys_MissingKey
 	for key, meta := range p.config {
 		if meta.Required && !config.IsSet(key) {
-			name := TerraformToPulumiName(key, meta, false)
+			name := TerraformToPulumiName(key, meta, nil, false)
 			fullyQualifiedName := tokens.NewModuleToken(p.pkg(), tokens.ModuleName(name))
 
 			// TF descriptions often have newlines in inopportune positions. This makes them present
@@ -430,8 +431,9 @@ func (p *Provider) formatFailureReason(res Resource, reason string) string {
 	parts := requiredFieldRegex.FindStringSubmatch(reason)
 	if len(parts) == 2 {
 		schema := res.TF.Schema[parts[1]]
+		info := res.Schema.Fields[parts[1]]
 		if schema != nil {
-			name := TerraformToPulumiName(parts[1], schema, false)
+			name := TerraformToPulumiName(parts[1], schema, info, false)
 			message := fmt.Sprintf("Missing required property '%s'", name)
 			// If a required field is missing and the value can be set via config,
 			// extend the error with a hint to set the proper config value

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -974,7 +974,7 @@ func getInfoFromTerraformName(key string,
 			name = key
 		} else {
 			// If no name override exists, use the default name mangling scheme.
-			name = TerraformToPulumiName(key, tfs[key], false)
+			name = TerraformToPulumiName(key, tfs[key], ps[key], false)
 		}
 	}
 
@@ -1000,7 +1000,7 @@ func getInfoFromPulumiName(key resource.PropertyKey,
 		name = ks
 	} else {
 		// Otherwise, transform the Pulumi name to the Terraform name using the standard mangling scheme.
-		name = PulumiToTerraformName(ks, tfs)
+		name = PulumiToTerraformName(ks, tfs, ps)
 	}
 	return name, tfs[name], ps[name]
 }

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -1044,7 +1044,7 @@ func propertyName(key string, sch *schema.Schema, custom *tfbridge.SchemaInfo) s
 		key = key[:len(key)-1]
 	}
 
-	return tfbridge.TerraformToPulumiName(key, sch, false /*no to PascalCase; we want camelCase*/)
+	return tfbridge.TerraformToPulumiName(key, sch, custom, false /*no to PascalCase; we want camelCase*/)
 }
 
 // propertyVariable creates a new property, with the Pulumi name, out of the given components.
@@ -1069,9 +1069,9 @@ func propertyVariable(key string, sch *schema.Schema, info *tfbridge.SchemaInfo,
 func dataSourceName(provider string, rawname string, info *tfbridge.DataSourceInfo) (string, string) {
 	if info == nil || info.Tok == "" {
 		// default transformations.
-		name := withoutPackageName(provider, rawname)            // strip off the pkg prefix.
-		return tfbridge.TerraformToPulumiName(name, nil, false), // camelCase the data source name.
-			tfbridge.TerraformToPulumiName(name, nil, false) // camelCase the filename.
+		name := withoutPackageName(provider, rawname)                 // strip off the pkg prefix.
+		return tfbridge.TerraformToPulumiName(name, nil, nil, false), // camelCase the data source name.
+			tfbridge.TerraformToPulumiName(name, nil, nil, false) // camelCase the filename.
 	}
 	// otherwise, a custom transformation exists; use it.
 	return string(info.Tok.Name()), string(info.Tok.Module().Name())
@@ -1084,9 +1084,9 @@ func resourceName(provider string, rawname string, info *tfbridge.ResourceInfo, 
 	}
 	if info == nil || info.Tok == "" {
 		// default transformations.
-		name := withoutPackageName(provider, rawname)           // strip off the pkg prefix.
-		return tfbridge.TerraformToPulumiName(name, nil, true), // PascalCase the resource name.
-			tfbridge.TerraformToPulumiName(name, nil, false) // camelCase the filename.
+		name := withoutPackageName(provider, rawname)                // strip off the pkg prefix.
+		return tfbridge.TerraformToPulumiName(name, nil, nil, true), // PascalCase the resource name.
+			tfbridge.TerraformToPulumiName(name, nil, nil, false) // camelCase the filename.
 	}
 	// otherwise, a custom transformation exists; use it.
 	return string(info.Tok.Name()), string(info.Tok.Module().Name())


### PR DESCRIPTION
It didn't matter what we had in our SchemaInfo, the naming was
always coming from the TF Schema which wasn't quite correct. It should
take into account what we wanted to do about pluralizing the names
based on our schema overrides

Fixes: https://github.com/pulumi/pulumi-aws/issues/900