### PR TITLE
Temporarily revert the diff and config check due to nested object bug

### DIFF
--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -147,6 +147,7 @@ func TestCamelPascalPulumiName(t *testing.T) {
 }
 
 func TestDiffConfig(t *testing.T) {
+	t.Skip("Temporarily skipped")
 	provider := &Provider{
 		tf:     testTFProvider,
 		config: testTFProvider.Schema,


### PR DESCRIPTION
This feature was not yet in use anywhere so reverting this means we don't lose any functionality. It has a bug which is causing https://github.com/pulumi/pulumi-aws/issues/1075