### PR TITLE
Add a version flag to tfgen built providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,5 +23,6 @@ CHANGELOG
 * Ensure links to Terraform documentation pages are valid
 * Prefer errors over panics for potential upstream error catches
 * Ensure Pulumi SchemaInfo is taken into consideration when pluralizing parameters
+* Add a version flag to providers ([154](https://github.com/pulumi/pulumi-terraform-bridge/pull/91))
 
 ---

--- a/pkg/tfbridge/main.go
+++ b/pkg/tfbridge/main.go
@@ -17,6 +17,7 @@ package tfbridge
 import (
 	"encoding/json"
 	"flag"
+	"fmt"
 	"os"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/logging"
@@ -30,11 +31,16 @@ func Main(pkg string, version string, prov ProviderInfo, pulumiSchema []byte) {
 	// Look for a request to dump the provider info to stdout.
 	flags := flag.NewFlagSet("tf-provider-flags", flag.ContinueOnError)
 	dumpInfo := flags.Bool("get-provider-info", false, "dump provider info as JSON to stdout")
+	providerVersion := flags.Bool("version", false, "get built provider version")
 	contract.IgnoreError(flags.Parse(os.Args[1:]))
 	if *dumpInfo {
 		if err := json.NewEncoder(os.Stdout).Encode(MarshalProviderInfo(&prov)); err != nil {
 			cmdutil.ExitError(err.Error())
 		}
+		os.Exit(0)
+	}
+	if *providerVersion {
+		fmt.Println(version)
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
If you're building and testing providers locally, you can sometimes end up in a situation where you don't actually know which version of the provider you're using.

This adds a version flag to all providers built with pulumi-terraform-bridge:

```
/Users/lbriggs/src/go/src/github.com/jaxxstorm/pulumi-rke/dist/pulumi-rke_darwin_amd64/pulumi-resource-rke --help
Usage of tf-provider-flags:
  -get-provider-info
    	dump provider info as JSON to stdout
  -version
    	get built provider version
Usage of /Users/lbriggs/src/go/src/github.com/jaxxstorm/pulumi-rke/dist/pulumi-rke_darwin_amd64/pulumi-resource-rke:
  -alsologtostderr
    	log to standard error as well as files
  -log_backtrace_at value
    	when logging hits line file:N, emit a stack trace
  -log_dir string
    	If non-empty, write log files in this directory
  -logtostderr
    	log to standard error instead of files
  -stderrthreshold value
    	logs at or above this threshold go to stderr
  -tracing string
    	Emit tracing to a Zipkin-compatible tracing endpoint
  -v value
    	log level for V logs
  -vmodule value
    	comma-separated list of pattern=N settings for file-filtered logging

/Users/lbriggs/src/go/src/github.com/jaxxstorm/pulumi-rke/dist/pulumi-rke_darwin_amd64/pulumi-resource-rke -version
v0.2.1-SNAPSHOT
```

When we build these providers, we nearly always pass the version through using `ldflags` anyway, so this just gives us an option to write it to stdout for verification 

Fixes #151 