### PR TITLE
Map the `google` TF provider to `google-beta`.

### DIFF
--- a/pkg/tf2pulumi/il/graph.go
+++ b/pkg/tf2pulumi/il/graph.go
@@ -607,10 +607,7 @@ func (b *builder) getProviderInfo(p *ProviderNode) (*tfbridge.ProviderInfo, stri
 	if err != nil {
 		return nil, "", err
 	}
-	packageName, ok := pluginNames[p.Name]
-	if !ok {
-		packageName = p.Name
-	}
+	packageName := GetPulumiProviderName(p.Name)
 	return info, packageName, nil
 }
 

--- a/pkg/tfgen/pluginHost.go
+++ b/pkg/tfgen/pluginHost.go
@@ -54,7 +54,7 @@ func (host *inmemoryProviderHost) Provider(pkg tokens.Package, version *semver.V
 func (host *inmemoryProviderHost) GetProviderInfo(
 	registryName, namespace, name, version string) (*tfbridge.ProviderInfo, error) {
 
-	if name == host.provider.info.Name {
+	if name == il.GetTerraformProviderName(host.provider.info) {
 		return &host.provider.info, nil
 	}
 	return host.ProviderInfoSource.GetProviderInfo(registryName, namespace, name, version)


### PR DESCRIPTION
This is necessary for the in-memory plugin info host to load the cached
info for the GCP provider.