### PR TITLE
Allow overriding TF Schema types to be optional

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -178,6 +178,9 @@ type SchemaInfo struct {
 	// this will make the parameter as computed and not allow the user to set it
 	MarkAsComputedOnly *bool
 
+	// this will make the parameter optional in the schema
+	MarkAsOptional *bool
+
 	// the deprecation message for the property
 	DeprecationMessage string
 }

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -990,6 +990,41 @@ func TestInvalidAsset(t *testing.T) {
 	}, outputs)
 }
 
+func TestOverridingTFSchema(t *testing.T) {
+	result := MakeTerraformOutputs(
+		map[string]interface{}{
+			"pulumi_override_tf_string_to_boolean":    MyString("true"),
+			"pulumi_empty_tf_override":                MyString("true"),
+			"tf_empty_string_to_pulumi_bool_override": MyString(""),
+		},
+		map[string]*schema.Schema{
+			"pulumi_override_tf_string_to_boolean":    {Type: schema.TypeString},
+			"pulumi_empty_tf_override":                {Type: schema.TypeString},
+			"tf_empty_string_to_pulumi_bool_override": {Type: schema.TypeString},
+		},
+		map[string]*SchemaInfo{
+			"pulumi_override_tf_string_to_boolean": {
+				Type: "boolean",
+			},
+			"pulumi_empty_tf_override": {
+				Type: "",
+			},
+			"tf_empty_string_to_pulumi_bool_override": {
+				Type:           "boolean",
+				MarkAsOptional: boolPointer(true),
+			},
+		},
+		nil,   /* assets */
+		false, /*useRawNames*/
+		true,
+	)
+	assert.Equal(t, resource.NewPropertyMapFromMap(map[string]interface{}{
+		"pulumiOverrideTfStringToBoolean":   true,
+		"pulumiEmptyTfOverride":             "true",
+		"tfEmptyStringToPulumiBoolOverride": nil,
+	}), result)
+}
+
 func TestArchiveAsAsset(t *testing.T) {
 	assets := make(AssetTable)
 	tfs := map[string]*schema.Schema{

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -373,6 +373,11 @@ func (v *variable) optional() bool {
 		return true
 	}
 
+	//if we have an explicit marked as optional then let's return that
+	if v.info != nil && v.info.MarkAsOptional != nil {
+		return *v.info.MarkAsOptional
+	}
+
 	// If we're checking a property used in an output position, it isn't optional if it's computed.
 	//
 	// Note that config values with custom defaults are _not_ considered optional unless they are marked as such.


### PR DESCRIPTION
Fixes: #176

When TF schema is set as a string
pulumi override with bool and TF passes "true" or "false" == true | false in the output
pulumi override with bool but with an empty type and TF passes "true" or "false" then we get "true" or "false" in the output as we don't have a type to override it with
pulumi override with bool and TF passes "" then we get nil in the output
For this to work, we need to do the following in resources.go in the provider:

```
			"aws_launch_template": {
				Tok: awsDataSource(ec2Mod, "getLaunchTemplate"),
				Fields: map[string]*tfbridge.SchemaInfo{
					"network_interfaces": {
						Elem: &tfbridge.SchemaInfo{
							Fields: map[string]*tfbridge.SchemaInfo{
								"associate_public_ip_address": {
									Type:           "boolean",
									MarkAsOptional: boolRef(true),
								},
							},
						},
					},
				},
			},
```

This gives us the correct output type:

```
	modified:   sdk/nodejs/elasticloadbalancingv2/listener.ts
diff --git a/sdk/nodejs/types/output.ts b/sdk/nodejs/types/output.ts
index 0d2c33364..c63569a08 100644
--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -5806,7 +5806,7 @@ export namespace ec2 {
     }
     export interface GetLaunchTemplateNetworkInterface {
-        associatePublicIpAddress: boolean;
+        associatePublicIpAddress?: boolean;
         deleteOnTermination: boolean;
         /**
          * Description of the launch template.
```