### PR TITLE
tfbridge: handle unidirectional conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Avoid setting defaults on conflicting fields when the schema specifies
+  `ConflictsWith` in one direction but not the other.
+  [#376](https://github.com/pulumi/pulumi-terraform-bridge/pull/376)
+
 - Add flags to skip docs and examples processing.
   [#365](https://github.com/pulumi/pulumi-terraform-bridge/pull/365)
 

--- a/internal/testprovider/schema.go
+++ b/internal/testprovider/schema.go
@@ -521,6 +521,17 @@ func ProviderV2() *schemav2.Provider {
 						Optional:      true,
 						ConflictsWith: []string{"conflicting_property"},
 					},
+					// Conflicts with conflicting_property, but not vice-versa,
+					// and has a default. The Terraform docs don't say whether
+					// specifying a `ConflictsWith` in one direction but not the
+					// other is permissible, but providers do it in practice:
+					// https://github.com/pulumi/pulumi-snowflake/issues/11
+					"conflicting_property_unidirectional": {
+						Type:          schemav2.TypeBool,
+						Optional:      true,
+						Default:       false,
+						ConflictsWith: []string{"conflicting_property"},
+					},
 				},
 				SchemaVersion: 1,
 				MigrateState: func(v int, is *terraformv2.InstanceState, p interface{}) (*terraformv2.InstanceState, error) {
@@ -547,6 +558,7 @@ func ProviderV2() *schemav2.Provider {
 					})
 					MustSetIfUnset(data, "set_property_value", []interface{}{"set member 1", "set member 2"})
 					MustSetIfUnset(data, "string_with_bad_interpolation", "some ${interpolated:value} with syntax errors")
+					MustSetIfUnset(data, "conflicting_property_unidirectional", false)
 					return nil
 				},
 				Read: func(data *schemav2.ResourceData, p interface{}) error {
@@ -569,6 +581,7 @@ func ProviderV2() *schemav2.Provider {
 					})
 					MustSetIfUnset(data, "set_property_value", []interface{}{"set member 1", "set member 2"})
 					MustSetIfUnset(data, "string_with_bad_interpolation", "some ${interpolated:value} with syntax errors")
+					MustSetIfUnset(data, "conflicting_property_unidirectional", false)
 					return nil
 				},
 				Update: func(data *schemav2.ResourceData, p interface{}) error {
@@ -591,6 +604,7 @@ func ProviderV2() *schemav2.Provider {
 					})
 					MustSetIfUnset(data, "set_property_value", []interface{}{"set member 1", "set member 2"})
 					MustSetIfUnset(data, "string_with_bad_interpolation", "some ${interpolated:value} with syntax errors")
+					MustSetIfUnset(data, "conflicting_property_unidirectional", false)
 					return nil
 				},
 				Delete: func(data *schemav2.ResourceData, p interface{}) error {

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -355,8 +355,18 @@ func (ctx *conversionContext) applyDefaults(result map[string]interface{}, olds,
 	if tfs != nil {
 		tfs.Range(func(name string, sch shim.Schema) bool {
 			if _, has := result[name]; has {
+				// `name` is present, so mark any names that are declared to
+				// conflict with `name` for exclusiion.
 				for _, conflictingName := range sch.ConflictsWith() {
 					conflictsWith[conflictingName] = struct{}{}
+				}
+			} else {
+				// `name` is not present, so mark it for exclusion if any fields
+				// that conflict with `name` are present.
+				for _, conflictingName := range sch.ConflictsWith() {
+					if _, has := result[conflictingName]; has {
+						conflictsWith[name] = struct{}{}
+					}
 				}
 			}
 			return true

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -356,7 +356,7 @@ func (ctx *conversionContext) applyDefaults(result map[string]interface{}, olds,
 		tfs.Range(func(name string, sch shim.Schema) bool {
 			if _, has := result[name]; has {
 				// `name` is present, so mark any names that are declared to
-				// conflict with `name` for exclusiion.
+				// conflict with `name` for exclusion.
 				for _, conflictingName := range sch.ConflictsWith() {
 					conflictsWith[conflictingName] = struct{}{}
 				}
@@ -366,6 +366,7 @@ func (ctx *conversionContext) applyDefaults(result map[string]interface{}, olds,
 				for _, conflictingName := range sch.ConflictsWith() {
 					if _, has := result[conflictingName]; has {
 						conflictsWith[name] = struct{}{}
+						break
 					}
 				}
 			}

--- a/pkg/tfshim/tfplugin5/provider_test.go
+++ b/pkg/tfshim/tfplugin5/provider_test.go
@@ -375,10 +375,11 @@ func TestProviderResourcesMap(t *testing.T) {
 				"nested_resources": cty.List(cty.Object(map[string]cty.Type{
 					"configuration": cty.Map(cty.String),
 				})),
-				"set_property_value":            cty.Set(cty.String),
-				"string_with_bad_interpolation": cty.String,
-				"conflicting_property":          cty.String,
-				"conflicting_property2":         cty.String,
+				"set_property_value":                  cty.Set(cty.String),
+				"string_with_bad_interpolation":       cty.String,
+				"conflicting_property":                cty.String,
+				"conflicting_property2":               cty.String,
+				"conflicting_property_unidirectional": cty.Bool,
 			}),
 			schema: schema.SchemaMap{
 				"id": &attributeSchema{
@@ -505,6 +506,11 @@ func TestProviderResourcesMap(t *testing.T) {
 				"conflicting_property2": &attributeSchema{
 					ctyType:   cty.String,
 					valueType: shim.TypeString,
+					optional:  true,
+				},
+				"conflicting_property_unidirectional": &attributeSchema{
+					ctyType:   cty.Bool,
+					valueType: shim.TypeBool,
 					optional:  true,
 				},
 			},


### PR DESCRIPTION
Some Terraform providers specify ConflictsWith in one direction but not
the other (e.g., pulumi/pulumi-snowflake#11). Teach applyDefaults to
handle this situation too to avoid spurious conflict warnings.

Arguably, specifying ConflictsWith in one direction but not the other is
a bug in the provider schema, but at the very least it's a mistake
that's easy to make. Since Terraform seems to handle it just fine, it
seems worth handling in Pulumi too.