### PR TITLE
Add NoUpstreamDocs()

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -261,6 +261,15 @@ type DocInfo struct {
 	IncludeAttributesFromArguments string // optionally include attributes from another raw resource's arguments.
 }
 
+// NoUpstreamDocs is used to indicate that a resource has no upstream docs. It returns a pointer to DocInfo which
+// contains a simple whitespace string for the literal contents of the documentation. This value will allow tfgen
+// to pass when PULUMI_MISSING_DOCS_ERROR=true while clearly indicating the reason for the docs override.
+func NoUpstreamDocs() *DocInfo {
+	return &DocInfo{
+		Markdown: []byte(" "),
+	}
+}
+
 // HasDefault returns true if there is a default value for this property.
 func (info SchemaInfo) HasDefault() bool {
 	return info.Default != nil


### PR DESCRIPTION
@stack72 Feel free to reject if you think this is a bad idea, but it's a use case that's come up more than a few times in different providers, and so rather than repeating the same literal and adding the same comment, I figured an upstream function will make it clearer to the reader and also easier to manipulate since it's a single symbol to reference.