### PR TITLE
Update the `GetProviderInfo` signature.

### DIFF
--- a/pkg/tf2pulumi/convert/tf12.go
+++ b/pkg/tf2pulumi/convert/tf12.go
@@ -1689,7 +1689,7 @@ func (b *tf12binder) resourceType(addr addrs.Resource,
 
 	info, ok := b.providers[providerName]
 	if !ok {
-		i, err := b.providerInfo.GetProviderInfo(providerName)
+		i, err := b.providerInfo.GetProviderInfo("", "", providerName, "")
 		if err != nil {
 			// Fake up a root-level token.
 			tok := providerName + ":index:" + addr.Type
@@ -1736,7 +1736,7 @@ func (b *tf12binder) providerType(providerName string,
 
 	info, ok := b.providers[providerName]
 	if !ok {
-		i, err := b.providerInfo.GetProviderInfo(providerName)
+		i, err := b.providerInfo.GetProviderInfo("", "", providerName, "")
 		if err != nil {
 			return tok, il.Schemas{}, model.DynamicType, hcl.Diagnostics{{
 				Subject: &subject,

--- a/pkg/tf2pulumi/il/graph.go
+++ b/pkg/tf2pulumi/il/graph.go
@@ -603,7 +603,7 @@ func (b *builder) getProviderInfo(p *ProviderNode) (*tfbridge.ProviderInfo, stri
 		return info, p.Name, nil
 	}
 
-	info, err := b.providerInfo.GetProviderInfo(p.Name)
+	info, err := b.providerInfo.GetProviderInfo("", "", p.Name, "")
 	if err != nil {
 		return nil, "", err
 	}

--- a/pkg/tf2pulumi/test/provider_info.go
+++ b/pkg/tf2pulumi/test/provider_info.go
@@ -42,15 +42,17 @@ func (s *ProviderInfoSource) getProviderInfo(tfProviderName string) (*tfbridge.P
 
 // GetProviderInfo returns the tfbridge information for the indicated Terraform provider as well as the name of the
 // corresponding Pulumi resource provider.
-func (s *ProviderInfoSource) GetProviderInfo(tfProviderName string) (*tfbridge.ProviderInfo, error) {
-	if info, ok := s.getProviderInfo(tfProviderName); ok {
+func (s *ProviderInfoSource) GetProviderInfo(
+	registryName, namespace, name, version string) (*tfbridge.ProviderInfo, error) {
+
+	if info, ok := s.getProviderInfo(name); ok {
 		return info, nil
 	}
 
 	s.m.Lock()
 	defer s.m.Unlock()
 
-	f, err := os.Open(filepath.Join(s.infoDirectoryPath, tfProviderName+".json"))
+	f, err := os.Open(filepath.Join(s.infoDirectoryPath, name+".json"))
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +64,7 @@ func (s *ProviderInfoSource) GetProviderInfo(tfProviderName string) (*tfbridge.P
 	}
 
 	info := m.Unmarshal()
-	s.entries[tfProviderName] = info
+	s.entries[name] = info
 	return info, nil
 }
 

--- a/pkg/tfgen/pluginHost.go
+++ b/pkg/tfgen/pluginHost.go
@@ -51,11 +51,13 @@ func (host *inmemoryProviderHost) Provider(pkg tokens.Package, version *semver.V
 	return host.Host.Provider(pkg, version)
 }
 
-func (host *inmemoryProviderHost) GetProviderInfo(tfProviderName string) (*tfbridge.ProviderInfo, error) {
-	if tfProviderName == host.provider.info.Name {
+func (host *inmemoryProviderHost) GetProviderInfo(
+	registryName, namespace, name, version string) (*tfbridge.ProviderInfo, error) {
+
+	if name == host.provider.info.Name {
 		return &host.provider.info, nil
 	}
-	return host.ProviderInfoSource.GetProviderInfo(tfProviderName)
+	return host.ProviderInfoSource.GetProviderInfo(registryName, namespace, name, version)
 }
 
 type cachingProviderHost struct {


### PR DESCRIPTION
Add parameters for the registry name, namespace, and version associated
with a Terraform provider. This is in preparation for improved support
for [TF12/TF13 provider requirement blocks](https://www.terraform.io/docs/configuration/provider-requirements.html).