### PR TITLE
feat: Support omitting properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 ## HEAD (Unreleased)
 * Upgrade to Pulumi v3.12.0 for sdk and pkg
 * Add support for exporting provider example conversion metrics
+* Support omitting properties from `DataSources` and `Resources`.
 
 ---
 

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -218,6 +218,9 @@ type SchemaInfo struct {
 	// whether or not this property has been removed from the Terraform schema
 	Removed bool
 
+	// if set, this property will not be added to the schema and no bindings will be generated for it
+	Omit bool
+
 	// whether or not to treat this property as secret
 	Secret *bool
 }

--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -451,6 +451,10 @@ func (g *schemaGenerator) genResourceType(mod string, res *resourceType) pschema
 
 	spec.Properties = map[string]pschema.PropertySpec{}
 	for _, prop := range res.outprops {
+		// The property will be dropped from the schema
+		if prop.info != nil && prop.info.Omit {
+			continue
+		}
 		spec.Properties[prop.name] = g.genProperty(mod, prop, true)
 
 		if !prop.optional() {
@@ -460,6 +464,10 @@ func (g *schemaGenerator) genResourceType(mod string, res *resourceType) pschema
 
 	spec.InputProperties = map[string]pschema.PropertySpec{}
 	for _, prop := range res.inprops {
+		// The property will be dropped from the schema
+		if prop.info != nil && prop.info.Omit {
+			continue
+		}
 		spec.InputProperties[prop.name] = g.genProperty(mod, prop, true)
 
 		if !prop.optional() {
@@ -545,6 +553,10 @@ func (g *schemaGenerator) genObjectType(mod string, typInfo *schemaNestedType) (
 
 	spec.Properties = map[string]pschema.PropertySpec{}
 	for _, prop := range typ.properties {
+		// The property will be dropped from the schema
+		if prop.info != nil && prop.info.Omit {
+			continue
+		}
 		spec.Properties[prop.name] = g.genProperty(mod, prop, typInfo.pyMapCase)
 
 		if !prop.optional() {


### PR DESCRIPTION
Currently there is no way to not generate Pulumi bindings for a
`DataSource` or a `Resource` for which a property in the underlying
Terraform provider exists.

This commit adds a new `Omit` flag in the `SchemaInfo`. When `Omit` is
enabled, the property is dropped from the schema and no bindings will
be generated for it.