### PR TITLE
Correct data source naming in Python doc strings

### DIFF
--- a/pkg/tf2pulumi/gen/python/generator.go
+++ b/pkg/tf2pulumi/gen/python/generator.go
@@ -140,7 +140,7 @@ func (g *generator) GenerateResource(r *il.ResourceNode) error {
 	// data source call itself into the apply.
 	if r.IsDataSource {
 		// Qualified member names are snake cased for data sources.
-		qualifiedMemberName := fmt.Sprintf("%s%s.%s", pkg, subpkg, pyName(class))
+		qualifiedMemberName := fmt.Sprintf("%s%s.%s", pkg, subpkg, PyName(class))
 		properties := newDataSourceCall(qualifiedMemberName, r.Properties)
 		inputs, transformed, err := g.computeProperty(properties, false, "")
 		if err != nil {
@@ -357,8 +357,8 @@ func resourceTypeName(r *il.ResourceNode) (string, string, string, error) {
 // Copy-pasted from tfgen
 //
 
-// pyName turns a variable or function name, normally using camelCase, to an underscore_case name.
-func pyName(name string) string {
+// PyName turns a variable or function name, normally using camelCase, to an underscore_case name.
+func PyName(name string) string {
 	// This method is a state machine with four states:
 	//   stateFirst - the initial state.
 	//   stateUpper - The last character we saw was an uppercase letter and the character before it

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -30,6 +30,7 @@ import (
 	"sync"
 
 	"github.com/hashicorp/go-multierror"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tf2pulumi/gen/python"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/spf13/afero"
 
@@ -1304,9 +1305,12 @@ func fixupPropertyReferences(language Language, pkg string, info tfbridge.Provid
 			}
 
 			switch language {
-			case Golang, Python:
+			case Golang:
 				// Use `ec2.getAmi` format
 				return open + modname + getname + close
+			case Python:
+				// Use `ec2.get_ami` format
+				return python.PyName(open + modname + getname + close)
 			default:
 				// Use `aws.ec2.getAmi` format
 				return open + pkg + "." + modname + getname + close


### PR DESCRIPTION
This commit corrects the name representation of a Terraform data source if used in a docstring for Python.

Before this change a data source named `aws_some_data_source` would have been converted to `aws.someDataSource` for Python, which does not follow the naming standards for Python. After this change the function would be correctly called `aws.some_data_source`.