### PR TITLE
Add boilerplate functions.

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -16,6 +16,8 @@ package tfbridge
 
 import (
 	"fmt"
+	"unicode"
+
 	"github.com/blang/semver"
 	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -736,3 +738,46 @@ func GetModuleMajorVersion(version string) string {
 	}
 	return majorVersion
 }
+
+// MakeMember manufactures a type token for the package and the given module and type.
+func MakeMember(pkg string, mod string, mem string) tokens.ModuleMember {
+	return tokens.ModuleMember(pkg + ":" + mod + ":" + mem)
+}
+
+// MakeType manufactures a type token for the package and the given module and type.
+func MakeType(pkg string, mod string, typ string) tokens.Type {
+	return tokens.Type(MakeMember(pkg, mod, typ))
+}
+
+// MakeDataSource manufactures a standard Pulumi function token given a package, module, and data source name.  It
+// automatically uses the main package and names the file by simply lower casing the data source's
+// first character.
+func MakeDataSource(pkg string, mod string, res string) tokens.ModuleMember {
+	fn := string(unicode.ToLower(rune(res[0]))) + res[1:]
+	return MakeMember(pkg, mod+"/"+fn, res)
+}
+
+// MakeResource manufactures a standard resource token given a module and resource name.  It
+// automatically uses the main package and names the file by simply lower casing the resource's
+// first character.
+func MakeResource(pkg string, mod string, res string) tokens.Type {
+	fn := string(unicode.ToLower(rune(res[0]))) + res[1:]
+	return MakeType(pkg, mod+"/"+fn, res)
+}
+
+// BoolRef returns a reference to the bool argument.
+func BoolRef(b bool) *bool {
+	return &b
+}
+
+// StringValue gets a string value from a property map if present, else ""
+func StringValue(vars resource.PropertyMap, prop resource.PropertyKey) string {
+	val, ok := vars[prop]
+	if ok && val.IsString() {
+		return val.StringValue()
+	}
+	return ""
+}
+
+// ManagedByPulumi is a default used for some managed resources, in the absence of something more meaningful.
+var ManagedByPulumi = &DefaultInfo{Value: "Managed by Pulumi"}

--- a/pkg/tfbridge/info_test.go
+++ b/pkg/tfbridge/info_test.go
@@ -1,8 +1,10 @@
 package tfbridge
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetModuleMajorVersion(t *testing.T) {
@@ -34,4 +36,29 @@ func TestGetModuleMajorVersion(t *testing.T) {
 		majorVersion := GetModuleMajorVersion(test.version)
 		assert.Equal(t, test.expectedMajorVersion, majorVersion)
 	}
+}
+
+func TestMakeMember(t *testing.T) {
+	assert.Equal(t, "package:module:member", MakeMember("package", "module", "member").String())
+}
+
+func TestMakeType(t *testing.T) {
+	assert.Equal(t, "package:module:member", MakeType("package", "module", "member").String())
+}
+
+func TestMakeDataSource(t *testing.T) {
+	assert.Equal(t, "package:module/getSomething:getSomething", MakeDataSource("package", "module", "getSomething").String())
+	assert.Equal(t, "package:module/getSomething:GetSomething", MakeDataSource("package", "module", "GetSomething").String())
+}
+
+func TestMakeResource(t *testing.T) {
+	assert.Equal(t, "package:module/myResource:MyResource", MakeResource("package", "module", "MyResource").String())
+}
+
+func TestStringValue(t *testing.T) {
+	myMap := map[resource.PropertyKey]resource.PropertyValue{
+		"key1": {V: "value1"},
+	}
+	assert.Equal(t, "value1", StringValue(myMap, "key1"))
+	assert.Equal(t, "", StringValue(myMap, "keyThatDoesNotExist"))
 }


### PR DESCRIPTION
Adds functions to tfbridge that were in the Terraform provider
boilerplate code so that they are not repeated in each provider and have
a consistent implementation.

Fixes #412 