### PR TITLE
Refactor TF Markdown parsing.

### DIFF
--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -385,7 +385,9 @@ func (p *tfMarkdownParser) parse() (parsedDoc, error) {
 
 	// Split the sections by H2 topics in the Markdown file.
 	for _, section := range splitGroupLines(markdown, "## ") {
-		p.parseSection(section)
+		if err := p.parseSection(section); err != nil {
+			return parsedDoc{}, err
+		}
 	}
 
 	// Get links.

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -204,14 +204,16 @@ func TestArgumentRegex(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		ret := parsedDoc{
-			Arguments: make(map[string]*argument),
+		parser := &tfMarkdownParser{
+			ret: parsedDoc{
+				Arguments: make(map[string]*argument),
+			},
 		}
-		processArgumentReferenceSection(tt.input, &ret)
+		parser.parseArgReferenceSection(tt.input)
 
-		assert.Len(t, ret.Arguments, len(tt.expected))
+		assert.Len(t, parser.ret.Arguments, len(tt.expected))
 		for k, v := range tt.expected {
-			actualArg := ret.Arguments[k]
+			actualArg := parser.ret.Arguments[k]
 			assert.NotNil(t, actualArg, fmt.Sprintf("%s should not be nil", k))
 			assert.Equal(t, v.description, actualArg.description)
 			assert.Equal(t, v.isNested, actualArg.isNested)


### PR DESCRIPTION
- Collect most of the context into a struct type
- Factor section and subsection parsing into methods
- Simplify subsection kinds