### PR TITLE
Allow specifying a different githost to github.com

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -39,6 +39,7 @@ type ProviderInfo struct {
 	Name                    string                             // the TF provider name (e.g. terraform-provider-XXXX).
 	ResourcePrefix          string                             // the prefix on resources the provider exposes, if different to `Name`.
 	GitHubOrg               string                             // the GitHub org of the provider. Defaults to `terraform-providers`.
+	GitHubHost              string                             // the GitHub host for the provider. Defaults to `github.com`.
 	Description             string                             // an optional descriptive overview of the package (a default supplied).
 	Keywords                []string                           // an optional list of keywords to help discovery of this package.
 	License                 string                             // the license, if any, the resulting package has (default is none).
@@ -83,6 +84,14 @@ func (info ProviderInfo) GetGitHubOrg() string {
 	}
 
 	return info.GitHubOrg
+}
+
+func (info ProviderInfo) GetGitHubHost() string {
+	if info.GitHubHost == "" {
+		return "github.com"
+	}
+
+	return info.GitHubHost
 }
 
 func (info ProviderInfo) GetTFProviderLicense() TFProviderLicense {

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -939,7 +939,8 @@ func (g *Generator) gatherResource(rawname string,
 	var entityDocs entityDocs
 	if !isProvider {
 		pd, err := getDocsForProvider(g, g.info.GetGitHubOrg(), g.info.Name,
-			g.info.GetResourcePrefix(), ResourceDocs, rawname, info, g.info.GetProviderModuleVersion())
+			g.info.GetResourcePrefix(), ResourceDocs, rawname, info, g.info.GetProviderModuleVersion(),
+			g.info.GetGitHubHost())
 		if err != nil {
 			return "", nil, err
 		}
@@ -1088,7 +1089,8 @@ func (g *Generator) gatherDataSource(rawname string,
 
 	// Collect documentation information for this data source.
 	entityDocs, err := getDocsForProvider(g, g.info.GetGitHubOrg(), g.info.Name,
-		g.info.GetResourcePrefix(), DataSourceDocs, rawname, info, g.info.GetProviderModuleVersion())
+		g.info.GetResourcePrefix(), DataSourceDocs, rawname, info, g.info.GetProviderModuleVersion(),
+		g.info.GetGitHubHost())
 	if err != nil {
 		return "", nil, err
 	}

--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -212,7 +212,7 @@ func (g *schemaGenerator) genPackageSpec(pack *pkg) (pschema.PackageSpec, error)
 	}
 
 	spec.Description = g.info.Description
-	spec.Attribution = fmt.Sprintf(attributionFormatString, g.info.Name, g.info.GetGitHubOrg())
+	spec.Attribution = fmt.Sprintf(attributionFormatString, g.info.Name, g.info.GetGitHubOrg(), g.info.GetGitHubHost())
 
 	var config []*variable
 	for _, mod := range pack.modules.values() {
@@ -262,7 +262,8 @@ func (g *schemaGenerator) genPackageSpec(pack *pkg) (pschema.PackageSpec, error)
 	downstreamLicense := g.info.GetTFProviderLicense()
 	licenseTypeURL := getLicenseTypeURL(downstreamLicense)
 	readme := fmt.Sprintf(
-		standardDocReadme, g.pkg, g.info.Name, g.info.GetGitHubOrg(), downstreamLicense, licenseTypeURL)
+		standardDocReadme, g.pkg, g.info.Name, g.info.GetGitHubOrg(), downstreamLicense, licenseTypeURL,
+		g.info.GetGitHubHost())
 	nodeData := map[string]interface{}{
 		"readme":                  readme,
 		"disableUnionOutputTypes": true,


### PR DESCRIPTION
Fixes: #281

This allows us to reference modules that are stored in any git host
outside of github.com

The default is "github.com"

It is expected for there to be no changes to the downstream codegen as this would indicate a bug!