### PR TITLE
Elide empty inputs from Read

### DIFF
--- a/internal/testprovider/schema.go
+++ b/internal/testprovider/schema.go
@@ -45,6 +45,7 @@ func ProviderV1() *schemav1.Provider {
 		ResourcesMap: map[string]*schemav1.Resource{
 			"example_resource": {
 				Schema: map[string]*schemav1.Schema{
+					"opt_bool":              {Type: schemav1.TypeBool, Optional: true, Default: true},
 					"nil_property_value":    {Type: schemav1.TypeMap, Optional: true},
 					"bool_property_value":   {Type: schemav1.TypeBool, Optional: true},
 					"number_property_value": {Type: schemav1.TypeInt, Optional: true},
@@ -65,6 +66,7 @@ func ProviderV1() *schemav1.Provider {
 						Elem: &schemav1.Resource{
 							Schema: map[string]*schemav1.Schema{
 								"kind":          {Type: schemav1.TypeString, Optional: true},
+								"opt_bool":      {Type: schemav1.TypeBool, Optional: true, Default: true},
 								"configuration": {Type: schemav1.TypeMap, Required: true},
 							},
 						},
@@ -106,6 +108,7 @@ func ProviderV1() *schemav1.Provider {
 					return nil
 				},
 				Read: func(data *schemav1.ResourceData, p interface{}) error {
+					MustSetIfUnset(data, "opt_bool", false)
 					MustSetIfUnset(data, "bool_property_value", false)
 					MustSetIfUnset(data, "number_property_value", 42)
 					MustSetIfUnset(data, "float_property_value", 99.6767932)

--- a/internal/testprovider/schema.go
+++ b/internal/testprovider/schema.go
@@ -107,7 +107,10 @@ func ProviderV1() *schemav1.Provider {
 					return nil
 				},
 				Read: func(data *schemav1.ResourceData, p interface{}) error {
-					if data.Id() == "resource-id" {
+					if data.Id() == "empty-resource-id" {
+						MustSetIfUnset(data, "array_property_value", []interface{}{"an array"})
+						MustSetIfUnset(data, "nested_resources", nil)
+					} else {
 						MustSetIfUnset(data, "bool_property_value", false)
 						MustSetIfUnset(data, "number_property_value", 42)
 						MustSetIfUnset(data, "float_property_value", 99.6767932)
@@ -127,9 +130,6 @@ func ProviderV1() *schemav1.Provider {
 						})
 						MustSetIfUnset(data, "set_property_value", []interface{}{"set member 1", "set member 2"})
 						MustSetIfUnset(data, "string_with_bad_interpolation", "some ${interpolated:value} with syntax errors")
-					} else {
-						MustSetIfUnset(data, "array_property_value", []interface{}{"an array"})
-						MustSetIfUnset(data, "nested_resources", nil)
 					}
 					return nil
 				},
@@ -386,6 +386,7 @@ func ProviderV2() *schemav2.Provider {
 						Elem: &schemav2.Resource{
 							Schema: map[string]*schemav2.Schema{
 								"kind":          {Type: schemav2.TypeString, Optional: true},
+								"opt_bool":      {Type: schemav2.TypeBool, Optional: true},
 								"configuration": {Type: schemav2.TypeMap, Required: true},
 							},
 						},
@@ -427,25 +428,30 @@ func ProviderV2() *schemav2.Provider {
 					return nil
 				},
 				Read: func(data *schemav2.ResourceData, p interface{}) error {
-					MustSetIfUnset(data, "bool_property_value", false)
-					MustSetIfUnset(data, "number_property_value", 42)
-					MustSetIfUnset(data, "float_property_value", 99.6767932)
-					MustSetIfUnset(data, "string_property_value", "ognirts")
-					MustSetIfUnset(data, "array_property_value", []interface{}{"an array"})
-					MustSetIfUnset(data, "object_property_value", map[string]interface{}{
-						"property_a": "a",
-						"property_b": "true",
-						"property.c": "some.value",
-					})
-					MustSetIfUnset(data, "nested_resources", []interface{}{
-						map[string]interface{}{
-							"configuration": map[string]interface{}{
-								"configurationValue": "true",
+					if data.Id() == "empty-resource-id" {
+						MustSetIfUnset(data, "array_property_value", []interface{}{"an array"})
+						MustSetIfUnset(data, "nested_resources", nil)
+					} else {
+						MustSetIfUnset(data, "bool_property_value", false)
+						MustSetIfUnset(data, "number_property_value", 42)
+						MustSetIfUnset(data, "float_property_value", 99.6767932)
+						MustSetIfUnset(data, "string_property_value", "ognirts")
+						MustSetIfUnset(data, "array_property_value", []interface{}{"an array"})
+						MustSetIfUnset(data, "object_property_value", map[string]interface{}{
+							"property_a": "a",
+							"property_b": "true",
+							"property.c": "some.value",
+						})
+						MustSetIfUnset(data, "nested_resources", []interface{}{
+							map[string]interface{}{
+								"configuration": map[string]interface{}{
+									"configurationValue": "true",
+								},
 							},
-						},
-					})
-					MustSetIfUnset(data, "set_property_value", []interface{}{"set member 1", "set member 2"})
-					MustSetIfUnset(data, "string_with_bad_interpolation", "some ${interpolated:value} with syntax errors")
+						})
+						MustSetIfUnset(data, "set_property_value", []interface{}{"set member 1", "set member 2"})
+						MustSetIfUnset(data, "string_with_bad_interpolation", "some ${interpolated:value} with syntax errors")
+					}
 					return nil
 				},
 				Update: func(data *schemav2.ResourceData, p interface{}) error {

--- a/internal/testprovider/schema.go
+++ b/internal/testprovider/schema.go
@@ -66,7 +66,7 @@ func ProviderV1() *schemav1.Provider {
 						Elem: &schemav1.Resource{
 							Schema: map[string]*schemav1.Schema{
 								"kind":          {Type: schemav1.TypeString, Optional: true},
-								"opt_bool":      {Type: schemav1.TypeBool, Optional: true, Default: true},
+								"opt_bool":      {Type: schemav1.TypeBool, Optional: true},
 								"configuration": {Type: schemav1.TypeMap, Required: true},
 							},
 						},

--- a/internal/testprovider/schema.go
+++ b/internal/testprovider/schema.go
@@ -45,7 +45,6 @@ func ProviderV1() *schemav1.Provider {
 		ResourcesMap: map[string]*schemav1.Resource{
 			"example_resource": {
 				Schema: map[string]*schemav1.Schema{
-					"opt_bool":              {Type: schemav1.TypeBool, Optional: true, Default: true},
 					"nil_property_value":    {Type: schemav1.TypeMap, Optional: true},
 					"bool_property_value":   {Type: schemav1.TypeBool, Optional: true},
 					"number_property_value": {Type: schemav1.TypeInt, Optional: true},
@@ -108,26 +107,30 @@ func ProviderV1() *schemav1.Provider {
 					return nil
 				},
 				Read: func(data *schemav1.ResourceData, p interface{}) error {
-					MustSetIfUnset(data, "opt_bool", false)
-					MustSetIfUnset(data, "bool_property_value", false)
-					MustSetIfUnset(data, "number_property_value", 42)
-					MustSetIfUnset(data, "float_property_value", 99.6767932)
-					MustSetIfUnset(data, "string_property_value", "ognirts")
-					MustSetIfUnset(data, "array_property_value", []interface{}{"an array"})
-					MustSetIfUnset(data, "object_property_value", map[string]interface{}{
-						"property_a": "a",
-						"property_b": "true",
-						"property.c": "some.value",
-					})
-					MustSetIfUnset(data, "nested_resources", []interface{}{
-						map[string]interface{}{
-							"configuration": map[string]interface{}{
-								"configurationValue": "true",
+					if data.Id() == "resource-id" {
+						MustSetIfUnset(data, "bool_property_value", false)
+						MustSetIfUnset(data, "number_property_value", 42)
+						MustSetIfUnset(data, "float_property_value", 99.6767932)
+						MustSetIfUnset(data, "string_property_value", "ognirts")
+						MustSetIfUnset(data, "array_property_value", []interface{}{"an array"})
+						MustSetIfUnset(data, "object_property_value", map[string]interface{}{
+							"property_a": "a",
+							"property_b": "true",
+							"property.c": "some.value",
+						})
+						MustSetIfUnset(data, "nested_resources", []interface{}{
+							map[string]interface{}{
+								"configuration": map[string]interface{}{
+									"configurationValue": "true",
+								},
 							},
-						},
-					})
-					MustSetIfUnset(data, "set_property_value", []interface{}{"set member 1", "set member 2"})
-					MustSetIfUnset(data, "string_with_bad_interpolation", "some ${interpolated:value} with syntax errors")
+						})
+						MustSetIfUnset(data, "set_property_value", []interface{}{"set member 1", "set member 2"})
+						MustSetIfUnset(data, "string_with_bad_interpolation", "some ${interpolated:value} with syntax errors")
+					} else {
+						MustSetIfUnset(data, "array_property_value", []interface{}{"an array"})
+						MustSetIfUnset(data, "nested_resources", nil)
+					}
 					return nil
 				},
 				Update: func(data *schemav1.ResourceData, p interface{}) error {

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -570,6 +570,8 @@ func testProviderRead(t *testing.T, provider *Provider, typeName tokens.Type) {
 	ins, err := plugin.UnmarshalProperties(readResp.GetInputs(), plugin.MarshalOptions{KeepUnknowns: true})
 	assert.NoError(t, err)
 	// Check all the expected inputs were read
+	assert.Equal(t, resource.NewBoolProperty(false), ins["optBool"]) // This was "false" from Read but it's default is true so we need to keep it
+	assert.NotContains(t, ins, "boolPropertyValue")                  // This was "false" from Read, but it's default is false
 	assert.Equal(t, resource.NewNumberProperty(42), ins["numberPropertyValue"])
 	assert.Equal(t, resource.NewNumberProperty(99.6767932), ins["floatPropertyValue"])
 	assert.Equal(t, resource.NewStringProperty("ognirts"), ins["stringPropertyValue"])
@@ -588,8 +590,9 @@ func testProviderRead(t *testing.T, provider *Provider, typeName tokens.Type) {
 			"configurationValue": resource.NewStringProperty("true"),
 		}),
 		// Uncomment the line below to make the test pass:
-		// "kind": resource.NewStringProperty(""),
-		// But this is not really expected! The Read function for ExampleResource in internal/testprovider/schema.go does not set "kind"!
+		//"optBool": resource.NewBoolProperty(false),
+		// But this is not really expected! The Read function for ExampleResource in internal/testprovider/schema.go does not set "optBool" and it's default value is true!
+		// This should either be missing (like kind is missing) or be true
 	}), ins["nestedResources"])
 	assert.Equal(t, resource.NewArrayProperty(
 		[]resource.PropertyValue{

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -353,6 +353,7 @@ func testProviderPreview(t *testing.T, provider *Provider) {
 			"configuration": resource.NewObjectProperty(resource.PropertyMap{
 				"name": resource.NewStringProperty("foo"),
 			}),
+			"optBool": resource.NewBoolProperty(false),
 		}),
 	}.DeepEquals(outs))
 
@@ -415,6 +416,7 @@ func testProviderPreview(t *testing.T, provider *Provider) {
 		"configuration": resource.NewObjectProperty(resource.PropertyMap{
 			"name": resource.NewStringProperty("foo"),
 		}),
+		"optBool": resource.NewBoolProperty(false),
 	}).DeepEquals(outs["nestedResources"]))
 }
 
@@ -598,7 +600,7 @@ func testProviderRead(t *testing.T, provider *Provider, typeName tokens.Type) {
 
 	// Read again with the ID that results in all the optinal fields not being set
 	readResp, err = provider.Read(context.Background(), &pulumirpc.ReadRequest{
-		Id:         string("resource-id-empty"),
+		Id:         string("empty-resource-id"),
 		Urn:        string(urn),
 		Properties: nil,
 	})

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -570,7 +570,6 @@ func testProviderRead(t *testing.T, provider *Provider, typeName tokens.Type) {
 	ins, err := plugin.UnmarshalProperties(readResp.GetInputs(), plugin.MarshalOptions{KeepUnknowns: true})
 	assert.NoError(t, err)
 	// Check all the expected inputs were read
-	assert.Equal(t, resource.NewBoolProperty(false), ins["boolPropertyValue"])
 	assert.Equal(t, resource.NewNumberProperty(42), ins["numberPropertyValue"])
 	assert.Equal(t, resource.NewNumberProperty(99.6767932), ins["floatPropertyValue"])
 	assert.Equal(t, resource.NewStringProperty("ognirts"), ins["stringPropertyValue"])

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -589,10 +589,6 @@ func testProviderRead(t *testing.T, provider *Provider, typeName tokens.Type) {
 			"__defaults":         resource.NewArrayProperty([]resource.PropertyValue{}),
 			"configurationValue": resource.NewStringProperty("true"),
 		}),
-		// Uncomment the line below to make the test pass:
-		//"optBool": resource.NewBoolProperty(false),
-		// But this is not really expected! The Read function for ExampleResource in internal/testprovider/schema.go does not set "optBool" and it's default value is true!
-		// This should either be missing (like kind is missing) or be true
 	}), ins["nestedResources"])
 	assert.Equal(t, resource.NewArrayProperty(
 		[]resource.PropertyValue{

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -1115,6 +1115,8 @@ func isDefaultOrZeroValue(tfs shim.Schema, ps *SchemaInfo, v resource.PropertyVa
 	}
 
 	switch {
+	case v.IsNull():
+		return true
 	case v.IsBool():
 		return v.BoolValue() == false
 	case v.IsNumber():

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -1110,8 +1110,8 @@ func getDefaultValue(tfs shim.Schema, ps *SchemaInfo) interface{} {
 }
 
 func isDefaultOrZeroValue(tfs shim.Schema, ps *SchemaInfo, v resource.PropertyValue) bool {
-	if dv := getDefaultValue(tfs, ps); dv == v.V {
-		return true
+	if dv := getDefaultValue(tfs, ps); dv != nil {
+		return dv == v.V
 	}
 
 	switch {

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -1391,6 +1391,11 @@ func TestExtractInputsFromOutputs(t *testing.T) {
 					return strings.ToLower(v.(string))
 				},
 			},
+
+			// input_i, inout_j, and inout_k test import scenarios where attributes are set to "".
+			"input_i": {Type: schemav1.TypeString, Required: true},
+			"inout_j": {Type: schemav1.TypeString, Optional: true, Computed: true},
+			"inout_k": {Type: schemav1.TypeString, Optional: true, Computed: true, Default: "inout_k_default"},
 		},
 		func(d *schemav1.ResourceData, meta interface{}) ([]*schemav1.ResourceData, error) {
 			return []*schemav1.ResourceData{d}, nil
@@ -1413,6 +1418,9 @@ func TestExtractInputsFromOutputs(t *testing.T) {
 		}
 		set(d, "inout_d", "inout_d_read")
 		set(d, "output_g", "output_g_read")
+		set(d, "input_i", "")
+		set(d, "inout_j", "")
+		set(d, "inout_k", "")
 		return nil
 	}
 	tfres.Create = func(d *schemav1.ResourceData, meta interface{}) error {
@@ -1470,6 +1478,9 @@ func TestExtractInputsFromOutputs(t *testing.T) {
 		"inoutC":  "inout_c_read",
 		"inoutD":  "inout_d_read",
 		"outputG": "output_g_read",
+		"inputI":  "",
+		"inoutJ":  "",
+		"inoutK":  "",
 	}), outs)
 
 	ins, err := plugin.UnmarshalProperties(resp.GetInputs(), plugin.MarshalOptions{})
@@ -1479,6 +1490,8 @@ func TestExtractInputsFromOutputs(t *testing.T) {
 		"inputA":    "input_a_read",
 		"inoutC":    "inout_c_read",
 		"inoutD":    "inout_d_read",
+		"inputI":    "",
+		"inoutK":    "",
 	})
 	assert.Equal(t, expected, ins)
 
@@ -1505,7 +1518,7 @@ func TestExtractInputsFromOutputs(t *testing.T) {
 	assert.NoError(t, err)
 	sortDefaultsList(checkedIns)
 	assert.Equal(t, resource.NewPropertyMapFromMap(map[string]interface{}{
-		defaultsKey: []interface{}{"inoutD", "inputF", "inputH"},
+		defaultsKey: []interface{}{"inoutD", "inoutK", "inputF", "inputH"},
 		"inputA":    "input_a_create",
 		"inoutD":    "inout_d_default",
 		"inputE": map[string]interface{}{
@@ -1514,6 +1527,7 @@ func TestExtractInputsFromOutputs(t *testing.T) {
 		},
 		"inputF": "input_f_default",
 		"inputH": "Input_H_Default",
+		"inoutK": "inout_k_default",
 	}), checkedIns)
 
 	// Step 2: create a resource using the checked input bag. The inputs should be smuggled along with the state.
@@ -1536,6 +1550,7 @@ func TestExtractInputsFromOutputs(t *testing.T) {
 		"inputF":  "input_f_default",
 		"outputG": "output_g_create",
 		"inputH":  "input_h_default",
+		"inoutK":  "inout_k_default",
 	}), outs)
 
 	// Step 3: read the resource we just created. The read should make the following changes to the inputs:
@@ -1565,6 +1580,9 @@ func TestExtractInputsFromOutputs(t *testing.T) {
 		"inputF":  "input_f_default",
 		"outputG": "output_g_read",
 		"inputH":  "input_h_default",
+		"inputI":  "",
+		"inoutJ":  "",
+		"inoutK":  "",
 	}), outs)
 
 	ins, err = plugin.UnmarshalProperties(resp.GetInputs(), plugin.MarshalOptions{})
@@ -1579,6 +1597,7 @@ func TestExtractInputsFromOutputs(t *testing.T) {
 		},
 		"inputF": "input_f_default",
 		"inputH": "Input_H_Default",
+		"inoutK": "",
 	}), ins)
 
 	// Step 3a. delete the default annotations from the checked inputs and re-run the read. No default annotations
@@ -1609,6 +1628,9 @@ func TestExtractInputsFromOutputs(t *testing.T) {
 		"inputF":  "input_f_default",
 		"outputG": "output_g_read",
 		"inputH":  "input_h_default",
+		"inputI":  "",
+		"inoutJ":  "",
+		"inoutK":  "",
 	}), outs)
 
 	ins, err = plugin.UnmarshalProperties(resp.GetInputs(), plugin.MarshalOptions{})
@@ -1621,6 +1643,7 @@ func TestExtractInputsFromOutputs(t *testing.T) {
 		},
 		"inputF": "input_f_default",
 		"inputH": "Input_H_Default",
+		"inoutK": "",
 	}), ins)
 
 }

--- a/pkg/tfshim/tfplugin5/provider_test.go
+++ b/pkg/tfshim/tfplugin5/provider_test.go
@@ -231,6 +231,7 @@ func TestProviderResourcesMap(t *testing.T) {
 				"array_property_value":  cty.List(cty.String),
 				"object_property_value": cty.Map(cty.String),
 				"nested_resources": cty.List(cty.Object(map[string]cty.Type{
+					"opt_bool":      cty.Bool,
 					"kind":          cty.String,
 					"configuration": cty.Map(cty.String),
 				})),
@@ -311,16 +312,23 @@ func TestProviderResourcesMap(t *testing.T) {
 				},
 				"nested_resources": &attributeSchema{
 					ctyType: cty.List(cty.Object(map[string]cty.Type{
+						"opt_bool":      cty.Bool,
 						"kind":          cty.String,
 						"configuration": cty.Map(cty.String),
 					})),
 					valueType: shim.TypeList,
 					elem: &resource{
 						ctyType: cty.Object(map[string]cty.Type{
+							"opt_bool":      cty.Bool,
 							"kind":          cty.String,
 							"configuration": cty.Map(cty.String),
 						}),
 						schema: schema.SchemaMap{
+							"opt_bool": &attributeSchema{
+								ctyType:   cty.Bool,
+								valueType: shim.TypeBool,
+								optional:  true,
+							},
 							"kind": &attributeSchema{
 								ctyType:   cty.String,
 								valueType: shim.TypeString,
@@ -923,6 +931,7 @@ func TestDiff(t *testing.T) {
 				"array_property_value":  cty.ListValEmpty(cty.String),
 				"object_property_value": cty.NullVal(cty.Map(cty.String)),
 				"nested_resources": cty.ListValEmpty(cty.Object(map[string]cty.Type{
+					"opt_bool":      cty.Bool,
 					"kind":          cty.String,
 					"configuration": cty.Map(cty.String),
 				})),
@@ -1032,7 +1041,8 @@ func TestApply(t *testing.T) {
 				"array_property_value": []interface{}{"foo"},
 				"nested_resources": []interface{}{
 					map[string]interface{}{
-						"kind": cty.StringVal(""),
+						"opt_bool": cty.BoolVal(false),
+						"kind":     cty.StringVal(""),
 						"configuration": map[string]interface{}{
 							"baz": "qux",
 						},
@@ -1060,7 +1070,8 @@ func TestApply(t *testing.T) {
 					"property.c": cty.StringVal("some.value"),
 				}),
 				"nested_resources": cty.ListVal([]cty.Value{cty.ObjectVal(map[string]cty.Value{
-					"kind": cty.StringVal(""),
+					"opt_bool": cty.BoolVal(false),
+					"kind":     cty.StringVal(""),
 					"configuration": cty.MapVal(map[string]cty.Value{
 						"configurationValue": cty.StringVal("true"),
 					}),
@@ -1112,7 +1123,8 @@ func TestApply(t *testing.T) {
 						"property.c": cty.StringVal("some.value"),
 					}),
 					"nested_resources": cty.ListVal([]cty.Value{cty.ObjectVal(map[string]cty.Value{
-						"kind": cty.StringVal(""),
+						"opt_bool": cty.BoolVal(false),
+						"kind":     cty.StringVal(""),
 						"configuration": cty.MapVal(map[string]cty.Value{
 							"configurationValue": cty.StringVal("true"),
 						}),
@@ -1198,7 +1210,8 @@ func TestRefresh(t *testing.T) {
 			"property.c": cty.StringVal("some.value"),
 		}),
 		"nested_resources": cty.ListVal([]cty.Value{cty.ObjectVal(map[string]cty.Value{
-			"kind": cty.StringVal(""),
+			"opt_bool": cty.BoolVal(false),
+			"kind":     cty.StringVal(""),
 			"configuration": cty.MapVal(map[string]cty.Value{
 				"configurationValue": cty.StringVal("true"),
 			}),


### PR DESCRIPTION
Currently when we issue a refresh to terraform it sets properties to a zero value if they were reported unset by the underlying provider. This results in a lot of properties with “”, false, or 0 values which should have just been unset. 

This commit uses the schema reported back to strip out these empty properties. This should result in much better Read results from the tfbridge providers.
