### PR TITLE
Fix edge case in diffing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Fix an edge case where replacements were not being correctly identified.
+  [#295](https://github.com/pulumi/pulumi-terraform-bridge/pull/295)
+
 - Add support for previewing `Create` and `Update` operations.
   [#276](https://github.com/pulumi/pulumi-terraform-bridge/pull/276)
 

--- a/pkg/tfbridge/diff.go
+++ b/pkg/tfbridge/diff.go
@@ -52,14 +52,14 @@ func containsComputedValues(v resource.PropertyValue) bool {
 // the value.
 type propertyVisitor func(attributeKey, propertyPath string, value resource.PropertyValue) bool
 
-// visitPropertyDiff checks the given property for diffs and invokes the given callback if a diff is found.
+// visitPropertyValue checks the given property for diffs and invokes the given callback if a diff is found.
 //
 // This function contains the core logic used to convert a terraform.InstanceDiff to a list of Pulumi property paths
 // that have changed and the type of change for each path.
 //
 // If not for the presence of sets and the fact that they are mapped to Pulumi array properties, this process would be
 // rather straightforward: we could loop over each path in the instance diff, convert its path to a Pulumi property
-// path, and convert the diff kind to a Pulumi diff kind. Unforunately, the set mapping complicates this process, as
+// path, and convert the diff kind to a Pulumi diff kind. Unfortunately, the set mapping complicates this process, as
 // the array index that corresponds to a set element cannot be derived from the set element's path: part of the path of
 // a set element is the element's hash code, and we cannot derive the corresponding array element's index from this
 // hash code.
@@ -209,7 +209,7 @@ func makePropertyDiff(name, path string, v resource.PropertyValue, tfDiff shim.I
 					kind = pulumirpc.PropertyDiff_ADD
 				}
 			default:
-				if d.RequiresNew {
+				if d.RequiresNew || other.Kind == pulumirpc.PropertyDiff_DELETE_REPLACE {
 					kind = pulumirpc.PropertyDiff_UPDATE_REPLACE
 				} else {
 					kind = pulumirpc.PropertyDiff_UPDATE

--- a/pkg/tfbridge/diff_test.go
+++ b/pkg/tfbridge/diff_test.go
@@ -673,6 +673,30 @@ func TestSetDeleteReplace(t *testing.T) {
 		})
 }
 
+func TestSetDeleteReplaceMultipleItems(t *testing.T) {
+	diffTest(t,
+		map[string]*schema.Schema{
+			"prop": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				ForceNew: true,
+			},
+			"outp": {Type: schema.TypeString, Computed: true},
+		},
+		map[string]*SchemaInfo{},
+		map[string]interface{}{
+			"prop": []interface{}{"ruby", "tineke"},
+		},
+		map[string]interface{}{
+			"prop": []interface{}{"burgundy", "ruby", "tineke"},
+			"outp": "bar",
+		},
+		map[string]DiffKind{
+			"prop[0]": UR,
+			"prop[1]": U,
+		})
+}
+
 func TestSetUpdate(t *testing.T) {
 	diffTest(t,
 		map[string]*schema.Schema{


### PR DESCRIPTION
We got into this situation because the first item in the array is the one that is a `DELETE_REPLACE` gets overwritten when we cycle through the config diffs. I added a check that if the other diff (i.e. the state diff) is a `DELETE_REPLACE` then consider the current diff an `UPDATE_REPLACE` instead of `UPDATE`.

Fixes: https://github.com/pulumi/pulumi/issues/5637