### PR TITLE
Fix a bug building TF config.

### DIFF
--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -351,7 +351,7 @@ func buildTerraformConfig(p *Provider, vars resource.PropertyMap) (shim.Resource
 		}
 	}
 
-	inputs, _, err := MakeTerraformInputs(nil, tfVars, nil, nil, p.config, p.info.Config)
+	inputs, _, err := MakeTerraformInputs(nil, tfVars, nil, tfVars, p.config, p.info.Config)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -175,3 +175,22 @@ func TestDiffConfig(t *testing.T) {
 	assert.True(t, resp.HasDetailedDiff)
 	assert.Len(t, resp.DetailedDiff, 1)
 }
+
+func TestBuildConfig(t *testing.T) {
+	provider := &Provider{
+		tf:     shimv1.NewProvider(testTFProvider),
+		config: shimv1.NewSchemaMap(testTFProvider.Schema),
+	}
+
+	configIn := resource.PropertyMap{
+		"configValue": resource.NewStringProperty("foo"),
+		"version":     resource.NewStringProperty("0.0.1"),
+	}
+	configOut, err := buildTerraformConfig(provider, configIn)
+	assert.NoError(t, err)
+
+	expected := provider.tf.NewResourceConfig(map[string]interface{}{
+		"config_value": "foo",
+	})
+	assert.Equal(t, expected, configOut)
+}


### PR DESCRIPTION
Recent changes to the way we build Terraform configuration
unintentionally dropped the user input and only applied defaults. These
changes ensure that the user's inputs are taken into account.