### PR TITLE
Enable better tfgen resource mapping errors

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -59,6 +59,7 @@ type ProviderInfo struct {
 	Resources               map[string]*ResourceInfo           // a map of TF name to Pulumi name; standard mangling occurs if no entry.
 	DataSources             map[string]*DataSourceInfo         // a map of TF name to Pulumi resource info.
 	ExtraTypes              map[string]pschema.ComplexTypeSpec // a map of Pulumi token to schema type for overlaid types.
+	IgnoreMappings          []string                           // a list of TF resources and data sources to ignore in mappings errors
 	PluginDownloadURL       string                             // an optional URL to download the provider binary from.
 	JavaScript              *JavaScriptInfo                    // optional overlay information for augmented JavaScript code-generation.
 	Python                  *PythonInfo                        // optional overlay information for augmented Python code-generation.


### PR DESCRIPTION
Fixes: #427

1. We now can control a list of tf resources and datasources to ignore in
mappings errors via `IgnoreMappings`
2. We can pass `PULUMI_MISSING_MAPPING_ERROR` or `PULUMI_PROVIDER_MAP_ERROR`
to error when a tf resource / datasource is missed in the Pulumi provider
resources.go
3. We can pass `PULUMI_EXTRA_MAPPING_ERROR` to error when a mapping exists
in resources.go to a TF resource / datasource that doesn't exist

For scenario 2, if a resource is in the ignore list, then we do not error
BUT we pass a debug info message
