### PR TITLE
Do not generate .NET invoke functions if AsyncDataSources is set

### DIFF
--- a/pkg/tfgen/generate_csharp.go
+++ b/pkg/tfgen/generate_csharp.go
@@ -736,7 +736,10 @@ func (rg *csharpResourceGenerator) emit() (string, error) {
 		rg.generateResourceState()
 	} else {
 		contract.Assert(rg.fun != nil)
-		rg.generateDatasourceFunc()
+		// Treat 'JavaScript.AsyncDataSources' as '2.0 data sources', also for .NET.
+		if !rg.g.info.JavaScript.AsyncDataSources {
+			rg.generateDatasourceFunc()
+		}
 		rg.generateDatasourceClass()
 		rg.generateDatasourceArgs()
 		rg.generateDatasourceResult()


### PR DESCRIPTION
Resolves #131 
Removes method-style invokes from 2.0 .NET code.

No doubt that using `JavaScript.AsyncDataSources` to augment .NET generation is hacky, but the flag perfectly aligns with when we don't want to gen the code (in 2.0), and I feel it's short-lived enough to go for it and avoid adding an extra flag in every 2.0 provider (risking a mistake of forgetting doing so). Let me know if that's not a good idea.