### PR TITLE
Consume the TF SDK shim.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Support terraform-plugin-sdk/v2. This is an API breaking change.
+  [#264](https://github.com/pulumi/pulumi-terraform-bridge/pull/264)
+
 - Support alternative documentation path.
   [#256](https://github.com/pulumi/pulumi-terraform-bridge/pull/256)
 

--- a/go.sum
+++ b/go.sum
@@ -502,7 +502,6 @@ github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/pulumi/pulumi-terraform-bridge v1.8.4 h1:pfDNoYxduzsSEWj3M7hRuDw9Ic0z+Siks7uCJulPsow=
 github.com/pulumi/pulumi/pkg/v2 v2.10.0 h1:GTUffKvweAzcCZ2Ok44MFY62nT4FY/u+eX8bWlzDs2A=
 github.com/pulumi/pulumi/pkg/v2 v2.10.0/go.mod h1:zQWe2D4tYJDeXNzSclqNmP8/SMSKOh8k22AbWg3+mVc=
 github.com/pulumi/pulumi/sdk/v2 v2.2.1/go.mod h1:QNbWpL4gvf3X0lUFT7TXA2Jo1ff/Ti2l97AyFGYwvW4=

--- a/pkg/tf2pulumi/gen/nodejs/generator.go
+++ b/pkg/tf2pulumi/gen/nodejs/generator.go
@@ -23,7 +23,6 @@ import (
 	"unicode"
 
 	"github.com/blang/semver"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/util/contract"
 
@@ -31,6 +30,7 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/v2/pkg/tf2pulumi/il"
 	"github.com/pulumi/pulumi-terraform-bridge/v2/pkg/tf2pulumi/internal/config"
 	"github.com/pulumi/pulumi-terraform-bridge/v2/pkg/tfbridge"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v2/pkg/tfshim"
 )
 
 // Options defines parameters that are specific to the NodeJS code generator.
@@ -143,7 +143,7 @@ func cleanName(name string) string {
 }
 
 // tsName returns the Pulumi name for the property with the given Terraform name and schemas.
-func tsName(tfName string, tfSchema *schema.Schema, schemaInfo *tfbridge.SchemaInfo, isObjectKey bool) string {
+func tsName(tfName string, tfSchema shim.Schema, schemaInfo *tfbridge.SchemaInfo, isObjectKey bool) string {
 	if schemaInfo != nil && schemaInfo.Name != "" {
 		return schemaInfo.Name
 	}

--- a/pkg/tf2pulumi/gen/nodejs/hil.go
+++ b/pkg/tf2pulumi/gen/nodejs/hil.go
@@ -148,7 +148,7 @@ func (g *generator) genNestedPropertyAccess(w io.Writer, v *il.BoundVariableAcce
 			}
 		} else {
 			g.Fgenf(w, ".%s", tfbridge.TerraformToPulumiName(e, sch.TF, nil, false))
-			if sch.TF != nil && sch.TF.Optional {
+			if sch.TF != nil && sch.TF.Optional() {
 				g.Fgen(w, "!")
 			}
 		}

--- a/pkg/tf2pulumi/gen/nodejs/lower.go
+++ b/pkg/tf2pulumi/gen/nodejs/lower.go
@@ -16,7 +16,6 @@ package nodejs
 
 import (
 	"path/filepath"
-	"strings"
 
 	"github.com/pulumi/pulumi/sdk/v2/go/common/util/contract"
 
@@ -48,8 +47,6 @@ func (g *generator) lowerToLiterals(prop il.BoundNode) (il.BoundNode, error) {
 				path = rel
 			}
 
-			// Normalize the file separator.
-			path = strings.Join(filepath.SplitList(path), "/")
 			return &il.BoundLiteral{ExprType: il.TypeString, Value: path}, nil
 		case config.PathValueRoot:
 			// NOTE: this might not be the most useful or correct value. Might want Node's __directory or similar.
@@ -68,7 +65,7 @@ func (g *generator) canLiftVariableAccess(v *il.BoundVariableAccess) bool {
 	sch, elements := g.getNestedPropertyAccessElementInfo(v)
 
 	for _, e := range elements {
-		if sch.TF != nil && sch.TF.Optional {
+		if sch.TF != nil && sch.TF.Optional() {
 			return false
 		}
 		sch = sch.PropertySchemas(e)

--- a/pkg/tf2pulumi/gen/nodejs/properties.go
+++ b/pkg/tf2pulumi/gen/nodejs/properties.go
@@ -18,10 +18,9 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-
 	"github.com/pulumi/pulumi-terraform-bridge/v2/pkg/tf2pulumi/gen"
 	"github.com/pulumi/pulumi-terraform-bridge/v2/pkg/tf2pulumi/il"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v2/pkg/tfshim"
 )
 
 // genListProperty generates code for as single list property.
@@ -71,7 +70,7 @@ func (g *generator) GenMapProperty(w io.Writer, n *il.BoundMapProperty) {
 	if len(n.Elements) == 0 {
 		g.Fgen(w, "{}")
 	} else {
-		useExactKeys := n.Schemas.TF != nil && n.Schemas.TF.Type == schema.TypeMap
+		useExactKeys := n.Schemas.TF != nil && n.Schemas.TF.Type() == shim.TypeMap
 
 		g.Fgen(w, "{")
 		g.Indented(func() {

--- a/pkg/tf2pulumi/il/binder_properties.go
+++ b/pkg/tf2pulumi/il/binder_properties.go
@@ -19,11 +19,11 @@ import (
 	"reflect"
 
 	"github.com/hashicorp/hil"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/util/contract"
 
 	"github.com/pulumi/pulumi-terraform-bridge/v2/pkg/tfbridge"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v2/pkg/tfshim"
 )
 
 // propertyBinder is used to convert Terraform configuration properties into a form better suited for static analysis
@@ -47,7 +47,7 @@ func (b *propertyBinder) bindListProperty(path string, s reflect.Value, sch Sche
 
 	// If this is a max-single-element list that we intend to project as its element, just bind its element and return.
 	var projectListElement bool
-	if sch.TF != nil && sch.TF.Type == schema.TypeMap {
+	if sch.TF != nil && sch.TF.Type() == shim.TypeMap {
 		elemSchemas, projectListElement = sch, true
 	} else {
 		projectListElement = tfbridge.IsMaxItemsOne(sch.TF, sch.Pulumi)

--- a/pkg/tf2pulumi/il/builtin_providers.go
+++ b/pkg/tf2pulumi/il/builtin_providers.go
@@ -20,6 +20,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-http/http"
 
 	"github.com/pulumi/pulumi-terraform-bridge/v2/pkg/tfbridge"
+	shimv1 "github.com/pulumi/pulumi-terraform-bridge/v2/pkg/tfshim/sdk-v1"
 )
 
 // builtinProviderInfo provides a static map from provider name to propvider information for the small set of providers
@@ -27,8 +28,8 @@ import (
 // archive and http providers. Resources from the former provider are translated as Pulumi assets; resources/data
 // sources from the latter should be translated as calls to the target langauge's appropriate HTTP client libraries.
 var builtinProviderInfo = map[string]*tfbridge.ProviderInfo{
-	"archive": {
-		P:      archive.Provider().(*schema.Provider),
+	"archive": tfbridge.MarshalProviderInfo(&tfbridge.ProviderInfo{
+		P:      shimv1.NewProvider(archive.Provider().(*schema.Provider)),
 		Config: map[string]*tfbridge.SchemaInfo{},
 		DataSources: map[string]*tfbridge.DataSourceInfo{
 			"archive_file": {Tok: "archive:archive:archiveFile"},
@@ -36,13 +37,13 @@ var builtinProviderInfo = map[string]*tfbridge.ProviderInfo{
 		Resources: map[string]*tfbridge.ResourceInfo{
 			"archive_file": {Tok: "archive:archive/archiveFile:ArchiveFile"},
 		},
-	},
-	"http": {
-		P:      http.Provider().(*schema.Provider),
+	}).Unmarshal(),
+	"http": tfbridge.MarshalProviderInfo(&tfbridge.ProviderInfo{
+		P:      shimv1.NewProvider(http.Provider().(*schema.Provider)),
 		Config: map[string]*tfbridge.SchemaInfo{},
 		DataSources: map[string]*tfbridge.DataSourceInfo{
 			"http": {Tok: "http:http:http"},
 		},
 		Resources: map[string]*tfbridge.ResourceInfo{},
-	},
+	}).Unmarshal(),
 }

--- a/pkg/tfbridge/main.go
+++ b/pkg/tfbridge/main.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/logging"
-
 	"github.com/pulumi/pulumi/sdk/v2/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/util/contract"
 )
@@ -45,7 +43,7 @@ func Main(pkg string, version string, prov ProviderInfo, pulumiSchema []byte) {
 	}
 
 	// Initialize Terraform logging.
-	logging.SetOutput()
+	prov.P.InitLogging()
 
 	if err := Serve(pkg, version, prov, pulumiSchema); err != nil {
 		cmdutil.ExitError(err.Error())

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -4,105 +4,107 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/resource/plugin"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v2/proto/go"
 	"github.com/stretchr/testify/assert"
+
+	shim "github.com/pulumi/pulumi-terraform-bridge/v2/pkg/tfshim"
+	shimv1 "github.com/pulumi/pulumi-terraform-bridge/v2/pkg/tfshim/sdk-v1"
 )
 
 func TestConvertStringToPropertyValue(t *testing.T) {
 	type testcase struct {
 		str      string
-		typ      schema.ValueType
+		typ      shim.ValueType
 		expected interface{}
 	}
 
 	cases := []testcase{
 		{
-			typ:      schema.TypeBool,
+			typ:      shim.TypeBool,
 			expected: false,
 		},
 		{
 			str:      "false",
-			typ:      schema.TypeBool,
+			typ:      shim.TypeBool,
 			expected: false,
 		},
 		{
 			str:      "true",
-			typ:      schema.TypeBool,
+			typ:      shim.TypeBool,
 			expected: true,
 		},
 		{
 			str: "root",
-			typ: schema.TypeBool,
+			typ: shim.TypeBool,
 		},
 
 		{
-			typ:      schema.TypeString,
+			typ:      shim.TypeString,
 			expected: "",
 		},
 		{
 			str:      "stringP",
-			typ:      schema.TypeString,
+			typ:      shim.TypeString,
 			expected: "stringP",
 		},
 
 		{
-			typ:      schema.TypeInt,
+			typ:      shim.TypeInt,
 			expected: 0,
 		},
 		{
 			str:      "42",
-			typ:      schema.TypeInt,
+			typ:      shim.TypeInt,
 			expected: 42,
 		},
 		{
 			str: "root",
-			typ: schema.TypeInt,
+			typ: shim.TypeInt,
 		},
 
 		{
-			typ:      schema.TypeFloat,
+			typ:      shim.TypeFloat,
 			expected: 0,
 		},
 		{
 			str:      "42",
-			typ:      schema.TypeFloat,
+			typ:      shim.TypeFloat,
 			expected: 42,
 		},
 		{
 			str: "root",
-			typ: schema.TypeFloat,
+			typ: shim.TypeFloat,
 		},
 
 		{
-			typ:      schema.TypeList,
+			typ:      shim.TypeList,
 			expected: []interface{}{},
 		},
 		{
 			str:      "[ \"foo\", \"bar\" ]",
-			typ:      schema.TypeList,
+			typ:      shim.TypeList,
 			expected: []interface{}{"foo", "bar"},
 		},
 
 		{
-			typ:      schema.TypeSet,
+			typ:      shim.TypeSet,
 			expected: []interface{}{},
 		},
 		{
 			str:      "[ \"foo\", \"bar\" ]",
-			typ:      schema.TypeSet,
+			typ:      shim.TypeSet,
 			expected: []interface{}{"foo", "bar"},
 		},
 
 		{
-			typ:      schema.TypeMap,
+			typ:      shim.TypeMap,
 			expected: map[string]interface{}{},
 		},
 		{
 			str: "{ \"foo\": { \"bar\": 42 }, \"baz\": [ true ] }",
-			typ: schema.TypeMap,
+			typ: shim.TypeMap,
 			expected: map[string]interface{}{
 				"foo": map[string]interface{}{
 					"bar": 42,
@@ -149,8 +151,8 @@ func TestCamelPascalPulumiName(t *testing.T) {
 func TestDiffConfig(t *testing.T) {
 	t.Skip("Temporarily skipped")
 	provider := &Provider{
-		tf:     testTFProvider,
-		config: testTFProvider.Schema,
+		tf:     shimv1.NewProvider(testTFProvider),
+		config: shimv1.NewSchemaMap(testTFProvider.Schema),
 	}
 
 	oldConfig := resource.PropertyMap{"configValue": resource.NewStringProperty("foo")}

--- a/pkg/tfbridge/schema_provider_test.go
+++ b/pkg/tfbridge/schema_provider_test.go
@@ -3,11 +3,30 @@ package tfbridge
 import (
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	schemav1 "github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	terraformv1 "github.com/hashicorp/terraform-plugin-sdk/terraform"
+	schemav2 "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	terraformv2 "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	shim "github.com/pulumi/pulumi-terraform-bridge/v2/pkg/tfshim"
+	"github.com/pulumi/pulumi-terraform-bridge/v2/pkg/tfshim/schema"
+	shimv1 "github.com/pulumi/pulumi-terraform-bridge/v2/pkg/tfshim/sdk-v1"
+	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v2/pkg/tfshim/sdk-v2"
 )
 
-func mustSet(data *schema.ResourceData, key string, value interface{}) {
+func schemaMap(m map[string]*schema.Schema) shim.SchemaMap {
+	mm := schema.SchemaMap{}
+	for k, v := range m {
+		mm[k] = v.Shim()
+	}
+	return mm
+}
+
+type settable interface {
+	Set(key string, value interface{}) error
+}
+
+func mustSet(data settable, key string, value interface{}) {
 	err := data.Set(key, value)
 	if err != nil {
 		panic(err)
@@ -18,46 +37,46 @@ func timeout(d time.Duration) *time.Duration {
 	return &d
 }
 
-var testTFProvider = &schema.Provider{
-	Schema: map[string]*schema.Schema{
-		"config_value": {Type: schema.TypeString},
+var testTFProvider = &schemav1.Provider{
+	Schema: map[string]*schemav1.Schema{
+		"config_value": {Type: schemav1.TypeString},
 	},
-	ResourcesMap: map[string]*schema.Resource{
+	ResourcesMap: map[string]*schemav1.Resource{
 		"example_resource": {
-			Schema: map[string]*schema.Schema{
-				"nil_property_value":    {Type: schema.TypeMap},
-				"bool_property_value":   {Type: schema.TypeBool},
-				"number_property_value": {Type: schema.TypeInt},
-				"float_property_value":  {Type: schema.TypeFloat},
-				"string_property_value": {Type: schema.TypeString},
+			Schema: map[string]*schemav1.Schema{
+				"nil_property_value":    {Type: schemav1.TypeMap},
+				"bool_property_value":   {Type: schemav1.TypeBool},
+				"number_property_value": {Type: schemav1.TypeInt},
+				"float_property_value":  {Type: schemav1.TypeFloat},
+				"string_property_value": {Type: schemav1.TypeString},
 				"array_property_value": {
-					Type: schema.TypeList,
-					Elem: &schema.Schema{Type: schema.TypeString},
+					Type: schemav1.TypeList,
+					Elem: &schemav1.Schema{Type: schemav1.TypeString},
 				},
-				"object_property_value": {Type: schema.TypeMap},
+				"object_property_value": {Type: schemav1.TypeMap},
 				"nested_resources": {
-					Type:     schema.TypeList,
+					Type:     schemav1.TypeList,
 					MaxItems: 1,
-					// Embed a `*schema.Resource` to validate that type directed
+					// Embed a `*schemav1.Resource` to validate that type directed
 					// walk of the schema successfully walks inside Resources as well
 					// as Schemas.
-					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
-							"configuration": {Type: schema.TypeMap},
+					Elem: &schemav1.Resource{
+						Schema: map[string]*schemav1.Schema{
+							"configuration": {Type: schemav1.TypeMap},
 						},
 					},
 				},
 				"set_property_value": {
-					Type: schema.TypeSet,
-					Elem: &schema.Schema{Type: schema.TypeString},
+					Type: schemav1.TypeSet,
+					Elem: &schemav1.Schema{Type: schemav1.TypeString},
 				},
-				"string_with_bad_interpolation": {Type: schema.TypeString},
+				"string_with_bad_interpolation": {Type: schemav1.TypeString},
 			},
 			SchemaVersion: 1,
-			MigrateState: func(v int, is *terraform.InstanceState, p interface{}) (*terraform.InstanceState, error) {
+			MigrateState: func(v int, is *terraformv1.InstanceState, p interface{}) (*terraformv1.InstanceState, error) {
 				return is, nil
 			},
-			Create: func(data *schema.ResourceData, p interface{}) error {
+			Create: func(data *schemav1.ResourceData, p interface{}) error {
 				data.SetId("0")
 				mustSet(data, "bool_property_value", false)
 				mustSet(data, "number_property_value", 42)
@@ -80,7 +99,7 @@ var testTFProvider = &schema.Provider{
 				mustSet(data, "string_with_bad_interpolation", "some ${interpolated:value} with syntax errors")
 				return nil
 			},
-			Read: func(data *schema.ResourceData, p interface{}) error {
+			Read: func(data *schemav1.ResourceData, p interface{}) error {
 				mustSet(data, "bool_property_value", false)
 				mustSet(data, "number_property_value", 42)
 				mustSet(data, "float_property_value", 99.6767932)
@@ -102,7 +121,7 @@ var testTFProvider = &schema.Provider{
 				mustSet(data, "string_with_bad_interpolation", "some ${interpolated:value} with syntax errors")
 				return nil
 			},
-			Update: func(data *schema.ResourceData, p interface{}) error {
+			Update: func(data *schemav1.ResourceData, p interface{}) error {
 				mustSet(data, "bool_property_value", false)
 				mustSet(data, "number_property_value", 42)
 				mustSet(data, "float_property_value", 99.6767932)
@@ -124,48 +143,48 @@ var testTFProvider = &schema.Provider{
 				mustSet(data, "string_with_bad_interpolation", "some ${interpolated:value} with syntax errors")
 				return nil
 			},
-			Delete: func(data *schema.ResourceData, p interface{}) error {
+			Delete: func(data *schemav1.ResourceData, p interface{}) error {
 				return nil
 			},
-			Timeouts: &schema.ResourceTimeout{
+			Timeouts: &schemav1.ResourceTimeout{
 				Create: timeout(time.Second * 120),
 			},
 		},
 		"second_resource": {
-			Schema: map[string]*schema.Schema{
-				"nil_property_value":    {Type: schema.TypeMap},
-				"bool_property_value":   {Type: schema.TypeBool},
-				"number_property_value": {Type: schema.TypeInt},
-				"float_property_value":  {Type: schema.TypeFloat},
-				"string_property_value": {Type: schema.TypeString},
+			Schema: map[string]*schemav1.Schema{
+				"nil_property_value":    {Type: schemav1.TypeMap},
+				"bool_property_value":   {Type: schemav1.TypeBool},
+				"number_property_value": {Type: schemav1.TypeInt},
+				"float_property_value":  {Type: schemav1.TypeFloat},
+				"string_property_value": {Type: schemav1.TypeString},
 				"array_property_value": {
-					Type: schema.TypeList,
-					Elem: &schema.Schema{Type: schema.TypeString},
+					Type: schemav1.TypeList,
+					Elem: &schemav1.Schema{Type: schemav1.TypeString},
 				},
-				"object_property_value": {Type: schema.TypeMap},
+				"object_property_value": {Type: schemav1.TypeMap},
 				"nested_resources": {
-					Type:     schema.TypeList,
+					Type:     schemav1.TypeList,
 					MaxItems: 1,
-					// Embed a `*schema.Resource` to validate that type directed
+					// Embed a `*schemav1.Resource` to validate that type directed
 					// walk of the schema successfully walks inside Resources as well
 					// as Schemas.
-					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
-							"configuration": {Type: schema.TypeMap},
+					Elem: &schemav1.Resource{
+						Schema: map[string]*schemav1.Schema{
+							"configuration": {Type: schemav1.TypeMap},
 						},
 					},
 				},
 				"set_property_value": {
-					Type: schema.TypeSet,
-					Elem: &schema.Schema{Type: schema.TypeString},
+					Type: schemav1.TypeSet,
+					Elem: &schemav1.Schema{Type: schemav1.TypeString},
 				},
-				"string_with_bad_interpolation": {Type: schema.TypeString},
+				"string_with_bad_interpolation": {Type: schemav1.TypeString},
 			},
 			SchemaVersion: 1,
-			MigrateState: func(v int, is *terraform.InstanceState, p interface{}) (*terraform.InstanceState, error) {
+			MigrateState: func(v int, is *terraformv1.InstanceState, p interface{}) (*terraformv1.InstanceState, error) {
 				return is, nil
 			},
-			Create: func(data *schema.ResourceData, p interface{}) error {
+			Create: func(data *schemav1.ResourceData, p interface{}) error {
 				data.SetId("0")
 				mustSet(data, "bool_property_value", false)
 				mustSet(data, "number_property_value", 42)
@@ -188,7 +207,7 @@ var testTFProvider = &schema.Provider{
 				mustSet(data, "string_with_bad_interpolation", "some ${interpolated:value} with syntax errors")
 				return nil
 			},
-			Read: func(data *schema.ResourceData, p interface{}) error {
+			Read: func(data *schemav1.ResourceData, p interface{}) error {
 				mustSet(data, "bool_property_value", false)
 				mustSet(data, "number_property_value", 42)
 				mustSet(data, "float_property_value", 99.6767932)
@@ -210,7 +229,7 @@ var testTFProvider = &schema.Provider{
 				mustSet(data, "string_with_bad_interpolation", "some ${interpolated:value} with syntax errors")
 				return nil
 			},
-			Update: func(data *schema.ResourceData, p interface{}) error {
+			Update: func(data *schemav1.ResourceData, p interface{}) error {
 				mustSet(data, "bool_property_value", false)
 				mustSet(data, "number_property_value", 42)
 				mustSet(data, "float_property_value", 99.6767932)
@@ -232,49 +251,49 @@ var testTFProvider = &schema.Provider{
 				mustSet(data, "string_with_bad_interpolation", "some ${interpolated:value} with syntax errors")
 				return nil
 			},
-			Delete: func(data *schema.ResourceData, p interface{}) error {
+			Delete: func(data *schemav1.ResourceData, p interface{}) error {
 				return nil
 			},
-			Timeouts: &schema.ResourceTimeout{
+			Timeouts: &schemav1.ResourceTimeout{
 				Create: timeout(time.Second * 120),
 				Update: timeout(time.Second * 120),
 			},
 		},
 	},
-	DataSourcesMap: map[string]*schema.Resource{
+	DataSourcesMap: map[string]*schemav1.Resource{
 		"example_resource": {
-			Schema: map[string]*schema.Schema{
-				"nil_property_value":    {Type: schema.TypeMap},
-				"bool_property_value":   {Type: schema.TypeBool},
-				"number_property_value": {Type: schema.TypeInt},
-				"float_property_value":  {Type: schema.TypeFloat},
-				"string_property_value": {Type: schema.TypeString},
+			Schema: map[string]*schemav1.Schema{
+				"nil_property_value":    {Type: schemav1.TypeMap},
+				"bool_property_value":   {Type: schemav1.TypeBool},
+				"number_property_value": {Type: schemav1.TypeInt},
+				"float_property_value":  {Type: schemav1.TypeFloat},
+				"string_property_value": {Type: schemav1.TypeString},
 				"array_property_value": {
-					Type: schema.TypeList,
-					Elem: &schema.Schema{Type: schema.TypeString},
+					Type: schemav1.TypeList,
+					Elem: &schemav1.Schema{Type: schemav1.TypeString},
 				},
-				"object_property_value": {Type: schema.TypeMap},
-				"map_property_value":    {Type: schema.TypeMap},
+				"object_property_value": {Type: schemav1.TypeMap},
+				"map_property_value":    {Type: schemav1.TypeMap},
 				"nested_resources": {
-					Type:     schema.TypeList,
+					Type:     schemav1.TypeList,
 					MaxItems: 1,
-					// Embed a `*schema.Resource` to validate that type directed
+					// Embed a `*schemav1.Resource` to validate that type directed
 					// walk of the schema successfully walks inside Resources as well
 					// as Schemas.
-					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
-							"configuration": {Type: schema.TypeMap},
+					Elem: &schemav1.Resource{
+						Schema: map[string]*schemav1.Schema{
+							"configuration": {Type: schemav1.TypeMap},
 						},
 					},
 				},
 				"set_property_value": {
-					Type: schema.TypeSet,
-					Elem: &schema.Schema{Type: schema.TypeString},
+					Type: schemav1.TypeSet,
+					Elem: &schemav1.Schema{Type: schemav1.TypeString},
 				},
-				"string_with_bad_interpolation": {Type: schema.TypeString},
+				"string_with_bad_interpolation": {Type: schemav1.TypeString},
 			},
 			SchemaVersion: 1,
-			Read: func(data *schema.ResourceData, p interface{}) error {
+			Read: func(data *schemav1.ResourceData, p interface{}) error {
 				mustSet(data, "bool_property_value", false)
 				mustSet(data, "number_property_value", 42)
 				mustSet(data, "float_property_value", 99.6767932)
@@ -298,7 +317,523 @@ var testTFProvider = &schema.Provider{
 			},
 		},
 	},
-	ConfigureFunc: func(data *schema.ResourceData) (interface{}, error) {
+	ConfigureFunc: func(data *schemav1.ResourceData) (interface{}, error) {
 		return nil, nil
 	},
+}
+
+var testTFProviderV2 = &schemav2.Provider{
+	Schema: map[string]*schemav2.Schema{
+		"config_value": {Type: schemav2.TypeString},
+	},
+	ResourcesMap: map[string]*schemav2.Resource{
+		"example_resource": {
+			Schema: map[string]*schemav2.Schema{
+				"nil_property_value":    {Type: schemav2.TypeMap},
+				"bool_property_value":   {Type: schemav2.TypeBool},
+				"number_property_value": {Type: schemav2.TypeInt},
+				"float_property_value":  {Type: schemav2.TypeFloat},
+				"string_property_value": {Type: schemav2.TypeString},
+				"array_property_value": {
+					Type: schemav2.TypeList,
+					Elem: &schemav2.Schema{Type: schemav2.TypeString},
+				},
+				"object_property_value": {Type: schemav2.TypeMap},
+				"nested_resources": {
+					Type:     schemav2.TypeList,
+					MaxItems: 1,
+					// Embed a `*schemav2.Resource` to validate that type directed
+					// walk of the schema successfully walks inside Resources as well
+					// as Schemas.
+					Elem: &schemav2.Resource{
+						Schema: map[string]*schemav2.Schema{
+							"configuration": {Type: schemav2.TypeMap},
+						},
+					},
+				},
+				"set_property_value": {
+					Type: schemav2.TypeSet,
+					Elem: &schemav2.Schema{Type: schemav2.TypeString},
+				},
+				"string_with_bad_interpolation": {Type: schemav2.TypeString},
+			},
+			SchemaVersion: 1,
+			MigrateState: func(v int, is *terraformv2.InstanceState, p interface{}) (*terraformv2.InstanceState, error) {
+				return is, nil
+			},
+			Create: func(data *schemav2.ResourceData, p interface{}) error {
+				data.SetId("0")
+				mustSet(data, "bool_property_value", false)
+				mustSet(data, "number_property_value", 42)
+				mustSet(data, "float_property_value", 99.6767932)
+				mustSet(data, "string_property_value", "ognirts")
+				mustSet(data, "array_property_value", []interface{}{"an array"})
+				mustSet(data, "object_property_value", map[string]interface{}{
+					"property_a": "a",
+					"property_b": "true",
+					"property.c": "some.value",
+				})
+				mustSet(data, "nested_resources", []interface{}{
+					map[string]interface{}{
+						"configuration": map[string]interface{}{
+							"configurationValue": "true",
+						},
+					},
+				})
+				mustSet(data, "set_property_value", []interface{}{"set member 1", "set member 2"})
+				mustSet(data, "string_with_bad_interpolation", "some ${interpolated:value} with syntax errors")
+				return nil
+			},
+			Read: func(data *schemav2.ResourceData, p interface{}) error {
+				mustSet(data, "bool_property_value", false)
+				mustSet(data, "number_property_value", 42)
+				mustSet(data, "float_property_value", 99.6767932)
+				mustSet(data, "string_property_value", "ognirts")
+				mustSet(data, "array_property_value", []interface{}{"an array"})
+				mustSet(data, "object_property_value", map[string]interface{}{
+					"property_a": "a",
+					"property_b": "true",
+					"property.c": "some.value",
+				})
+				mustSet(data, "nested_resources", []interface{}{
+					map[string]interface{}{
+						"configuration": map[string]interface{}{
+							"configurationValue": "true",
+						},
+					},
+				})
+				mustSet(data, "set_property_value", []interface{}{"set member 1", "set member 2"})
+				mustSet(data, "string_with_bad_interpolation", "some ${interpolated:value} with syntax errors")
+				return nil
+			},
+			Update: func(data *schemav2.ResourceData, p interface{}) error {
+				mustSet(data, "bool_property_value", false)
+				mustSet(data, "number_property_value", 42)
+				mustSet(data, "float_property_value", 99.6767932)
+				mustSet(data, "string_property_value", "ognirts")
+				mustSet(data, "array_property_value", []interface{}{"an array"})
+				mustSet(data, "object_property_value", map[string]interface{}{
+					"property_a": "a",
+					"property_b": "true",
+					"property.c": "some.value",
+				})
+				mustSet(data, "nested_resources", []interface{}{
+					map[string]interface{}{
+						"configuration": map[string]interface{}{
+							"configurationValue": "true",
+						},
+					},
+				})
+				mustSet(data, "set_property_value", []interface{}{"set member 1", "set member 2"})
+				mustSet(data, "string_with_bad_interpolation", "some ${interpolated:value} with syntax errors")
+				return nil
+			},
+			Delete: func(data *schemav2.ResourceData, p interface{}) error {
+				return nil
+			},
+			Timeouts: &schemav2.ResourceTimeout{
+				Create: timeout(time.Second * 120),
+			},
+		},
+		"second_resource": {
+			Schema: map[string]*schemav2.Schema{
+				"nil_property_value":    {Type: schemav2.TypeMap},
+				"bool_property_value":   {Type: schemav2.TypeBool},
+				"number_property_value": {Type: schemav2.TypeInt},
+				"float_property_value":  {Type: schemav2.TypeFloat},
+				"string_property_value": {Type: schemav2.TypeString},
+				"array_property_value": {
+					Type: schemav2.TypeList,
+					Elem: &schemav2.Schema{Type: schemav2.TypeString},
+				},
+				"object_property_value": {Type: schemav2.TypeMap},
+				"nested_resources": {
+					Type:     schemav2.TypeList,
+					MaxItems: 1,
+					// Embed a `*schemav2.Resource` to validate that type directed
+					// walk of the schema successfully walks inside Resources as well
+					// as Schemas.
+					Elem: &schemav2.Resource{
+						Schema: map[string]*schemav2.Schema{
+							"configuration": {Type: schemav2.TypeMap},
+						},
+					},
+				},
+				"set_property_value": {
+					Type: schemav2.TypeSet,
+					Elem: &schemav2.Schema{Type: schemav2.TypeString},
+				},
+				"string_with_bad_interpolation": {Type: schemav2.TypeString},
+			},
+			SchemaVersion: 1,
+			MigrateState: func(v int, is *terraformv2.InstanceState, p interface{}) (*terraformv2.InstanceState, error) {
+				return is, nil
+			},
+			Create: func(data *schemav2.ResourceData, p interface{}) error {
+				data.SetId("0")
+				mustSet(data, "bool_property_value", false)
+				mustSet(data, "number_property_value", 42)
+				mustSet(data, "float_property_value", 99.6767932)
+				mustSet(data, "string_property_value", "ognirts")
+				mustSet(data, "array_property_value", []interface{}{"an array"})
+				mustSet(data, "object_property_value", map[string]interface{}{
+					"property_a": "a",
+					"property_b": "true",
+					"property.c": "some.value",
+				})
+				mustSet(data, "nested_resources", []interface{}{
+					map[string]interface{}{
+						"configuration": map[string]interface{}{
+							"configurationValue": "true",
+						},
+					},
+				})
+				mustSet(data, "set_property_value", []interface{}{"set member 1", "set member 2"})
+				mustSet(data, "string_with_bad_interpolation", "some ${interpolated:value} with syntax errors")
+				return nil
+			},
+			Read: func(data *schemav2.ResourceData, p interface{}) error {
+				mustSet(data, "bool_property_value", false)
+				mustSet(data, "number_property_value", 42)
+				mustSet(data, "float_property_value", 99.6767932)
+				mustSet(data, "string_property_value", "ognirts")
+				mustSet(data, "array_property_value", []interface{}{"an array"})
+				mustSet(data, "object_property_value", map[string]interface{}{
+					"property_a": "a",
+					"property_b": "true",
+					"property.c": "some.value",
+				})
+				mustSet(data, "nested_resources", []interface{}{
+					map[string]interface{}{
+						"configuration": map[string]interface{}{
+							"configurationValue": "true",
+						},
+					},
+				})
+				mustSet(data, "set_property_value", []interface{}{"set member 1", "set member 2"})
+				mustSet(data, "string_with_bad_interpolation", "some ${interpolated:value} with syntax errors")
+				return nil
+			},
+			Update: func(data *schemav2.ResourceData, p interface{}) error {
+				mustSet(data, "bool_property_value", false)
+				mustSet(data, "number_property_value", 42)
+				mustSet(data, "float_property_value", 99.6767932)
+				mustSet(data, "string_property_value", "ognirts")
+				mustSet(data, "array_property_value", []interface{}{"an array"})
+				mustSet(data, "object_property_value", map[string]interface{}{
+					"property_a": "a",
+					"property_b": "true",
+					"property.c": "some.value",
+				})
+				mustSet(data, "nested_resources", []interface{}{
+					map[string]interface{}{
+						"configuration": map[string]interface{}{
+							"configurationValue": "true",
+						},
+					},
+				})
+				mustSet(data, "set_property_value", []interface{}{"set member 1", "set member 2"})
+				mustSet(data, "string_with_bad_interpolation", "some ${interpolated:value} with syntax errors")
+				return nil
+			},
+			Delete: func(data *schemav2.ResourceData, p interface{}) error {
+				return nil
+			},
+			Timeouts: &schemav2.ResourceTimeout{
+				Create: timeout(time.Second * 120),
+				Update: timeout(time.Second * 120),
+			},
+		},
+	},
+	DataSourcesMap: map[string]*schemav2.Resource{
+		"example_resource": {
+			Schema: map[string]*schemav2.Schema{
+				"nil_property_value":    {Type: schemav2.TypeMap},
+				"bool_property_value":   {Type: schemav2.TypeBool},
+				"number_property_value": {Type: schemav2.TypeInt},
+				"float_property_value":  {Type: schemav2.TypeFloat},
+				"string_property_value": {Type: schemav2.TypeString},
+				"array_property_value": {
+					Type: schemav2.TypeList,
+					Elem: &schemav2.Schema{Type: schemav2.TypeString},
+				},
+				"object_property_value": {Type: schemav2.TypeMap},
+				"map_property_value":    {Type: schemav2.TypeMap},
+				"nested_resources": {
+					Type:     schemav2.TypeList,
+					MaxItems: 1,
+					// Embed a `*schemav2.Resource` to validate that type directed
+					// walk of the schema successfully walks inside Resources as well
+					// as Schemas.
+					Elem: &schemav2.Resource{
+						Schema: map[string]*schemav2.Schema{
+							"configuration": {Type: schemav2.TypeMap},
+						},
+					},
+				},
+				"set_property_value": {
+					Type: schemav2.TypeSet,
+					Elem: &schemav2.Schema{Type: schemav2.TypeString},
+				},
+				"string_with_bad_interpolation": {Type: schemav2.TypeString},
+			},
+			SchemaVersion: 1,
+			Read: func(data *schemav2.ResourceData, p interface{}) error {
+				mustSet(data, "bool_property_value", false)
+				mustSet(data, "number_property_value", 42)
+				mustSet(data, "float_property_value", 99.6767932)
+				mustSet(data, "string_property_value", "ognirts")
+				mustSet(data, "array_property_value", []interface{}{"an array"})
+				mustSet(data, "object_property_value", map[string]interface{}{
+					"property_a": "a",
+					"property_b": "true",
+					"property.c": "some.value",
+				})
+				mustSet(data, "nested_resources", []interface{}{
+					map[string]interface{}{
+						"configuration": map[string]interface{}{
+							"configurationValue": "true",
+						},
+					},
+				})
+				mustSet(data, "set_property_value", []interface{}{"set member 1", "set member 2"})
+				mustSet(data, "string_with_bad_interpolation", "some ${interpolated:value} with syntax errors")
+				return nil
+			},
+		},
+	},
+	ConfigureFunc: func(data *schemav2.ResourceData) (interface{}, error) {
+		return nil, nil
+	},
+}
+
+type shimFactory interface {
+	SDKVersion() string
+	NewSchema(s *schema.Schema) shim.Schema
+	NewSchemaMap(m map[string]*schema.Schema) shim.SchemaMap
+	NewResource(r *schema.Resource) shim.Resource
+	NewInstanceState(id string) shim.InstanceState
+	NewTestProvider() shim.Provider
+}
+
+type shimv1Factory int
+
+func (f shimv1Factory) SDKVersion() string {
+	return "v1"
+}
+
+func (f shimv1Factory) newSchema(m shim.Schema) *schemav1.Schema {
+	t := schemav1.TypeInvalid
+	switch m.Type() {
+	case shim.TypeBool:
+		t = schemav1.TypeBool
+	case shim.TypeInt:
+		t = schemav1.TypeInt
+	case shim.TypeFloat:
+		t = schemav1.TypeFloat
+	case shim.TypeString:
+		t = schemav1.TypeString
+	case shim.TypeList:
+		t = schemav1.TypeList
+	case shim.TypeMap:
+		t = schemav1.TypeMap
+	case shim.TypeSet:
+		t = schemav1.TypeSet
+	}
+
+	var elem interface{}
+	switch e := m.Elem().(type) {
+	case shim.Schema:
+		elem = f.newSchema(e)
+	case shim.Resource:
+		elem = f.newResource(e)
+	}
+
+	return &schemav1.Schema{
+		Type:          t,
+		Optional:      m.Optional(),
+		Required:      m.Required(),
+		Default:       m.Default(),
+		DefaultFunc:   schemav1.SchemaDefaultFunc(m.DefaultFunc()),
+		Description:   m.Description(),
+		Computed:      m.Computed(),
+		ForceNew:      m.ForceNew(),
+		StateFunc:     schemav1.SchemaStateFunc(m.StateFunc()),
+		Elem:          elem,
+		MaxItems:      m.MaxItems(),
+		MinItems:      m.MinItems(),
+		ConflictsWith: m.ConflictsWith(),
+		Deprecated:    m.Deprecated(),
+		Removed:       m.Removed(),
+		Sensitive:     m.Sensitive(),
+	}
+}
+
+func (f shimv1Factory) NewSchema(m *schema.Schema) shim.Schema {
+	return shimv1.NewSchema(f.newSchema(m.Shim()))
+}
+
+func (f shimv1Factory) newSchemaMap(m shim.SchemaMap) map[string]*schemav1.Schema {
+	tf := map[string]*schemav1.Schema{}
+	m.Range(func(k string, v shim.Schema) bool {
+		tf[k] = f.newSchema(v)
+		return true
+	})
+	return tf
+}
+
+func (f shimv1Factory) NewSchemaMap(m map[string]*schema.Schema) shim.SchemaMap {
+	tf := map[string]*schemav1.Schema{}
+	for k, v := range m {
+		tf[k] = f.newSchema(v.Shim())
+	}
+	return shimv1.NewSchemaMap(tf)
+}
+
+func (f shimv1Factory) newResource(r shim.Resource) *schemav1.Resource {
+	var timeouts *schemav1.ResourceTimeout
+	if t := r.Timeouts(); t != nil {
+		timeouts = &schemav1.ResourceTimeout{
+			Create:  t.Create,
+			Read:    t.Read,
+			Update:  t.Update,
+			Delete:  t.Delete,
+			Default: t.Default,
+		}
+	}
+
+	return &schemav1.Resource{
+		Schema:             f.newSchemaMap(r.Schema()),
+		SchemaVersion:      r.SchemaVersion(),
+		DeprecationMessage: r.DeprecationMessage(),
+		Timeouts:           timeouts,
+	}
+}
+
+func (f shimv1Factory) NewResource(r *schema.Resource) shim.Resource {
+	return shimv1.NewResource(f.newResource(r.Shim()))
+}
+
+func (f shimv1Factory) NewInstanceState(id string) shim.InstanceState {
+	return shimv1.NewInstanceState(&terraformv1.InstanceState{
+		ID: id, Attributes: map[string]string{}, Meta: map[string]interface{}{}})
+}
+
+func (f shimv1Factory) NewTestProvider() shim.Provider {
+	return shimv1.NewProvider(testTFProvider)
+}
+
+type shimv2Factory int
+
+func (f shimv2Factory) SDKVersion() string {
+	return "v2"
+}
+
+func (f shimv2Factory) newSchema(m shim.Schema) *schemav2.Schema {
+	t := schemav2.TypeInvalid
+	switch m.Type() {
+	case shim.TypeBool:
+		t = schemav2.TypeBool
+	case shim.TypeInt:
+		t = schemav2.TypeInt
+	case shim.TypeFloat:
+		t = schemav2.TypeFloat
+	case shim.TypeString:
+		t = schemav2.TypeString
+	case shim.TypeList:
+		t = schemav2.TypeList
+	case shim.TypeMap:
+		t = schemav2.TypeMap
+	case shim.TypeSet:
+		t = schemav2.TypeSet
+	}
+
+	var elem interface{}
+	switch e := m.Elem().(type) {
+	case shim.Schema:
+		elem = f.newSchema(e)
+	case shim.Resource:
+		elem = f.newResource(e)
+	}
+
+	return &schemav2.Schema{
+		Type:          t,
+		Optional:      m.Optional(),
+		Required:      m.Required(),
+		Default:       m.Default(),
+		DefaultFunc:   schemav2.SchemaDefaultFunc(m.DefaultFunc()),
+		Description:   m.Description(),
+		Computed:      m.Computed(),
+		ForceNew:      m.ForceNew(),
+		StateFunc:     schemav2.SchemaStateFunc(m.StateFunc()),
+		Elem:          elem,
+		MaxItems:      m.MaxItems(),
+		MinItems:      m.MinItems(),
+		ConflictsWith: m.ConflictsWith(),
+		Deprecated:    m.Deprecated(),
+		Sensitive:     m.Sensitive(),
+	}
+}
+
+func (f shimv2Factory) NewSchema(m *schema.Schema) shim.Schema {
+	return shimv2.NewSchema(f.newSchema(m.Shim()))
+}
+
+func (f shimv2Factory) newSchemaMap(m shim.SchemaMap) map[string]*schemav2.Schema {
+	tf := map[string]*schemav2.Schema{}
+	m.Range(func(k string, v shim.Schema) bool {
+		if v.Removed() == "" {
+			tf[k] = f.newSchema(v)
+		}
+		return true
+	})
+	return tf
+}
+
+func (f shimv2Factory) NewSchemaMap(m map[string]*schema.Schema) shim.SchemaMap {
+	tf := map[string]*schemav2.Schema{}
+	for k, v := range m {
+		if v.Removed == "" {
+			tf[k] = f.newSchema(v.Shim())
+		}
+	}
+	return shimv2.NewSchemaMap(tf)
+}
+
+func (f shimv2Factory) newResource(r shim.Resource) *schemav2.Resource {
+	var timeouts *schemav2.ResourceTimeout
+	if t := r.Timeouts(); t != nil {
+		timeouts = &schemav2.ResourceTimeout{
+			Create:  t.Create,
+			Read:    t.Read,
+			Update:  t.Update,
+			Delete:  t.Delete,
+			Default: t.Default,
+		}
+	}
+
+	return &schemav2.Resource{
+		Schema:             f.newSchemaMap(r.Schema()),
+		SchemaVersion:      r.SchemaVersion(),
+		DeprecationMessage: r.DeprecationMessage(),
+		Timeouts:           timeouts,
+	}
+}
+
+func (f shimv2Factory) NewResource(r *schema.Resource) shim.Resource {
+	return shimv2.NewResource(f.newResource(r.Shim()))
+}
+
+func (f shimv2Factory) NewInstanceState(id string) shim.InstanceState {
+	return shimv2.NewInstanceState(&terraformv2.InstanceState{
+		ID: id, Attributes: map[string]string{}, Meta: map[string]interface{}{}})
+}
+
+func (f shimv2Factory) NewTestProvider() shim.Provider {
+	return shimv2.NewProvider(testTFProviderV2)
+}
+
+var factories = []shimFactory{
+	shimv1Factory(0),
+	shimv2Factory(0),
 }

--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -26,13 +26,13 @@ import (
 	"strings"
 
 	"github.com/gedex/inflector"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/pulumi/pulumi/pkg/v2/codegen"
 	pschema "github.com/pulumi/pulumi/pkg/v2/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/util/contract"
 
 	"github.com/pulumi/pulumi-terraform-bridge/v2/pkg/tfbridge"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v2/pkg/tfshim"
 )
 
 type schemaGenerator struct {
@@ -158,7 +158,7 @@ func (nt *schemaNestedTypes) gatherFromProperties(declarer declarer, namePrefix 
 		// Due to bugs in earlier versions of the bridge, we want to keep the Python code generator from case-mapping
 		// properties an object-typed element that are not Map types. This is consistent with the earlier behavior. See
 		// https://github.com/pulumi/pulumi/issues/3151 for more details.
-		mapCase := pyMapCase && p.typ.kind == kindObject && p.schema.Type == schema.TypeMap
+		mapCase := pyMapCase && p.typ.kind == kindObject && p.schema.Type() == shim.TypeMap
 		nt.gatherFromPropertyType(declarer, namePrefix, name, p.typ, isInput, mapCase)
 	}
 }

--- a/pkg/tfgen/generate_test.go
+++ b/pkg/tfgen/generate_test.go
@@ -5,12 +5,14 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/stretchr/testify/assert"
+
+	shimv1 "github.com/pulumi/pulumi-terraform-bridge/v2/pkg/tfshim/sdk-v1"
 )
 
 func Test_DeprecationFromTFSchema(t *testing.T) {
 	v := &variable{
 		name:   "v",
-		schema: &schema.Schema{Type: schema.TypeString, Deprecated: "This is deprecated"},
+		schema: shimv1.NewSchema(&schema.Schema{Type: schema.TypeString, Deprecated: "This is deprecated"}),
 	}
 
 	deprecationMessage := v.deprecationMessage()

--- a/pkg/tfgen/pluginHost.go
+++ b/pkg/tfgen/pluginHost.go
@@ -20,6 +20,15 @@ type inmemoryProvider struct {
 	info   tfbridge.ProviderInfo
 }
 
+func newInMemoryProvider(name string, schema []byte, info tfbridge.ProviderInfo) *inmemoryProvider {
+	// Round-trip the info through a marshaler to normalize the types to the schema shim.
+	return &inmemoryProvider{
+		name:   name,
+		schema: schema,
+		info:   *tfbridge.MarshalProviderInfo(&info).Unmarshal(),
+	}
+}
+
 func (p *inmemoryProvider) Pkg() tokens.Package {
 	return tokens.Package(p.name)
 }


### PR DESCRIPTION
These changes update tfbridge, tfgen, and tf2pulumi to consume the
Terraform SDK shim. Most of the changes are mechanical: field accesses
are replace with method calls, ranges are replaced with calls to Range,
etc.

Consumers of the bridge must now wrap their provider's schema in the
appropriate shim implementation prior to handing it off to
tfbridge.Main. Providers that use the v1 SDK should use the v1 shim;
those that use the v2 SDK should use the v2 shim.

Fixes #245.