### PR TITLE
Stop emitting `mapCase` for Python properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Stop emitting `mapCase` for Python properties.
+  [#369](https://github.com/pulumi/pulumi-terraform-bridge/pull/369)
+
 - Add flags to skip docs and examples processing.
   [#365](https://github.com/pulumi/pulumi-terraform-bridge/pull/365)
 


### PR DESCRIPTION
The Python SDK code generator does not use `mapCase` anymore, so there's no need to continue emitting it in the generated schema.

Follow-up from https://github.com/pulumi/pulumi/pull/7647