### PR TITLE
Clarify renamed entities in missing docs message

### DIFF
--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -1234,7 +1234,7 @@ func (p *ProviderInfo) RenameResourceWithAlias(resourceName string, legacyTok to
 	legacyModule string, newModule string, info *ResourceInfo) {
 
 	resourcePrefix := p.Name + "_"
-	legacyResourceName := resourceName + "_legacy"
+	legacyResourceName := resourceName + RenamedEntitySuffix
 	if info == nil {
 		info = &ResourceInfo{}
 	}
@@ -1269,11 +1269,15 @@ func (p *ProviderInfo) RenameResourceWithAlias(resourceName string, legacyTok to
 	p.P.ResourcesMap().Set(legacyResourceName, p.P.ResourcesMap().Get(resourceName))
 }
 
+const (
+	RenamedEntitySuffix string = "_legacy"
+)
+
 func (p *ProviderInfo) RenameDataSource(resourceName string, legacyTok tokens.ModuleMember, newTok tokens.ModuleMember,
 	legacyModule string, newModule string, info *DataSourceInfo) {
 
 	resourcePrefix := p.Name + "_"
-	legacyResourceName := resourceName + "_legacy"
+	legacyResourceName := resourceName + RenamedEntitySuffix
 	if info == nil {
 		info = &DataSourceInfo{}
 	}

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -448,3 +448,8 @@ content 2`
 
 	runTest(gcpDoc2, gcpDoc2Expected)
 }
+
+func TestFormatEntityName(t *testing.T) {
+	assert.Equal(t, "'prov_entity'", formatEntityName("prov_entity"))
+	assert.Equal(t, "'prov_entity' (aliased or renamed)", formatEntityName("prov_entity_legacy"))
+}


### PR DESCRIPTION
Renamed and aliased entities are internally given the pseudo-name
x_legacy. This can cause confusion in the missing docs message in the
bridge output because there is no mapping for the provider for the name
x_legacy. When we know an entity is aliased or renamed, we now print
the original name with an indication that the entity has been aliases so
the user can more easily locate the source of the issue.

Sample output:

```
        * could not find docs for resource 'google_compute_managed_ssl_certificate' (aliased or renamed). Override the Docs property in the resource mapping. See type tfbridge.DocInfo for details.
        * could not find docs for resource 'google_compute_region_backend_service_iam_binding'. Override the Docs property in the resource mapping. See type tfbridge.DocInfo for details.
```