### PR TITLE
Panics converting HCL should be a warning

### DIFF
--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -1183,7 +1183,7 @@ func (g *Generator) convertHCL(hcl, path, exampleTitle string) (string, string, 
 			}
 
 			g.coverageTracker.languageConversionPanic(languageName, err.Error())
-			g.error("failed to convert HCL for %s to %v: %v", path, languageName, err)
+			g.warn("failed to convert HCL for %s to %v: %v", path, languageName, err)
 			return fmt.Errorf("failed to convert HCL for %s to %v: %w", path, languageName, err)
 		}
 		if diags.All.HasErrors() {


### PR DESCRIPTION
Panics converting HCL are incorrectly output as an error. They should be
a warning instead because an error in output typically implies a
non-zero exit code. HCL that could not convert is output elsewhere in
the bridge is already a warning, so this change also creates more
consistency with behavior elsewhere in the bridge.

Fixes #460