### PR TITLE
Address potential panic in array refresh

### DIFF
--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -995,6 +995,13 @@ func convertTfStringToFloat(stringValue string) (interface{}, error) {
 	return floatVal, nil
 }
 
+func min(a int, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
 func extractInputs(oldInput, newState resource.PropertyValue, tfs shim.Schema, ps *SchemaInfo,
 	rawNames bool) (resource.PropertyValue, bool) {
 
@@ -1016,7 +1023,8 @@ func extractInputs(oldInput, newState resource.PropertyValue, tfs shim.Schema, p
 				possibleDefault = false
 			}
 		}
-		return resource.NewArrayProperty(oldArray[:len(newArray)]), possibleDefault
+
+		return resource.NewArrayProperty(oldArray[:min(len(oldArray), len(newArray))]), possibleDefault
 	case oldInput.IsObject() && newState.IsObject():
 		var tfflds shim.SchemaMap
 		if tfs != nil {


### PR DESCRIPTION
This commit addresses a potential panic when extracting inputs for arrays, which can present during refresh operations if the length of the "new" array is longer than the length of the "old" array:

```
panic: runtime error: slice bounds out of range [:2] with capacity 1

[backtrace elided] pkg/tfbridge/schema.go:1019
```

The solution here is to use the min(len(oldArray), len(newArray)) as the index point for the mutated old array instead of len(newArray) unconditionally.