### PR TITLE
Add a language PCL that produces examples as PCL

### DIFF
--- a/pkg/tf2pulumi/convert/tf11.go
+++ b/pkg/tf2pulumi/convert/tf11.go
@@ -175,8 +175,12 @@ func newGenerator(w io.Writer, projectName string, opts Options) (gen.Generator,
 	case LanguagePython:
 		return python.New(projectName, w), "__main__.py", nil
 	default:
+		validLanguages := make([]string, len(ValidLanguages))
+		for i, l := range ValidLanguages {
+			validLanguages[i] = string(l)
+		}
 		return nil, "", errors.Errorf("invalid language '%s', expected one of %s",
-			opts.TargetLanguage, strings.Join(ValidLanguages[:], ", "))
+			opts.TargetLanguage, strings.Join(validLanguages, ", "))
 	}
 }
 

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -1194,7 +1194,14 @@ func (g *Generator) convertHCL(hcl, path string) (string, string, error) {
 			if result.Len() > 0 {
 				result.WriteByte('\n')
 			}
-			_, err := fmt.Fprintf(&result, "```%s\n%s\n```", languageName, strings.TrimSpace(string(output)))
+			out := strings.TrimSpace(string(output))
+
+			if g.convertedCode == nil {
+				g.convertedCode = map[string][]byte{}
+			}
+			g.convertedCode[path] = []byte(out)
+
+			_, err := fmt.Fprintf(&result, "```%s\n%s\n```", languageName, out)
 			contract.IgnoreError(err)
 		}
 
@@ -1204,13 +1211,16 @@ func (g *Generator) convertHCL(hcl, path string) (string, string, error) {
 
 	switch g.language {
 	case NodeJS:
-		err = convertHCL("typescript")
+		err = convertHCL(convert.LanguageTypescript)
 	case Python:
-		err = convertHCL("python")
+		err = convertHCL(convert.LanguagePython)
 	case CSharp:
-		err = convertHCL("csharp")
+		err = convertHCL(convert.LanguageCSharp)
 	case Golang:
-		err = convertHCL("go")
+		err = convertHCL(convert.LanguageGo)
+	case PCL:
+		convertHCL(convert.LanguagePulumi)
+
 	case Schema:
 		langs := []string{"typescript", "python", "csharp", "go"}
 		var anySucceeded bool = false

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -767,7 +767,7 @@ func (g *Generator) Generate() error {
 		}
 		files = map[string][]byte{}
 		for path, code := range g.convertedCode {
-			path = strings.TrimPrefix(path, "#/") + ".pcl"
+			path = strings.TrimPrefix(path, "#/") + ".pp"
 			files[path] = code
 		}
 	default:

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -69,6 +69,8 @@ type Generator struct {
 	skipDocs         bool
 	skipExamples     bool
 	coverageTracker  *CoverageTracker
+
+	convertedCode map[string][]byte
 }
 
 type Language string
@@ -79,11 +81,12 @@ const (
 	Python Language = "python"
 	CSharp Language = "dotnet"
 	Schema Language = "schema"
+	PCL    Language = "pulumi"
 )
 
 func (l Language) shouldConvertExamples() bool {
 	switch l {
-	case Golang, NodeJS, Python, CSharp, Schema:
+	case Golang, NodeJS, Python, CSharp, Schema, PCL:
 		return true
 	}
 	return false
@@ -624,7 +627,7 @@ func NewGenerator(opts GeneratorOptions) (*Generator, error) {
 
 	// Ensure the language is valid.
 	switch lang {
-	case Golang, NodeJS, Python, CSharp, Schema:
+	case Golang, NodeJS, Python, CSharp, Schema, PCL:
 		// OK
 	default:
 		return nil, errors.Errorf("unrecognized language runtime: %s", lang)
@@ -748,7 +751,8 @@ func (g *Generator) Generate() error {
 	// Go ahead and let the language generator do its thing. If we're emitting the schema, just go ahead and serialize
 	// it out.
 	var files map[string][]byte
-	if g.language == Schema {
+	switch g.language {
+	case Schema:
 		// Omit the version so that the spec is stable if the version is e.g. derived from the current Git commit hash.
 		pulumiPackageSpec.Version = ""
 
@@ -757,7 +761,16 @@ func (g *Generator) Generate() error {
 			return errors.Wrapf(err, "failed to marshal schema")
 		}
 		files = map[string][]byte{"schema.json": bytes}
-	} else {
+	case PCL:
+		if g.skipExamples {
+			return fmt.Errorf("Cannot set skipExamples and get PCL")
+		}
+		files = map[string][]byte{}
+		for path, code := range g.convertedCode {
+			path = strings.TrimPrefix(path, "#/") + ".pcl"
+			files[path] = code
+		}
+	default:
 		pulumiPackage, err := pschema.ImportSpec(pulumiPackageSpec, nil)
 		if err != nil {
 			return errors.Wrapf(err, "failed to import Pulumi schema")
@@ -1255,7 +1268,7 @@ func (g *Generator) gatherOverlays() (moduleMap, error) {
 		if csharpinfo := g.info.CSharp; csharpinfo != nil {
 			overlay = csharpinfo.Overlay
 		}
-	case Schema:
+	case Schema, PCL:
 		// N/A
 	default:
 		contract.Failf("unrecognized language: %s", g.language)


### PR DESCRIPTION
Add an additional language target: pcl. We use this to extract pcl from provider examples. The use case here is testing programgen against a larger corpus of examples. 