### PR TITLE
Refactor MakeTerraformInputs.

### DIFF
--- a/pkg/tfbridge/diff.go
+++ b/pkg/tfbridge/diff.go
@@ -117,8 +117,8 @@ func visitPropertyValue(name, path string, v resource.PropertyValue, tfs *schema
 				// forms part of the key. We round-trip through a config field reader so that TF has the opportunity to
 				// fill in default values for empty fields (note that this is a property of the field reader, not of
 				// the schema) as it does when computing the hash code for a set element.
-				ev, err := MakeTerraformInput(
-					nil, ep, resource.PropertyValue{}, e, etfs, eps, make(AssetTable), nil, false, rawNames)
+				ctx := &conversionContext{}
+				ev, err := ctx.MakeTerraformInput(ep, resource.PropertyValue{}, e, etfs, eps, rawNames)
 				if err != nil {
 					return
 				}

--- a/pkg/tfbridge/diff_test.go
+++ b/pkg/tfbridge/diff_test.go
@@ -50,7 +50,7 @@ func diffTest(t *testing.T, sch map[string]*schema.Schema, info map[string]*Sche
 	tfState, err := MakeTerraformState(r, "id", stateMap)
 	assert.NoError(t, err)
 
-	config, err := MakeTerraformConfig(nil, inputsMap, sch, info, nil, resource.PropertyMap{}, false)
+	config, _, err := MakeTerraformConfig(nil, inputsMap, sch, info)
 	assert.NoError(t, err)
 
 	tfDiff, err := provider.SimpleDiff(&terraform.InstanceInfo{Type: "resource"}, tfState, config)


### PR DESCRIPTION
Clarify the entry points and shorten the signatures by collecting static
data in a context type.