### PR TITLE
Allow packages to define extra schema types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
-- Populate default Tf timeouts. [#177](https://github.com/pulumi/pulumi-terraform-bridge/issues/177)
+- Allow providers to define additional object types in the schema.
+  [#192](https://github.com/pulumi/pulumi-terraform-bridge/pull/192)
+
+- Populate default TF timeouts.
+  [#177](https://github.com/pulumi/pulumi-terraform-bridge/issues/177)
 
 - Link in tf2pulumi for preliminary HCL2 support and Python codegen.
   [#162](https://github.com/pulumi/pulumi-terraform-bridge/pull/162)

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -17,6 +17,7 @@ package tfbridge
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	pschema "github.com/pulumi/pulumi/pkg/v2/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/tokens"
 )
@@ -29,28 +30,31 @@ const (
 
 // ProviderInfo contains information about a Terraform provider plugin that we will use to generate the Pulumi
 // metadata.  It primarily contains a pointer to the Terraform schema, but can also contain specific name translations.
+//
+//nolint: lll
 type ProviderInfo struct {
-	P                 *schema.Provider           // the TF provider/schema.
-	Name              string                     // the TF provider name (e.g. terraform-provider-XXXX).
-	ResourcePrefix    string                     // the prefix on resources the provider exposes, if different to `Name`.
-	GitHubOrg         string                     // the GitHub org of the provider. Defaults to `terraform-providers`.
-	Description       string                     // an optional descriptive overview of the package (a default supplied).
-	Keywords          []string                   // an optional list of keywords to help discovery of this package.
-	License           string                     // the license, if any, the resulting package has (default is none).
-	LogoURL           string                     // an optional URL to the logo of the package
-	Homepage          string                     // the URL to the project homepage.
-	Repository        string                     // the URL to the project source code repository.
-	Version           string                     // the version of the provider package.
-	Config            map[string]*SchemaInfo     // a map of TF name to config schema overrides.
-	ExtraConfig       map[string]*ConfigInfo     // a list of Pulumi-only configuration variables.
-	Resources         map[string]*ResourceInfo   // a map of TF name to Pulumi name; standard mangling occurs if no entry.
-	DataSources       map[string]*DataSourceInfo // a map of TF name to Pulumi resource info.
-	JavaScript        *JavaScriptInfo            // optional overlay information for augmented JavaScript code-generation.
-	Python            *PythonInfo                // optional overlay information for augmented Python code-generation.
-	Golang            *GolangInfo                // optional overlay information for augmented Golang code-generation.
-	CSharp            *CSharpInfo                // optional overlay information for augmented C# code-generation.
-	TFProviderVersion string                     // the version of the TF provider on which this was based
-	TFProviderLicense *TFProviderLicense         // license that the TF provider is distributed under. Default `MPL 2.0`.
+	P                 *schema.Provider                  // the TF provider/schema.
+	Name              string                            // the TF provider name (e.g. terraform-provider-XXXX).
+	ResourcePrefix    string                            // the prefix on resources the provider exposes, if different to `Name`.
+	GitHubOrg         string                            // the GitHub org of the provider. Defaults to `terraform-providers`.
+	Description       string                            // an optional descriptive overview of the package (a default supplied).
+	Keywords          []string                          // an optional list of keywords to help discovery of this package.
+	License           string                            // the license, if any, the resulting package has (default is none).
+	LogoURL           string                            // an optional URL to the logo of the package
+	Homepage          string                            // the URL to the project homepage.
+	Repository        string                            // the URL to the project source code repository.
+	Version           string                            // the version of the provider package.
+	Config            map[string]*SchemaInfo            // a map of TF name to config schema overrides.
+	ExtraConfig       map[string]*ConfigInfo            // a list of Pulumi-only configuration variables.
+	Resources         map[string]*ResourceInfo          // a map of TF name to Pulumi name; standard mangling occurs if no entry.
+	DataSources       map[string]*DataSourceInfo        // a map of TF name to Pulumi resource info.
+	ExtraTypes        map[string]pschema.ObjectTypeSpec // a map of Pulumi token to schema type for overlaid types.
+	JavaScript        *JavaScriptInfo                   // optional overlay information for augmented JavaScript code-generation.
+	Python            *PythonInfo                       // optional overlay information for augmented Python code-generation.
+	Golang            *GolangInfo                       // optional overlay information for augmented Golang code-generation.
+	CSharp            *CSharpInfo                       // optional overlay information for augmented C# code-generation.
+	TFProviderVersion string                            // the version of the TF provider on which this was based
+	TFProviderLicense *TFProviderLicense                // license that the TF provider is distributed under. Default `MPL 2.0`.
 
 	PreConfigureCallback PreConfigureCallback // a provider-specific callback to invoke prior to TF Configure
 }

--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -52,9 +52,13 @@ func newSchemaGenerator(pkg, version string, info tfbridge.ProviderInfo, outDir 
 }
 
 func (g *schemaGenerator) emitPackage(pack *pkg) error {
-	packageSpec := g.genPackageSpec(pack)
+	spec, err := g.genPackageSpec(pack)
+	if err != nil {
+		return errors.Wrap(err, "generating Pulumi schema")
+	}
+
 	packageSpec.Version = ""
-	schema, err := json.MarshalIndent(packageSpec, "", "    ")
+	schema, err := json.MarshalIndent(spec, "", "    ")
 	if err != nil {
 		return errors.Wrap(err, "marshaling Pulumi schema")
 	}
@@ -177,10 +181,14 @@ func genPulumiSchema(pack *pkg, name, version string, info tfbridge.ProviderInfo
 		version: version,
 		info:    info,
 	}
-	return pschema.ImportSpec(g.genPackageSpec(pack), nil)
+	spec, err := g.genPackageSpec(pack)
+	if err != nil {
+		return nil, err
+	}
+	return pschema.ImportSpec(spec, nil)
 }
 
-func (g *schemaGenerator) genPackageSpec(pack *pkg) pschema.PackageSpec {
+func (g *schemaGenerator) genPackageSpec(pack *pkg) (pschema.PackageSpec, error) {
 	spec := pschema.PackageSpec{
 		Name:       g.pkg,
 		Version:    g.version,
@@ -235,6 +243,13 @@ func (g *schemaGenerator) genPackageSpec(pack *pkg) pschema.PackageSpec {
 		spec.Provider = g.genResourceType("index", pack.provider)
 	}
 
+	for token, typ := range g.info.ExtraTypes {
+		if _, defined := spec.Types[token]; defined {
+			return pschema.PackageSpec{}, fmt.Errorf("failed to define extra types: %v is already defined", token)
+		}
+		spec.Types[token] = typ
+	}
+
 	if jsi := g.info.JavaScript; jsi != nil {
 		spec.Language["nodejs"] = rawMessage(map[string]interface{}{
 			"packageName":        jsi.PackageName,
@@ -258,7 +273,7 @@ func (g *schemaGenerator) genPackageSpec(pack *pkg) pschema.PackageSpec {
 		})
 	}
 
-	return spec
+	return spec, nil
 }
 
 func (g *schemaGenerator) genDocComment(comment, docURL string) string {

--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -57,7 +57,7 @@ func (g *schemaGenerator) emitPackage(pack *pkg) error {
 		return errors.Wrap(err, "generating Pulumi schema")
 	}
 
-	packageSpec.Version = ""
+	spec.Version = ""
 	schema, err := json.MarshalIndent(spec, "", "    ")
 	if err != nil {
 		return errors.Wrap(err, "marshaling Pulumi schema")


### PR DESCRIPTION
These types are only supported by the schema-based backends; NodeJS must
continue to use hand-written overlays.

This is part of #132.