### PR TITLE
feat: Support omitting properties

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -222,6 +222,9 @@ type SchemaInfo struct {
 	// whether or not this property has been removed from the Terraform schema
 	Removed bool
 
+	// if set, this property will not be added to the schema and no bindings will be generated for it
+	Omit bool
+
 	// whether or not to treat this property as secret
 	Secret *bool
 }

--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -454,6 +454,14 @@ func (g *schemaGenerator) genResourceType(mod string, res *resourceType) pschema
 
 	spec.Properties = map[string]pschema.PropertySpec{}
 	for _, prop := range res.outprops {
+		// The property will be dropped from the schema
+		if prop.info != nil && prop.info.Omit {
+			if prop.schema.Required() {
+				contract.Failf("required property %q may not be omitted from binding generation", prop.name)
+			} else {
+				continue
+			}
+		}
 		spec.Properties[prop.name] = g.genProperty(mod, prop, true)
 
 		if !prop.optional() {
@@ -463,6 +471,13 @@ func (g *schemaGenerator) genResourceType(mod string, res *resourceType) pschema
 
 	spec.InputProperties = map[string]pschema.PropertySpec{}
 	for _, prop := range res.inprops {
+		if prop.info != nil && prop.info.Omit {
+			if prop.schema.Required() {
+				contract.Failf("required input property %q may not be omitted from binding generation", prop.name)
+			} else {
+				continue
+			}
+		}
 		spec.InputProperties[prop.name] = g.genProperty(mod, prop, true)
 
 		if !prop.optional() {
@@ -548,6 +563,13 @@ func (g *schemaGenerator) genObjectType(mod string, typInfo *schemaNestedType) (
 
 	spec.Properties = map[string]pschema.PropertySpec{}
 	for _, prop := range typ.properties {
+		if prop.info != nil && prop.info.Omit {
+			if prop.schema.Required() {
+				contract.Failf("required object property %q may not be omitted from binding generation", prop.name)
+			} else {
+				continue
+			}
+		}
 		spec.Properties[prop.name] = g.genProperty(mod, prop, typInfo.pyMapCase)
 
 		if !prop.optional() {


### PR DESCRIPTION
Currently there is no way to not generate Pulumi bindings for a `DataSource` or a `Resource` for which a property in the underlying Terraform provider exists.

This commit adds a new `Omit` flag in the `SchemaInfo`. When `Omit` is enabled, the property is dropped from the schema and no bindings will be generated for it, provided the property is not required (which would render the provider unusable from the generated bindings).

Supercedes #392.