### PR TITLE
Make the comment for datasource `id` property slightly more generic

### DIFF
--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -903,7 +903,7 @@ func (g *generator) gatherDataSource(rawname string,
 			Computed: true,
 		}
 		cust := &tfbridge.SchemaInfo{}
-		rawdoc := "id is the provider-assigned unique ID for this managed resource."
+		rawdoc := "The provider-assigned unique ID for this managed resource."
 		fun.rets = append(fun.rets,
 			propertyVariable("id", sch, cust, "", rawdoc, "", true /*out*/, parsedDocs))
 	}


### PR DESCRIPTION
While it is `id` in the schema, it's not always `id` in each projected language. For example, in C# and Go it's `Id`. Instead of having the case mismatch in some languages, or having to fix-up the comment for each language, just remove the identifier from the comment.

This also matches the comment I added for the `id` resource output property that will be injected in the docs. https://github.com/pulumi/pulumi/pull/4443