### PR TITLE
Reimplement input extraction.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Adjust input extraction in `Read` s.t. it returns a safer set of values.
+  [#330](https://github.com/pulumi/pulumi-terraform-bridge/pull/330)
+
 - Fixes a panic caused by improper diffing of lists and sets with nested object elements.
   [#319](https://github.com/pulumi/pulumi-terraform-bridge/pull/319)
 

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -1457,7 +1457,10 @@ func TestExtractInputsFromOutputs(t *testing.T) {
 	ins, err := plugin.UnmarshalProperties(resp.GetInputs(), plugin.MarshalOptions{})
 	assert.NoError(t, err)
 	expected := resource.NewPropertyMapFromMap(map[string]interface{}{
-		"inputA": "input_a_read",
+		defaultsKey: []interface{}{},
+		"inputA":    "input_a_read",
+		"inoutC":    "inout_c_read",
+		"inoutD":    "inout_d_read",
 	})
 	assert.Equal(t, expected, ins)
 

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -1457,12 +1457,9 @@ func TestExtractInputsFromOutputs(t *testing.T) {
 	ins, err := plugin.UnmarshalProperties(resp.GetInputs(), plugin.MarshalOptions{})
 	assert.NoError(t, err)
 	expected := resource.NewPropertyMapFromMap(map[string]interface{}{
-		defaultsKey: []interface{}{},
-		"inputA":    "input_a_read",
-		"inoutC":    "inout_c_read",
-		"inoutD":    "inout_d_read",
+		"inputA": "input_a_read",
 	})
-	assert.True(t, expected.DeepEquals(ins))
+	assert.Equal(t, expected, ins)
 
 	// Case 2: read a resource that has old state (this is the refresh case)
 	//
@@ -1554,7 +1551,6 @@ func TestExtractInputsFromOutputs(t *testing.T) {
 	assert.Equal(t, resource.NewPropertyMapFromMap(map[string]interface{}{
 		defaultsKey: []interface{}{"inputF", "inputH"},
 		"inputA":    "input_a_create",
-		"inoutC":    "inout_c_create",
 		"inoutD":    "inout_d_read",
 		"inputE": map[string]interface{}{
 			defaultsKey: []interface{}{"fieldA"},
@@ -1598,7 +1594,6 @@ func TestExtractInputsFromOutputs(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, resource.NewPropertyMapFromMap(map[string]interface{}{
 		"inputA": "input_a_create",
-		"inoutC": "inout_c_create",
 		"inoutD": "inout_d_read",
 		"inputE": map[string]interface{}{
 			"fieldA": "field_a_default",


### PR DESCRIPTION
The original approach to input extraction pulled _all_ possible inputs
from a state object into an input object. Although this approach will
conservatively detect any possible inputs, the object that it produces
may not be usable:

- the allowable values for a property may be different when that
  property is an input vs. when it is an output
- certain combinations of output property values may be allowed where
  the same combinations of input property values are not
- etc.

This has caused serious usability issues, e.g. https://github.com/pulumi/pulumi/issues/6241.

The conservative approach was originally necessary in order for the Pulumi
engine to detect possible differences between the actual and desired state,
as that detection was done based on input differences only. The engine's
approach has since changed to defer to the provider for diffs, and
conservative input calculation is no longer necessary.

These changes rework the algorithm for a better user experience by
taking advantage of the fact that if old inputs are present, their shape
must already be correct. Instead of copying all possible inputs, the
bridge now copies only inputs that are present in the old inputs. If a
property was present in the old inputs and was populated as a default,
its "defaultness" is preserved iff its value has not changed.

The implementation used during CLI imports has also been changed to only
pull in properties that are pure inputs. This should pull in far fewer
inputs than the old approach, and has a better chance of generating
output that is immediately usable.

Contributes to https://github.com/pulumi/pulumi/issues/6241.