### PR TITLE
Add the ability to define additional HCL examples

### DIFF
--- a/pkg/tfbridge/examples.go
+++ b/pkg/tfbridge/examples.go
@@ -1,0 +1,101 @@
+package tfbridge
+
+import (
+	"bytes"
+	"io/ioutil"
+	"path/filepath"
+	"text/template"
+)
+
+// HclExampler represents a supplemental HCL example for a given resource or function.
+type HclExampler interface {
+	// GetPulumiIdentifier returns the fully qualified path to the resource or function in the schema, e.g.
+	// "provider:module/getFoo:getFoo" (function), or
+	// "provider:module/bar:Bar" (resource)
+	GetPulumiIdentifier() string
+	// GetMarkdown returns the Markdown that comprises the entire example, including the header.
+	//
+	// Headers should be an H3 ("###") and the header content should not contain any prefix, e.g. "Foo with Bar" not,
+	// "Example Usage - Foo with Bar".
+	//
+	// Code should be surrounded with code fences with an indicator of the language on the opening fence, e.g. "```hcl".
+	GetMarkdown() (string, error)
+}
+
+// LocalFileHclExample represents a supplemental HCL example that is on a relative path within the Pulumi provider repo.
+type LocalFileHclExample struct {
+	// ID is the Pulumi identifier for the resource or function to which the example pertains, e.g.
+	// "provider:module/getSomething:getSomething" (function), or
+	// "provider:module/something:Something" (resource)
+	ID string
+	// Title is title of the example, e.g. "Basic Something", "Advanced Something with Something Else".
+	Title string
+	// RelativePath is the path to the file in the Pulumi repo relative to the repo root.
+	RelativePath string
+}
+
+func (e LocalFileHclExample) GetPulumiIdentifier() string {
+	return e.ID
+}
+
+func (e LocalFileHclExample) GetMarkdown() (string, error) {
+	absPath, err := filepath.Abs(e.RelativePath)
+	if err != nil {
+		return "", err
+	}
+
+	fileBytes, err := ioutil.ReadFile(absPath)
+	if err != nil {
+		return "", err
+	}
+
+	return renderTemplate(e.Title, string(fileBytes))
+}
+
+// InlineHclExample represents a literal HCL example and is primarily used for testing the Bridge.
+type InlineHclExample struct {
+	// ID is the Pulumi identifier for the resource or function to which the example pertains, e.g.
+	// "provider:module/getSomething:getSomething" (function), or
+	// "provider:module/something:Something" (resource)
+	ID string
+	// Title is title of the example, e.g. "Basic Something", "Advanced Something with Something Else".
+	Title string
+	// Contents is the HCL that comprises the example with no surrounding Markdown constructs (e.g. ```hcl`).
+	Contents string
+}
+
+func (e InlineHclExample) GetPulumiIdentifier() string {
+	return e.ID
+}
+
+func (e InlineHclExample) GetMarkdown() (string, error) {
+	return renderTemplate(e.Title, e.Contents)
+}
+
+func renderTemplate(title, contents string) (string, error) {
+	tmpl := `### {{ .Title }}
+
+{{ .CodeFences }}hcl
+{{ .Contents }}
+{{ .CodeFences }}
+`
+
+	outputTemplate, _ := template.New("dummy").Parse(tmpl)
+	data := struct {
+		CodeFences string
+		Title      string
+		Contents   string
+	}{
+		CodeFences: "```",
+		Title:      title,
+		Contents:   contents,
+	}
+
+	var buf = bytes.Buffer{}
+	err := outputTemplate.Execute(&buf, data)
+	if err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}

--- a/pkg/tfbridge/examples.go
+++ b/pkg/tfbridge/examples.go
@@ -9,10 +9,10 @@ import (
 
 // HclExampler represents a supplemental HCL example for a given resource or function.
 type HclExampler interface {
-	// GetPulumiIdentifier returns the fully qualified path to the resource or function in the schema, e.g.
+	// GetToken returns the fully qualified path to the resource or function in the schema, e.g.
 	// "provider:module/getFoo:getFoo" (function), or
 	// "provider:module/bar:Bar" (resource)
-	GetPulumiIdentifier() string
+	GetToken() string
 	// GetMarkdown returns the Markdown that comprises the entire example, including the header.
 	//
 	// Headers should be an H3 ("###") and the header content should not contain any prefix, e.g. "Foo with Bar" not,
@@ -24,18 +24,30 @@ type HclExampler interface {
 
 // LocalFileHclExample represents a supplemental HCL example that is on a relative path within the Pulumi provider repo.
 type LocalFileHclExample struct {
-	// ID is the Pulumi identifier for the resource or function to which the example pertains, e.g.
-	// "provider:module/getSomething:getSomething" (function), or
-	// "provider:module/something:Something" (resource)
-	ID string
+	// Token is the Pulumi identifier for the resource or function to which the example pertains, e.g.
+	// "provider:module/getFoo:getFoo" (function), or
+	// "provider:module/bar:Bar" (resource)
+	Token string
 	// Title is title of the example, e.g. "Basic Something", "Advanced Something with Something Else".
 	Title string
 	// RelativePath is the path to the file in the Pulumi repo relative to the repo root.
 	RelativePath string
 }
 
-func (e LocalFileHclExample) GetPulumiIdentifier() string {
-	return e.ID
+// InlineHclExample represents a literal HCL example and is primarily used for testing the Bridge.
+type InlineHclExample struct {
+	// Token is the Pulumi identifier for the resource or function to which the example pertains, e.g.
+	// "provider:module/getFoo:getFoo" (function), or
+	// "provider:module/bar:Bar" (resource)
+	Token string
+	// Title is title of the example, e.g. "Basic Something", "Advanced Something with Something Else".
+	Title string
+	// Contents is the HCL that comprises the example with no surrounding Markdown constructs (e.g. ```hcl`).
+	Contents string
+}
+
+func (e LocalFileHclExample) GetToken() string {
+	return e.Token
 }
 
 func (e LocalFileHclExample) GetMarkdown() (string, error) {
@@ -52,20 +64,8 @@ func (e LocalFileHclExample) GetMarkdown() (string, error) {
 	return renderTemplate(e.Title, string(fileBytes))
 }
 
-// InlineHclExample represents a literal HCL example and is primarily used for testing the Bridge.
-type InlineHclExample struct {
-	// ID is the Pulumi identifier for the resource or function to which the example pertains, e.g.
-	// "provider:module/getSomething:getSomething" (function), or
-	// "provider:module/something:Something" (resource)
-	ID string
-	// Title is title of the example, e.g. "Basic Something", "Advanced Something with Something Else".
-	Title string
-	// Contents is the HCL that comprises the example with no surrounding Markdown constructs (e.g. ```hcl`).
-	Contents string
-}
-
-func (e InlineHclExample) GetPulumiIdentifier() string {
-	return e.ID
+func (e InlineHclExample) GetToken() string {
+	return e.Token
 }
 
 func (e InlineHclExample) GetMarkdown() (string, error) {

--- a/pkg/tfbridge/examples_test.go
+++ b/pkg/tfbridge/examples_test.go
@@ -1,0 +1,33 @@
+package tfbridge
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestInlineExampleGetMarkdown(t *testing.T) {
+	expected := "### Inline Title\n\n```hcl\n# HCL inline contents\n```\n"
+	example := InlineHclExample{
+		Title:    "Inline Title",
+		Contents: "# HCL inline contents",
+	}
+
+	actual, err := example.GetMarkdown()
+
+	assert.Equal(t, expected, actual)
+	assert.Nil(t, err)
+}
+
+func TestLocalFileExampleGetMarkdown(t *testing.T) {
+	expected := "### File Title\n\n```hcl\n# HCL file contents\n```\n"
+
+	example := LocalFileHclExample{
+		Title:        "File Title",
+		RelativePath: "examples_test.hcl",
+	}
+
+	actual, err := example.GetMarkdown()
+
+	assert.Equal(t, expected, actual)
+	assert.Nil(t, err)
+}

--- a/pkg/tfbridge/examples_test.hcl
+++ b/pkg/tfbridge/examples_test.hcl
@@ -1,0 +1,1 @@
+# HCL file contents

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -40,34 +40,40 @@ const (
 //
 //nolint: lll
 type ProviderInfo struct {
-	P                       shim.Provider                      // the TF provider/schema.
-	Name                    string                             // the TF provider name (e.g. terraform-provider-XXXX).
-	ResourcePrefix          string                             // the prefix on resources the provider exposes, if different to `Name`.
-	GitHubOrg               string                             // the GitHub org of the provider. Defaults to `terraform-providers`.
-	GitHubHost              string                             // the GitHub host for the provider. Defaults to `github.com`.
-	Description             string                             // an optional descriptive overview of the package (a default supplied).
-	Keywords                []string                           // an optional list of keywords to help discovery of this package. e.g. "category/cloud, category/infrastructure"
-	License                 string                             // the license, if any, the resulting package has (default is none).
-	LogoURL                 string                             // an optional URL to the logo of the package
-	DisplayName             string                             // the human friendly name of the package used in the Pulumi registry
-	Publisher               string                             // the name of the person or organization that authored and published the package.
-	Homepage                string                             // the URL to the project homepage.
-	Repository              string                             // the URL to the project source code repository.
-	Version                 string                             // the version of the provider package.
-	Config                  map[string]*SchemaInfo             // a map of TF name to config schema overrides.
-	ExtraConfig             map[string]*ConfigInfo             // a list of Pulumi-only configuration variables.
-	Resources               map[string]*ResourceInfo           // a map of TF name to Pulumi name; standard mangling occurs if no entry.
-	DataSources             map[string]*DataSourceInfo         // a map of TF name to Pulumi resource info.
-	ExtraTypes              map[string]pschema.ComplexTypeSpec // a map of Pulumi token to schema type for overlaid types.
-	IgnoreMappings          []string                           // a list of TF resources and data sources to ignore in mappings errors
-	PluginDownloadURL       string                             // an optional URL to download the provider binary from.
-	JavaScript              *JavaScriptInfo                    // optional overlay information for augmented JavaScript code-generation.
-	Python                  *PythonInfo                        // optional overlay information for augmented Python code-generation.
-	Golang                  *GolangInfo                        // optional overlay information for augmented Golang code-generation.
-	CSharp                  *CSharpInfo                        // optional overlay information for augmented C# code-generation.
-	TFProviderVersion       string                             // the version of the TF provider on which this was based
-	TFProviderLicense       *TFProviderLicense                 // license that the TF provider is distributed under. Default `MPL 2.0`.
-	TFProviderModuleVersion string                             // the Go module version of the provider. Default is unversioned e.g. v1
+	P              shim.Provider                      // the TF provider/schema.
+	Name           string                             // the TF provider name (e.g. terraform-provider-XXXX).
+	ResourcePrefix string                             // the prefix on resources the provider exposes, if different to `Name`.
+	GitHubOrg      string                             // the GitHub org of the provider. Defaults to `terraform-providers`.
+	GitHubHost     string                             // the GitHub host for the provider. Defaults to `github.com`.
+	Description    string                             // an optional descriptive overview of the package (a default supplied).
+	Keywords       []string                           // an optional list of keywords to help discovery of this package. e.g. "category/cloud, category/infrastructure"
+	License        string                             // the license, if any, the resulting package has (default is none).
+	LogoURL        string                             // an optional URL to the logo of the package
+	DisplayName    string                             // the human friendly name of the package used in the Pulumi registry
+	Publisher      string                             // the name of the person or organization that authored and published the package.
+	Homepage       string                             // the URL to the project homepage.
+	Repository     string                             // the URL to the project source code repository.
+	Version        string                             // the version of the provider package.
+	Config         map[string]*SchemaInfo             // a map of TF name to config schema overrides.
+	ExtraConfig    map[string]*ConfigInfo             // a list of Pulumi-only configuration variables.
+	Resources      map[string]*ResourceInfo           // a map of TF name to Pulumi name; standard mangling occurs if no entry.
+	DataSources    map[string]*DataSourceInfo         // a map of TF name to Pulumi resource info.
+	ExtraTypes     map[string]pschema.ComplexTypeSpec // a map of Pulumi token to schema type for overlaid types.
+	// ExtraResourceHclExamples is a slice of additional HCL examples attached to resources which are converted to the
+	// relevant target language(s)
+	ExtraResourceHclExamples []HclExampler
+	// ExtraFunctionHclExamples is a slice of additional HCL examples attached to functions which are converted to the
+	// relevant target language(s)
+	ExtraFunctionHclExamples []HclExampler
+	IgnoreMappings           []string           // a list of TF resources and data sources to ignore in mappings errors
+	PluginDownloadURL        string             // an optional URL to download the provider binary from.
+	JavaScript               *JavaScriptInfo    // optional overlay information for augmented JavaScript code-generation.
+	Python                   *PythonInfo        // optional overlay information for augmented Python code-generation.
+	Golang                   *GolangInfo        // optional overlay information for augmented Golang code-generation.
+	CSharp                   *CSharpInfo        // optional overlay information for augmented C# code-generation.
+	TFProviderVersion        string             // the version of the TF provider on which this was based
+	TFProviderLicense        *TFProviderLicense // license that the TF provider is distributed under. Default `MPL 2.0`.
+	TFProviderModuleVersion  string             // the Go module version of the provider. Default is unversioned e.g. v1
 
 	PreConfigureCallback PreConfigureCallback // a provider-specific callback to invoke prior to TF Configure
 }
@@ -246,7 +252,7 @@ type ConfigInfo struct {
 // the raw string is still accepted as a possible input value.
 type Transformer func(resource.PropertyValue) (resource.PropertyValue, error)
 
-// DocInfo contains optional overrids for finding and mapping TD docs.
+// DocInfo contains optional overrides for finding and mapping TF docs.
 type DocInfo struct {
 	Source                         string // an optional override to locate TF docs; "" uses the default.
 	Markdown                       []byte // an optional override for the source markdown.

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -400,7 +400,8 @@ var (
 	attributionFormatString = "This Pulumi package is based on the [`%[1]s` Terraform Provider](https://%[3]s/%[2]s/terraform-provider-%[1]s)."
 )
 
-// groupLines groups a collection of strings, lines, by a given separator, sep.
+// groupLines take a slice of strings, lines, and returns a nested slice of strings. When groupLines encounters a line
+// that in the input that starts with the supplied string sep, it will begin a new entry in the outer slice.
 func groupLines(lines []string, sep string) [][]string {
 	var buffer []string
 	var sections [][]string

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -18,6 +18,7 @@ package tfgen
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"testing"
 	"text/template"
 
@@ -503,4 +504,37 @@ FooFactory fooFactory = new FooFactory();
 	_ = outputTemplate.Execute(&buf, data)
 
 	assert.Equal(t, buf.String(), hclConversionsToString(input))
+}
+
+func TestGroupLines(t *testing.T) {
+	input := `description
+
+## subtitle 1
+
+subtitle 1 content
+
+## subtitle 2
+
+subtitle 2 content
+`
+	expected := [][]string{
+		{
+			"description",
+			"",
+		},
+		{
+			"## subtitle 1",
+			"",
+			"subtitle 1 content",
+			"",
+		},
+		{
+			"## subtitle 2",
+			"",
+			"subtitle 2 content",
+			"",
+		},
+	}
+
+	assert.Equal(t, expected, groupLines(strings.Split(input, "\n"), "## "))
 }

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -741,6 +741,17 @@ func (g *Generator) Generate() error {
 		return errors.Wrapf(err, "failed to marshal intermediate schema")
 	}
 
+	// Add any supplemental examples:
+	err = addExtraHclExamplesToResources(g.info.ExtraResourceHclExamples, &pulumiPackageSpec)
+	if err != nil {
+		return err
+	}
+
+	err = addExtraHclExamplesToFunctions(g.info.ExtraFunctionHclExamples, &pulumiPackageSpec)
+	if err != nil {
+		return err
+	}
+
 	// Convert examples.
 	if !g.skipExamples {
 		pulumiPackageSpec = g.convertExamplesInSchema(pulumiPackageSpec)

--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -763,7 +763,7 @@ func (g *Generator) convertExamplesInSchema(spec pschema.PackageSpec) pschema.Pa
 func addExtraHclExamplesToResources(extraExamples []tfbridge.HclExampler, spec *pschema.PackageSpec) error {
 	var err error
 	for _, ex := range extraExamples {
-		token := ex.GetPulumiIdentifier()
+		token := ex.GetToken()
 		res, ok := spec.Resources[token]
 		if !ok {
 			err = multierror.Append(err, fmt.Errorf("there is a supplemental HCL example for the resource with token '%s', but no "+
@@ -787,7 +787,7 @@ func addExtraHclExamplesToResources(extraExamples []tfbridge.HclExampler, spec *
 func addExtraHclExamplesToFunctions(extraExamples []tfbridge.HclExampler, spec *pschema.PackageSpec) error {
 	var err error
 	for _, ex := range extraExamples {
-		token := ex.GetPulumiIdentifier()
+		token := ex.GetToken()
 		fun, ok := spec.Functions[token]
 		if !ok {
 			err = multierror.Append(err, fmt.Errorf("there is a supplemental HCL example for the function with token '%s', but no "+

--- a/pkg/tfgen/generate_schema_test.go
+++ b/pkg/tfgen/generate_schema_test.go
@@ -1,0 +1,167 @@
+package tfgen
+
+import (
+	"bytes"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"text/template"
+)
+
+func TestAppendExample_InsertMiddle(t *testing.T) {
+	descTmpl := `Description text
+
+## Example Usage
+
+### Basic
+
+Basic example content
+
+## Import
+
+Import content
+`
+	markdownTmpl := `### My Example
+
+{{ .CodeFences }}hcl
+# My example
+{{ .CodeFences }}
+`
+
+	expectedTmpl := `Description text
+
+## Example Usage
+
+### Basic
+
+Basic example content
+
+### My Example
+
+{{ .CodeFences }}hcl
+# My example
+{{ .CodeFences }}
+
+## Import
+
+Import content
+`
+	assert.Equal(t, renderTemplate(expectedTmpl), appendExample(renderTemplate(descTmpl), renderTemplate(markdownTmpl)))
+}
+
+func TestAppendExample_InsertEnd(t *testing.T) {
+	descTmpl := `Description text
+
+## Example Usage
+
+### Basic
+
+Basic example content
+`
+	markdownTmpl := `### My Example
+
+{{ .CodeFences }}hcl
+# My example content
+{{ .CodeFences }}
+`
+
+	expectedTmpl := `Description text
+
+## Example Usage
+
+### Basic
+
+Basic example content
+
+### My Example
+
+{{ .CodeFences }}hcl
+# My example content
+{{ .CodeFences }}
+`
+	assert.Equal(t, renderTemplate(expectedTmpl), appendExample(renderTemplate(descTmpl), renderTemplate(markdownTmpl)))
+}
+
+// Extra test case to ensure that we do not modify the source material internally in the function.
+func TestAppendExample_NoOp(t *testing.T) {
+	assert.Equal(t, "", appendExample("", ""))
+	assert.Equal(t, "foo\nbar", appendExample("foo\nbar", ""))
+
+	input := `Description
+
+## Example Usage
+
+example usage content
+`
+	assert.Equal(t, input, appendExample(input, ""))
+}
+
+// There are resources (or more commonly, functions) that do not have ## Example Usage in the in the source description.
+// Therefore, we need to add the H2 if none exists to emit a well-formed doc page.
+func TestAppendExample_NoExampleUsage(t *testing.T) {
+	input := "Description Text"
+	markdownTmpl := `### My Example
+
+{{ .CodeFences }}hcl
+# My example content
+{{ .CodeFences }}
+`
+	expectedTmpl :=
+		`Description Text
+
+## Example Usage
+
+### My Example
+
+{{ .CodeFences }}hcl
+# My example content
+{{ .CodeFences }}
+`
+	assert.Equal(t, renderTemplate(expectedTmpl), appendExample(input, renderTemplate(markdownTmpl)))
+}
+
+func TestAppendExample_NoExampleUsage_ImportsPresent(t *testing.T) {
+	input := `Description Text
+
+## Import
+
+import content
+`
+	markdownTmpl := `### My Example
+
+{{ .CodeFences }}hcl
+# My example content
+{{ .CodeFences }}
+`
+	expectedTmpl :=
+		`Description Text
+
+## Example Usage
+
+### My Example
+
+{{ .CodeFences }}hcl
+# My example content
+{{ .CodeFences }}
+
+## Import
+
+import content
+`
+
+	assert.Equal(t, renderTemplate(expectedTmpl), appendExample(input, renderTemplate(markdownTmpl)))
+}
+
+/// renderTemplate allows us to easily use code fences with herestrings
+func renderTemplate(tmpl string) string {
+	outputTemplate, _ := template.New("dummy").Parse(tmpl)
+	data := struct {
+		CodeFences string
+	}{
+		CodeFences: "```",
+	}
+
+	var buf = bytes.Buffer{}
+	_ = outputTemplate.Execute(&buf, data)
+
+	return buf.String()
+}


### PR DESCRIPTION
Adds ExtraFunctionHclExamples and ExtraResourceHclExamples to
tfbridge.ProviderInfo to allow users to add supplemental HCL examples to
resources/functions. Examples will be inserted into resource/function
descriptions and translated like any original source content.

Sample usage:

```go
		ExtraResourceHclExamples: []tfbridge.HclExampler{
			tfbridge.LocalFileHclExample{
				ID:           "gcp:memcache/instance:Instance",
				RelativePath: "docs/test.hcl",
			},
		},
```

Fixes #434
Fixes #364 