### PR TITLE
Concurrency-proof the provider cache.

### DIFF
--- a/pkg/tfgen/pluginHost.go
+++ b/pkg/tfgen/pluginHost.go
@@ -26,8 +26,7 @@ func (host *cachingProviderHost) getProvider(key string) (plugin.Provider, bool)
 
 func (host *cachingProviderHost) Provider(pkg tokens.Package, version *semver.Version) (plugin.Provider, error) {
 	key := fmt.Sprintf("%v@%v", pkg, version)
-	provider, ok := host.getProvider(key)
-	if ok {
+	if provider, ok := host.getProvider(key); ok {
 		return provider, nil
 	}
 

--- a/pkg/tfgen/pluginHost.go
+++ b/pkg/tfgen/pluginHost.go
@@ -16,7 +16,7 @@ type cachingProviderHost struct {
 	cache map[string]plugin.Provider
 }
 
-func (host *cachingProviderHost) getProvider(key string) (Provider, bool) {
+func (host *cachingProviderHost) getProvider(key string) (plugin.Provider, bool) {
 	host.m.RLock()
 	defer host.m.RUnlock()
 

--- a/pkg/tfgen/pluginHost.go
+++ b/pkg/tfgen/pluginHost.go
@@ -2,6 +2,7 @@ package tfgen
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/blang/semver"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/resource/plugin"
@@ -11,18 +12,32 @@ import (
 type cachingProviderHost struct {
 	plugin.Host
 
+	m     sync.RWMutex
 	cache map[string]plugin.Provider
+}
+
+func (host *cachingProviderHost) getProvider(key string) (Provider, bool) {
+	host.m.RLock()
+	defer host.m.RUnlock()
+
+	provider, ok := host.cache[key]
+	return provider, ok
 }
 
 func (host *cachingProviderHost) Provider(pkg tokens.Package, version *semver.Version) (plugin.Provider, error) {
 	key := fmt.Sprintf("%v@%v", pkg, version)
-	provider, ok := host.cache[key]
-	if !ok {
-		prov, err := host.Host.Provider(pkg, version)
-		if err != nil {
-			return nil, err
-		}
-		host.cache[key], provider = prov, prov
+	provider, ok := host.getProvider(key)
+	if ok {
+		return provider, nil
 	}
+
+	host.m.Lock()
+	defer host.m.Unlock()
+
+	provider, err := host.Host.Provider(pkg, version)
+	if err != nil {
+		return nil, err
+	}
+	host.cache[key] = provider
 	return provider, nil
 }


### PR DESCRIPTION
Use an RWMutex to protect cache accesses and insertions. This allows the
cache to be safely used from multiple goroutines concurrently.