### PR TITLE
Check if docs/resources exists instead of only docs

### DIFF
--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -203,8 +203,8 @@ func getDocsForProvider(g *generator, org string, provider string, resourcePrefi
 // checkIfNewDocsExist checks if the new docs root exists
 func checkIfNewDocsExist(repo string) bool {
 	// Check if the new docs path exists
-	newDocsRoot := filepath.Join(repo, "docs")
-	_, err := os.Stat(newDocsRoot)
+	newDocsPath := filepath.Join(repo, "docs", "resources")
+	_, err := os.Stat(newDocsPath)
 	return !os.IsNotExist(err)
 }
 


### PR DESCRIPTION
The last PR https://github.com/pulumi/pulumi-terraform-bridge/pull/256 broke the AWS docs.

The AWS provider does have a docs folder at the root but it's not the true docs folder. Check if docs/resources exists instead.