### PR TITLE
Mark up property refs in schema comments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,16 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Add JSON path links to properties when generating doc comments and deprecation messages for
+  a Pulumi schema.
+  [#202](https://github.com/pulumi/pulumi-terraform-bridge/pull/202)
+
 - Convert examples using the current schema.
   [#224](https://github.com/pulumi/pulumi-terraform-bridge/pull/224)
 
 - Add support for generating Go examples.
   [#194](https://github.com/pulumi/pulumi-terraform-bridge/pull/218)
   
-- Add JSON path links to properties when generating doc comments and deprecation messages for
-  a Pulumi schema.
-  [#202](https://github.com/pulumi/pulumi-terraform-bridge/pull/202)
-
 - Update README generation for python. 
   [#217](https://github.com/pulumi/pulumi-terraform-bridge/pull/217)
 

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -1078,7 +1078,7 @@ func fixupPropertyReferences(language language, pkg string, info tfbridge.Provid
 				return open + modname + resname + close
 			case pulumiSchema:
 				// Use a hyperlink to the resource.
-				return makeSchemaLink(open, string(resInfo.Tok), "#/resources/", close)
+				return makeSchemaLink(open, string(resInfo.Tok), "#/resources", close)
 			default:
 				// Use `aws.ec2.Instance` format
 				return open + pkg + "." + modname + resname + close
@@ -1097,7 +1097,7 @@ func fixupPropertyReferences(language language, pkg string, info tfbridge.Provid
 				return open + modname + getname + close
 			case pulumiSchema:
 				// Use a hyperlink to the function.
-				return makeSchemaLink(open, string(dataInfo.Tok), "#/functions/", close)
+				return makeSchemaLink(open, string(dataInfo.Tok), "#/functions", close)
 			default:
 				// Use `aws.ec2.getAmi` format
 				return open + pkg + "." + modname + getname + close


### PR DESCRIPTION
When processing docs for a Pulumi schema, replace references to resource
properties with JSON Path links to the respective resource or type
properties in the schema. A link to a property looks like this:

```
[`b64Url`](#/resources/random:index%2FrandomId:RandomId/properties/b64Url)
```

This link refers to the `b64Url` output property of the
`random:index/randomId:RandomId` resource. These links can be
interpreted by downstream consumers when generating documentation.

Related to https://github.com/pulumi/pulumi/issues/4632 and https://github.com/pulumi/pulumi/issues/4159.

Fixes #199.