### PR TITLE
Perform metaschema validation during sdk generation

### DIFF
--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -769,7 +769,7 @@ func (g *Generator) Generate() error {
 			files[path] = code
 		}
 	default:
-		pulumiPackage, err := pschema.ImportSpec(pulumiPackageSpec, nil)
+		pulumiPackage, err := pschema.BindSpec(pulumiPackageSpec, nil)
 		if err != nil {
 			return errors.Wrapf(err, "failed to import Pulumi schema")
 		}


### PR DESCRIPTION
In https://github.com/pulumi/pulumi/pull/8543 we disabled metaschema validation in most typical user-facing code-paths. But we should try to validate at code-generation.