### PR TITLE
Improve output for HCL conversion

### DIFF
--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -869,6 +869,15 @@ var (
 	elidedArguments        int
 	elidedNestedArguments  int
 	elidedAttributes       int
+
+	hclAllLangsConversionFailures int // examples that failed to convert in any language
+
+	// examples that failed to convert in one, but not all, languages. This is less severe impact because users will
+	// at least have code in another language to reference:
+	hclGoPartialConversionFailures         int
+	hclPythonPartialConversionFailures     int
+	hclTypeScriptPartialConversionFailures int
+	hclCSharpPartialConversionFailures     int
 )
 
 // isBlank returns true if the line is all whitespace.
@@ -905,6 +914,26 @@ func printDocStats(g *Generator, printIgnoreDetails, printHCLFailureDetails bool
 
 	if elidedAttributes > 0 {
 		g.warn("%d attributes contained an <elided> reference and had their descriptions dropped.", elidedAttributes)
+	}
+
+	if hclAllLangsConversionFailures > 0 {
+		g.warn("%d HCL examples failed to convert in all languages", hclAllLangsConversionFailures)
+	}
+
+	if hclTypeScriptPartialConversionFailures > 0 {
+		g.warn("%d HCL examples were converted in at least one language but failed to convert to TypeScript", hclTypeScriptPartialConversionFailures)
+	}
+
+	if hclPythonPartialConversionFailures > 0 {
+		g.warn("%d HCL examples were converted in at least one language but failed to convert to Python", hclPythonPartialConversionFailures)
+	}
+
+	if hclGoPartialConversionFailures > 0 {
+		g.warn("%d HCL examples were converted in at least one language but failed to convert to Go", hclGoPartialConversionFailures)
+	}
+
+	if hclCSharpPartialConversionFailures > 0 {
+		g.warn("%d HCL examples were converted in at least one language but failed to convert to C#", hclCSharpPartialConversionFailures)
 	}
 
 	// These more detailed outputs are suppressed by default, but can be enabled to track down failures.
@@ -1024,7 +1053,14 @@ func (g *Generator) convertExamples(docs, name string, stripSubsectionsWithError
 
 						// We've got some code -- assume it's HCL and try to convert it.
 						g.coverageTracker.foundExample(name, hcl)
-						codeBlock, stderr, err := g.convertHCL(hcl, name)
+
+						exampleTitle := ""
+						if strings.Contains(subsection[0], "###") {
+							exampleTitle = strings.Replace(subsection[0], "### ", "", -1)
+						}
+
+						codeBlock, stderr, err := g.convertHCL(hcl, name, exampleTitle)
+
 						if err != nil {
 							skippedExamples = true
 							hclFailures[stderr] = true
@@ -1099,7 +1135,7 @@ func (g *Generator) convertExamples(docs, name string, stripSubsectionsWithError
 
 // convertHCL converts an in-memory, simple HCL program to Pulumi, and returns it as a string. In the event
 // of failure, the error returned will be non-nil, and the second string contains the stderr stream of details.
-func (g *Generator) convertHCL(hcl, path string) (string, string, error) {
+func (g *Generator) convertHCL(hcl, path, exampleTitle string) (string, string, error) {
 	g.debug("converting HCL for %s", path)
 
 	// Fixup the HCL as necessary.
@@ -1204,15 +1240,55 @@ func (g *Generator) convertHCL(hcl, path string) (string, string, error) {
 		err = convertHCL("go")
 	case Schema:
 		langs := []string{"typescript", "python", "csharp", "go"}
-		var anySucceeded bool = false
+		failedLangs := map[string]error{}
+		var passedLangs []string
+
 		for _, lang := range langs {
 			if langErr := convertHCL(lang); langErr != nil {
+				failedLangs[lang] = langErr
 				err = multierror.Append(err, langErr)
 			} else {
-				anySucceeded = true
+				passedLangs = append(passedLangs, lang)
 			}
 		}
-		if anySucceeded {
+
+		if len(failedLangs) == len(langs) {
+			hclAllLangsConversionFailures++
+
+			if exampleTitle == "" {
+				g.warn(fmt.Sprintf("unable to convert HCL example for Pulumi entity '%s' for all languages. The example will be dropped from any generated docs or SDKs.", path))
+			} else {
+				g.warn(fmt.Sprintf("unable to convert HCL example '%s' for Pulumi entity '%s' for all languages. The example will be dropped from any generated docs or SDKs.", exampleTitle, path))
+			}
+		}
+
+		// Log the results when an example fails to convert to some languages, but not all
+		if len(failedLangs) > 0 && len(failedLangs) < len(langs) {
+			var failedLangsStrings []string
+
+			for lang, _ := range failedLangs {
+				failedLangsStrings = append(failedLangsStrings, lang)
+
+				switch lang {
+				case "typescript":
+					hclTypeScriptPartialConversionFailures++
+				case "python":
+					hclPythonPartialConversionFailures++
+				case "csharp":
+					hclCSharpPartialConversionFailures++
+				case "go":
+					hclGoPartialConversionFailures++
+				}
+			}
+
+			if exampleTitle == "" {
+				g.warn(fmt.Sprintf("unable to convert HCL example for Pulumi entity '%s' in the following language(s): %s. Examples for these languages will be dropped from any generated docs or SDKs.", path, strings.Join(failedLangsStrings, ", ")))
+			} else {
+				g.warn(fmt.Sprintf("unable to convert HCL example '%s' for Pulumi entity '%s' in the following language(s): %s. Examples for these languages will be dropped from any generated docs or SDKs.", exampleTitle, path, strings.Join(failedLangsStrings, ", ")))
+			}
+		}
+
+		if len(passedLangs) > 0 {
 			// At least one language out of the given set has been generated, which is considered a success
 			err = nil
 		}

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -1244,9 +1244,17 @@ func (g *Generator) convertHCL(hcl, path, exampleTitle string) (string, string, 
 		var passedLangs []string
 
 		for _, lang := range langs {
+			resultLenBefore := result.Len()
+
+			// The inner function convertHCL above will return an error in the event of a panic, but in the event of an
+			// error the function will simply not append any content to result and swallow the error. Therefore, we
+			// need to account for both of these failure conditions. If neither of these conditions occurs, we can
+			// assume the HCL was converted successfully for this language.
 			if langErr := convertHCL(lang); langErr != nil {
 				failedLangs[lang] = langErr
 				err = multierror.Append(err, langErr)
+			} else if resultLenBefore == result.Len() {
+				failedLangs[lang] = langErr
 			} else {
 				passedLangs = append(passedLangs, lang)
 			}

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -861,8 +861,6 @@ func (p *tfMarkdownParser) parseFrontMatter(subsection []string) {
 var (
 	ignoredDocSections     int
 	ignoredDocHeaders      = make(map[string]int)
-	hclBlocksSucceeded     int
-	hclBlocksFailed        int
 	hclFailures            = make(map[string]bool)
 	elidedDescriptions     int // i.e., we discard the entire description, including examples
 	elidedDescriptionsOnly int // we discarded the description proper, but were able to preserve the examples
@@ -890,10 +888,6 @@ func printDocStats(g *Generator, printIgnoreDetails, printHCLFailureDetails bool
 	// These summaries are printed on each run, to help us keep an eye on success/failure rates.
 	if ignoredDocSections > 0 {
 		g.warn("%d documentation sections ignored", ignoredDocSections)
-	}
-	if hclBlocksFailed > 0 {
-		g.warn("%d/%d documentation code blocks failed to convert",
-			hclBlocksFailed, hclBlocksFailed+hclBlocksSucceeded)
 	}
 
 	if elidedDescriptions > 0 {
@@ -1064,10 +1058,8 @@ func (g *Generator) convertExamples(docs, name string, stripSubsectionsWithError
 						if err != nil {
 							skippedExamples = true
 							hclFailures[stderr] = true
-							hclBlocksFailed++
 						} else {
 							fprintf(subsectionOutput, "\n%s", codeBlock)
-							hclBlocksSucceeded++
 						}
 					} else {
 						skippedExamples = true


### PR DESCRIPTION
* Add warnings that indicate which example failed to convert, and
  in which language(s)
* Add partial and total conversion metrics to output

Fixes #455 

Sample output (from the GCP provider):

```
warning: unable to convert HCL example 'Save Key In Kubernetes Secret' for Pulumi entity '#/functions/gcp:serviceAccount/getAccount:getAccount' for all languages. The example will be dropped from any generated docs or SDKs.
error: failed to convert HCL for #/functions/gcp:serviceAccount/getAccountIdToken:getAccountIdToken to typescript: no resource plugin 'http' found in the workspace or on your $PATH
error: failed to convert HCL for #/functions/gcp:serviceAccount/getAccountIdToken:getAccountIdToken to python: no resource plugin 'http' found in the workspace or on your $PATH
error: failed to convert HCL for #/functions/gcp:serviceAccount/getAccountIdToken:getAccountIdToken to csharp: no resource plugin 'http' found in the workspace or on your $PATH
error: failed to convert HCL for #/functions/gcp:serviceAccount/getAccountIdToken:getAccountIdToken to go: no resource plugin 'http' found in the workspace or on your $PATH
warning: unable to convert HCL example 'Invoking Cloud Run Endpoint' for Pulumi entity '#/functions/gcp:serviceAccount/getAccountIdToken:getAccountIdToken' for all languages. The example will be dropped from any generated docs or SDKs.
warning: unable to convert HCL example 'OpenID Connect W/ Kubernetes Provider + RBAC IAM Role' for Pulumi entity '#/functions/gcp:organizations/getClientOpenIdUserInfo:getClientOpenIdUserInfo' for all languages. The example will be dropped from any generated docs or SDKs.
warning: unable to convert HCL example for Pulumi entity '#/functions/gcp:compute/getRegionInstanceGroup:getRegionInstanceGroup' for all languages. The example will be dropped from any generated docs or SDKs.
warning: unable to convert HCL example for Pulumi entity '#/functions/gcp:kms/getKMSSecret:getKMSSecret' for all languages. The example will be dropped from any generated docs or SDKs.
warning: unable to convert HCL example for Pulumi entity '#/functions/gcp:kms/getKMSSecretAsymmetric:getKMSSecretAsymmetric' for all languages. The example will be dropped from any generated docs or SDKs.
warning: unable to convert HCL example 'Multi-Regional Cloud Run Deployment' for Pulumi entity '#/functions/gcp:cloudrun/getLocations:getLocations' for all languages. The example will be dropped from any generated docs or SDKs.
warning: unable to convert HCL example for Pulumi entity '#/functions/gcp:sql/getCaCerts:getCaCerts' for all languages. The example will be dropped from any generated docs or SDKs.
warning: unable to convert HCL example 'Configure Kubernetes Provider With OAuth2 Access Token' for Pulumi entity '#/functions/gcp:organizations/getClientConfig:getClientConfig' for all languages. The example will be dropped from any generated docs or SDKs.
warning: unable to convert HCL example for Pulumi entity '#/functions/gcp:compute/getZones:getZones' for all languages. The example will be dropped from any generated docs or SDKs.
warning: unable to convert HCL example for Pulumi entity '#/functions/gcp:serviceAccount/getAccountAccessToken:getAccountAccessToken' for all languages. The example will be dropped from any generated docs or SDKs.
warning: unable to convert HCL example for Pulumi entity '#/functions/gcp:kms/getKMSSecretCiphertext:getKMSSecretCiphertext' for all languages. The example will be dropped from any generated docs or SDKs.
warning: unable to convert HCL example for Pulumi entity '#/functions/gcp:composer/getEnvironment:getEnvironment' for all languages. The example will be dropped from any generated docs or SDKs.
warning: 586 documentation sections ignored
warning: 4 entity descriptions contained an <elided> reference and were dropped, including examples.
warning: 15 entity descriptions contained an <elided> reference and were dropped, but examples were preserved.
warning: 8 arguments contained an <elided> reference and had their descriptions dropped.
warning: 2 attributes contained an <elided> reference and had their descriptions dropped.
warning: 63 HCL examples failed to convert in all languages
warning: 6 HCL examples were converted in at least one language but failed to convert to Python
warning: 8 HCL examples were converted in at least one language but failed to convert to Go
warning: 6 HCL examples were converted in at least one language but failed to convert to C#
```