### PR TITLE
Do not fixup property refs in code blocks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Add JSON path links to properties when generating doc comments and deprecation messages for
+  a Pulumi schema.
+  [#202](https://github.com/pulumi/pulumi-terraform-bridge/pull/202)
+
 - Update README generation for python. 
   [#217](https://github.com/pulumi/pulumi-terraform-bridge/pull/217)
 


### PR DESCRIPTION
Code blocks should not be reinterpreted as text. Changing the content of
a code block can alter its meaning (though this is rare).

This is part of #212.