### PR TITLE
Add flags to skip docs and examples processing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Add flags to skip docs and examples processing.
+  [#365](https://github.com/pulumi/pulumi-terraform-bridge/pull/365)
+
 - Remove async resource option in nodejs datasources
   [#348](https://github.com/pulumi/pulumi-terraform-bridge/pull/348)
 

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -211,6 +211,10 @@ func getDocsForProvider(g *Generator, org string, provider string, resourcePrefi
 	rawname string, info tfbridge.ResourceOrDataSourceInfo, providerModuleVersion string,
 	githost string) (entityDocs, error) {
 
+	if g.skipDocs {
+		return entityDocs{}, nil
+	}
+
 	markdownBytes, markdownFileName, found := getMarkdownDetails(g, org, provider, resourcePrefix, kind, rawname, info,
 		providerModuleVersion, githost)
 	if !found {

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -66,6 +66,8 @@ type Generator struct {
 	terraformVersion string                // the Terraform version to target for example codegen, if any
 	sink             diag.Sink
 	printStats       bool
+	skipDocs         bool
+	skipExamples     bool
 }
 
 type Language string
@@ -610,6 +612,8 @@ type GeneratorOptions struct {
 	TerraformVersion   string
 	Sink               diag.Sink
 	Debug              bool
+	SkipDocs           bool
+	SkipExamples       bool
 }
 
 // NewGenerator returns a code-generator for the given language runtime and package info.
@@ -687,6 +691,8 @@ func NewGenerator(opts GeneratorOptions) (*Generator, error) {
 		terraformVersion: opts.TerraformVersion,
 		sink:             sink,
 		printStats:       opts.Debug,
+		skipDocs:         opts.SkipDocs,
+		skipExamples:     opts.SkipExamples,
 	}, nil
 }
 
@@ -732,7 +738,9 @@ func (g *Generator) Generate() error {
 	}
 
 	// Convert examples.
-	pulumiPackageSpec = g.convertExamplesInSchema(pulumiPackageSpec)
+	if !g.skipExamples {
+		pulumiPackageSpec = g.convertExamplesInSchema(pulumiPackageSpec)
+	}
 
 	// Go ahead and let the language generator do its thing. If we're emitting the schema, just go ahead and serialize
 	// it out.

--- a/pkg/tfgen/main.go
+++ b/pkg/tfgen/main.go
@@ -45,6 +45,8 @@ func newTFGenCmd(pkg string, version string, prov tfbridge.ProviderInfo) *cobra.
 	var verbose int
 	var profile string
 	var debug bool
+	var skipDocs bool
+	var skipExamples bool
 	cmd := &cobra.Command{
 		Use:   os.Args[0] + " <LANGUAGE>",
 		Args:  cmdutil.SpecificArgs([]string{"language"}),
@@ -92,6 +94,8 @@ func newTFGenCmd(pkg string, version string, prov tfbridge.ProviderInfo) *cobra.
 				ProviderInfo: prov,
 				Root:         root,
 				Debug:        debug,
+				SkipDocs:     skipDocs,
+				SkipExamples: skipExamples,
 			})
 			if err != nil {
 				return err
@@ -122,6 +126,10 @@ func newTFGenCmd(pkg string, version string, prov tfbridge.ProviderInfo) *cobra.
 		&profile, "profile", "", "Write a CPU profile to this file")
 	cmd.PersistentFlags().BoolVarP(
 		&debug, "debug", "d", false, "Enable debug logging")
+	cmd.PersistentFlags().BoolVar(
+		&skipDocs, "skip-docs", false, "Do not convert docs from TF Markdown")
+	cmd.PersistentFlags().BoolVar(
+		&skipExamples, "skip-examples", false, "Do not convert examples from HCL")
 
 	cmd.PersistentFlags().StringVar(
 		&overlaysDir, "overlays", "",


### PR DESCRIPTION
These are intended to speed up inner-loop debugging.