### PR TITLE
Populate default TF timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Populate default Tf timeouts. [#177](https://github.com/pulumi/pulumi-terraform-bridge/issues/177)
+
 - Link in tf2pulumi for preliminary HCL2 support and Python codegen.
   [#162](https://github.com/pulumi/pulumi-terraform-bridge/pull/162)
-
 
 - Update how description is populated for schema codegen.
   [#148](https://github.com/pulumi/pulumi-terraform-bridge/pull/148))

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -1035,8 +1035,13 @@ func setTimeout(diff *terraform.InstanceDiff, timeout float64, timeoutKey string
 		diff.Meta = map[string]interface{}{}
 	}
 
-	diff.Meta[schema.TimeoutKey] = map[string]interface{}{
-		timeoutKey: timeoutValue,
+	timeouts, ok := diff.Meta[schema.TimeoutKey].(map[string]interface{})
+	if !ok {
+		diff.Meta[schema.TimeoutKey] = map[string]interface{}{
+			timeoutKey: timeoutValue,
+		}
+	} else {
+		timeouts[timeoutKey] = timeoutValue
 	}
 
 	return diff

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -656,12 +656,11 @@ func (p *Provider) Create(ctx context.Context, req *pulumirpc.CreateRequest) (*p
 
 	// To populate default timeouts, we take the timeouts from the resource schema and insert them into the diff
 	timeouts := &schema.ResourceTimeout{}
-	err = timeouts.ConfigDecode(res.TF, config)
-	if err != nil {
+	if err = timeouts.ConfigDecode(res.TF, config); err != nil {
 		return nil, errors.Errorf("error decoding timeout: %s", err)
 	}
 	if err = timeouts.DiffEncode(diff); err != nil {
-		glog.V(9).Infof("error encoding timeout to diff: %s", err)
+		return nil, errors.Errorf("error setting default timeouts to diff: %s", err)
 	}
 
 	// If a custom timeout has been set for this method, overwrite the default timeout

--- a/pkg/tfbridge/schema_provider_test.go
+++ b/pkg/tfbridge/schema_provider_test.go
@@ -235,6 +235,10 @@ var testTFProvider = &schema.Provider{
 			Delete: func(data *schema.ResourceData, p interface{}) error {
 				return nil
 			},
+			Timeouts: &schema.ResourceTimeout{
+				Create: timeout(time.Second * 120),
+				Update: timeout(time.Second * 120),
+			},
 		},
 	},
 	DataSourcesMap: map[string]*schema.Resource{


### PR DESCRIPTION
Fixes: https://github.com/pulumi/pulumi-terraform-bridge/issues/177

When creating a new resource, we start with an empty Meta object in state, so default timeout information has to be populated through the diff. For other operations, the timeout info is already in state.