### PR TITLE
Initial attempt to add attribute info for check errors

### DIFF
--- a/pkg/tfbridge/names.go
+++ b/pkg/tfbridge/names.go
@@ -55,7 +55,7 @@ func PulumiToTerraformName(name string, tfs shim.SchemaMap, ps map[string]*Schem
 			}
 		}
 
-		if ok && checkTfMaxItems(sch, false) || isPulmiMaxItemsOne(info) {
+		if ok && checkTfMaxItems(sch, false) || isPulumiMaxItemsOne(info) {
 			result = singularResult
 		}
 	}
@@ -74,7 +74,7 @@ func checkTfMaxItems(tfs shim.Schema, maxItemsOne bool) bool {
 	return (tfs.MaxItems() == 1) == maxItemsOne
 }
 
-func isPulmiMaxItemsOne(ps *SchemaInfo) bool {
+func isPulumiMaxItemsOne(ps *SchemaInfo) bool {
 	return ps != nil && ps.MaxItemsOne != nil && *ps.MaxItemsOne
 }
 
@@ -86,7 +86,7 @@ func TerraformToPulumiName(name string, sch shim.Schema, ps *SchemaInfo, upper b
 	var prev rune
 
 	// Pluralize names that will become array-shaped Pulumi values
-	if !isPulmiMaxItemsOne(ps) && checkTfMaxItems(sch, false) {
+	if !isPulumiMaxItemsOne(ps) && checkTfMaxItems(sch, false) {
 		pluralized := inflector.Pluralize(name)
 		if pluralized == name || inflector.Singularize(pluralized) == name {
 			//			contract.Assertf(

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -560,7 +560,7 @@ var requiredFieldRegex = regexp.MustCompile("\"(.*?)\": required field is not se
 func (p *Provider) formatFailureReason(tokenType tokens.Type, res Resource, err error) string {
 	reason := err.Error()
 	var attributePath string
-	var d *diagnostics.Error
+	var d *diagnostics.ValidationError
 	if errors.As(err, &d) {
 		path := d.AttributePath
 		if len(path) > 0 {

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -512,11 +512,11 @@ func TestProviderCheckV2(t *testing.T) {
 
 	failures := testCheckFailures(t, provider, "SecondResource")
 	sort.SliceStable(failures, func(i, j int) bool { return failures[i].Reason < failures[j].Reason })
-	assert.Equal(t, "ConflictsWith: \"conflicting_property\": conflicts with conflicting_property2", failures[0].Reason)
+	assert.Equal(t, "ConflictsWith: \"conflicting_property\": conflicts with conflicting_property2. Examine values at 'SecondResource.ConflictingProperty'.", failures[0].Reason)
 	assert.Equal(t, "", failures[0].Property)
-	assert.Equal(t, "ConflictsWith: \"conflicting_property2\": conflicts with conflicting_property", failures[1].Reason)
+	assert.Equal(t, "ConflictsWith: \"conflicting_property2\": conflicts with conflicting_property. Examine values at 'SecondResource.ConflictingProperty2'.", failures[1].Reason)
 	assert.Equal(t, "", failures[1].Property)
-	assert.Equal(t, "Required attribute is not set", failures[2].Reason)
+	assert.Equal(t, "Required attribute is not set. Examine values at 'SecondResource.ArrayPropertyValues'.", failures[2].Reason)
 	assert.Equal(t, "", failures[2].Property)
 }
 

--- a/pkg/tfshim/diagnostics/error.go
+++ b/pkg/tfshim/diagnostics/error.go
@@ -1,0 +1,19 @@
+package diagnostics
+
+import (
+	"fmt"
+	"github.com/hashicorp/go-cty/cty"
+)
+
+type Error struct {
+	AttributePath cty.Path
+	Summary       string
+	Detail        string
+}
+
+func (e Error) Error() string {
+	if e.Detail != "" {
+		return fmt.Sprintf("%s: %s", e.Summary, e.Detail)
+	}
+	return e.Summary
+}

--- a/pkg/tfshim/diagnostics/error.go
+++ b/pkg/tfshim/diagnostics/error.go
@@ -5,13 +5,14 @@ import (
 	"github.com/hashicorp/go-cty/cty"
 )
 
-type Error struct {
+// ValidationError wraps validation errors reported by shims (currently shim v2 and tf5)
+type ValidationError struct {
 	AttributePath cty.Path
 	Summary       string
 	Detail        string
 }
 
-func (e Error) Error() string {
+func (e ValidationError) Error() string {
 	if e.Detail != "" {
 		return fmt.Sprintf("%s: %s", e.Summary, e.Detail)
 	}

--- a/pkg/tfshim/sdk-v2/diagnostics.go
+++ b/pkg/tfshim/sdk-v2/diagnostics.go
@@ -31,9 +31,10 @@ func errors(diags diag.Diagnostics) error {
 }
 
 func fromV2Diag(diagnostic diag.Diagnostic) error {
-	return &diagnostics.Error{
+	return &diagnostics.ValidationError{
 		AttributePath: diagnostic.AttributePath,
 		Summary:       diagnostic.Summary,
 		Detail:        diagnostic.Detail,
 	}
 }
+

--- a/pkg/tfshim/tfplugin5/diagnostics.go
+++ b/pkg/tfshim/tfplugin5/diagnostics.go
@@ -46,6 +46,9 @@ func fromTF5ProtoDiag(diagnostic *proto.Diagnostic) error {
 
 func pathToCty(path *proto.AttributePath) cty.Path {
 	var p cty.Path
+	if path == nil {
+		return p
+	}
 	for _, s := range path.Steps {
 		switch s := s.Selector.(type) {
 		case *proto.AttributePath_Step_AttributeName:

--- a/pkg/tfshim/tfplugin5/diagnostics_test.go
+++ b/pkg/tfshim/tfplugin5/diagnostics_test.go
@@ -1,7 +1,7 @@
 package tfplugin5
 
 import (
-	"fmt"
+	"github.com/pulumi/pulumi-terraform-bridge/v2/pkg/tfshim/diagnostics"
 	"testing"
 
 	"github.com/hashicorp/go-multierror"
@@ -29,11 +29,15 @@ func TestWarningsAndErrors(t *testing.T) {
 
 	warnings, errors = unmarshalWarningsAndErrors(errorsOnly)
 	assert.Empty(t, warnings)
-	assert.Equal(t, []error{fmt.Errorf("error 1"), fmt.Errorf("error 2")}, errors)
+	assert.Equal(t, errors, []error{&diagnostics.ValidationError{Summary: "error 1"}, &diagnostics.ValidationError{Summary: "error 2"}})
+	assert.EqualError(t, errors[0], "error 1")
+	assert.EqualError(t, errors[1], "error 2")
 
 	warnings, errors = unmarshalWarningsAndErrors(mixed)
 	assert.Equal(t, []string{"warning 1", "warning 2"}, warnings)
-	assert.Equal(t, []error{fmt.Errorf("error 1"), fmt.Errorf("error 2")}, errors)
+	assert.Equal(t, errors, []error{&diagnostics.ValidationError{Summary: "error 1"}, &diagnostics.ValidationError{Summary: "error 2"}})
+	assert.EqualError(t, errors[0], "error 1")
+	assert.EqualError(t, errors[1], "error 2")
 }
 
 func TestErrors(t *testing.T) {
@@ -41,8 +45,8 @@ func TestErrors(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = unmarshalErrors(errorsOnly)
-	assert.Equal(t, multierror.Append(nil, fmt.Errorf("error 1"), fmt.Errorf("error 2")), err)
+	assert.Equal(t, multierror.Append(nil, &diagnostics.ValidationError{Summary: "error 1"}, &diagnostics.ValidationError{Summary: "error 2"}), err)
 
 	err = unmarshalErrors(mixed)
-	assert.Equal(t, multierror.Append(nil, fmt.Errorf("error 1"), fmt.Errorf("error 2")), err)
+	assert.Equal(t, multierror.Append(nil, &diagnostics.ValidationError{Summary: "error 1"}, &diagnostics.ValidationError{Summary: "error 2"}), err)
 }


### PR DESCRIPTION
Fixes #311

The PR currently gets additional context on check failures but still has some contextual gaps:
1. No insight into the user program's language so "pulumified" attributes may not directly match the user's program. Can't really use the provided input either since the problem may be due to required attributes not being specified.
2. Only supports v2 and tf5 shims. v1 doesn't seem to emit attribute information.