### PR TITLE
Convert examples using an intermediate schema.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Convert examples using the current schema.
+  [#224](https://github.com/pulumi/pulumi-terraform-bridge/pull/224)
+
 - Add support for generating Go examples.
   [#194](https://github.com/pulumi/pulumi-terraform-bridge/pull/218)
   

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -382,18 +382,6 @@ func (p *tfMarkdownParser) parse() (entityDocs, error) {
 			"Resource %v contains an <elided> doc reference that needs updated"), p.rawname)
 	}
 
-	// Convert examples.
-	doc.Description = p.g.convertExamples(doc.Description, true)
-	for _, arg := range doc.Arguments {
-		arg.description = p.g.convertExamples(arg.description, false)
-		for argName, argDoc := range arg.arguments {
-			arg.arguments[argName] = p.g.convertExamples(argDoc, false)
-		}
-	}
-	for attrName, attrDoc := range doc.Attributes {
-		doc.Attributes[attrName] = p.g.convertExamples(attrDoc, false)
-	}
-
 	return doc, nil
 }
 


### PR DESCRIPTION
These changes convert examples using an intermediate, in-memory schema.
This removes the need to install a prior version of the resource plugin
before generation, and ensures that the generated examples use the
current version of the schema.

Fixes #212.