### PR TITLE
Propagate better errors from Check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Improve `Check` error messages.
+  [#310](https://github.com/pulumi/pulumi-terraform-bridge/pull/310)
+
 - Ensure that nested unknowns are preserved during previews of `Create` and `Update` operations.
   [#308](https://github.com/pulumi/pulumi-terraform-bridge/pull/308)
 

--- a/internal/testprovider/schema.go
+++ b/internal/testprovider/schema.go
@@ -77,16 +77,6 @@ func ProviderV1() *schemav1.Provider {
 						ForceNew: true,
 					},
 					"string_with_bad_interpolation": {Type: schemav1.TypeString, Optional: true},
-					"conflicting_property": {
-						Type:          schemav1.TypeString,
-						Optional:      true,
-						ConflictsWith: []string{"conflicting_property2"},
-					},
-					"conflicting_property2": {
-						Type:          schemav1.TypeString,
-						Optional:      true,
-						ConflictsWith: []string{"conflicting_property"},
-					},
 				},
 				SchemaVersion: 1,
 				MigrateState: func(v int, is *terraformv1.InstanceState, p interface{}) (*terraformv1.InstanceState, error) {
@@ -204,6 +194,16 @@ func ProviderV1() *schemav1.Provider {
 						ForceNew: true,
 					},
 					"string_with_bad_interpolation": {Type: schemav1.TypeString, Optional: true},
+					"conflicting_property": {
+						Type:          schemav1.TypeString,
+						Optional:      true,
+						ConflictsWith: []string{"conflicting_property2"},
+					},
+					"conflicting_property2": {
+						Type:          schemav1.TypeString,
+						Optional:      true,
+						ConflictsWith: []string{"conflicting_property"},
+					},
 				},
 				SchemaVersion: 1,
 				MigrateState: func(v int, is *terraformv1.InstanceState, p interface{}) (*terraformv1.InstanceState, error) {
@@ -392,16 +392,6 @@ func ProviderV2() *schemav2.Provider {
 						ForceNew: true,
 					},
 					"string_with_bad_interpolation": {Type: schemav2.TypeString, Optional: true},
-					"conflicting_property": {
-						Type:          schemav2.TypeString,
-						Optional:      true,
-						ConflictsWith: []string{"conflicting_property2"},
-					},
-					"conflicting_property2": {
-						Type:          schemav2.TypeString,
-						Optional:      true,
-						ConflictsWith: []string{"conflicting_property"},
-					},
 				},
 				SchemaVersion: 1,
 				MigrateState: func(v int, is *terraformv2.InstanceState, p interface{}) (*terraformv2.InstanceState, error) {
@@ -521,6 +511,16 @@ func ProviderV2() *schemav2.Provider {
 						ForceNew: true,
 					},
 					"string_with_bad_interpolation": {Type: schemav2.TypeString, Optional: true},
+					"conflicting_property": {
+						Type:          schemav2.TypeString,
+						Optional:      true,
+						ConflictsWith: []string{"conflicting_property2"},
+					},
+					"conflicting_property2": {
+						Type:          schemav2.TypeString,
+						Optional:      true,
+						ConflictsWith: []string{"conflicting_property"},
+					},
 				},
 				SchemaVersion: 1,
 				MigrateState: func(v int, is *terraformv2.InstanceState, p interface{}) (*terraformv2.InstanceState, error) {

--- a/internal/testprovider/schema.go
+++ b/internal/testprovider/schema.go
@@ -77,6 +77,16 @@ func ProviderV1() *schemav1.Provider {
 						ForceNew: true,
 					},
 					"string_with_bad_interpolation": {Type: schemav1.TypeString, Optional: true},
+					"conflicting_property": {
+						Type:          schemav1.TypeString,
+						Optional:      true,
+						ConflictsWith: []string{"conflicting_property2"},
+					},
+					"conflicting_property2": {
+						Type:          schemav1.TypeString,
+						Optional:      true,
+						ConflictsWith: []string{"conflicting_property"},
+					},
 				},
 				SchemaVersion: 1,
 				MigrateState: func(v int, is *terraformv1.InstanceState, p interface{}) (*terraformv1.InstanceState, error) {
@@ -382,6 +392,16 @@ func ProviderV2() *schemav2.Provider {
 						ForceNew: true,
 					},
 					"string_with_bad_interpolation": {Type: schemav2.TypeString, Optional: true},
+					"conflicting_property": {
+						Type:          schemav2.TypeString,
+						Optional:      true,
+						ConflictsWith: []string{"conflicting_property2"},
+					},
+					"conflicting_property2": {
+						Type:          schemav2.TypeString,
+						Optional:      true,
+						ConflictsWith: []string{"conflicting_property"},
+					},
 				},
 				SchemaVersion: 1,
 				MigrateState: func(v int, is *terraformv2.InstanceState, p interface{}) (*terraformv2.InstanceState, error) {

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -2,6 +2,7 @@ package tfbridge
 
 import (
 	"context"
+	"sort"
 	"testing"
 
 	"github.com/pulumi/pulumi/sdk/v2/go/common/resource"
@@ -304,6 +305,33 @@ func testProviderPreview(t *testing.T, provider *Provider) {
 	}).DeepEquals(outs["nestedResources"]))
 }
 
+func testCheckFailures(t *testing.T, provider *Provider) []*pulumirpc.CheckFailure {
+	urn := resource.NewURN("stack", "project", "", "ExampleResource", "name")
+	unknown := resource.MakeComputed(resource.NewStringProperty(""))
+
+	pulumiIns, err := plugin.MarshalProperties(resource.PropertyMap{
+		"stringPropertyValue": resource.NewStringProperty("foo"),
+		"setPropertyValues":   resource.NewArrayProperty([]resource.PropertyValue{resource.NewStringProperty("foo")}),
+		"nestedResources": resource.NewObjectProperty(resource.PropertyMap{
+			"kind": unknown,
+			"configuration": resource.NewObjectProperty(resource.PropertyMap{
+				"name": resource.NewStringProperty("foo"),
+			}),
+		}),
+		"conflictingProperty":  resource.NewStringProperty("foo"),
+		"conflictingProperty2": resource.NewStringProperty("foo"),
+	}, plugin.MarshalOptions{KeepUnknowns: true})
+	assert.NoError(t, err)
+	checkResp, err := provider.Check(context.Background(), &pulumirpc.CheckRequest{
+		Urn:  string(urn),
+		News: pulumiIns,
+	})
+	assert.NoError(t, err)
+	assert.Len(t, checkResp.Failures, 3)
+	return checkResp.Failures
+
+}
+
 func TestProviderPreview(t *testing.T) {
 	provider := &Provider{
 		tf:     shimv1.NewProvider(testTFProvider),
@@ -316,7 +344,17 @@ func TestProviderPreview(t *testing.T) {
 			Schema: &ResourceInfo{Tok: "ExampleResource"},
 		},
 	}
+
 	testProviderPreview(t, provider)
+
+	failures := testCheckFailures(t, provider)
+	sort.SliceStable(failures, func(i, j int) bool { return failures[i].Reason < failures[j].Reason })
+	assert.Equal(t, "\"conflicting_property\": conflicts with conflicting_property2", failures[0].Reason)
+	assert.Equal(t, "", failures[0].Property)
+	assert.Equal(t, "\"conflicting_property2\": conflicts with conflicting_property", failures[1].Reason)
+	assert.Equal(t, "", failures[1].Property)
+	assert.Equal(t, "Missing required property 'arrayPropertyValues'", failures[2].Reason)
+	assert.Equal(t, "", failures[2].Property)
 }
 
 func TestProviderPreviewV2(t *testing.T) {
@@ -331,5 +369,15 @@ func TestProviderPreviewV2(t *testing.T) {
 			Schema: &ResourceInfo{Tok: "ExampleResource"},
 		},
 	}
+
 	testProviderPreview(t, provider)
+
+	failures := testCheckFailures(t, provider)
+	sort.SliceStable(failures, func(i, j int) bool { return failures[i].Reason < failures[j].Reason })
+	assert.Equal(t, "ConflictsWith: \"conflicting_property\": conflicts with conflicting_property2", failures[0].Reason)
+	assert.Equal(t, "", failures[0].Property)
+	assert.Equal(t, "ConflictsWith: \"conflicting_property2\": conflicts with conflicting_property", failures[1].Reason)
+	assert.Equal(t, "", failures[1].Property)
+	assert.Equal(t, "Required attribute is not set", failures[2].Reason)
+	assert.Equal(t, "", failures[2].Property)
 }

--- a/pkg/tfshim/sdk-v2/diagnostics.go
+++ b/pkg/tfshim/sdk-v2/diagnostics.go
@@ -13,7 +13,11 @@ func warningsAndErrors(diags diag.Diagnostics) ([]string, []error) {
 	for _, d := range diags {
 		switch d.Severity {
 		case diag.Error:
-			errors = append(errors, fmt.Errorf("%s", d.Summary))
+			if d.Detail != "" {
+				errors = append(errors, fmt.Errorf("%s: %s", d.Summary, d.Detail))
+			} else {
+				errors = append(errors, fmt.Errorf("%s", d.Summary))
+			}
 		case diag.Warning:
 			warnings = append(warnings, d.Summary)
 		}
@@ -25,7 +29,11 @@ func errors(diags diag.Diagnostics) error {
 	var err error
 	for _, d := range diags {
 		if d.Severity == diag.Error {
-			err = multierror.Append(err, fmt.Errorf("%s", d.Summary))
+			if d.Detail != "" {
+				err = multierror.Append(err, fmt.Errorf("%s: %s", d.Summary, d.Detail))
+			} else {
+				err = multierror.Append(err, fmt.Errorf("%s", d.Summary))
+			}
 		}
 	}
 	return err

--- a/pkg/tfshim/tfplugin5/diagnostics.go
+++ b/pkg/tfshim/tfplugin5/diagnostics.go
@@ -16,7 +16,11 @@ func unmarshalWarningsAndErrors(diags []*proto.Diagnostic) ([]string, []error) {
 	for _, d := range diags {
 		switch d.Severity {
 		case proto.Diagnostic_ERROR:
-			errors = append(errors, fmt.Errorf("%s", d.Summary))
+			if d.Detail != "" {
+				errors = append(errors, fmt.Errorf("%s: %s", d.Summary, d.Detail))
+			} else {
+				errors = append(errors, fmt.Errorf("%s", d.Summary))
+			}
 		case proto.Diagnostic_WARNING:
 			warnings = append(warnings, d.Summary)
 		}
@@ -30,7 +34,11 @@ func unmarshalErrors(diags []*proto.Diagnostic) error {
 	var err error
 	for _, d := range diags {
 		if d.Severity == proto.Diagnostic_ERROR {
-			err = multierror.Append(err, fmt.Errorf("%s", d.Summary))
+			if d.Detail != "" {
+				err = multierror.Append(err, fmt.Errorf("%s: %s", d.Summary, d.Detail))
+			} else {
+				err = multierror.Append(err, fmt.Errorf("%s", d.Summary))
+			}
 		}
 	}
 	return err

--- a/pkg/tfshim/tfplugin5/provider_test.go
+++ b/pkg/tfshim/tfplugin5/provider_test.go
@@ -375,6 +375,8 @@ func TestProviderResourcesMap(t *testing.T) {
 				})),
 				"set_property_value":            cty.Set(cty.String),
 				"string_with_bad_interpolation": cty.String,
+				"conflicting_property":          cty.String,
+				"conflicting_property2":         cty.String,
 			}),
 			schema: schema.SchemaMap{
 				"id": &attributeSchema{
@@ -489,6 +491,16 @@ func TestProviderResourcesMap(t *testing.T) {
 					optional: true,
 				},
 				"string_with_bad_interpolation": &attributeSchema{
+					ctyType:   cty.String,
+					valueType: shim.TypeString,
+					optional:  true,
+				},
+				"conflicting_property": &attributeSchema{
+					ctyType:   cty.String,
+					valueType: shim.TypeString,
+					optional:  true,
+				},
+				"conflicting_property2": &attributeSchema{
 					ctyType:   cty.String,
 					valueType: shim.TypeString,
 					optional:  true,


### PR DESCRIPTION
In the `sdk-v2` and `tfplugin5` shim implementations, ensure that we bubble up a more complete error message from the underlying Terraform provider.

Also add test coverage for Check errors.

Fixes #309.