### PR TITLE
Omit version from schema.PackageSpec

### DIFF
--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -52,7 +52,9 @@ func newSchemaGenerator(pkg, version string, info tfbridge.ProviderInfo, outDir 
 }
 
 func (g *schemaGenerator) emitPackage(pack *pkg) error {
-	schema, err := json.MarshalIndent(g.genPackageSpec(pack), "", "    ")
+	packageSpec := g.genPackageSpec(pack)
+	packageSpec.Version = ""
+	schema, err := json.MarshalIndent(packageSpec, "", "    ")
 	if err != nil {
 		return errors.Wrap(err, "marshaling Pulumi schema")
 	}


### PR DESCRIPTION
This will be passed as part of provider builds so that we can
check the schema.json files in to allow schema diffs

Fixes: #200