### PR TITLE
Use a struct for generator options.

### DIFF
--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -48,12 +48,17 @@ func TestURLRewrite(t *testing.T) {
 		},
 	}
 
-	g, err := NewGenerator("google", "0.1.2", "nodejs", tfbridge.ProviderInfo{
-		Name: "google",
-		Resources: map[string]*tfbridge.ResourceInfo{
-			"google_container_node_pool": {Tok: "google:container/nodePool:NodePool"},
+	g, err := NewGenerator(GeneratorOptions{
+		Package:  "google",
+		Version:  "0.1.2",
+		Language: "nodejs",
+		ProviderInfo: tfbridge.ProviderInfo{
+			Name: "google",
+			Resources: map[string]*tfbridge.ResourceInfo{
+				"google_container_node_pool": {Tok: "google:container/nodePool:NodePool"},
+			},
 		},
-	}, nil)
+	})
 	assert.NoError(t, err)
 
 	for _, test := range tests {

--- a/pkg/tfgen/main.go
+++ b/pkg/tfgen/main.go
@@ -84,7 +84,13 @@ func newTFGenCmd(pkg string, version string, prov tfbridge.ProviderInfo) *cobra.
 			}
 
 			// Create a generator with the specified settings.
-			g, err := NewGenerator(pkg, version, Language(args[0]), prov, root)
+			g, err := NewGenerator(GeneratorOptions{
+				Package:      pkg,
+				Version:      version,
+				Language:     Language(args[0]),
+				ProviderInfo: prov,
+				Root:         root,
+			})
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
And add options for the provider info source, plugin host, and
diagnostic sink. This allows the caller more control over the
generator's behavior.