### PR TITLE
Ensure replaceOnChange is set on schema

### DIFF
--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -494,6 +494,21 @@ func (v *variable) deprecationMessage() string {
 	return ""
 }
 
+func (v *variable) forceNew() bool {
+	// Output properties don't forceNew so we can return false by default
+	if v.out {
+		return false
+	}
+
+	// if we have an explicit marked as ForceNew then let's return that as that overrides
+	// the TF schema
+	if v.info != nil && v.info.ForceNew != nil {
+		return *v.info.ForceNew
+	}
+
+	return v.schema != nil && v.schema.ForceNew()
+}
+
 // optional checks whether the given property is optional, either due to Terraform or an overlay.
 func (v *variable) optional() bool {
 	if v.opt {

--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -425,6 +425,7 @@ func (g *schemaGenerator) genProperty(mod string, prop *variable, pyMapCase bool
 		DeprecationMessage: prop.deprecationMessage(),
 		Language:           language,
 		Secret:             secret,
+		ReplaceOnChanges:   prop.forceNew(),
 	}
 }
 

--- a/pkg/tfgen/generate_test.go
+++ b/pkg/tfgen/generate_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	shimv1 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v1"
 )
 
@@ -17,4 +18,51 @@ func Test_DeprecationFromTFSchema(t *testing.T) {
 
 	deprecationMessage := v.deprecationMessage()
 	assert.Equal(t, "This is deprecated", deprecationMessage)
+}
+
+func Test_ForceNew(t *testing.T) {
+	cases := []struct {
+		Name           string
+		Var            variable
+		ShouldForceNew bool
+	}{
+		{Name: "Pulumi Schema with ForceNew Override ShouldForceNew true",
+			Var: variable{
+				name: "v",
+				schema: shimv1.NewSchema(&schema.Schema{
+					Type: schema.TypeString,
+				}),
+				info: &tfbridge.SchemaInfo{
+					ForceNew: tfbridge.True(),
+				},
+			},
+			ShouldForceNew: true,
+		},
+		{
+			Name: "TF Schema ForceNew ShouldForceNew true",
+			Var: variable{
+				name: "v",
+				schema: shimv1.NewSchema(&schema.Schema{
+					Type:     schema.TypeString,
+					ForceNew: true,
+				}),
+			},
+			ShouldForceNew: true,
+		},
+		{
+			Name: "Output Parameter ShouldForceNew false",
+			Var: variable{
+				out: true,
+			},
+			ShouldForceNew: false,
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.Name, func(t *testing.T) {
+			v := &test.Var
+			actuallyForcesNew := v.forceNew()
+			assert.Equal(t, test.ShouldForceNew, actuallyForcesNew)
+		})
+	}
 }


### PR DESCRIPTION
Fixes: #458
Fixes: #337

when a parameter will force a new resource, it is now marked in
the schema as ReplaceOnChange: true

You can see the generated code this changes by clicking on the name of the provider link
