### PR TITLE
Ensure Renamed Resources and DataSources are marked as deprecated

### DIFF
--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -1061,6 +1061,8 @@ func (p *ProviderInfo) RenameResourceWithAlias(resourceName string, legacyTok to
 		}
 	}
 
+	legacyInfo.DeprecationMessage = fmt.Sprintf("%s.%s has been deprecated in favour of %s.%s",
+		legacyInfo.Tok.Module().Package(), legacyInfo.Tok.Name(), currentInfo.Tok.Module().Package(), currentInfo.Tok.Name())
 	p.Resources[resourceName] = &currentInfo
 	p.Resources[legacyResourceName] = &legacyInfo
 	p.P.ResourcesMap[legacyResourceName] = p.P.ResourcesMap[resourceName]
@@ -1091,6 +1093,8 @@ func (p *ProviderInfo) RenameDataSource(resourceName string, legacyTok tokens.Mo
 		}
 	}
 
+	legacyInfo.DeprecationMessage = fmt.Sprintf("%s.%s has been deprecated in favour of %s.%s",
+		legacyInfo.Tok.Module().Package(), legacyInfo.Tok.Name(), currentInfo.Tok.Module().Package(), currentInfo.Tok.Name())
 	p.DataSources[resourceName] = &currentInfo
 	p.DataSources[legacyResourceName] = &legacyInfo
 	p.P.DataSourcesMap[legacyResourceName] = p.P.DataSourcesMap[resourceName]

--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -372,6 +372,7 @@ func (g *schemaGenerator) genResourceType(mod string, res *resourceType) pschema
 	}
 	if !res.IsProvider() {
 		if res.info.DeprecationMessage != "" {
+			spec.DeprecationMessage = res.info.DeprecationMessage
 			description = fmt.Sprintf("%s\nDeprecated: %s\n", description, res.info.DeprecationMessage)
 		}
 	}
@@ -419,6 +420,7 @@ func (g *schemaGenerator) genDatasourceFunc(mod string, fun *resourceFunc) psche
 		description = g.genDocComment(fun.doc, fun.docURL)
 	}
 	if fun.info.DeprecationMessage != "" {
+		spec.DeprecationMessage = fun.info.DeprecationMessage
 		description = fmt.Sprintf("%s\nDeprecated: %s\n", description, fun.info.DeprecationMessage)
 	}
 	spec.Description = description


### PR DESCRIPTION
This just adds a deprecation message to these renamed resources / datasources

It doesn't change the functionality apart from export that DeprecationMessage as part of the schema