### PR TITLE
Move GetModuleMajorVersion to the bridge so it can be shared

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -15,6 +15,8 @@
 package tfbridge
 
 import (
+	"fmt"
+	"github.com/blang/semver"
 	pschema "github.com/pulumi/pulumi/pkg/v2/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/tokens"
@@ -715,4 +717,20 @@ func (m *MarshallableProviderInfo) Unmarshal() *ProviderInfo {
 	}
 
 	return &info
+}
+
+// Calculates the major version of a go sdk
+// go module paths only care about appending a version when the version is
+// 2 or greater. github.com/org/my-repo/sdk/v1/go is not a valid
+// go module path but github.com/org/my-repo/sdk/v2/go is
+func GetModuleMajorVersion(version string) string {
+	var majorVersion string
+	sver, err := semver.ParseTolerant(version)
+	if err != nil {
+		panic(err)
+	}
+	if sver.Major > 1 {
+		majorVersion = fmt.Sprintf("v%d", sver.Major)
+	}
+	return majorVersion
 }

--- a/pkg/tfbridge/info_test.go
+++ b/pkg/tfbridge/info_test.go
@@ -1,0 +1,37 @@
+package tfbridge
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGetModuleMajorVersion(t *testing.T) {
+	type testcase struct {
+		version              string
+		expectedMajorVersion string
+	}
+
+	tests := []testcase{
+		{
+			"v0.0.100",
+			"",
+		},
+		{
+			"v1.0.0-alpha.sdqq.dirty",
+			"",
+		},
+		{
+			"v2.0.0",
+			"v2",
+		},
+		{
+			"v3.147.2-alpha.sdqq.dirty",
+			"v3",
+		},
+	}
+
+	for _, test := range tests {
+		majorVersion := GetModuleMajorVersion(test.version)
+		assert.Equal(t, test.expectedMajorVersion, majorVersion)
+	}
+}


### PR DESCRIPTION
This function should only return a version string to be appended
to a go sdk path if it is v2 or later. v1 go modules do not specify
a path like github.com/org/my-repo/sdk/v1/go