### PR TITLE
Support different random char sets for autonames

### DIFF
--- a/pkg/tfbridge/names.go
+++ b/pkg/tfbridge/names.go
@@ -15,12 +15,12 @@
 package tfbridge
 
 import (
+	"math/rand"
 	"unicode"
 
 	"github.com/pkg/errors"
 
 	"github.com/gedex/inflector"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
@@ -132,8 +132,11 @@ type AutoNameOptions struct {
 	Separator string
 	// Maximum length of the generated name
 	Maxlen int
-	// Number of characters of random hex digits to add to the name
+	// Number of random characters to add to the name
 	Randlen int
+	// A string of characters that are valid for the generated part of the name, defaults to the set of
+	// hexadecimal characters.
+	Randchars []rune
 	// A transform to apply to the name prior to adding random characters
 	Transform func(string) string
 	// A transform to apply after the auto naming has been computed
@@ -196,11 +199,25 @@ func FromName(options AutoNameOptions) func(res *PulumiResource) (interface{}, e
 			vs = options.Transform(vs)
 		}
 		if options.Randlen > 0 {
-			uniqueHex, err := resource.NewUniqueHex(vs+options.Separator, options.Randlen, options.Maxlen)
-			if err != nil {
-				return uniqueHex, errors.Wrapf(err, "could not make instance of '%v'", res.URN.Type())
+			// If Randchars is nil use hex chars
+			randchars := options.Randchars
+			if randchars == nil {
+				randchars = []rune("0123456789abcdef")
 			}
-			vs = uniqueHex
+
+			prefix := vs + options.Separator
+			// Generate a unique name using the restricted set
+			if options.Maxlen > 0 && len(prefix)+options.Randlen > options.Maxlen {
+				err := errors.Errorf("name '%s' plus %d random chars is longer than maximum length %d", prefix, options.Randlen, options.Maxlen)
+				return "", errors.Wrapf(err, "could not make instance of '%v'", res.URN.Type())
+			}
+
+			b := make([]rune, options.Randlen)
+			for i := range b {
+				b[i] = randchars[rand.Intn(len(randchars))]
+			}
+
+			vs = prefix + string(b)
 		}
 		if options.PostTransform != nil {
 			return options.PostTransform(res, vs)

--- a/pkg/tfbridge/names_test.go
+++ b/pkg/tfbridge/names_test.go
@@ -15,7 +15,6 @@
 package tfbridge
 
 import (
-	"regexp"
 	"strings"
 	"testing"
 
@@ -158,7 +157,7 @@ func TestFromNameRandchars(t *testing.T) {
 		Separator: "%",
 		Maxlen:    80,
 		Randlen:   7,
-		Randchars: []rune("abcdefghijklmnopqrstuvwxyz"),
+		Randchars: []rune("a"),
 		PostTransform: func(res *PulumiResource, name string) (string, error) {
 			if fifo, hasfifo := res.Properties["fifo"]; hasfifo {
 				if fifo.IsBool() && fifo.BoolValue() {
@@ -171,5 +170,5 @@ func TestFromNameRandchars(t *testing.T) {
 	out1, err := f1(res1)
 	outStr := out1.(string)
 	assert.NoError(t, err)
-	assert.Regexp(t, regexp.MustCompile(`^n1%[a-z]{7}\.fifo$`), outStr)
+	assert.Equal(t, "n1%aaaaaaa.fifo", outStr)
 }


### PR DESCRIPTION
Add a way for providers to opt-into autonames where the name can't contain hex characters (the default random suffix for autonames).

This should allow us to replace such things as the below from the aws provider:
```
Default: &tfbridge.DefaultInfo{
	// This means the name will adhere to ^[a-z]+(_[a-z]+)*$  as per
	// https://docs.aws.amazon.com/athena/latest/ug/tables-databases-columns-names.html
	From: tfbridge.FromName(tfbridge.AutoNameOptions{
		Transform: func(name string) string {
			newName := fmt.Sprintf("%s_%s", name, transformWithRandomString(8))
			return strings.ToLower(newName)
		},
	}),
},
```
With:
```
Default: &tfbridge.DefaultInfo{
	// This means the name will adhere to ^[a-z]+(_[a-z]+)*$  as per
	// https://docs.aws.amazon.com/athena/latest/ug/tables-databases-columns-names.html
	From: tfbridge.FromName(tfbridge.AutoNameOptions{
		Separator: "_",
		Randchars: []rune("abcdefghijklmnopqrstuvwxyz"),
	}),
},
```

This will allow us to fix these resources for deterministic names purely in tfbridge.