### PR TITLE
handle nested argument sections

### DIFF
--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -462,6 +462,13 @@ func parseTFMarkdown(g *generator, info tfbridge.ResourceOrDataSourceInfo, kind 
 					cmdutil.Diag().Warningf(diag.Message("", "Expected an H1 in markdown for resource %v"), rawname)
 				}
 			default:
+				// Determine if this is a nested argument section.
+				_, isArgument := ret.Arguments[header]
+				if isArgument || strings.HasSuffix(header, "Configuration Block") {
+					processArgumentReferenceSection(subsection, &ret)
+					continue
+				}
+
 				// For all other sections, append them to the description section.
 				if !wroteHeader {
 					ret.Description += fmt.Sprintf("## %s\n", header)


### PR DESCRIPTION
This fixes the extra sections we are seeing on this [doc](https://www.pulumi.com/docs/reference/pkg/aws/emr/cluster/) page. There are a few more I am still determining how to handle. 

For example the `Block devices` header [here](https://github.com/terraform-providers/terraform-provider-aws/blob/master/website/docs/r/launch_configuration.html.markdown) is not fixed by this.

Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/159