### PR TITLE
Add ability to mark any resource property as a secret

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -205,6 +205,9 @@ type SchemaInfo struct {
 
 	// whether or not this property has been removed from the Terraform schema
 	Removed bool
+
+	// whether or not to treat this property as secret
+	Secret *bool
 }
 
 // ConfigInfo represents a synthetic configuration variable that is Pulumi-only, and not passed to Terraform.
@@ -474,6 +477,7 @@ type MarshallableSchemaInfo struct {
 	MaxItemsOne *bool                              `json:"maxItemsOne,omitempty"`
 	Deprecated  string                             `json:"deprecated,omitempty"`
 	ForceNew    *bool                              `json:"forceNew,omitempty"`
+	Secret      *bool                              `json:"secret,omitempty"`
 }
 
 // MarshalSchemaInfo converts a Pulumi SchemaInfo value into a MarshallableSchemaInfo value.
@@ -498,6 +502,7 @@ func MarshalSchemaInfo(s *SchemaInfo) *MarshallableSchemaInfo {
 		MaxItemsOne: s.MaxItemsOne,
 		Deprecated:  s.DeprecationMessage,
 		ForceNew:    s.ForceNew,
+		Secret:      s.Secret,
 	}
 }
 
@@ -523,6 +528,7 @@ func (m *MarshallableSchemaInfo) Unmarshal() *SchemaInfo {
 		MaxItemsOne:        m.MaxItemsOne,
 		DeprecationMessage: m.Deprecated,
 		ForceNew:           m.ForceNew,
+		Secret:             m.Secret,
 	}
 }
 

--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -375,6 +375,11 @@ func (g *schemaGenerator) genProperty(mod string, prop *variable, pyMapCase bool
 		}
 	}
 
+	var secret bool
+	if prop.info != nil && prop.info.Secret != nil {
+		secret = *prop.info.Secret
+	}
+
 	return pschema.PropertySpec{
 		TypeSpec:           g.schemaType(mod, prop.typ, prop.out),
 		Description:        description,
@@ -382,6 +387,7 @@ func (g *schemaGenerator) genProperty(mod string, prop *variable, pyMapCase bool
 		DefaultInfo:        defaultInfo,
 		DeprecationMessage: prop.deprecationMessage(),
 		Language:           language,
+		Secret:             secret,
 	}
 }
 


### PR DESCRIPTION
This will bide us some time until we can fix up #10

We are able to do the following in the SchemaInfo:

```
"tls_private_key":         {
	Tok: tlsResource(tlsMod, "PrivateKey"),
	Fields: map[string]*tfbridge.SchemaInfo{
		"private_key_pem": {
			MarkAsSecret: boolRef(true),
		},
	},
},
```

This then manifests itself as follows in the generated SDK:

```
    constructor(name: string, argsOrState?: PrivateKeyArgs | PrivateKeyState, opts?: pulumi.CustomResourceOptions) {
        let inputs: pulumi.Inputs = {};
        if (opts && opts.id) {
            const state = argsOrState as PrivateKeyState | undefined;
            inputs["algorithm"] = state ? state.algorithm : undefined;
            inputs["ecdsaCurve"] = state ? state.ecdsaCurve : undefined;
            inputs["privateKeyPem"] = state ? state.privateKeyPem : undefined;
            inputs["publicKeyFingerprintMd5"] = state ? state.publicKeyFingerprintMd5 : undefined;
            inputs["publicKeyOpenssh"] = state ? state.publicKeyOpenssh : undefined;
            inputs["publicKeyPem"] = state ? state.publicKeyPem : undefined;
            inputs["rsaBits"] = state ? state.rsaBits : undefined;
        } else {
            const args = argsOrState as PrivateKeyArgs | undefined;
            if (!args || args.algorithm === undefined) {
                throw new Error("Missing required property 'algorithm'");
            }
            inputs["algorithm"] = args ? args.algorithm : undefined;
            inputs["ecdsaCurve"] = args ? args.ecdsaCurve : undefined;
            inputs["rsaBits"] = args ? args.rsaBits : undefined;
            inputs["privateKeyPem"] = undefined /*out*/;
            inputs["publicKeyFingerprintMd5"] = undefined /*out*/;
            inputs["publicKeyOpenssh"] = undefined /*out*/;
            inputs["publicKeyPem"] = undefined /*out*/;
        }
        if (!opts) {
            opts = {}
        }

        if (!opts.version) {
            opts.version = utilities.getVersion();
        }
        const secretOpts = { additionalSecretOutputs: ["privateKeyPem"] };
        opts = opts ? pulumi.mergeOptions(opts, secretOpts) : secretOpts;
        super(PrivateKey.__pulumiType, name, inputs, opts);
    }
```

This will be a non-breaking change as it will be an opt-in only and we can enable this
on any property we deem important to not leak through to the state