### PR TITLE
Remove unused doc URLs

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -227,7 +227,6 @@ type Transformer func(resource.PropertyValue) (resource.PropertyValue, error)
 type DocInfo struct {
 	Source                         string // an optional override to locate TF docs; "" uses the default.
 	Markdown                       []byte // an optional override for the source markdown.
-	MarkdownURL                    string // an optional override for the source URL.
 	IncludeAttributesFrom          string // optionally include attributes from another raw resource for docs.
 	IncludeArgumentsFrom           string // optionally include arguments from another raw resource for docs.
 	IncludeAttributesFromArguments string // optionally include attributes from another raw resource's arguments.

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -76,9 +76,6 @@ type entityDocs struct {
 
 	// Attributes includes the names and descriptions for each attribute of the resource
 	Attributes map[string]string
-
-	// URL is the source documentation URL page
-	URL string
 }
 
 // DocKind indicates what kind of entity's documentation is being requested.
@@ -302,10 +299,6 @@ var (
 
 	attributeBulletRegexp = regexp.MustCompile("^\\s*[*+-]\\s+`([a-zA-z0-9_]*)`\\s+[–-]?\\s+(.*)")
 
-	providerURL    = "https://github.com/%s/terraform-provider-%s"
-	docsBaseURL    = providerURL + "/blob/master/website/docs"
-	docsDetailsURL = docsBaseURL + "/%s/%s"
-
 	standardDocReadme = `> This provider is a derived work of the [Terraform Provider](https://github.com/%[3]s/terraform-provider-%[2]s)
 > distributed under [%[4]s](%[5]s). If you encounter a bug or missing feature,
 > first check the [` + "`pulumi/pulumi-%[1]s`" + ` repo](https://github.com/pulumi/pulumi-%[1]s/issues); however, if that doesn't turn up anything,
@@ -333,21 +326,6 @@ func groupLines(lines []string, sep string) [][]string {
 // splitGroupLines splits and groups a string, s, by a given separator, sep.
 func splitGroupLines(s, sep string) [][]string {
 	return groupLines(strings.Split(s, "\n"), sep)
-}
-
-// getDocsBaseURL gets the base URL for a given provider's documentation source.
-func getDocsBaseURL(org, p string) string {
-	return fmt.Sprintf(docsBaseURL, org, p)
-}
-
-// getDocsDetailsURL gets the detailed resource or data source documentation source.
-func getDocsDetailsURL(org, p, kind, markdownFileName string) string {
-	return fmt.Sprintf(docsDetailsURL, org, p, kind, markdownFileName)
-}
-
-// getDocsIndexURL gets the given provider's documentation index page's source URL.
-func getDocsIndexURL(org, p string) string {
-	return getDocsBaseURL(org, p) + "/index.html.markdown"
 }
 
 // parseTFMarkdown takes a TF website markdown doc and extracts a structured representation for use in
@@ -388,20 +366,9 @@ const (
 )
 
 func (p *tfMarkdownParser) parse() (entityDocs, error) {
-	var url string
-	if p.info != nil {
-		if docInfo := p.info.GetDocs(); docInfo != nil {
-			url = docInfo.MarkdownURL
-		}
-	}
-	if url == "" {
-		getDocsDetailsURL(p.g.info.GetGitHubOrg(), p.resourcePrefix, string(p.kind), p.markdownFileName)
-	}
-
 	p.ret = entityDocs{
 		Arguments:  make(map[string]*argumentDocs),
 		Attributes: make(map[string]string),
-		URL:        url,
 	}
 
 	// Replace any Windows-style newlines.
@@ -1072,7 +1039,6 @@ func cleanupDoc(name string, g *Generator, info tfbridge.ResourceOrDataSourceInf
 		Description: cleanupText,
 		Arguments:   newargs,
 		Attributes:  newattrs,
-		URL:         doc.URL,
 	}, elidedDoc
 
 }

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -466,7 +466,6 @@ type variable struct {
 	config bool // config is true if this variable represents a Pulumi config value.
 	doc    string
 	rawdoc string
-	docURL string
 
 	schema shim.Schema
 	info   *tfbridge.SchemaInfo
@@ -556,7 +555,6 @@ type resourceFunc struct {
 	retst      *propertyType
 	schema     shim.Resource
 	info       *tfbridge.DataSourceInfo
-	docURL     string
 	entityDocs entityDocs
 }
 

--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -295,8 +295,8 @@ func (g *schemaGenerator) genPackageSpec(pack *pkg) (pschema.PackageSpec, error)
 	return spec, nil
 }
 
-func (g *schemaGenerator) genDocComment(comment, docURL string) string {
-	if comment == elidedDocComment && docURL == "" {
+func (g *schemaGenerator) genDocComment(comment string) string {
+	if comment == elidedDocComment {
 		return ""
 	}
 
@@ -344,7 +344,7 @@ func (g *schemaGenerator) genRawDocComment(comment string) string {
 func (g *schemaGenerator) genProperty(mod string, prop *variable, pyMapCase bool) pschema.PropertySpec {
 	description := ""
 	if prop.doc != "" && prop.doc != elidedDocComment {
-		description = g.genDocComment(prop.doc, prop.docURL)
+		description = g.genDocComment(prop.doc)
 	} else if prop.rawdoc != "" {
 		description = g.genRawDocComment(prop.rawdoc)
 	}
@@ -404,7 +404,7 @@ func (g *schemaGenerator) genResourceType(mod string, res *resourceType) pschema
 
 	description := ""
 	if res.doc != "" {
-		description = g.genDocComment(res.doc, res.docURL)
+		description = g.genDocComment(res.doc)
 	}
 	if !res.IsProvider() {
 		if res.info.DeprecationMessage != "" {
@@ -452,7 +452,7 @@ func (g *schemaGenerator) genDatasourceFunc(mod string, fun *resourceFunc) psche
 
 	description := ""
 	if fun.doc != "" {
-		description = g.genDocComment(fun.doc, fun.docURL)
+		description = g.genDocComment(fun.doc)
 	}
 	if fun.info.DeprecationMessage != "" {
 		spec.DeprecationMessage = fun.info.DeprecationMessage
@@ -504,7 +504,7 @@ func (g *schemaGenerator) genObjectType(mod string, typInfo *schemaNestedType) (
 	}
 
 	if typ.doc != "" {
-		spec.Description = g.genDocComment(typ.doc, "")
+		spec.Description = g.genDocComment(typ.doc)
 	}
 
 	spec.Properties = map[string]pschema.PropertySpec{}


### PR DESCRIPTION
It appears the doc URLs are unused, and the diffs don't lead to any changes.

It looks like they were added back in this PR by @lukehoban  https://github.com/pulumi/pulumi-terraform-bridge/commit/6c3ee3e2a025764c50871b17d6bc622665902361

But it appears we are no longer emitting the doc URL as we were in the past: https://github.com/pulumi/pulumi-terraform-bridge/commit/6c3ee3e2a025764c50871b17d6bc622665902361#diff-ed94ae040f7d490ffd43deb106eed5c3R330-R333

Is this an oversight (i.e should we be emitting these) or is it safe to remove this code?