### PR TITLE
Optionally fail tfgen for an extra field mapping

### DIFF
--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -1068,7 +1068,13 @@ func (g *Generator) gatherResource(rawname string,
 	// Ensure there weren't any custom fields that were unrecognized.
 	for key := range info.Fields {
 		if _, has := schema.Schema().GetOk(key); !has {
-			g.warn("custom resource schema %s.%s was not present in the Terraform metadata", name, key)
+			msg := fmt.Sprintf("there is a custom mapping on resource '%s' for field '%s', but the field was not found in the Terraform metadata and will be ignored. To fix, remove the mapping.", rawname, key)
+
+			if isTruthy(os.Getenv("PULUMI_EXTRA_MAPPING_ERROR")) {
+				return "", nil, fmt.Errorf(msg)
+			}
+
+			g.warn(msg)
 		}
 	}
 
@@ -1345,7 +1351,7 @@ func propertyVariable(key string, sch shim.Schema, info *tfbridge.SchemaInfo,
 func dataSourceName(provider string, rawname string, info *tfbridge.DataSourceInfo) (string, string) {
 	if info == nil || info.Tok == "" {
 		// default transformations.
-		name := withoutPackageName(provider, rawname)                 // strip off the pkg prefix.
+		name := withoutPackageName(provider, rawname) // strip off the pkg prefix.
 		return tfbridge.TerraformToPulumiName(name, nil, nil, false), // camelCase the data source name.
 			tfbridge.TerraformToPulumiName(name, nil, nil, false) // camelCase the filename.
 	}
@@ -1360,7 +1366,7 @@ func resourceName(provider string, rawname string, info *tfbridge.ResourceInfo, 
 	}
 	if info == nil || info.Tok == "" {
 		// default transformations.
-		name := withoutPackageName(provider, rawname)                // strip off the pkg prefix.
+		name := withoutPackageName(provider, rawname) // strip off the pkg prefix.
 		return tfbridge.TerraformToPulumiName(name, nil, nil, true), // PascalCase the resource name.
 			tfbridge.TerraformToPulumiName(name, nil, nil, false) // camelCase the filename.
 	}


### PR DESCRIPTION
Fixes #452 

This change expands PULUMI_EXTRA_MAPPING_ERROR to also cover
superfluous mappings on fields, not just resources/data sources. We've
also improved the error message to use the TF identifier and improved
working that more directly describes the issue, its effects, and how to
remedy.

Sample output when set:

```
error: failed to gather package metadata: problem gathering resources: 1 error occurred:
        * there is a custom mapping on resource 'google_cloudfunctions_function' for field 'foo', but the field was not found in the Terraform metadata and will be ignored. Remove the mapping.
```