### PR TITLE
Fix nil pointer panic

### DIFF
--- a/pkg/tf2pulumi/il/plugin_info.go
+++ b/pkg/tf2pulumi/il/plugin_info.go
@@ -97,8 +97,10 @@ func (s multiProviderInfoSource) GetProviderInfo(
 	registryName, namespace, name, version string) (*tfbridge.ProviderInfo, error) {
 
 	for _, s := range s {
-		if info, err := s.GetProviderInfo(registryName, namespace, name, version); err == nil && info != nil {
-			return info, nil
+		if s != nil {
+			if info, err := s.GetProviderInfo(registryName, namespace, name, version); err == nil && info != nil {
+				return info, nil
+			}
 		}
 	}
 


### PR DESCRIPTION
`opts.ProviderInfoSource` in [this change](https://github.com/pulumi/pulumi-terraform-bridge/pull/273/files#diff-1e9fb3ec2c3be8da026575d86e7b5694R655) can be nil, leading to a panic. 