### PR TITLE
Add a flag to enable debug output from tfgen.

### DIFF
--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -932,7 +932,7 @@ func (p *tfMarkdownParser) reformatSubsection(lines []string) ([]string, bool, b
 
 // parseExamples converts any code snippets in a subsection to Pulumi-compatible code. This conversion is done on a
 // per-subsection basis; subsections with failing examples will be elided upon the caller's request.
-func (g *Generator) convertExamples(docs string, stripSubsectionsWithErrors bool) string {
+func (g *Generator) convertExamples(docs, name string, stripSubsectionsWithErrors bool) string {
 	if docs == "" {
 		return ""
 	}
@@ -991,7 +991,7 @@ func (g *Generator) convertExamples(docs string, stripSubsectionsWithErrors bool
 						hcl := strings.Join(subsection[codeBlockStart+1:i], "\n")
 
 						// We've got some code -- assume it's HCL and try to convert it.
-						codeBlock, stderr, err := g.convertHCL(hcl)
+						codeBlock, stderr, err := g.convertHCL(hcl, name)
 						if err != nil {
 							skippedExamples = true
 							hclFailures[stderr] = true
@@ -1066,14 +1066,14 @@ func (g *Generator) convertExamples(docs string, stripSubsectionsWithErrors bool
 
 // convertHCL converts an in-memory, simple HCL program to Pulumi, and returns it as a string. In the event
 // of failure, the error returned will be non-nil, and the second string contains the stderr stream of details.
-func (g *Generator) convertHCL(hcl string) (string, string, error) {
+func (g *Generator) convertHCL(hcl, path string) (string, string, error) {
 	// Fixup the HCL as necessary.
 	if fixed, ok := fixHcl(hcl); ok {
 		hcl = fixed
 	}
 
 	input := afero.NewMemMapFs()
-	f, err := input.Create("/main.tf")
+	f, err := input.Create(fmt.Sprintf("/%s.tf", strings.ReplaceAll(path, "/", "-")))
 	contract.AssertNoError(err)
 	_, err = f.Write([]byte(hcl))
 	contract.AssertNoError(err)
@@ -1103,14 +1103,14 @@ func (g *Generator) convertHCL(hcl string) (string, string, error) {
 			TerraformVersion:         g.terraformVersion,
 		})
 		if err != nil {
-			return fmt.Errorf("failied to convert HCL to %v: %w", languageName, err)
+			return fmt.Errorf("failied to convert HCL %s to %v: %w", path, languageName, err)
 		}
 		if diags.All.HasErrors() {
 			if stderr.Len() != 0 {
 				_, err := fmt.Fprintf(&stderr, "\n")
 				contract.IgnoreError(err)
 			}
-			_, err := fmt.Fprintf(&stderr, "# %s\n", languageName)
+			_, err := fmt.Fprintf(&stderr, "# %s: %s\n", path, languageName)
 			contract.IgnoreError(err)
 
 			_, err = fmt.Fprintf(&stderr, "%s\n\n", hcl)
@@ -1159,7 +1159,7 @@ func (g *Generator) convertHCL(hcl string) (string, string, error) {
 		return "", stderr.String(), err
 	}
 	if result.Len() == 0 {
-		return "", stderr.String(), fmt.Errorf("failed to convert HCL to %v", g.language)
+		return "", stderr.String(), fmt.Errorf("failed to convert HCL %s to %v", path, g.language)
 	}
 	return result.String(), stderr.String(), nil
 }

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -65,6 +65,7 @@ type Generator struct {
 	infoSource       il.ProviderInfoSource // the provider info source for tf2pulumi.
 	terraformVersion string                // the Terraform version to target for example codegen, if any
 	sink             diag.Sink
+	printStats       bool
 }
 
 type Language string
@@ -608,6 +609,7 @@ type GeneratorOptions struct {
 	PluginHost         plugin.Host
 	TerraformVersion   string
 	Sink               diag.Sink
+	Debug              bool
 }
 
 // NewGenerator returns a code-generator for the given language runtime and package info.
@@ -637,6 +639,11 @@ func NewGenerator(opts GeneratorOptions) (*Generator, error) {
 
 	sink := opts.Sink
 	if sink == nil {
+		diagOpts := diag.FormatOptions{
+			Color: cmdutil.GetGlobalColorization(),
+			Debug: opts.Debug,
+		}
+		cmdutil.InitDiag(diagOpts)
 		sink = cmdutil.Diag()
 	}
 
@@ -679,6 +686,7 @@ func NewGenerator(opts GeneratorOptions) (*Generator, error) {
 		infoSource:       host,
 		terraformVersion: opts.TerraformVersion,
 		sink:             sink,
+		printStats:       opts.Debug,
 	}, nil
 }
 
@@ -766,7 +774,7 @@ func (g *Generator) Generate() error {
 	}
 
 	// Print out some documentation stats as a summary afterwards.
-	printDocStats(g, false, false)
+	printDocStats(g, g.printStats, g.printStats)
 
 	// Close the plugin host.
 	g.pluginHost.Close()

--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -669,44 +669,44 @@ func (g *schemaGenerator) schemaType(mod string, typ *propertyType, out bool) ps
 	}
 }
 
-func (g *Generator) convertExamplesInPropertySpec(spec pschema.PropertySpec) pschema.PropertySpec {
-	spec.Description = g.convertExamples(spec.Description, false)
-	spec.DeprecationMessage = g.convertExamples(spec.DeprecationMessage, false)
+func (g *Generator) convertExamplesInPropertySpec(path string, spec pschema.PropertySpec) pschema.PropertySpec {
+	spec.Description = g.convertExamples(spec.Description, path, false)
+	spec.DeprecationMessage = g.convertExamples(spec.DeprecationMessage, path, false)
 	return spec
 }
 
-func (g *Generator) convertExamplesInObjectSpec(spec pschema.ObjectTypeSpec) pschema.ObjectTypeSpec {
-	spec.Description = g.convertExamples(spec.Description, false)
+func (g *Generator) convertExamplesInObjectSpec(path string, spec pschema.ObjectTypeSpec) pschema.ObjectTypeSpec {
+	spec.Description = g.convertExamples(spec.Description, path, false)
 	for name, prop := range spec.Properties {
-		spec.Properties[name] = g.convertExamplesInPropertySpec(prop)
+		spec.Properties[name] = g.convertExamplesInPropertySpec(fmt.Sprintf("%s/%s", path, name), prop)
 	}
 	return spec
 }
 
-func (g *Generator) convertExamplesInResourceSpec(spec pschema.ResourceSpec) pschema.ResourceSpec {
-	spec.Description = g.convertExamples(spec.Description, true)
-	spec.DeprecationMessage = g.convertExamples(spec.DeprecationMessage, false)
+func (g *Generator) convertExamplesInResourceSpec(path string, spec pschema.ResourceSpec) pschema.ResourceSpec {
+	spec.Description = g.convertExamples(spec.Description, path, true)
+	spec.DeprecationMessage = g.convertExamples(spec.DeprecationMessage, path, false)
 	for name, prop := range spec.Properties {
-		spec.Properties[name] = g.convertExamplesInPropertySpec(prop)
+		spec.Properties[name] = g.convertExamplesInPropertySpec(fmt.Sprintf("%s/%s", path, name), prop)
 	}
 	for name, prop := range spec.InputProperties {
-		spec.InputProperties[name] = g.convertExamplesInPropertySpec(prop)
+		spec.InputProperties[name] = g.convertExamplesInPropertySpec(fmt.Sprintf("%s/%s", path, name), prop)
 	}
 	if spec.StateInputs != nil {
-		stateInputs := g.convertExamplesInObjectSpec(*spec.StateInputs)
+		stateInputs := g.convertExamplesInObjectSpec(path+"/stateInputs", *spec.StateInputs)
 		spec.StateInputs = &stateInputs
 	}
 	return spec
 }
 
-func (g *Generator) convertExamplesInFunctionSpec(spec pschema.FunctionSpec) pschema.FunctionSpec {
-	spec.Description = g.convertExamples(spec.Description, true)
+func (g *Generator) convertExamplesInFunctionSpec(path string, spec pschema.FunctionSpec) pschema.FunctionSpec {
+	spec.Description = g.convertExamples(spec.Description, path, true)
 	if spec.Inputs != nil {
-		inputs := g.convertExamplesInObjectSpec(*spec.Inputs)
+		inputs := g.convertExamplesInObjectSpec(path+"/inputs", *spec.Inputs)
 		spec.Inputs = &inputs
 	}
 	if spec.Outputs != nil {
-		outputs := g.convertExamplesInObjectSpec(*spec.Outputs)
+		outputs := g.convertExamplesInObjectSpec(path+"/outputs", *spec.Outputs)
 		spec.Outputs = &outputs
 	}
 	return spec
@@ -714,18 +714,18 @@ func (g *Generator) convertExamplesInFunctionSpec(spec pschema.FunctionSpec) psc
 
 func (g *Generator) convertExamplesInSchema(spec pschema.PackageSpec) pschema.PackageSpec {
 	for name, variable := range spec.Config.Variables {
-		spec.Config.Variables[name] = g.convertExamplesInPropertySpec(variable)
+		spec.Config.Variables[name] = g.convertExamplesInPropertySpec(name, variable)
 	}
 	for token, object := range spec.Types {
-		object.ObjectTypeSpec = g.convertExamplesInObjectSpec(object.ObjectTypeSpec)
+		object.ObjectTypeSpec = g.convertExamplesInObjectSpec("#/types/"+token, object.ObjectTypeSpec)
 		spec.Types[token] = object
 	}
-	spec.Provider = g.convertExamplesInResourceSpec(spec.Provider)
+	spec.Provider = g.convertExamplesInResourceSpec("#/provider", spec.Provider)
 	for token, resource := range spec.Resources {
-		spec.Resources[token] = g.convertExamplesInResourceSpec(resource)
+		spec.Resources[token] = g.convertExamplesInResourceSpec("#/resources/"+token, resource)
 	}
 	for token, function := range spec.Functions {
-		spec.Functions[token] = g.convertExamplesInFunctionSpec(function)
+		spec.Functions[token] = g.convertExamplesInFunctionSpec("#/functions/"+token, function)
 	}
 	return spec
 }

--- a/pkg/tfgen/main.go
+++ b/pkg/tfgen/main.go
@@ -44,6 +44,7 @@ func newTFGenCmd(pkg string, version string, prov tfbridge.ProviderInfo) *cobra.
 	var quiet bool
 	var verbose int
 	var profile string
+	var debug bool
 	cmd := &cobra.Command{
 		Use:   os.Args[0] + " <LANGUAGE>",
 		Args:  cmdutil.SpecificArgs([]string{"language"}),
@@ -90,6 +91,7 @@ func newTFGenCmd(pkg string, version string, prov tfbridge.ProviderInfo) *cobra.
 				Language:     Language(args[0]),
 				ProviderInfo: prov,
 				Root:         root,
+				Debug:        debug,
 			})
 			if err != nil {
 				return err
@@ -118,6 +120,8 @@ func newTFGenCmd(pkg string, version string, prov tfbridge.ProviderInfo) *cobra.
 		&verbose, "verbose", "v", 0, "Enable verbose logging (e.g., v=3); anything >3 is very verbose")
 	cmd.PersistentFlags().StringVar(
 		&profile, "profile", "", "Write a CPU profile to this file")
+	cmd.PersistentFlags().BoolVarP(
+		&debug, "debug", "d", false, "Enable debug logging")
 
 	cmd.PersistentFlags().StringVar(
 		&overlaysDir, "overlays", "",


### PR DESCRIPTION
tfgen will print debug output to stdout if this flag is passed. These
changes also add a bit more information to HCL errors to aid in
determining the sources of conversion failures.