### PR TITLE
Fix TransformJSONDoc when passing null due to regression in CoerceTerraformString

### DIFF
--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -1027,10 +1027,12 @@ func CleanTerraformSchema(tfs map[string]*schema.Schema) map[string]*schema.Sche
 func CoerceTerraformString(schType schema.ValueType, ps *SchemaInfo, stringValue string) (interface{}, error) {
 	// check for the override and use that over terraform if available
 	// we do this to ensure that we are following the explicit call to action of the override
+	// For now, we will only return nil when an override of the type is a boolean and there is no
+	// default value supplied - this will allow us to replicate the nullable-esquq bools that Terraform are
+	// creating by using strings in place of bools
+	// if we return nil for *all* override types when there is an empty string, then we can hit an edge case of
+	// breaking overrides where we have a string and a TransformJSONDocument (see pulumi/pulumi#4592)
 	if ps != nil && ps.Type != "" {
-		if stringValue == "" {
-			return nil, nil
-		}
 		switch strings.ToLower(ps.Type.String()) {
 		case "boolean":
 			if stringValue == "" {

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -1093,6 +1093,18 @@ func TestCustomTransforms(t *testing.T) {
 		tfs, psi, nil, nil, false, false)
 	assert.NoError(t, err)
 	assert.Equal(t, TerraformUnknownVariableValue, v4)
+
+	// This checks the fix to the regression caused via CoerceTerraformString to ensure we handle nil in Transforms
+	v5, err := MakeTerraformInput(nil, "v", resource.PropertyValue{}, resource.NewNullProperty(), tfs,
+		psi, nil, nil, false, false)
+	assert.NoError(t, err)
+	assert.Equal(t, "", v5)
+
+	emptyDoc := ""
+	v6, err := MakeTerraformInput(nil, "v", resource.PropertyValue{}, resource.NewStringProperty(emptyDoc), tfs,
+		psi, nil, nil, false, false)
+	assert.NoError(t, err)
+	assert.Equal(t, "", v6)
 }
 
 func TestImporterOnRead(t *testing.T) {

--- a/pkg/tfbridge/transforms.go
+++ b/pkg/tfbridge/transforms.go
@@ -39,6 +39,15 @@ func TransformJSONDocument(v resource.PropertyValue) (resource.PropertyValue, er
 		}
 		return resource.NewStringProperty(string(b)), nil
 	}
+
+	// This is a special case. Due to a regression introduced in CoerceTerraformString, there are
+	// some string overrides that not are nil rather than "". This causes this transform func to
+	// return an error that a string or JSON map was required. We can now check specifically for
+	// the null and catch this specific usecase
+	if v.IsNull() {
+		return resource.NewStringProperty(""), nil
+	}
+
 	return resource.PropertyValue{},
 		errors.Errorf("expected string or JSON map; got %T", v.V)
 }


### PR DESCRIPTION
The changes made in #180 introduced a regression. When a Pulumi override
was present and there was an empty string, the CoerceTerraformString func
returned nil, rather than the empty string. This was problematic when
there was a coupled TransformJSONDocument with that. We need to change
the functionality to do 2 things:

1. CoerceTerraformString - don't return nil for any empty string override
except boolean. This allows us to manage the Terraform changes to be strings
for bools that can be unset e.g. AssociatePublicIp

2. We now need to understand when a `nil` value is passed to the
TransformJSONDocument that we need to treat this as there is an empty
string being passed to it

Before:

```
▶ pulumi up
Previewing update (dev):
     Type                 Name        Plan     Info
     pulumi:pulumi:Stack  create-dev
     └─ aws:s3:Bucket     test                 1 error

Diagnostics:
  aws:s3:Bucket (test):
    error: preparing urn:pulumi:dev::create::aws:s3/bucket:Bucket::test's old property state: expected string or JSON map; got <nil>

```

After:

```
▶ pulumi up
Previewing update (dev):
     Type                 Name        Plan
     pulumi:pulumi:Stack  create-dev

Resources:
    2 unchanged

Do you want to perform this update? details
  pulumi:pulumi:Stack: (same)
    [urn=urn:pulumi:dev::create::pulumi:pulumi:Stack::create-dev]

```