### PR TITLE
Add helper functions for name conversion

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -16,6 +16,7 @@ package tfbridge
 
 import (
 	"fmt"
+	"strings"
 	"unicode"
 
 	"github.com/blang/semver"
@@ -781,6 +782,42 @@ func StringValue(vars resource.PropertyMap, prop resource.PropertyKey) string {
 		return val.StringValue()
 	}
 	return ""
+}
+
+// TfDataSourceToPulumi converts a given Terraform data source name tfName (e.g. "provider_foo_bar") and returns the
+// standard conversion to a Pulumi function name (e.g. "getFooBar")
+func TfDataSourceToPulumi(tfName string) string {
+	parts := strings.Split(tfName, "_")
+	if len(parts) < 2 {
+		return ""
+	}
+
+	// The first segment is the provider name, which we do not include in the Pulumi name.
+	parts = parts[1:]
+
+	for i, part := range parts {
+		parts[i] = strings.Title(part)
+	}
+
+	return fmt.Sprintf("get%s", strings.Join(parts, ""))
+}
+
+// TfResourceToPulumi converts a given Terraform resource name tfName (e.g. "provider_foo_bar") and returns the
+// standard conversion to a Pulumi resource name (e.g. "FooBar")
+func TfResourceToPulumi(tfName string) string {
+	parts := strings.Split(tfName, "_")
+	if len(parts) < 2 {
+		return ""
+	}
+
+	// The first segment is the provider name, which we do not include in the Pulumi name.
+	parts = parts[1:]
+
+	for i, part := range parts {
+		parts[i] = strings.Title(part)
+	}
+
+	return strings.Join(parts, "")
 }
 
 // ManagedByPulumi is a default used for some managed resources, in the absence of something more meaningful.

--- a/pkg/tfbridge/info_test.go
+++ b/pkg/tfbridge/info_test.go
@@ -62,3 +62,16 @@ func TestStringValue(t *testing.T) {
 	assert.Equal(t, "value1", StringValue(myMap, "key1"))
 	assert.Equal(t, "", StringValue(myMap, "keyThatDoesNotExist"))
 }
+
+func TestTfDataSourceToPulumi(t *testing.T) {
+	assert.Equal(t, "", TfDataSourceToPulumi("invalid"))
+	assert.Equal(t, "getFoo", TfDataSourceToPulumi("provider_foo"))
+	assert.Equal(t, "getFooBar", TfDataSourceToPulumi("provider_foo_bar"))
+	assert.Equal(t, "getFooBarBaz", TfDataSourceToPulumi("provider_foo_bar_baz"))
+}
+
+func TestTfResourceToPulumi(t *testing.T) {
+	assert.Equal(t, "", TfResourceToPulumi("invalid"))
+	assert.Equal(t, "Foo", TfResourceToPulumi("provider_foo"))
+	assert.Equal(t, "FooBarBaz", TfResourceToPulumi("provider_foo_bar_baz"))
+}


### PR DESCRIPTION
Changes this:

```go
"mongodbatlas_privatelink_endpoint_service_adl":    {Tok: makeResource(mainMod, "PrivatelinkEndpointServiceAdl")},

"mongodbatlas_cloud_backup_snapshot_export_job": {
  Tok: makeDataSource(mainMod, "getCloudBackupSnapshotExportJob"),
},
```

To this:

```
"mongodbatlas_privatelink_endpoint_service_adl":    {Tok: makeResource(mainMod, tfbridge.TfResourceToPulumi("mongodbatlas_privatelink_endpoint_service_adl"))},

"mongodbatlas_cloud_backup_snapshot_export_job": {
  Tok: makeDataSource(mainMod, tfbridge.TfResourceToPulumi("mongodbatlas_cloud_backup_snapshot_export_job")),
},
```