### PR TITLE
refactor: return less meaningless error

### DIFF
--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -855,7 +855,8 @@ func (p *Provider) Create(ctx context.Context, req *pulumirpc.CreateRequest) (*p
 		newstate, err = p.tf.Apply(res.TFName, nil, diff)
 		if newstate == nil {
 			if err == nil {
-				return nil, fmt.Errorf("expected non-nil error with nil state during Create of %s", urn)
+				// This should never happen or never bubble up to the end user
+				log.Panicf("expected non-nil error with nil state during Create of %s", urn)
 			}
 			return nil, err
 		}

--- a/pkg/tfshim/tfplugin5/provider.go
+++ b/pkg/tfshim/tfplugin5/provider.go
@@ -407,6 +407,10 @@ func (p *provider) Apply(t string, s shim.InstanceState, d shim.InstanceDiff) (s
 	if err != nil {
 		return nil, err
 	}
+	if newState == nil {
+		// Should retry before reaching here or check empty response etc.
+		return nil, fmt.Errorf("internal error: empty new state value received.")
+	}
 
 	return newState, unmarshalErrors(resp.Diagnostics)
 }


### PR DESCRIPTION
Don't think messages like: `expected non-nil error with nil state during Create of ...` should be returned up. 

There must be either response value or error not both empty. If the provider returns empty or unexpected response then we should either:

- Query resource state and if resource not actually created then retry or 
- Let the user do so by offering some error handling on resources like `new docker.RemoteImage()` or
- Fail but report meaningful error message like: `the underlying provider has returned empty response for resource creation` etc. instead of:

> docker:index:RemoteImage xxxx creating replacement [diff: ~pullTriggers]; error: expected non-nil error with nil state during Create of urn:pulumi:***::xxx::xxx:group$xxx:xxx$docker:index/remoteImage:RemoteImage::xxxx

The above error goes away with a simple re-run without any changes but it happens intermittently 