### PR TITLE
Process ignoreChanges before asserting diff does not cause deletion or replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Fixes a panic caused by ignoreChanges not being processed before the assertion leading to the panic.
+  [#317](https://github.com/pulumi/pulumi-terraform-bridge/pull/317)
+
 - Add "Unlicensed" license type.
   [#312](https://github.com/pulumi/pulumi-terraform-bridge/pull/312)
 

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -962,10 +962,13 @@ func (p *Provider) Update(ctx context.Context, req *pulumirpc.UpdateRequest) (*p
 		// moment.
 		return &pulumirpc.UpdateResponse{Properties: req.GetOlds()}, nil
 	}
+
+	// Apply any ignoreChanges before we check that the diff doesn't require replacement or deletion since we may be
+	// ignoring changes to the keys that would result in replacement/deletion.
+	doIgnoreChanges(res.TF.Schema(), res.Schema.Fields, olds, news, req.GetIgnoreChanges(), diff)
+
 	contract.Assertf(!diff.Destroy() && !diff.RequiresNew(),
 		"Expected diff to not require deletion or replacement during Update of %s", urn)
-
-	doIgnoreChanges(res.TF.Schema(), res.Schema.Fields, olds, news, req.GetIgnoreChanges(), diff)
 
 	if req.Timeout != 0 {
 		diff.SetTimeout(req.Timeout, shim.TimeoutUpdate)


### PR DESCRIPTION
Fixes a panic caused by ignoreChanges not being processed before the assertion leading to the panic.

The codegen test failures are unrelated to this PR.

Fixes: https://github.com/pulumi/pulumi-aws/issues/1276