### PR TITLE
WIP: fix https://github.com/pulumi/pulumi-aws/issues/1521

### DIFF
--- a/pkg/tfbridge/diff_test.go
+++ b/pkg/tfbridge/diff_test.go
@@ -50,7 +50,7 @@ func diffTest(t *testing.T, tfs map[string]*schema.Schema, info map[string]*Sche
 		TF:     shimv1.NewResource(res),
 		Schema: &ResourceInfo{Fields: info},
 	}
-	tfState, err := MakeTerraformState(r, "id", stateMap)
+	tfState, _, err := MakeTerraformState(r, "id", stateMap)
 	assert.NoError(t, err)
 
 	config, _, err := MakeTerraformConfig(&Provider{tf: provider}, inputsMap, sch, info)

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -727,7 +727,7 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 	if err != nil {
 		return nil, err
 	}
-	state, err := MakeTerraformState(res, req.GetId(), olds)
+	state, _, err := MakeTerraformState(res, req.GetId(), olds)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unmarshaling %s's instance state", urn)
 	}
@@ -915,7 +915,7 @@ func (p *Provider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*pulum
 	if err != nil {
 		return nil, err
 	}
-	state, err := UnmarshalTerraformState(res, id, req.GetProperties(), fmt.Sprintf("%s.state", label))
+	state, assets, err := UnmarshalTerraformState(res, id, req.GetProperties(), fmt.Sprintf("%s.state", label))
 	if err != nil {
 		return nil, errors.Wrapf(err, "unmarshaling %s's instance state", urn)
 	}
@@ -945,7 +945,7 @@ func (p *Provider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*pulum
 	// Store the ID and properties in the output.  The ID *should* be the same as the input ID, but in the case
 	// that the resource no longer exists, we will simply return the empty string and an empty property map.
 	if newstate != nil {
-		props, err := MakeTerraformResult(p.tf, newstate, res.TF.Schema(), res.Schema.Fields, nil, p.supportsSecrets)
+		props, err := MakeTerraformResult(p.tf, newstate, res.TF.Schema(), res.Schema.Fields, assets, p.supportsSecrets)
 		if err != nil {
 			return nil, err
 		}
@@ -994,7 +994,7 @@ func (p *Provider) Update(ctx context.Context, req *pulumirpc.UpdateRequest) (*p
 	if err != nil {
 		return nil, err
 	}
-	state, err := MakeTerraformState(res, req.GetId(), olds)
+	state, _, err := MakeTerraformState(res, req.GetId(), olds)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unmarshaling %s's instance state", urn)
 	}
@@ -1091,7 +1091,7 @@ func (p *Provider) Delete(ctx context.Context, req *pulumirpc.DeleteRequest) (*p
 	glog.V(9).Infof("%s executing", label)
 
 	// Fetch the resource attributes since many providers need more than just the ID to perform the delete.
-	state, err := UnmarshalTerraformState(res, req.GetId(), req.GetProperties(), label)
+	state, _, err := UnmarshalTerraformState(res, req.GetId(), req.GetProperties(), label)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
https://github.com/pulumi/pulumi-aws/issues/1521 is caused by the fact that `Read` does not ensure that any output properties that were assets remain assets nor that any output properties that _should_ be assets are returned as assets. These changes include a fix for the former case, but not for the latter fix. I believe that we cannot fully fix either case without additional changes in pulumi/pulumi or without making breaking changes in provider SDKs for output properties that are typed as assets.

The core of the issue is that some output properties in the generated SDKs have asset types, but the bridge's implementation of `Read` never returns assets for any output properties. If the bridge has a prior set of output properties and if an asset-typed property's underlying value has not changed, then the bridge can simply return the existing asset value (that is the fix applied in these changes). If the value has changed, however, then returning the existing value is not correct, and may lead to `Diff` returning incorrect results. Unfortunately, the Pulumi asset types don't really accommodate returning an opaque asset value, so it isn't possible for the bridge to return an arbitrary value for a new asset without access to the asset's contents (which may not be locally available).

I believe that we're going to need an additional feature in the core Pulumi SDK to accommodate opaque assets. In the meantime, we might be able to work around the marshaling failure by allowing _any_ time to unmarshal into an asset in the Go + .NET runtimes. In that case, each runtime would be responsible for inventing some arbitrary asset.

One last possibility would be to ensure that there are any output property that may be projected as an asset is represented in the schema as an `Asset | underlyingType`, though this would cause breaking changes.