### PR TITLE
Ensure that specific naming cases in the examples are picked up

### DIFF
--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -457,6 +457,11 @@ func (p *tfMarkdownParser) reformatExamples(sections [][]string) [][]string {
 				exampleUsageSection = append(exampleUsageSection, "", "### Additional Examples")
 				exampleUsageSection = append(exampleUsageSection, s[1:]...)
 			}
+		} else if strings.Contains(s[0], "## Example Usage -") {
+			// this is a specific usecase where all of the examples are being requalified as top level examples with a
+			// title. We should process these as children of the top level examples
+			exampleUsageSection = append(exampleUsageSection, "### "+strings.Title(matches[2]))
+			exampleUsageSection = append(exampleUsageSection, s[1:]...)
 		} else {
 			// This is a qualified example usage section. Retitle it using an H3 and its qualifier, and append it to
 			// the output.


### PR DESCRIPTION
Fixes: #https://github.com/pulumi/docs/issues/4507

The GCP docs now use the format

```
## Example Usage - Secret Config Basic
```

Our parser was ignoring that as it only checked for

## Example Usage or

### <Named>

We have now broken that title up to ensure they are actually picked
up as specific child named examples