### PR TITLE
Ensure all variants of primitives are covered in TF Schema Overrides

### DIFF
--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -955,12 +955,12 @@ func CoerceTerraformString(schType shim.ValueType, ps *SchemaInfo, stringValue s
 	// breaking overrides where we have a string and a TransformJSONDocument (see pulumi/pulumi#4592)
 	if ps != nil && ps.Type != "" {
 		switch strings.ToLower(ps.Type.String()) {
-		case "boolean":
+		case "bool", "boolean":
 			if stringValue == "" {
 				return nil, nil
 			}
 			return convertTfStringToBool(stringValue)
-		case "int":
+		case "int", "integer":
 			return convertTfStringToInt(stringValue)
 		case "float":
 			return convertTfStringToFloat(stringValue)

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -937,20 +937,35 @@ func TestOverridingTFSchema(t *testing.T) {
 		shimv1.NewProvider(testTFProvider),
 		map[string]interface{}{
 			"pulumi_override_tf_string_to_boolean":    MyString("true"),
+			"pulumi_override_tf_string_to_bool":       MyString("true"),
 			"pulumi_empty_tf_override":                MyString("true"),
+			"pulumi_override_tf_string_to_int":        MyString("1"),
+			"pulumi_override_tf_string_to_integer":    MyString("1"),
 			"tf_empty_string_to_pulumi_bool_override": MyString(""),
 		},
 		shimv1.NewSchemaMap(map[string]*schemav1.Schema{
 			"pulumi_override_tf_string_to_boolean":    {Type: schemav1.TypeString},
+			"pulumi_override_tf_string_to_bool":       {Type: schemav1.TypeString},
 			"pulumi_empty_tf_override":                {Type: schemav1.TypeString},
+			"pulumi_override_tf_string_to_int":        {Type: schemav1.TypeString},
+			"pulumi_override_tf_string_to_integer":    {Type: schemav1.TypeString},
 			"tf_empty_string_to_pulumi_bool_override": {Type: schemav1.TypeString},
 		}),
 		map[string]*SchemaInfo{
 			"pulumi_override_tf_string_to_boolean": {
 				Type: "boolean",
 			},
+			"pulumi_override_tf_string_to_bool": {
+				Type: "bool",
+			},
 			"pulumi_empty_tf_override": {
 				Type: "",
+			},
+			"pulumi_override_tf_string_to_int": {
+				Type: "int",
+			},
+			"pulumi_override_tf_string_to_integer": {
+				Type: "integer",
 			},
 			"tf_empty_string_to_pulumi_bool_override": {
 				Type:           "boolean",
@@ -963,7 +978,10 @@ func TestOverridingTFSchema(t *testing.T) {
 	)
 	assert.Equal(t, resource.NewPropertyMapFromMap(map[string]interface{}{
 		"pulumiOverrideTfStringToBoolean":   true,
+		"pulumiOverrideTfStringToBool":      true,
 		"pulumiEmptyTfOverride":             "true",
+		"pulumiOverrideTfStringToInt":       1,
+		"pulumiOverrideTfStringToInteger":   1,
 		"tfEmptyStringToPulumiBoolOverride": nil,
 	}), result)
 }


### PR DESCRIPTION
Currently, the type needed to be correct "int" or "boolean" and that
wasn't obvious in the TF providers. So we now cater for "integer" and
"bool" to ensure that they are now all defaulting to strings

Without these additional cases, we could end up in a statement of
DotNet getting the incorrect type (i.e a string when it expected a double)
and thus throwing an error as follows:

```
System.InvalidOperationException: Expected System.Double but got System.String deserializing Pulumi.Aws.LB.TargetGroup.deregistrationDelay
```
