### PR TITLE
Perform metaschema validation during sdk generation

### DIFF
--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -780,9 +780,12 @@ func (g *Generator) Generate() error {
 			files[path] = code
 		}
 	default:
-		pulumiPackage, err := pschema.ImportSpec(pulumiPackageSpec, nil)
+		pulumiPackage, diags, err := pschema.BindSpec(pulumiPackageSpec, nil)
 		if err != nil {
 			return errors.Wrapf(err, "failed to import Pulumi schema")
+		}
+		if diags.HasErrors() {
+			return err
 		}
 		if files, err = g.language.emitSDK(pulumiPackage, g.info, g.root); err != nil {
 			return errors.Wrapf(err, "failed to generate package")


### PR DESCRIPTION
In https://github.com/pulumi/pulumi/pull/8543 we disabled metaschema validation in most typical user-facing code-paths. But we should try to validate at code-generation.