### PR TITLE
Added file for locally debugging HCL converter

### DIFF
--- a/pkg/tfgen/examples_coverage_test.go
+++ b/pkg/tfgen/examples_coverage_test.go
@@ -1,0 +1,53 @@
+// Copyright 2016-2021, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file implements a simple system for testing the HCL converter.
+package tfgen
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_HclConversion(t *testing.T) {
+	g, err := NewGenerator(GeneratorOptions{
+		Version:         "version",
+		Language:        Language("go"),
+		Debug:           false,
+		SkipDocs:        false,
+		SkipExamples:    false,
+		CoverageTracker: newCoverageTracker("Provider", "Version"),
+	})
+	assert.NoError(t, err, "Failed to create generator")
+
+	// HCL code to be given to the converter
+	hcl := `
+	resource "aws_pinpoint_apns_voip_channel" "apns_voip" {
+		certificate = file("./certificate.pem")
+	}`
+
+	name := "EXAMPLE_NAME"
+
+	g.coverageTracker.foundExample(name, hcl)
+	codeBlock, stderr, err := g.convertHCL(hcl, name)
+
+	if err != nil {
+		fmt.Println("Test failed: ", err.Error())
+	}
+	fmt.Println(codeBlock)
+	fmt.Println(stderr)
+	assert.NoError(t, err, "Failed to convert")
+}

--- a/pkg/tfgen/examples_coverage_test.go
+++ b/pkg/tfgen/examples_coverage_test.go
@@ -12,21 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This file implements a simple system for locally testing and debugging the
-// HCL converter without the use of GitHub Actions.
+// This file implements a simple system for locally testing and efficiently
+// debugging the HCL converter without the use of GitHub Actions.
 package tfgen
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/go/common/diag/colors"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/stretchr/testify/assert"
 )
 
 func Test_HclConversion(t *testing.T) {
+
+	// Test is ignored by default so as to not interrupt GitHub Actions.
+	// Set as false in order to allow the test to fail and display conversion info.
+	IGNORE_TEST := true
+	if IGNORE_TEST {
+		return
+	}
 
 	//============================= HCL code to be given to the converter =============================//
 	hcl := `
@@ -82,16 +86,13 @@ func Test_HclConversion(t *testing.T) {
 		Debug:        false,
 		SkipDocs:     false,
 		SkipExamples: false,
-		Sink: diag.DefaultSink(os.Stdout, os.Stderr, diag.FormatOptions{
-			Color: colors.Auto,
-		}),
 	})
 	assert.NoError(t, err, "Failed to create generator")
 
 	// Attempting to convert our HCL code
 	codeBlock, stderr, err := g.convertHCL(hcl, "EXAMPLE_NAME")
 
-	// Checking for error
+	// Checking for error and printing if it exists
 	if err != nil {
 		fmt.Println(err.Error())
 		fmt.Println(stderr)
@@ -100,6 +101,6 @@ func Test_HclConversion(t *testing.T) {
 	// Printing translated code in the case that it was successfully converted
 	fmt.Println(codeBlock)
 
-	// Throwing a panic so that we see the translated code
+	// Failing the test so that we see the all the printed information
 	panic("")
 }

--- a/pkg/tfgen/examples_coverage_test.go
+++ b/pkg/tfgen/examples_coverage_test.go
@@ -18,8 +18,11 @@ package tfgen
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
+	"github.com/pulumi/pulumi/sdk/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -79,6 +82,9 @@ func Test_HclConversion(t *testing.T) {
 		Debug:        false,
 		SkipDocs:     false,
 		SkipExamples: false,
+		Sink: diag.DefaultSink(os.Stdout, os.Stderr, diag.FormatOptions{
+			Color: colors.Auto,
+		}),
 	})
 	assert.NoError(t, err, "Failed to create generator")
 

--- a/pkg/tfgen/examples_coverage_test.go
+++ b/pkg/tfgen/examples_coverage_test.go
@@ -21,8 +21,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/go/common/diag"
-	"github.com/pulumi/pulumi/sdk/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/tfgen/examples_coverage_test.go
+++ b/pkg/tfgen/examples_coverage_test.go
@@ -18,8 +18,11 @@ package tfgen
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
+	"github.com/pulumi/pulumi/sdk/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/go/common/diag/colors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -27,73 +30,26 @@ func Test_HclConversion(t *testing.T) {
 
 	//============================= HCL code to be given to the converter =============================//
 	hcl := `
-	data "azurerm_client_config" "current" {}
-
-	resource "azurerm_resource_group" "example" {
-	  name     = "example-resources"
-	  location = "West Europe"
-	}
-	
-	resource "azurerm_key_vault" "example" {
-	  name                = "examplekv"
-	  location            = azurerm_resource_group.example.location
-	  resource_group_name = azurerm_resource_group.example.name
-	  tenant_id           = data.azurerm_client_config.current.tenant_id
-	  sku_name            = "standard"
-	
-	  purge_protection_enabled = true
-	}
-	
-	resource "azurerm_key_vault_access_policy" "storage" {
-	  key_vault_id = azurerm_key_vault.example.id
-	  tenant_id    = data.azurerm_client_config.current.tenant_id
-	  object_id    = azurerm_storage_account.example.identity.0.principal_id
-	
-	  key_permissions    = ["get", "create", "list", "restore", "recover", "unwrapkey", "wrapkey", "purge", "encrypt", "decrypt", "sign", "verify"]
-	  secret_permissions = ["get"]
-	}
-	
-	resource "azurerm_key_vault_access_policy" "client" {
-	  key_vault_id = azurerm_key_vault.example.id
-	  tenant_id    = data.azurerm_client_config.current.tenant_id
-	  object_id    = data.azurerm_client_config.current.object_id
-	
-	  key_permissions    = ["get", "create", "delete", "list", "restore", "recover", "unwrapkey", "wrapkey", "purge", "encrypt", "decrypt", "sign", "verify"]
-	  secret_permissions = ["get"]
-	}
-	
-	
-	resource "azurerm_key_vault_key" "example" {
-	  name         = "tfex-key"
-	  key_vault_id = azurerm_key_vault.example.id
-	  key_type     = "RSA"
-	  key_size     = 2048
-	  key_opts     = ["decrypt", "encrypt", "sign", "unwrapKey", "verify", "wrapKey"]
-	
-	  depends_on = [
-		azurerm_key_vault_access_policy.client,
-		azurerm_key_vault_access_policy.storage,
-	  ]
-	}
-	
-	
-	resource "azurerm_storage_account" "example" {
-	  name                     = "examplestor"
-	  resource_group_name      = azurerm_resource_group.example.name
-	  location                 = azurerm_resource_group.example.location
-	  account_tier             = "Standard"
-	  account_replication_type = "GRS"
-	
-	  identity {
-		type = "SystemAssigned"
+	resource "aws_vpc" "vpc" {
+		cidr_block = "10.0.0.0/16"
 	  }
-	}
-	
-	resource "azurerm_storage_account_customer_managed_key" "example" {
-	  storage_account_id = azurerm_storage_account.example.id
-	  key_vault_id       = azurerm_key_vault.example.id
-	  key_name           = azurerm_key_vault_key.example.name
-	}
+	  
+	  resource "aws_vpn_gateway" "vpn_gateway" {
+		vpc_id = aws_vpc.vpc.id
+	  }
+	  
+	  resource "aws_customer_gateway" "customer_gateway" {
+		bgp_asn    = 65000
+		ip_address = "172.0.0.1"
+		type       = "ipsec.1"
+	  }
+	  
+	  resource "aws_vpn_connection" "main" {
+		vpn_gateway_id      = aws_vpn_gateway.vpn_gateway.id
+		customer_gateway_id = aws_customer_gateway.customer_gateway.id
+		type                = "ipsec.1"
+		static_routes_only  = true
+	  }
 	`
 	//=================================================================================================//
 
@@ -107,6 +63,9 @@ func Test_HclConversion(t *testing.T) {
 		Debug:        false,
 		SkipDocs:     false,
 		SkipExamples: false,
+		Sink: diag.DefaultSink(os.Stdout, os.Stderr, diag.FormatOptions{
+			Color: colors.Never,
+		}),
 	})
 	assert.NoError(t, err, "Failed to create generator")
 


### PR DESCRIPTION
Added a simple unit test that runs the Pulumi converter on any given block of HCL code. This opens up the ability to experiment with the converter, reproduce errors, and to efficiently debug issues.