### PR TITLE
Fix Set diffing to exclude items whose values are unchanged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Improve Set diffs to correctly identify replacements.
+  [#304](https://github.com/pulumi/pulumi-terraform-bridge/pull/304)
+
 - Deprecate UsesIOClasses bool.
   [#300](https://github.com/pulumi/pulumi-terraform-bridge/pull/300)
 

--- a/pkg/tfbridge/diff.go
+++ b/pkg/tfbridge/diff.go
@@ -52,14 +52,14 @@ func containsComputedValues(v resource.PropertyValue) bool {
 // the value.
 type propertyVisitor func(attributeKey, propertyPath string, value resource.PropertyValue) bool
 
-// visitPropertyDiff checks the given property for diffs and invokes the given callback if a diff is found.
+// visitPropertyValue checks the given property for diffs and invokes the given callback if a diff is found.
 //
 // This function contains the core logic used to convert a terraform.InstanceDiff to a list of Pulumi property paths
 // that have changed and the type of change for each path.
 //
 // If not for the presence of sets and the fact that they are mapped to Pulumi array properties, this process would be
 // rather straightforward: we could loop over each path in the instance diff, convert its path to a Pulumi property
-// path, and convert the diff kind to a Pulumi diff kind. Unforunately, the set mapping complicates this process, as
+// path, and convert the diff kind to a Pulumi diff kind. Unfortunately, the set mapping complicates this process, as
 // the array index that corresponds to a set element cannot be derived from the set element's path: part of the path of
 // a set element is the element's hash code, and we cannot derive the corresponding array element's index from this
 // hash code.
@@ -209,7 +209,7 @@ func makePropertyDiff(name, path string, v resource.PropertyValue, tfDiff shim.I
 					kind = pulumirpc.PropertyDiff_ADD
 				}
 			default:
-				if d.RequiresNew {
+				if d.RequiresNew || other.Kind == pulumirpc.PropertyDiff_DELETE_REPLACE {
 					kind = pulumirpc.PropertyDiff_UPDATE_REPLACE
 				} else {
 					kind = pulumirpc.PropertyDiff_UPDATE

--- a/pkg/tfbridge/diff.go
+++ b/pkg/tfbridge/diff.go
@@ -181,7 +181,7 @@ func makePropertyDiff(name, path string, v resource.PropertyValue, tfDiff shim.I
 				name += ".%"
 			}
 		}
-		if d := tfDiff.Attribute(name); d != nil {
+		if d := tfDiff.Attribute(name); d != nil && d.Old != d.New {
 			other, hasOtherDiff := diff[path]
 
 			// If we're finalizing the diff, we want to remove any ADD diffs that were only present in the state.

--- a/pkg/tfbridge/diff.go
+++ b/pkg/tfbridge/diff.go
@@ -194,28 +194,43 @@ func makePropertyDiff(name, path string, v resource.PropertyValue, tfDiff shim.I
 				return false
 			}
 
-			var kind pulumirpc.PropertyDiff_Kind
+			// Set the diff kind based on whether this is a replacement or not.
+			var newKind pulumirpc.PropertyDiff_Kind
 			switch {
 			case d.NewRemoved:
 				if d.RequiresNew {
-					kind = pulumirpc.PropertyDiff_DELETE_REPLACE
+					newKind = pulumirpc.PropertyDiff_DELETE_REPLACE
 				} else {
-					kind = pulumirpc.PropertyDiff_DELETE
+					newKind = pulumirpc.PropertyDiff_DELETE
 				}
 			case !hasOtherDiff:
 				if d.RequiresNew {
-					kind = pulumirpc.PropertyDiff_ADD_REPLACE
+					newKind = pulumirpc.PropertyDiff_ADD_REPLACE
 				} else {
-					kind = pulumirpc.PropertyDiff_ADD
+					newKind = pulumirpc.PropertyDiff_ADD
 				}
 			default:
-				if d.RequiresNew || other.Kind == pulumirpc.PropertyDiff_DELETE_REPLACE {
-					kind = pulumirpc.PropertyDiff_UPDATE_REPLACE
+				if d.RequiresNew {
+					newKind = pulumirpc.PropertyDiff_UPDATE_REPLACE
 				} else {
-					kind = pulumirpc.PropertyDiff_UPDATE
+					newKind = pulumirpc.PropertyDiff_UPDATE
 				}
 			}
-			diff[path] = &pulumirpc.PropertyDiff{Kind: kind}
+
+			// Ensure that the new diff kind isn't "weaker" than the existing one (i.e., the existing diff
+			// claims a replacement is needed, but the new one doesn't). This can happen for certain set operations
+			// because changes are represented using arrays and, though the paths will be the same, the name of the
+			// properties will include a hash and can have different values when elements are reordered within the set.
+			isReplacement := func(k pulumirpc.PropertyDiff_Kind) bool {
+				return k == pulumirpc.PropertyDiff_DELETE_REPLACE ||
+					k == pulumirpc.PropertyDiff_ADD_REPLACE ||
+					k == pulumirpc.PropertyDiff_UPDATE_REPLACE
+			}
+			if !isReplacement(newKind) && hasOtherDiff && isReplacement(other.Kind) {
+				newKind = other.Kind
+			}
+
+			diff[path] = &pulumirpc.PropertyDiff{Kind: newKind}
 		}
 		return false
 	}

--- a/pkg/tfbridge/diff.go
+++ b/pkg/tfbridge/diff.go
@@ -209,7 +209,7 @@ func makePropertyDiff(name, path string, v resource.PropertyValue, tfDiff shim.I
 					kind = pulumirpc.PropertyDiff_ADD
 				}
 			default:
-				if d.RequiresNew || other.Kind == pulumirpc.PropertyDiff_DELETE_REPLACE {
+				if d.RequiresNew {
 					kind = pulumirpc.PropertyDiff_UPDATE_REPLACE
 				} else {
 					kind = pulumirpc.PropertyDiff_UPDATE

--- a/pkg/tfbridge/diff_test.go
+++ b/pkg/tfbridge/diff_test.go
@@ -1336,7 +1336,6 @@ func TestCollectionsWithMultipleItems(t *testing.T) {
 			[]interface{}{"ruby", "tineke"},
 			map[string]DiffKind{
 				"prop[0]": DR,
-				"prop[1]": U,
 			},
 			map[string]DiffKind{
 				"prop[0]": UR,
@@ -1349,7 +1348,6 @@ func TestCollectionsWithMultipleItems(t *testing.T) {
 			[]interface{}{"burgundy", "ruby", "tineke"},
 			[]interface{}{"burgundy", "tineke"},
 			map[string]DiffKind{
-				"prop[0]": U,
 				"prop[1]": DR,
 			},
 			map[string]DiffKind{
@@ -1362,8 +1360,6 @@ func TestCollectionsWithMultipleItems(t *testing.T) {
 			[]interface{}{"burgundy", "ruby", "tineke"},
 			[]interface{}{"burgundy", "ruby"},
 			map[string]DiffKind{
-				"prop[0]": U,
-				"prop[1]": U,
 				"prop[2]": DR,
 			},
 			map[string]DiffKind{
@@ -1375,9 +1371,7 @@ func TestCollectionsWithMultipleItems(t *testing.T) {
 			[]interface{}{"ruby", "tineke"},
 			[]interface{}{"burgundy", "ruby", "tineke"},
 			map[string]DiffKind{
-				"prop[0]": UR,
-				"prop[1]": U,
-				"prop[2]": A,
+				"prop[0]": AR,
 			},
 			map[string]DiffKind{
 				"prop[0]": UR,
@@ -1390,9 +1384,7 @@ func TestCollectionsWithMultipleItems(t *testing.T) {
 			[]interface{}{"burgundy", "tineke"},
 			[]interface{}{"burgundy", "ruby", "tineke"},
 			map[string]DiffKind{
-				"prop[0]": U,
-				"prop[1]": UR,
-				"prop[2]": A,
+				"prop[1]": AR,
 			},
 			map[string]DiffKind{
 				"prop[1]": UR,
@@ -1404,8 +1396,6 @@ func TestCollectionsWithMultipleItems(t *testing.T) {
 			[]interface{}{"burgundy", "ruby"},
 			[]interface{}{"burgundy", "ruby", "tineke"},
 			map[string]DiffKind{
-				"prop[0]": U,
-				"prop[1]": U,
 				"prop[2]": AR,
 			},
 			map[string]DiffKind{
@@ -1418,8 +1408,6 @@ func TestCollectionsWithMultipleItems(t *testing.T) {
 			[]interface{}{"robusta", "ruby", "tineke"},
 			map[string]DiffKind{
 				"prop[0]": UR,
-				"prop[1]": U,
-				"prop[2]": U,
 			},
 			map[string]DiffKind{
 				"prop[0]": UR,
@@ -1430,9 +1418,7 @@ func TestCollectionsWithMultipleItems(t *testing.T) {
 			[]interface{}{"burgundy", "ruby", "tineke"},
 			[]interface{}{"burgundy", "robusta", "tineke"},
 			map[string]DiffKind{
-				"prop[0]": U,
 				"prop[1]": UR,
-				"prop[2]": U,
 			},
 			map[string]DiffKind{
 				"prop[1]": UR,
@@ -1443,8 +1429,6 @@ func TestCollectionsWithMultipleItems(t *testing.T) {
 			[]interface{}{"burgundy", "ruby", "tineke"},
 			[]interface{}{"burgundy", "ruby", "robusta"},
 			map[string]DiffKind{
-				"prop[0]": U,
-				"prop[1]": U,
 				"prop[2]": UR,
 			},
 			map[string]DiffKind{

--- a/pkg/tfbridge/diff_test.go
+++ b/pkg/tfbridge/diff_test.go
@@ -1335,11 +1335,8 @@ func TestCollectionsWithMultipleItems(t *testing.T) {
 			[]interface{}{"burgundy", "ruby", "tineke"},
 			[]interface{}{"ruby", "tineke"},
 			map[string]DiffKind{
-				"prop[0]": U,
+				"prop[0]": DR,
 				"prop[1]": U,
-				// This seems wrong.
-				// I would expect
-				// "prop[0]": DR
 			},
 			map[string]DiffKind{
 				"prop[0]": UR,
@@ -1353,10 +1350,7 @@ func TestCollectionsWithMultipleItems(t *testing.T) {
 			[]interface{}{"burgundy", "tineke"},
 			map[string]DiffKind{
 				"prop[0]": U,
-				"prop[1]": U,
-				// This seems wrong.
-				// I would expect
-				// "prop[1]": DR
+				"prop[1]": DR,
 			},
 			map[string]DiffKind{
 				"prop[1]": UR,
@@ -1371,9 +1365,6 @@ func TestCollectionsWithMultipleItems(t *testing.T) {
 				"prop[0]": U,
 				"prop[1]": U,
 				"prop[2]": DR,
-				// This seems wrong, the first two are not updated, there is no diff.
-				// I would expect it to match List, i.e.
-				// "prop[2]": DR,
 			},
 			map[string]DiffKind{
 				"prop[2]": DR,
@@ -1387,10 +1378,6 @@ func TestCollectionsWithMultipleItems(t *testing.T) {
 				"prop[0]": UR,
 				"prop[1]": U,
 				"prop[2]": A,
-				// This seems wrong. I would expect:
-				// "prop[0]": AR,
-				// "prop[1]": UR,
-				// "prop[2]": AR,
 			},
 			map[string]DiffKind{
 				"prop[0]": UR,
@@ -1406,9 +1393,6 @@ func TestCollectionsWithMultipleItems(t *testing.T) {
 				"prop[0]": U,
 				"prop[1]": UR,
 				"prop[2]": A,
-				// This seems wrong.  I would expect:
-				// "prop[1]": UR,
-				// "prop[2]": AR,
 			},
 			map[string]DiffKind{
 				"prop[1]": UR,
@@ -1423,9 +1407,6 @@ func TestCollectionsWithMultipleItems(t *testing.T) {
 				"prop[0]": U,
 				"prop[1]": U,
 				"prop[2]": AR,
-				// This seems wrong, the first two are not updated, there is no diff.
-				// I would expect it to match List, i.e.
-				// "prop[2]": AR,
 			},
 			map[string]DiffKind{
 				"prop[2]": AR,
@@ -1439,9 +1420,6 @@ func TestCollectionsWithMultipleItems(t *testing.T) {
 				"prop[0]": UR,
 				"prop[1]": U,
 				"prop[2]": U,
-				// This seems wrong.
-				// I would expect it to match List, i.e.
-				// "prop[0]": UR,
 			},
 			map[string]DiffKind{
 				"prop[0]": UR,
@@ -1455,9 +1433,6 @@ func TestCollectionsWithMultipleItems(t *testing.T) {
 				"prop[0]": U,
 				"prop[1]": UR,
 				"prop[2]": U,
-				// This seems wrong.
-				// I would expect it to match List, i.e.
-				// "prop[1]": UR,
 			},
 			map[string]DiffKind{
 				"prop[1]": UR,
@@ -1471,9 +1446,6 @@ func TestCollectionsWithMultipleItems(t *testing.T) {
 				"prop[0]": U,
 				"prop[1]": U,
 				"prop[2]": UR,
-				// This seems wrong.
-				// I would expect it to match List, i.e.
-				// "prop[2]": UR,
 			},
 			map[string]DiffKind{
 				"prop[2]": UR,

--- a/pkg/tfbridge/diff_test.go
+++ b/pkg/tfbridge/diff_test.go
@@ -1453,6 +1453,7 @@ func TestCollectionsWithMultipleItems(t *testing.T) {
 		},
 	}
 
+	// nolint:lll
 	runTestCase := func(t *testing.T, name string, typ schema.ValueType, inputs, state []interface{}, expected map[string]DiffKind) {
 		t.Run(name, func(t *testing.T) {
 			diffTest(t,

--- a/pkg/tfbridge/diff_test.go
+++ b/pkg/tfbridge/diff_test.go
@@ -673,6 +673,30 @@ func TestSetDeleteReplace(t *testing.T) {
 		})
 }
 
+func TestSetDeleteReplaceMultipleItems(t *testing.T) {
+	diffTest(t,
+		map[string]*schema.Schema{
+			"prop": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				ForceNew: true,
+			},
+			"outp": {Type: schema.TypeString, Computed: true},
+		},
+		map[string]*SchemaInfo{},
+		map[string]interface{}{
+			"prop": []interface{}{"ruby", "tineke"},
+		},
+		map[string]interface{}{
+			"prop": []interface{}{"burgundy", "ruby", "tineke"},
+			"outp": "bar",
+		},
+		map[string]DiffKind{
+			"prop[0]": UR,
+			"prop[1]": U,
+		})
+}
+
 func TestSetUpdate(t *testing.T) {
 	diffTest(t,
 		map[string]*schema.Schema{


### PR DESCRIPTION
`tfDiff` includes each item of the set, even when that specific item hasn't changed (i.e. d.Old == d.New). So if we just check for and exclude those cases, we get the results we expect.

Fixes: #296