### PR TITLE
Add support for literal Markdown in doc info.

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -226,6 +226,8 @@ type Transformer func(resource.PropertyValue) (resource.PropertyValue, error)
 // DocInfo contains optional overrids for finding and mapping TD docs.
 type DocInfo struct {
 	Source                         string // an optional override to locate TF docs; "" uses the default.
+	Markdown                       []byte // an optional override for the source markdown.
+	MarkdownURL                    string // an optional override for the source URL.
 	IncludeAttributesFrom          string // optionally include attributes from another raw resource for docs.
 	IncludeArgumentsFrom           string // optionally include arguments from another raw resource for docs.
 	IncludeAttributesFromArguments string // optionally include attributes from another raw resource's arguments.


### PR DESCRIPTION
Just what it says on the tin. This allows callers to implement their own
paths for finding documentation.