### PR TITLE
Provide a way to set UsesIOClasses for TF-based providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Add UsesIOClasses field to PythonInfo.
+  [#241](https://github.com/pulumi/pulumi-terraform-bridge/pull/241)
+
 - Add PluginDownloadURL field to package definition
   [#231](https://github.com/pulumi/pulumi-terraform-bridge/pull/231)
 

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -273,8 +273,9 @@ type JavaScriptInfo struct {
 
 // PythonInfo contains optional overlay information for Python code-generation.
 type PythonInfo struct {
-	Requires map[string]string // Pip install_requires information.
-	Overlay  *OverlayInfo      // optional overlay information for augmented code-generation.
+	Requires      map[string]string // Pip install_requires information.
+	Overlay       *OverlayInfo      // optional overlay information for augmented code-generation.
+	UsesIOClasses bool              // Indicates whether the package generates input/output classes.
 }
 
 // GolangInfo contains optional overlay information for Golang code-generation.

--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -277,6 +277,7 @@ func (g *schemaGenerator) genPackageSpec(pack *pkg) (pschema.PackageSpec, error)
 	}
 	if pi := g.info.Python; pi != nil {
 		pythonData["requires"] = pi.Requires
+		pythonData["usesIOClasses"] = pi.UsesIOClasses
 	}
 	spec.Language["python"] = rawMessage(pythonData)
 


### PR DESCRIPTION
The `UsesIOClasses` option controls whether the generated Python examples and docgen should use input/output classes. This adds the option to the `PythonInfo` struct so it can be set by TF-based providers.

Here's an example of what it'd look like to update a TF-provider, using this option: https://github.com/pulumi/pulumi-aws/commit/e548fd9822f25690c4e37958de268f9c2689bcc3 (the commit does not include the necessary go.mod changes to reference this change in `pulumi-terraform-bridge` and the changes needed in `pulumi`).

Note: the alternative would be to just always set `pythonData["usesIOClasses"] = true` here in the bridge, and not expose the `UsesIOClasses` option on the struct, and a provider would opt-in implicitly when updating to a more recent `pulumi-terraform-bridge` commit. Any preference?