### PR TITLE
Refactor state/config unmarshaling.

### DIFF
--- a/pkg/tfbridge/diff_test.go
+++ b/pkg/tfbridge/diff_test.go
@@ -43,14 +43,17 @@ func diffTest(t *testing.T, sch map[string]*schema.Schema, info map[string]*Sche
 	}
 
 	// Convert the inputs and state to TF config and resource attributes.
-	attrs, meta, err := MakeTerraformAttributes(res, stateMap, sch, info, resource.PropertyMap{}, false)
+	r := Resource{
+		TF:     res,
+		Schema: &ResourceInfo{Fields: info},
+	}
+	tfState, err := MakeTerraformState(r, "id", stateMap)
 	assert.NoError(t, err)
 
 	config, err := MakeTerraformConfig(nil, inputsMap, sch, info, nil, resource.PropertyMap{}, false)
 	assert.NoError(t, err)
 
-	tfDiff, err := provider.SimpleDiff(&terraform.InstanceInfo{Type: "resource"},
-		&terraform.InstanceState{ID: "id", Attributes: attrs, Meta: meta}, config)
+	tfDiff, err := provider.SimpleDiff(&terraform.InstanceInfo{Type: "resource"}, tfState, config)
 	assert.NoError(t, err)
 
 	// ProcessIgnoreChanges


### PR DESCRIPTION
- Replace `MakeTerraformAttributes` with `MakeTerraformState`. This function
  now creates and returns an instance state instead of attributes and
  meta info.
- Rename `Make*FromRPC` to `Unmarshal*`, which better indicates what these
  functions do.