### PR TITLE
Add an option to fail the build for missing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,11 @@ typed enums in places where the underlying provider may only have weakly typed s
 To do this, first add the files in the appropriate package sub-directory of the sdk, and then add the requisite directives to the
 provider file.  See the [AWS overlays section in resources.go](https://github.com/pulumi/pulumi-aws/blob/master/provider/resources.go#L4486) for
 an example of this in action.
+
+# tfgen options
+
+tfgen, the command that generates Pulumi schema/code for a bridged provider supports the following environment variables:
+
+`PULUMI_MISSING_MAPPING_ERROR`: If truthy, fail if a data source/resource in the TF provider is not mapped to the Pulumi provider.
+`PULUMI_MISSING_DOCS_ERROR`: If truthy, fail if docs cannot be found for a data source/resource.
+`PULUMI_EXTRA_MAPPING_ERROR`: If truthy, fail if a mapped resource does not exist in the TF provider.

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -229,6 +229,7 @@ func getDocsForProvider(g *Generator, org string, provider string, resourcePrefi
 	markdownBytes, markdownFileName, found := getMarkdownDetails(org, provider, resourcePrefix, kind, rawname, info, providerModuleVersion, githost)
 	if !found {
 		g.warn("Could not find docs for resource %v; consider overriding doc source location", rawname)
+		entitiesMissingDocs++
 		return entityDocs{}, nil
 	}
 
@@ -877,6 +878,8 @@ var (
 	hclPythonPartialConversionFailures     int
 	hclTypeScriptPartialConversionFailures int
 	hclCSharpPartialConversionFailures     int
+
+	entitiesMissingDocs int
 )
 
 // isBlank returns true if the line is all whitespace.
@@ -887,6 +890,10 @@ func isBlank(line string) bool {
 // printDocStats outputs warnings and, if flags are set, stdout diagnostics pertaining to documentation conversion.
 func printDocStats(g *Generator, printIgnoreDetails, printHCLFailureDetails bool) {
 	// These summaries are printed on each run, to help us keep an eye on success/failure rates.
+	if entitiesMissingDocs > 0 {
+		g.warn("%d entities have missing docs.", entitiesMissingDocs)
+	}
+
 	if elidedDescriptions > 0 {
 		g.warn("%d entity descriptions contained an <elided> reference and were dropped, including examples.", elidedDescriptions)
 	}


### PR DESCRIPTION
Fixes #432 

Sample output with the option set (GCP provider):

```
error: failed to gather package metadata: problem gathering resources: 19 errors occurred:
        * could not find docs for resource 'google_billing_account_iam_binding'. Override the Docs property in the resource mapping. See type DocInfo in the source code for details.
        * could not find docs for resource 'google_billing_account_iam_member'. Override the Docs property in the resource mapping. See type DocInfo in the source code for details.
        * could not find docs for resource 'google_billing_account_iam_policy'. Override the Docs property in the resource mapping. See type DocInfo in the source code for details.
        * could not find docs for resource 'google_cloudfunctions_function_iam_binding'. Override the Docs property in the resource mapping. See type DocInfo in the source code for details.
        * could not find docs for resource 'google_cloudfunctions_function_iam_member'. Override the Docs property in the resource mapping. See type DocInfo in the source code for details.
        * could not find docs for resource 'google_cloudfunctions_function_iam_policy'. Override the Docs property in the resource mapping. See type DocInfo in the source code for details.
        * could not find docs for resource 'google_cloudiot_registry_legacy'. Override the Docs property in the resource mapping. See type DocInfo in the source code for details.
        * could not find docs for resource 'google_compute_backend_service_iam_binding'. Override the Docs property in the resource mapping. See type DocInfo in the source code for details.
        * could not find docs for resource 'google_compute_backend_service_iam_member'. Override the Docs property in the resource mapping. See type DocInfo in the source code for details.
        * could not find docs for resource 'google_compute_backend_service_iam_policy'. Override the Docs property in the resource mapping. See type DocInfo in the source code for details.
        * could not find docs for resource 'google_compute_managed_ssl_certificate_legacy'. Override the Docs property in the resource mapping. See type DocInfo in the source code for details.
        * could not find docs for resource 'google_data_catalog_tag_template_iam_binding'. Override the Docs property in the resource mapping. See type DocInfo in the source code for details.
        * could not find docs for resource 'google_data_catalog_tag_template_iam_member'. Override the Docs property in the resource mapping. See type DocInfo in the source code for details.
```