### PR TITLE
Correctly handle replacements for sets and lists with nested elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Fixes a panic caused by improper diffing of lists and sets with nested object elements.
+  [#319](https://github.com/pulumi/pulumi-terraform-bridge/pull/319)
+
 - Add go package info options to schema
   [#321](https://github.com/pulumi/pulumi-terraform-bridge/pull/321)
 

--- a/pkg/tfbridge/diff.go
+++ b/pkg/tfbridge/diff.go
@@ -157,7 +157,8 @@ func makePropertyDiff(name, path string, v resource.PropertyValue, tfDiff shim.I
 		case v.IsArray():
 			// If this value has a diff and is considered computed by Terraform, the diff will be woefully incomplete. In
 			// this case, do not recurse into the array; instead, just use the count diff for the details.
-			if d := tfDiff.Attribute(name + ".#"); d == nil {
+			d := tfDiff.Attribute(name + ".#")
+			if d == nil {
 				return true
 			}
 			name += ".#"
@@ -165,7 +166,8 @@ func makePropertyDiff(name, path string, v resource.PropertyValue, tfDiff shim.I
 		case v.IsObject():
 			// If this value has a diff and is considered computed by Terraform, the diff will be woefully incomplete. In
 			// this case, do not recurse into the array; instead, just use the count diff for the details.
-			if d := tfDiff.Attribute(name + ".%"); d == nil {
+			d := tfDiff.Attribute(name + ".%")
+			if d == nil {
 				return true
 			}
 			name += ".%"

--- a/pkg/tfbridge/diff_test.go
+++ b/pkg/tfbridge/diff_test.go
@@ -219,6 +219,7 @@ func TestNestedAdd(t *testing.T) {
 			"outp": "bar",
 		},
 		map[string]DiffKind{
+			"prop":      A,
 			"prop.nest": A,
 		})
 }
@@ -237,6 +238,7 @@ func TestNestedAddReplace(t *testing.T) {
 			"outp": "bar",
 		},
 		map[string]DiffKind{
+			"prop":      AR,
 			"prop.nest": AR,
 		})
 }
@@ -345,6 +347,7 @@ func TestListAdd(t *testing.T) {
 			"outp": "bar",
 		},
 		map[string]DiffKind{
+			"prop":    A,
 			"prop[0]": A,
 		})
 }
@@ -363,6 +366,7 @@ func TestListAddReplace(t *testing.T) {
 			"outp": "bar",
 		},
 		map[string]DiffKind{
+			"prop":    AR,
 			"prop[0]": AR,
 		})
 }
@@ -380,6 +384,7 @@ func TestListDelete(t *testing.T) {
 			"outp": "bar",
 		},
 		map[string]DiffKind{
+			"prop":    D,
 			"prop[0]": D,
 		})
 }
@@ -397,6 +402,7 @@ func TestListDeleteReplace(t *testing.T) {
 			"outp": "bar",
 		},
 		map[string]DiffKind{
+			"prop":    DR,
 			"prop[0]": DR,
 		})
 }
@@ -603,6 +609,7 @@ func TestSetAdd(t *testing.T) {
 			"outp": "bar",
 		},
 		map[string]DiffKind{
+			"prop":    A,
 			"prop[0]": A,
 		})
 }
@@ -626,6 +633,7 @@ func TestSetAddReplace(t *testing.T) {
 			"outp": "bar",
 		},
 		map[string]DiffKind{
+			"prop":    AR,
 			"prop[0]": AR,
 		})
 }
@@ -647,6 +655,7 @@ func TestSetDelete(t *testing.T) {
 			"outp": "bar",
 		},
 		map[string]DiffKind{
+			"prop":    D,
 			"prop[0]": D,
 		})
 }
@@ -669,6 +678,7 @@ func TestSetDeleteReplace(t *testing.T) {
 			"outp": "bar",
 		},
 		map[string]DiffKind{
+			"prop":    DR,
 			"prop[0]": DR,
 		})
 }
@@ -1335,9 +1345,11 @@ func TestCollectionsWithMultipleItems(t *testing.T) {
 			[]interface{}{"burgundy", "ruby", "tineke"},
 			[]interface{}{"ruby", "tineke"},
 			map[string]DiffKind{
+				"prop":    UR,
 				"prop[0]": DR,
 			},
 			map[string]DiffKind{
+				"prop":    UR,
 				"prop[0]": UR,
 				"prop[1]": UR,
 				"prop[2]": DR,
@@ -1348,9 +1360,11 @@ func TestCollectionsWithMultipleItems(t *testing.T) {
 			[]interface{}{"burgundy", "ruby", "tineke"},
 			[]interface{}{"burgundy", "tineke"},
 			map[string]DiffKind{
+				"prop":    UR,
 				"prop[1]": DR,
 			},
 			map[string]DiffKind{
+				"prop":    UR,
 				"prop[1]": UR,
 				"prop[2]": DR,
 			},
@@ -1360,9 +1374,11 @@ func TestCollectionsWithMultipleItems(t *testing.T) {
 			[]interface{}{"burgundy", "ruby", "tineke"},
 			[]interface{}{"burgundy", "ruby"},
 			map[string]DiffKind{
+				"prop":    UR,
 				"prop[2]": DR,
 			},
 			map[string]DiffKind{
+				"prop":    UR,
 				"prop[2]": DR,
 			},
 		},
@@ -1371,9 +1387,11 @@ func TestCollectionsWithMultipleItems(t *testing.T) {
 			[]interface{}{"ruby", "tineke"},
 			[]interface{}{"burgundy", "ruby", "tineke"},
 			map[string]DiffKind{
+				"prop":    UR,
 				"prop[0]": AR,
 			},
 			map[string]DiffKind{
+				"prop":    UR,
 				"prop[0]": UR,
 				"prop[1]": UR,
 				"prop[2]": AR,
@@ -1384,9 +1402,11 @@ func TestCollectionsWithMultipleItems(t *testing.T) {
 			[]interface{}{"burgundy", "tineke"},
 			[]interface{}{"burgundy", "ruby", "tineke"},
 			map[string]DiffKind{
+				"prop":    UR,
 				"prop[1]": AR,
 			},
 			map[string]DiffKind{
+				"prop":    UR,
 				"prop[1]": UR,
 				"prop[2]": AR,
 			},
@@ -1396,9 +1416,11 @@ func TestCollectionsWithMultipleItems(t *testing.T) {
 			[]interface{}{"burgundy", "ruby"},
 			[]interface{}{"burgundy", "ruby", "tineke"},
 			map[string]DiffKind{
+				"prop":    UR,
 				"prop[2]": AR,
 			},
 			map[string]DiffKind{
+				"prop":    UR,
 				"prop[2]": AR,
 			},
 		},

--- a/pkg/tfbridge/diff_test.go
+++ b/pkg/tfbridge/diff_test.go
@@ -1474,3 +1474,161 @@ func TestCollectionsWithMultipleItems(t *testing.T) {
 		}
 	})
 }
+
+func TestSetNestedAddReplace(t *testing.T) {
+	diffTest(t,
+		map[string]*schema.Schema{
+			"prop": {
+				Type: schema.TypeSet,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"nest": {Type: schema.TypeString, Required: true},
+					},
+				},
+				ForceNew: true,
+			},
+			"outp": {Type: schema.TypeString, Computed: true},
+		},
+		map[string]*SchemaInfo{},
+		map[string]interface{}{
+			"prop": []interface{}{map[string]interface{}{"nest": "baz"}},
+		},
+		map[string]interface{}{
+			"prop": nil,
+			"outp": "bar",
+		},
+		map[string]DiffKind{
+			// "prop[0]": AR or "prop[0].nest": AR?
+			// Currently, this results in "prop[0].nest": A
+		})
+}
+
+func TestListNestedAddReplace(t *testing.T) {
+	diffTest(t,
+		// tfSchema
+		map[string]*schema.Schema{
+			"prop": {
+				Type: schema.TypeList,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"nest": {Type: schema.TypeString, Required: true},
+					},
+				},
+				ForceNew: true,
+			},
+			"outp": {Type: schema.TypeString, Computed: true},
+		},
+		// info
+		map[string]*SchemaInfo{},
+		// inputs
+		map[string]interface{}{
+			"prop": []interface{}{map[string]interface{}{"nest": "foo"}},
+		},
+		// state
+		map[string]interface{}{
+			"prop": nil,
+			"outp": "bar",
+		},
+		// expected
+		map[string]DiffKind{
+			// "prop[0]": AR or "prop[0].nest": AR?
+			// Currently, this results in "prop[0].nest": A
+		})
+}
+
+func TestListNestedUpdate(t *testing.T) {
+	diffTest(t,
+		// tfSchema
+		map[string]*schema.Schema{
+			"prop": {
+				Type: schema.TypeList,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"nest": {Type: schema.TypeString, Required: true},
+					},
+				},
+				ForceNew: true,
+			},
+			"outp": {Type: schema.TypeString, Computed: true},
+		},
+		// info
+		map[string]*SchemaInfo{},
+		// inputs
+		map[string]interface{}{
+			"prop": []interface{}{map[string]interface{}{"nest": "foo"}},
+		},
+		// state
+		map[string]interface{}{
+			"prop": []interface{}{map[string]interface{}{"nest": "bar"}},
+			"outp": "bar",
+		},
+		// expected
+		map[string]DiffKind{
+			"prop[0].nest": U,
+		})
+}
+
+func TestListNestedDeleteReplace(t *testing.T) {
+	diffTest(t,
+		// tfSchema
+		map[string]*schema.Schema{
+			"prop": {
+				Type: schema.TypeList,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"nest": {Type: schema.TypeString, Required: true},
+					},
+				},
+				ForceNew: true,
+			},
+			"outp": {Type: schema.TypeString, Computed: true},
+		},
+		// info
+		map[string]*SchemaInfo{},
+		// inputs
+		map[string]interface{}{},
+		// state
+		map[string]interface{}{
+			"prop": []interface{}{map[string]interface{}{"nest": "bar"}},
+			"outp": "bar",
+		},
+		// expected
+		map[string]DiffKind{
+			// "prop[0]": DR or "prop[0].nest": DR?
+			// Currently, this results in `"prop[0].nest": D`
+		})
+}
+
+func TestListNestedAddMaxItemsOne(t *testing.T) {
+	diffTest(t,
+		// tfSchema
+		map[string]*schema.Schema{
+			"prop": {
+				Type: schema.TypeList,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"nest": {Type: schema.TypeString, Required: true},
+					},
+				},
+				MaxItems: 1,
+				ForceNew: true,
+			},
+			"outp": {Type: schema.TypeString, Computed: true},
+		},
+		// info
+		map[string]*SchemaInfo{},
+		// inputs
+		map[string]interface{}{
+			"prop": map[string]interface{}{"nest": "foo"},
+		},
+		// state
+		map[string]interface{}{
+			"prop": nil,
+			"outp": "bar",
+		},
+		// expected
+		map[string]DiffKind{
+			// "prop": AR or "prop.nest": AR?
+			// The actual result we are getting right now is `"prop.nest": A`
+		})
+}

--- a/pkg/tfbridge/diff_test.go
+++ b/pkg/tfbridge/diff_test.go
@@ -1599,6 +1599,37 @@ func TestListNestedDeleteReplace(t *testing.T) {
 		})
 }
 
+func TestSetNestedDeleteReplace(t *testing.T) {
+	diffTest(t,
+		// tfSchema
+		map[string]*schema.Schema{
+			"prop": {
+				Type: schema.TypeSet,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"nest": {Type: schema.TypeString, Required: true},
+					},
+				},
+				ForceNew: true,
+			},
+			"outp": {Type: schema.TypeString, Computed: true},
+		},
+		// info
+		map[string]*SchemaInfo{},
+		// inputs
+		map[string]interface{}{},
+		// state
+		map[string]interface{}{
+			"prop": []interface{}{map[string]interface{}{"nest": "bar"}},
+			"outp": "bar",
+		},
+		// expected
+		map[string]DiffKind{
+			"prop":         DR,
+			"prop[0].nest": D,
+		})
+}
+
 func TestListNestedAddMaxItemsOne(t *testing.T) {
 	diffTest(t,
 		// tfSchema

--- a/pkg/tfbridge/diff_test.go
+++ b/pkg/tfbridge/diff_test.go
@@ -1498,8 +1498,8 @@ func TestSetNestedAddReplace(t *testing.T) {
 			"outp": "bar",
 		},
 		map[string]DiffKind{
-			// "prop[0]": AR or "prop[0].nest": AR?
-			// Currently, this results in "prop[0].nest": A
+			"prop":         AR,
+			"prop[0].nest": A,
 		})
 }
 
@@ -1531,8 +1531,8 @@ func TestListNestedAddReplace(t *testing.T) {
 		},
 		// expected
 		map[string]DiffKind{
-			// "prop[0]": AR or "prop[0].nest": AR?
-			// Currently, this results in "prop[0].nest": A
+			"prop":         AR,
+			"prop[0].nest": A,
 		})
 }
 
@@ -1594,8 +1594,8 @@ func TestListNestedDeleteReplace(t *testing.T) {
 		},
 		// expected
 		map[string]DiffKind{
-			// "prop[0]": DR or "prop[0].nest": DR?
-			// Currently, this results in `"prop[0].nest": D`
+			"prop":         DR,
+			"prop[0].nest": D,
 		})
 }
 
@@ -1623,12 +1623,11 @@ func TestListNestedAddMaxItemsOne(t *testing.T) {
 		},
 		// state
 		map[string]interface{}{
-			"prop": nil,
 			"outp": "bar",
 		},
 		// expected
 		map[string]DiffKind{
-			// "prop": AR or "prop.nest": AR?
-			// The actual result we are getting right now is `"prop.nest": A`
+			"prop":      AR,
+			"prop.nest": A,
 		})
 }

--- a/pkg/tfbridge/diff_test.go
+++ b/pkg/tfbridge/diff_test.go
@@ -219,7 +219,6 @@ func TestNestedAdd(t *testing.T) {
 			"outp": "bar",
 		},
 		map[string]DiffKind{
-			"prop":      A,
 			"prop.nest": A,
 		})
 }
@@ -238,7 +237,6 @@ func TestNestedAddReplace(t *testing.T) {
 			"outp": "bar",
 		},
 		map[string]DiffKind{
-			"prop":      AR,
 			"prop.nest": AR,
 		})
 }
@@ -347,7 +345,6 @@ func TestListAdd(t *testing.T) {
 			"outp": "bar",
 		},
 		map[string]DiffKind{
-			"prop":    A,
 			"prop[0]": A,
 		})
 }
@@ -366,7 +363,6 @@ func TestListAddReplace(t *testing.T) {
 			"outp": "bar",
 		},
 		map[string]DiffKind{
-			"prop":    AR,
 			"prop[0]": AR,
 		})
 }
@@ -384,7 +380,6 @@ func TestListDelete(t *testing.T) {
 			"outp": "bar",
 		},
 		map[string]DiffKind{
-			"prop":    D,
 			"prop[0]": D,
 		})
 }
@@ -402,7 +397,6 @@ func TestListDeleteReplace(t *testing.T) {
 			"outp": "bar",
 		},
 		map[string]DiffKind{
-			"prop":    DR,
 			"prop[0]": DR,
 		})
 }
@@ -609,7 +603,6 @@ func TestSetAdd(t *testing.T) {
 			"outp": "bar",
 		},
 		map[string]DiffKind{
-			"prop":    A,
 			"prop[0]": A,
 		})
 }
@@ -633,7 +626,6 @@ func TestSetAddReplace(t *testing.T) {
 			"outp": "bar",
 		},
 		map[string]DiffKind{
-			"prop":    AR,
 			"prop[0]": AR,
 		})
 }
@@ -655,7 +647,6 @@ func TestSetDelete(t *testing.T) {
 			"outp": "bar",
 		},
 		map[string]DiffKind{
-			"prop":    D,
 			"prop[0]": D,
 		})
 }
@@ -678,7 +669,6 @@ func TestSetDeleteReplace(t *testing.T) {
 			"outp": "bar",
 		},
 		map[string]DiffKind{
-			"prop":    DR,
 			"prop[0]": DR,
 		})
 }
@@ -1345,11 +1335,9 @@ func TestCollectionsWithMultipleItems(t *testing.T) {
 			[]interface{}{"burgundy", "ruby", "tineke"},
 			[]interface{}{"ruby", "tineke"},
 			map[string]DiffKind{
-				"prop":    UR,
 				"prop[0]": DR,
 			},
 			map[string]DiffKind{
-				"prop":    UR,
 				"prop[0]": UR,
 				"prop[1]": UR,
 				"prop[2]": DR,
@@ -1360,11 +1348,9 @@ func TestCollectionsWithMultipleItems(t *testing.T) {
 			[]interface{}{"burgundy", "ruby", "tineke"},
 			[]interface{}{"burgundy", "tineke"},
 			map[string]DiffKind{
-				"prop":    UR,
 				"prop[1]": DR,
 			},
 			map[string]DiffKind{
-				"prop":    UR,
 				"prop[1]": UR,
 				"prop[2]": DR,
 			},
@@ -1374,11 +1360,9 @@ func TestCollectionsWithMultipleItems(t *testing.T) {
 			[]interface{}{"burgundy", "ruby", "tineke"},
 			[]interface{}{"burgundy", "ruby"},
 			map[string]DiffKind{
-				"prop":    UR,
 				"prop[2]": DR,
 			},
 			map[string]DiffKind{
-				"prop":    UR,
 				"prop[2]": DR,
 			},
 		},
@@ -1387,11 +1371,9 @@ func TestCollectionsWithMultipleItems(t *testing.T) {
 			[]interface{}{"ruby", "tineke"},
 			[]interface{}{"burgundy", "ruby", "tineke"},
 			map[string]DiffKind{
-				"prop":    UR,
 				"prop[0]": AR,
 			},
 			map[string]DiffKind{
-				"prop":    UR,
 				"prop[0]": UR,
 				"prop[1]": UR,
 				"prop[2]": AR,
@@ -1402,11 +1384,9 @@ func TestCollectionsWithMultipleItems(t *testing.T) {
 			[]interface{}{"burgundy", "tineke"},
 			[]interface{}{"burgundy", "ruby", "tineke"},
 			map[string]DiffKind{
-				"prop":    UR,
 				"prop[1]": AR,
 			},
 			map[string]DiffKind{
-				"prop":    UR,
 				"prop[1]": UR,
 				"prop[2]": AR,
 			},
@@ -1416,11 +1396,9 @@ func TestCollectionsWithMultipleItems(t *testing.T) {
 			[]interface{}{"burgundy", "ruby"},
 			[]interface{}{"burgundy", "ruby", "tineke"},
 			map[string]DiffKind{
-				"prop":    UR,
 				"prop[2]": AR,
 			},
 			map[string]DiffKind{
-				"prop":    UR,
 				"prop[2]": AR,
 			},
 		},
@@ -1520,8 +1498,7 @@ func TestSetNestedAddReplace(t *testing.T) {
 			"outp": "bar",
 		},
 		map[string]DiffKind{
-			"prop":         AR,
-			"prop[0].nest": A,
+			"prop[0].nest": AR,
 		})
 }
 
@@ -1553,8 +1530,7 @@ func TestListNestedAddReplace(t *testing.T) {
 		},
 		// expected
 		map[string]DiffKind{
-			"prop":         AR,
-			"prop[0].nest": A,
+			"prop[0].nest": AR,
 		})
 }
 
@@ -1616,8 +1592,7 @@ func TestListNestedDeleteReplace(t *testing.T) {
 		},
 		// expected
 		map[string]DiffKind{
-			"prop":         DR,
-			"prop[0].nest": D,
+			"prop[0].nest": DR,
 		})
 }
 
@@ -1647,8 +1622,7 @@ func TestSetNestedDeleteReplace(t *testing.T) {
 		},
 		// expected
 		map[string]DiffKind{
-			"prop":         DR,
-			"prop[0].nest": D,
+			"prop[0].nest": DR,
 		})
 }
 
@@ -1680,7 +1654,6 @@ func TestListNestedAddMaxItemsOne(t *testing.T) {
 		},
 		// expected
 		map[string]DiffKind{
-			"prop":      AR,
-			"prop.nest": A,
+			"prop.nest": AR,
 		})
 }


### PR DESCRIPTION
There is a bug in our diffing function's handling of sets and lists with nested elements when the set or list itself has `ForceNew` but the nested element does not.

To correct this, we also check if the list/set count diff has `ForceNew` and treat `A`/`D` as `AR`/`DR` if so.

Fixes: https://github.com/pulumi/pulumi-aws/issues/1297