### PR TITLE
Allow passing the Go module version of an upstream repository for docs resolution

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -33,28 +33,29 @@ const (
 //
 //nolint: lll
 type ProviderInfo struct {
-	P                 *schema.Provider                  // the TF provider/schema.
-	Name              string                            // the TF provider name (e.g. terraform-provider-XXXX).
-	ResourcePrefix    string                            // the prefix on resources the provider exposes, if different to `Name`.
-	GitHubOrg         string                            // the GitHub org of the provider. Defaults to `terraform-providers`.
-	Description       string                            // an optional descriptive overview of the package (a default supplied).
-	Keywords          []string                          // an optional list of keywords to help discovery of this package.
-	License           string                            // the license, if any, the resulting package has (default is none).
-	LogoURL           string                            // an optional URL to the logo of the package
-	Homepage          string                            // the URL to the project homepage.
-	Repository        string                            // the URL to the project source code repository.
-	Version           string                            // the version of the provider package.
-	Config            map[string]*SchemaInfo            // a map of TF name to config schema overrides.
-	ExtraConfig       map[string]*ConfigInfo            // a list of Pulumi-only configuration variables.
-	Resources         map[string]*ResourceInfo          // a map of TF name to Pulumi name; standard mangling occurs if no entry.
-	DataSources       map[string]*DataSourceInfo        // a map of TF name to Pulumi resource info.
-	ExtraTypes        map[string]pschema.ObjectTypeSpec // a map of Pulumi token to schema type for overlaid types.
-	JavaScript        *JavaScriptInfo                   // optional overlay information for augmented JavaScript code-generation.
-	Python            *PythonInfo                       // optional overlay information for augmented Python code-generation.
-	Golang            *GolangInfo                       // optional overlay information for augmented Golang code-generation.
-	CSharp            *CSharpInfo                       // optional overlay information for augmented C# code-generation.
-	TFProviderVersion string                            // the version of the TF provider on which this was based
-	TFProviderLicense *TFProviderLicense                // license that the TF provider is distributed under. Default `MPL 2.0`.
+	P                       *schema.Provider                  // the TF provider/schema.
+	Name                    string                            // the TF provider name (e.g. terraform-provider-XXXX).
+	ResourcePrefix          string                            // the prefix on resources the provider exposes, if different to `Name`.
+	GitHubOrg               string                            // the GitHub org of the provider. Defaults to `terraform-providers`.
+	Description             string                            // an optional descriptive overview of the package (a default supplied).
+	Keywords                []string                          // an optional list of keywords to help discovery of this package.
+	License                 string                            // the license, if any, the resulting package has (default is none).
+	LogoURL                 string                            // an optional URL to the logo of the package
+	Homepage                string                            // the URL to the project homepage.
+	Repository              string                            // the URL to the project source code repository.
+	Version                 string                            // the version of the provider package.
+	Config                  map[string]*SchemaInfo            // a map of TF name to config schema overrides.
+	ExtraConfig             map[string]*ConfigInfo            // a list of Pulumi-only configuration variables.
+	Resources               map[string]*ResourceInfo          // a map of TF name to Pulumi name; standard mangling occurs if no entry.
+	DataSources             map[string]*DataSourceInfo        // a map of TF name to Pulumi resource info.
+	ExtraTypes              map[string]pschema.ObjectTypeSpec // a map of Pulumi token to schema type for overlaid types.
+	JavaScript              *JavaScriptInfo                   // optional overlay information for augmented JavaScript code-generation.
+	Python                  *PythonInfo                       // optional overlay information for augmented Python code-generation.
+	Golang                  *GolangInfo                       // optional overlay information for augmented Golang code-generation.
+	CSharp                  *CSharpInfo                       // optional overlay information for augmented C# code-generation.
+	TFProviderVersion       string                            // the version of the TF provider on which this was based
+	TFProviderLicense       *TFProviderLicense                // license that the TF provider is distributed under. Default `MPL 2.0`.
+	TFProviderModuleVersion string                            // the Go module version of the provider. Default is unversioned e.g. v1
 
 	PreConfigureCallback PreConfigureCallback // a provider-specific callback to invoke prior to TF Configure
 }
@@ -87,6 +88,14 @@ func (info ProviderInfo) GetTFProviderLicense() TFProviderLicense {
 	}
 
 	return *info.TFProviderLicense
+}
+
+func (info ProviderInfo) GetProviderModuleVersion() string {
+	if info.TFProviderModuleVersion == "" {
+		return "" // there is no such thing as a v1 module - there is just a missing version declaration
+	}
+
+	return info.TFProviderModuleVersion
 }
 
 // AliasInfo is a partial description of prior named used for a resource. It can be processed in the

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -878,7 +878,7 @@ func (g *generator) gatherResource(rawname string,
 	var entityDocs entityDocs
 	if !isProvider {
 		pd, err := getDocsForProvider(g, g.info.GetGitHubOrg(), g.info.Name,
-			g.info.GetResourcePrefix(), ResourceDocs, rawname, info)
+			g.info.GetResourcePrefix(), ResourceDocs, rawname, info, g.info.GetProviderModuleVersion())
 		if err != nil {
 			return "", nil, err
 		}
@@ -1032,7 +1032,7 @@ func (g *generator) gatherDataSource(rawname string,
 
 	// Collect documentation information for this data source.
 	entityDocs, err := getDocsForProvider(g, g.info.GetGitHubOrg(), g.info.Name,
-		g.info.GetResourcePrefix(), DataSourceDocs, rawname, info)
+		g.info.GetResourcePrefix(), DataSourceDocs, rawname, info, g.info.GetProviderModuleVersion())
 	if err != nil {
 		return "", nil, err
 	}


### PR DESCRIPTION
Fixes: #237

When a provider adds a major version to it's go.mod file, we can't find
the specific version in the go.mod file and therefore, we skip using
the module for docs usage.

By passing "v2" / "v3" etc, pulumi will be able to find the source docs

The default behaviour is to have no go.mod version prefix and will use
a non moduled version by default