### PR TITLE
External language hooks for pulumi-terraform-bridge

### DIFF
--- a/pkg/tfgen/language.go
+++ b/pkg/tfgen/language.go
@@ -42,6 +42,14 @@ func initializeLanguageBackend(lang Language) (languageBackend, error) {
 		return &csharpLanguageBackend{}, nil
 	case Schema:
 		return &schemaLanguageBackend{}, nil
+	default:
+		maybeBackend, err := parseExternalLanguage(lang)
+		if err != nil {
+			return nil, err
+		}
+		if maybeBackend == nil {
+			return nil, fmt.Errorf("%v does not support SDK generation", lang)
+		}
+		return maybeBackend, nil
 	}
-	return nil, fmt.Errorf("%v does not support SDK generation", lang)
 }

--- a/pkg/tfgen/language.go
+++ b/pkg/tfgen/language.go
@@ -1,0 +1,47 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfgen
+
+import (
+	"fmt"
+
+	"github.com/spf13/afero"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+)
+
+type languageBackend interface {
+	name() string
+	shouldConvertExamples() bool
+	overlayInfo(info *tfbridge.ProviderInfo) *tfbridge.OverlayInfo
+	emitFiles(spec *pschema.PackageSpec, overlay *tfbridge.OverlayInfo, root afero.Fs) (map[string][]byte, error)
+}
+
+func initializeLanguageBackend(lang Language) (languageBackend, error) {
+	switch lang {
+	case Golang:
+		return &golangLanguageBackend{}, nil
+	case NodeJS:
+		return &nodejsLanguageBackend{}, nil
+	case Python:
+		return &pythonLanguageBackend{}, nil
+	case CSharp:
+		return &csharpLanguageBackend{}, nil
+	case Schema:
+		return &schemaLanguageBackend{}, nil
+	}
+	return nil, fmt.Errorf("%v does not support SDK generation", lang)
+}

--- a/pkg/tfgen/language_csharp.go
+++ b/pkg/tfgen/language_csharp.go
@@ -1,0 +1,83 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfgen
+
+import (
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/afero"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	dotnetgen "github.com/pulumi/pulumi/pkg/v3/codegen/dotnet"
+	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+)
+
+type csharpLanguageBackend struct{}
+
+var _ languageBackend = &csharpLanguageBackend{}
+
+func (b *csharpLanguageBackend) name() string {
+	return string(CSharp)
+}
+
+func (b *csharpLanguageBackend) shouldConvertExamples() bool {
+	return true
+}
+
+func (b *csharpLanguageBackend) overlayInfo(info *tfbridge.ProviderInfo) *tfbridge.OverlayInfo {
+	if cinfo := info.CSharp; cinfo != nil {
+		return cinfo.Overlay
+	}
+	return nil
+}
+
+func (b *csharpLanguageBackend) emitFiles(
+	pulumiPackageSpec *pschema.PackageSpec,
+	overlay *tfbridge.OverlayInfo,
+	root afero.Fs,
+) (map[string][]byte, error) {
+	empty := map[string][]byte{}
+	pulumiPackage, err := pschema.ImportSpec(*pulumiPackageSpec, nil)
+	if err != nil {
+		return empty, errors.Wrapf(err, "failed to import Pulumi schema")
+	}
+	files, err := b.emitSDK(pulumiPackage, overlay, root)
+	if err != nil {
+		return empty, errors.Wrapf(err, "failed to generate package")
+	}
+	return files, nil
+}
+
+func (b *csharpLanguageBackend) emitSDK(
+	pkg *pschema.Package,
+	overlay *tfbridge.OverlayInfo,
+	root afero.Fs,
+) (map[string][]byte, error) {
+	var extraFiles map[string][]byte
+	var err error
+
+	if overlay != nil {
+		extraFiles, err = getOverlayFiles(overlay, ".cs", root)
+		if err != nil {
+			return nil, err
+		}
+	}
+	err = cleanDir(root, "", nil)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	return dotnetgen.GeneratePackage(tfgen, pkg, extraFiles)
+}

--- a/pkg/tfgen/language_external.go
+++ b/pkg/tfgen/language_external.go
@@ -71,10 +71,10 @@ func (b *externalLanguageBackend) exec(operation string, input json.RawMessage) 
 	}
 	cmd := exec.Command(exe, "-operation", operation)
 	cmd.Stdin = bytes.NewBuffer(input)
-	out, err := cmd.Output()
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, b.errorf("Failed to execute `%s -operation %s`: %w",
-			b.executableName, operation, err)
+		return nil, b.errorf("Failed to execute `%s -operation %s`: %w\n%s",
+			exe, operation, err, out)
 	}
 	return out, err
 }

--- a/pkg/tfgen/language_external.go
+++ b/pkg/tfgen/language_external.go
@@ -1,0 +1,161 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// External languages allow extending tfgen with new SDK generators
+// without liking them in as a build dependency of tfgen itself.
+//
+// If you specify "external:mylang" as the desired language, tfgen
+// will search for `pulumi-tfgen-external-language-mylang` executable
+// in PATH, and delegate language backend operations to that
+// executable.
+//
+// To implement an external language, use `tfgen.ExternalLanguageMain`
+// in a Go CLI program.
+
+package tfgen
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"github.com/spf13/afero"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+)
+
+type externalLanguageBackend struct {
+	languageName string
+}
+
+var _ languageBackend = &externalLanguageBackend{}
+
+func (b *externalLanguageBackend) validateName() error {
+	var isAlpha = regexp.MustCompile(`^[-a-zA-Z][-a-zA-Z0-9]*$`).MatchString
+	if !isAlpha(b.languageName) {
+		return b.errorf("Invalid language name `%s`: must be alphanumeric and non-empty", b.languageName)
+	}
+	return nil
+}
+
+func (b *externalLanguageBackend) executableName() (string, error) {
+	err := b.validateName()
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("pulumi-tfgen-external-language-%s", b.languageName), nil
+}
+
+func (b *externalLanguageBackend) exec(operation string, input json.RawMessage) (json.RawMessage, error) {
+	exe, err := b.executableName()
+	if err != nil {
+		return nil, err
+	}
+	cmd := exec.Command(exe, "-operation", operation)
+	cmd.Stdin = bytes.NewBuffer(input)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, b.errorf("Failed to execute `%s -operation %s`: %w",
+			b.executableName, operation, err)
+	}
+	return out, err
+}
+
+func (b *externalLanguageBackend) name() string {
+	return b.languageName
+}
+
+func (b *externalLanguageBackend) shouldConvertExamples() bool {
+	return false
+}
+
+func (b *externalLanguageBackend) overlayInfo(info *tfbridge.ProviderInfo) *tfbridge.OverlayInfo {
+	return nil
+}
+
+func (b *externalLanguageBackend) emitFiles(
+	pulumiPackageSpec *pschema.PackageSpec,
+	overlay *tfbridge.OverlayInfo,
+	_ afero.Fs,
+) (map[string][]byte, error) {
+
+	if overlay != nil {
+		return nil, b.errorf("Expecting overlay to be nil")
+	}
+
+	input, err := json.Marshal(pulumiPackageSpec)
+	if err != nil {
+		return nil, b.errorf("Cannot marshal PackageSpec to JSON: %v", err)
+	}
+
+	output, err := b.exec("emitFiles", input)
+	if err != nil {
+		return nil, err
+	}
+
+	var files map[string][]byte
+
+	if err = json.Unmarshal(output, &files); err != nil {
+		return nil, b.errorf("Cannot parse emitted files from JSON: %v", err)
+	}
+
+	return files, nil
+}
+
+func (b *externalLanguageBackend) errorf(format string, args ...interface{}) error {
+	f := fmt.Sprintf("[externalLanguageBackend %s] %s", b.languageName, format)
+	return fmt.Errorf(f, args...)
+}
+
+func parseExternalLanguage(lang Language) (languageBackend, error) {
+	prefix := "external:"
+	if strings.HasPrefix(string(lang), prefix) {
+		lang := strings.TrimPrefix(string(lang), prefix)
+		backend := &externalLanguageBackend{lang}
+		if err := backend.validateName(); err != nil {
+			return nil, err
+		}
+		return backend, nil
+	}
+	return nil, nil
+}
+
+func ExternalLanguageMain(emitFiles func(*pschema.PackageSpec) (map[string][]byte, error)) {
+	operation := flag.String("operation", "", "operation to perform, typically emitFiles")
+	flag.Parse()
+	switch *operation {
+	case "emitFiles":
+		var pulumiPackageSpec *pschema.PackageSpec
+		err := json.NewDecoder(os.Stdin).Decode(&pulumiPackageSpec)
+		if err != nil {
+			log.Fatal(fmt.Errorf("Cannot parse PackageSpec from JSON: %w", err))
+		}
+		files, err := emitFiles(pulumiPackageSpec)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if err := json.NewEncoder(os.Stdout).Encode(files); err != nil {
+			log.Fatal(err)
+		}
+	default:
+		log.Fatal(fmt.Errorf("Required -operation, supported values: [emitFiles]"))
+	}
+}

--- a/pkg/tfgen/language_golang.go
+++ b/pkg/tfgen/language_golang.go
@@ -1,0 +1,68 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfgen
+
+import (
+	"github.com/pkg/errors"
+	"github.com/spf13/afero"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	gogen "github.com/pulumi/pulumi/pkg/v3/codegen/go"
+	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+)
+
+type golangLanguageBackend struct{}
+
+var _ languageBackend = &golangLanguageBackend{}
+
+func (b *golangLanguageBackend) name() string {
+	return string(Golang)
+}
+
+func (b *golangLanguageBackend) shouldConvertExamples() bool {
+	return true
+}
+
+func (b *golangLanguageBackend) overlayInfo(info *tfbridge.ProviderInfo) *tfbridge.OverlayInfo {
+	if goinfo := info.Golang; goinfo != nil {
+		return goinfo.Overlay
+	}
+	return nil
+}
+
+func (b *golangLanguageBackend) emitFiles(
+	pulumiPackageSpec *pschema.PackageSpec,
+	overlay *tfbridge.OverlayInfo,
+	root afero.Fs,
+) (map[string][]byte, error) {
+	empty := map[string][]byte{}
+	pulumiPackage, err := pschema.ImportSpec(*pulumiPackageSpec, nil)
+	if err != nil {
+		return empty, errors.Wrapf(err, "failed to import Pulumi schema")
+	}
+	files, err := b.emitSDK(pulumiPackage, overlay, root)
+	if err != nil {
+		return empty, errors.Wrapf(err, "failed to generate package")
+	}
+	return files, nil
+}
+
+func (b *golangLanguageBackend) emitSDK(
+	pkg *pschema.Package,
+	overlay *tfbridge.OverlayInfo,
+	root afero.Fs,
+) (map[string][]byte, error) {
+	return gogen.GeneratePackage(tfgen, pkg)
+}

--- a/pkg/tfgen/language_nodejs.go
+++ b/pkg/tfgen/language_nodejs.go
@@ -1,0 +1,92 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfgen
+
+import (
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/afero"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi/pkg/v3/codegen"
+	nodejsgen "github.com/pulumi/pulumi/pkg/v3/codegen/nodejs"
+	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+)
+
+type nodejsLanguageBackend struct{}
+
+var _ languageBackend = &nodejsLanguageBackend{}
+
+func (b *nodejsLanguageBackend) name() string {
+	return string(NodeJS)
+}
+
+func (b *nodejsLanguageBackend) shouldConvertExamples() bool {
+	return true
+}
+
+func (b *nodejsLanguageBackend) overlayInfo(info *tfbridge.ProviderInfo) *tfbridge.OverlayInfo {
+	if jsinfo := info.JavaScript; jsinfo != nil {
+		return jsinfo.Overlay
+	}
+	return nil
+}
+
+func (b *nodejsLanguageBackend) emitFiles(
+	pulumiPackageSpec *pschema.PackageSpec,
+	overlay *tfbridge.OverlayInfo,
+	root afero.Fs,
+) (map[string][]byte, error) {
+	empty := map[string][]byte{}
+	pulumiPackage, err := pschema.ImportSpec(*pulumiPackageSpec, nil)
+	if err != nil {
+		return empty, errors.Wrapf(err, "failed to import Pulumi schema")
+	}
+	files, err := b.emitSDK(pulumiPackage, overlay, root)
+	if err != nil {
+		return empty, errors.Wrapf(err, "failed to generate package")
+	}
+	return files, nil
+}
+
+func (b *nodejsLanguageBackend) emitSDK(
+	pkg *pschema.Package,
+	overlay *tfbridge.OverlayInfo,
+	root afero.Fs,
+) (map[string][]byte, error) {
+	var extraFiles map[string][]byte
+	var err error
+
+	if overlay != nil {
+		extraFiles, err = getOverlayFiles(overlay, ".ts", root)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// We exclude the "tests" directory because some nodejs package dirs (e.g. pulumi-docker)
+	// store tests here. We don't want to include them in the overlays because we don't want it
+	// exported with the module, but we don't want them deleted in a cleanup of the directory.
+	exclusions := codegen.NewStringSet("tests")
+
+	// We don't need to add overlays to the exclusion list because they have already been read
+	// into memory so deleting the files is not a problem.
+	err = cleanDir(root, "", exclusions)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	return nodejsgen.GeneratePackage(tfgen, pkg, extraFiles)
+}

--- a/pkg/tfgen/language_python.go
+++ b/pkg/tfgen/language_python.go
@@ -1,0 +1,87 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfgen
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/afero"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	pygen "github.com/pulumi/pulumi/pkg/v3/codegen/python"
+	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+)
+
+type pythonLanguageBackend struct{}
+
+var _ languageBackend = &pythonLanguageBackend{}
+
+func (b *pythonLanguageBackend) name() string {
+	return string(Python)
+}
+
+func (b *pythonLanguageBackend) shouldConvertExamples() bool {
+	return true
+}
+
+func (b *pythonLanguageBackend) overlayInfo(info *tfbridge.ProviderInfo) *tfbridge.OverlayInfo {
+	if pyinfo := info.Python; pyinfo != nil {
+		return pyinfo.Overlay
+	}
+	return nil
+}
+
+func (b *pythonLanguageBackend) emitFiles(
+	pulumiPackageSpec *pschema.PackageSpec,
+	overlay *tfbridge.OverlayInfo,
+	root afero.Fs,
+) (map[string][]byte, error) {
+	empty := map[string][]byte{}
+	pulumiPackage, err := pschema.ImportSpec(*pulumiPackageSpec, nil)
+	if err != nil {
+		return empty, errors.Wrapf(err, "failed to import Pulumi schema")
+	}
+	files, err := b.emitSDK(pulumiPackage, overlay, root)
+	if err != nil {
+		return empty, errors.Wrapf(err, "failed to generate package")
+	}
+	return files, nil
+}
+
+func (b *pythonLanguageBackend) emitSDK(
+	pkg *pschema.Package,
+	overlay *tfbridge.OverlayInfo,
+	root afero.Fs,
+) (map[string][]byte, error) {
+	var extraFiles map[string][]byte
+	var err error
+
+	if overlay != nil {
+		extraFiles, err = getOverlayFiles(overlay, ".py", root)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// python's outdir path follows the pattern [provider]/sdk/python/pulumi_[pkg name]
+	pyOutDir := fmt.Sprintf("pulumi_%s", pkg.Name)
+	err = cleanDir(root, pyOutDir, nil)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	return pygen.GeneratePackage(tfgen, pkg, extraFiles)
+}

--- a/pkg/tfgen/language_schema.go
+++ b/pkg/tfgen/language_schema.go
@@ -1,0 +1,56 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfgen
+
+import (
+	"encoding/json"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/afero"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+)
+
+type schemaLanguageBackend struct{}
+
+var _ languageBackend = &schemaLanguageBackend{}
+
+func (b *schemaLanguageBackend) name() string {
+	return string(Schema)
+}
+
+func (b *schemaLanguageBackend) shouldConvertExamples() bool {
+	return true
+}
+
+func (b *schemaLanguageBackend) overlayInfo(info *tfbridge.ProviderInfo) *tfbridge.OverlayInfo {
+	return nil
+}
+
+func (b *schemaLanguageBackend) emitFiles(
+	pulumiPackageSpec *pschema.PackageSpec,
+	overlay *tfbridge.OverlayInfo,
+	root afero.Fs,
+) (map[string][]byte, error) {
+	// Omit the version so that the spec is stable if the version is e.g. derived from the current Git commit hash.
+	var pkgSpec pschema.PackageSpec = *pulumiPackageSpec
+	pkgSpec.Version = ""
+	bytes, err := json.MarshalIndent(pkgSpec, "", "    ")
+	if err != nil {
+		return map[string][]byte{}, errors.Wrapf(err, "failed to marshal schema")
+	}
+	return map[string][]byte{"schema.json": bytes}, nil
+}


### PR DESCRIPTION
These changes aim to support more languages than the standard set without taking a build-dependency in pulumi-terraform-bridge. For example I am able to do this:

```
pulumi-tfgen-random external:pascal --out sdk/pascal
```

And it will interop with `pulumi-tfgen-external-language-pascal` binary I can provide at the call site to have the right codegen backend. 

The programgen (docs, examples) is not yet supported for these.

I can proceed with experimental development without this being merged. Also marking WIP for now until I have evidence it's working end to end.
