### PR TITLE
Fixed major error in Coverage Tracker

### DIFF
--- a/pkg/tfgen/examples_coverage_tracker.go
+++ b/pkg/tfgen/examples_coverage_tracker.go
@@ -34,38 +34,55 @@ import (
 	"github.com/hashicorp/hcl/v2"
 )
 
-// Main overarching structure for storing coverage data on how many examples were processed,
-// how many failed, and for what reason. At different stages, the code translator notifies
-// the tracker of what is going on. Notifications are treated as an ordered stream of events.
-// INTERFACE:
-// foundExample(), languageConversionSuccess(), languageConversionFailure(), languageConversionPanic().
+/*
+Main overarching structure for storing coverage data on how many examples were processed,
+how many failed, and for what reason. At different stages, the code translator notifies
+the tracker of what is going on. Notifications are treated as an ordered sequence of events.
+
+NOTIFICATION INTERFACE:
+
+foundExample(pageName, hcl)
+
+languageConversionSuccess(targetLanguage)
+
+languageConversionWarning(targetLanguage, warningDiagnostics)
+
+languageConversionFailure(targetLanguage, failureDiagnostics)
+
+languageConversionPanic(targetLanguage, panicInfo)
+*/
 type CoverageTracker struct {
-	ProviderName        string                         // Name of the provider
-	ProviderVersion     string                         // Version of the provider
-	currentExampleName  string                         // Name of current example that is being processed
-	EncounteredExamples map[string]*GeneralExampleInfo // Mapping example names to their general information
+	ProviderName     string                        // Name of the provider
+	ProviderVersion  string                        // Version of the provider
+	currentPageName  string                        // Name of current page that is being processed
+	EncounteredPages map[string]*DocumentationPage // Map linking page IDs to their data
 }
 
-// General information about an example, and how successful it was at being converted to different languages
-type GeneralExampleInfo struct {
-	Name                   string
-	OriginalHCL            string
-	LanguagesConvertedTo   map[string]*LanguageConversionResult // Mapping language names to their conversion diagnostics
-	NameFoundMultipleTimes bool                                 // Current name has already been encountered before
+// A structure encompassing a single page, which contains one or more examples.
+// This closely resembles the web pages seen in Pulumi/Terraform documentation.
+type DocumentationPage struct {
+	Name     string    // The unique ID of this documentation page
+	Examples []Example // This page's examples, stored in the order they were found
+}
+
+// Contains information about a single example, consisting of a block of HCL and
+// one or more language conversion results.
+type Example struct {
+	OriginalHCL       string                               // Original HCL code that the example was found with
+	ConversionResults map[string]*LanguageConversionResult // Mapping language names to their conversion results
 }
 
 // Individual language information concerning how successfully an example was converted to Pulumi
 type LanguageConversionResult struct {
-	TargetLanguage  string
-	FailureSeverity int    // [Success, Warning, Failure, Fatal]
+	FailureSeverity int    // This conversion's outcome: [Success, Warning, Failure, Fatal]
 	FailureInfo     string // Additional in-depth information
 
-	// !! Current example name has already been converted for this specific language before.
-	// Either the example is duplicated, or a bug is present !!
-	MultipleTranslations bool
+	// How many times this example has been converted to this language.
+	// It is expected that this will be equal to 1.
+	TranslationCount int
 }
 
-// Failure severity values
+// Conversion outcome severity values
 const (
 	Success = 0
 	Warning = 1
@@ -75,96 +92,99 @@ const (
 
 func newCoverageTracker(ProviderName string, ProviderVersion string) *CoverageTracker {
 	return &CoverageTracker{ProviderName, ProviderVersion, "",
-		make(map[string]*GeneralExampleInfo)}
+		make(map[string]*DocumentationPage)}
 }
 
-// Used when: generator has found a new example with a convertible block of HCL
-func (ct *CoverageTracker) foundExample(exampleName string, hcl string) {
+// Used when: generator has found a brand new example, with a convertible block
+// of HCL that hasn't been encountered before.
+func (ct *CoverageTracker) foundExample(pageName string, hcl string) {
 	if ct == nil {
 		return
 	}
-	ct.currentExampleName = exampleName
-	if val, ok := ct.EncounteredExamples[exampleName]; ok {
-		val.NameFoundMultipleTimes = true
+	ct.currentPageName = pageName
+
+	if existingPage, ok := ct.EncounteredPages[pageName]; ok {
+		// This example's page already exists. Appending example to it.
+		existingPage.Examples = append(existingPage.Examples, Example{hcl, make(map[string]*LanguageConversionResult)})
 	} else {
-		ct.EncounteredExamples[exampleName] = &GeneralExampleInfo{exampleName, hcl,
-			make(map[string]*LanguageConversionResult), false}
+		// Initializing a page for this example.
+		ct.EncounteredPages[pageName] = &DocumentationPage{
+			pageName,
+			[]Example{Example{hcl, make(map[string]*LanguageConversionResult)}},
+		}
 	}
 }
 
 // Used when: current example has been successfully converted to a certain language
-func (ct *CoverageTracker) languageConversionSuccess(targetLanguage string) {
+func (ct *CoverageTracker) languageConversionSuccess(languageName string) {
 	if ct == nil {
 		return
 	}
-	ct.insertLanguageConversionResult(LanguageConversionResult{
-		TargetLanguage:       targetLanguage,
-		FailureSeverity:      0,
-		FailureInfo:          "",
-		MultipleTranslations: false,
+	ct.insertLanguageConversionResult(languageName, LanguageConversionResult{
+		FailureSeverity:  Success,
+		FailureInfo:      "",
+		TranslationCount: 1,
 	})
 }
 
 //nolint
 // Used when: generator has successfully converted current example, but threw out some warnings
-func (ct *CoverageTracker) languageConversionWarning(targetLanguage string, warningDiagnostics hcl.Diagnostics) {
+func (ct *CoverageTracker) languageConversionWarning(languageName string, warningDiagnostics hcl.Diagnostics) {
 	if ct == nil {
 		return
 	}
-	ct.insertLanguageConversionResult(LanguageConversionResult{
-		TargetLanguage:       targetLanguage,
-		FailureSeverity:      1,
-		FailureInfo:          formatDiagnostics(warningDiagnostics),
-		MultipleTranslations: false,
+	ct.insertLanguageConversionResult(languageName, LanguageConversionResult{
+		FailureSeverity:  Warning,
+		FailureInfo:      formatDiagnostics(warningDiagnostics),
+		TranslationCount: 1,
 	})
 }
 
 // Used when: generator has failed to convert the current example to a certain language
-func (ct *CoverageTracker) languageConversionFailure(targetLanguage string, failureDiagnostics hcl.Diagnostics) {
+func (ct *CoverageTracker) languageConversionFailure(languageName string, failureDiagnostics hcl.Diagnostics) {
 	if ct == nil {
 		return
 	}
-	ct.insertLanguageConversionResult(LanguageConversionResult{
-		TargetLanguage:       targetLanguage,
-		FailureSeverity:      2,
-		FailureInfo:          formatDiagnostics(failureDiagnostics),
-		MultipleTranslations: false,
+	ct.insertLanguageConversionResult(languageName, LanguageConversionResult{
+		FailureSeverity:  Failure,
+		FailureInfo:      formatDiagnostics(failureDiagnostics),
+		TranslationCount: 1,
 	})
 }
 
 // Used when: generator encountered a fatal internal error when trying to convert the
 // current example to a certain language
-func (ct *CoverageTracker) languageConversionPanic(targetLanguage string, panicInfo string) {
+func (ct *CoverageTracker) languageConversionPanic(languageName string, panicInfo string) {
 	if ct == nil {
 		return
 	}
-	ct.insertLanguageConversionResult(LanguageConversionResult{
-		TargetLanguage:       targetLanguage,
-		FailureSeverity:      3,
-		FailureInfo:          panicInfo,
-		MultipleTranslations: false,
+	ct.insertLanguageConversionResult(languageName, LanguageConversionResult{
+		FailureSeverity:  Fatal,
+		FailureInfo:      panicInfo,
+		TranslationCount: 1,
 	})
 }
 
 // Adding a language conversion result to the current example. If a conversion result with the same
 // target language already exists, keep the lowest severity one and mark the example as possibly duplicated
-func (ct *CoverageTracker) insertLanguageConversionResult(conversionResult LanguageConversionResult) {
-	if currentExample, ok := ct.EncounteredExamples[ct.currentExampleName]; ok {
-		if existingConversionResult, ok := currentExample.LanguagesConvertedTo[conversionResult.TargetLanguage]; ok {
+func (ct *CoverageTracker) insertLanguageConversionResult(languageName string, newConversionResult LanguageConversionResult) {
+	if currentPage, ok := ct.EncounteredPages[ct.currentPageName]; ok {
+		lastExample := currentPage.lastExample()
 
-			// If incoming result is of a lower severity, keep it instead of the existing one
-			if conversionResult.FailureSeverity < existingConversionResult.FailureSeverity {
-				currentExample.LanguagesConvertedTo[conversionResult.TargetLanguage] = &conversionResult
+		if existingConversionResult, ok := lastExample.ConversionResults[languageName]; ok {
+			// Example already has this language conversion attempt. Replace if new one has a lower severity
+			if newConversionResult.FailureSeverity < existingConversionResult.FailureSeverity {
+				lastExample.ConversionResults[languageName] = &newConversionResult
 			}
-			existingConversionResult.MultipleTranslations = true
+			existingConversionResult.TranslationCount += 1
 		} else {
-
-			// A brand new language conversion result is being added for this example
-			currentExample.LanguagesConvertedTo[conversionResult.TargetLanguage] = &conversionResult
+			// The new language conversion result is added for this example
+			lastExample.ConversionResults[languageName] = &newConversionResult
 		}
 	} else {
-		fmt.Println("Error: attempted to log the result of a language conversion without first finding an example")
-		fmt.Println(conversionResult)
+		// Check that foundExample() is called before all other Coverage Tracker interface methods
+		fmt.Println("Error: attempted to log an example language conversion result without first finding its page")
+		fmt.Println(newConversionResult)
 		panic("")
 	}
 }
@@ -200,6 +220,11 @@ func formatDiagnostics(diagnostics hcl.Diagnostics) string {
 
 	// Returning all the formatted diagnostics as a single string
 	return strings.Join(results[:], "; ")
+}
+
+// Returning the page's last example, to which conversion results will be added.
+func (Page *DocumentationPage) lastExample() *Example {
+	return &Page.Examples[len(Page.Examples)-1]
 }
 
 // Exporting the coverage results


### PR DESCRIPTION
In certain cases, multiple HCL examples all under the same example name are provided to the coverage tracker, which leads to their conversion results being overwritten by eachother and lost. The coverage tracker has been updated to handle such cases, and the exporter has been updated to differentiate between these examples in the resulting JSONs by appending "#[INDEX]" to the example name based on the order it was encountered.