### PR TITLE
Use release v3 of action-test-provider-downstream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Check out source code
         uses: actions/checkout@master
       - name: Test Downstream
-        uses: pulumi/action-test-provider-downstream@releases/v2
+        uses: pulumi/action-test-provider-downstream@releases/v3
         env:
           GOPROXY: "https://proxy.golang.org"
         with:
@@ -87,7 +87,7 @@ jobs:
       - name: Check out source code
         uses: actions/checkout@master
       - name: Test Downstream
-        uses: pulumi/action-test-provider-downstream@releases/v2
+        uses: pulumi/action-test-provider-downstream@releases/v3
         env:
           GOPROXY: "https://proxy.golang.org"
         with:
@@ -123,7 +123,7 @@ jobs:
       - name: Check out source code
         uses: actions/checkout@master
       - name: Test Downstream
-        uses: pulumi/action-test-provider-downstream@releases/v2
+        uses: pulumi/action-test-provider-downstream@releases/v3
         env:
           GOPROXY: "https://proxy.golang.org"
         with:
@@ -159,7 +159,7 @@ jobs:
       - name: Check out source code
         uses: actions/checkout@master
       - name: Test Downstream
-        uses: pulumi/action-test-provider-downstream@releases/v2
+        uses: pulumi/action-test-provider-downstream@releases/v3
         env:
           GOPROXY: "https://proxy.golang.org"
         with:


### PR DESCRIPTION
This should fix the issues seen in #161 where diffs are not displayed for v2 of the module.