### PR TITLE
Allow setting a custom package name for the generated Python SDK

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -325,6 +325,7 @@ type PythonInfo struct {
 	Requires      map[string]string // Pip install_requires information.
 	Overlay       *OverlayInfo      // optional overlay information for augmented code-generation.
 	UsesIOClasses bool              // Deprecated: No longer required, all providers use IO classes.
+	PackageName   string            // Name of the Python package to generate
 }
 
 // GolangInfo contains optional overlay information for Golang code-generation.

--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -312,6 +312,9 @@ func (g *schemaGenerator) genPackageSpec(pack *pkg) (pschema.PackageSpec, error)
 	}
 	if pi := g.info.Python; pi != nil {
 		pythonData["requires"] = pi.Requires
+		if pyPackageName := pi.PackageName; pyPackageName != "" {
+			pythonData["packageName"] = pyPackageName
+		}
 	}
 	spec.Language["python"] = rawMessage(pythonData)
 


### PR DESCRIPTION
@stack72 the Pulumi code generator allows to set the package name for the generated Python SDK within `schema.json`:

https://github.com/pulumi/pulumi/blob/45f7a064846a4a8e541e5d6647ba5f673a07f040/pkg/codegen/python/gen_program.go#L133-L138

But this TF bridge doesn't have a way to configure this yet via `provider/resources.go` in a bridged provider. This PR changes that. I tested this locally with the pulumiverse/pulumi-unifi provider and it seems to work. Rather than having a Python package named `pulumi_unifi`, I generate `pulumiverse_unifi`:

```
make build_python
[ -x /usr/local/bin/pulumi ] || curl -fsSL https://get.pulumi.com | sh
pulumi plugin install resource random 4.3.1
(cd provider && go build -o /Users/ringods/Projects/pulumiverse/pulumi-unifi/bin/pulumi-tfgen-unifi -ldflags "-X github.com/pulumiverse/pulumi-unifi/provider/pkg/version.Version=0.0.1-alpha.1647554518+9bc642ea.dirty" github.com/pulumiverse/pulumi-unifi/provider/cmd/pulumi-tfgen-unifi)
/Users/ringods/Projects/pulumiverse/pulumi-unifi/bin/pulumi-tfgen-unifi schema --out provider/cmd/pulumi-resource-unifi
warning: Found <elided> in description for [unifi_device], but was able to preserve the examples. The description proper will be dropped in the Pulumi provider.
warning: 1 entity descriptions contained an <elided> reference and were dropped, but examples were preserved.
(cd provider && VERSION=0.0.1-alpha.1647554518+9bc642ea.dirty go generate cmd/pulumi-resource-unifi/main.go)
/Users/ringods/Projects/pulumiverse/pulumi-unifi/bin/pulumi-tfgen-unifi python --overlays provider/overlays/python --out sdk/python/
warning: Found <elided> in description for [unifi_device], but was able to preserve the examples. The description proper will be dropped in the Pulumi provider.
warning: 1 entity descriptions contained an <elided> reference and were dropped, but examples were preserved.
cd sdk/python/ && \
        cp ../../README.md . && \
        python3 setup.py clean --all 2>/dev/null && \
        rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
        sed -i.bak -e 's/^VERSION = .*/VERSION = "0.0.1a1647554518+dirty"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "0.0.1-alpha.1647554518+9bc642ea.dirty"/g' ./bin/setup.py && \
        rm ./bin/setup.py.bak && \
        cd ./bin && python3 setup.py build sdist
running clean
running build
running build_py
creating build
creating build/lib
creating build/lib/pulumiverse_unifi
copying pulumiverse_unifi/get_port_profile.py -> build/lib/pulumiverse_unifi
copying pulumiverse_unifi/user_group.py -> build/lib/pulumiverse_unifi
copying pulumiverse_unifi/user.py -> build/lib/pulumiverse_unifi
copying pulumiverse_unifi/get_network.py -> build/lib/pulumiverse_unifi
copying pulumiverse_unifi/provider.py -> build/lib/pulumiverse_unifi
copying pulumiverse_unifi/firewall_group.py -> build/lib/pulumiverse_unifi
copying pulumiverse_unifi/static_route.py -> build/lib/pulumiverse_unifi
copying pulumiverse_unifi/device.py -> build/lib/pulumiverse_unifi
copying pulumiverse_unifi/dynamic_dns.py -> build/lib/pulumiverse_unifi
copying pulumiverse_unifi/port_forward.py -> build/lib/pulumiverse_unifi
copying pulumiverse_unifi/_inputs.py -> build/lib/pulumiverse_unifi
copying pulumiverse_unifi/wlan.py -> build/lib/pulumiverse_unifi
copying pulumiverse_unifi/__init__.py -> build/lib/pulumiverse_unifi
copying pulumiverse_unifi/get_user_group.py -> build/lib/pulumiverse_unifi
copying pulumiverse_unifi/setting_mgmt.py -> build/lib/pulumiverse_unifi
copying pulumiverse_unifi/_utilities.py -> build/lib/pulumiverse_unifi
copying pulumiverse_unifi/site.py -> build/lib/pulumiverse_unifi
copying pulumiverse_unifi/get_user.py -> build/lib/pulumiverse_unifi
copying pulumiverse_unifi/network.py -> build/lib/pulumiverse_unifi
copying pulumiverse_unifi/get_radius_profile.py -> build/lib/pulumiverse_unifi
copying pulumiverse_unifi/port_profile.py -> build/lib/pulumiverse_unifi
copying pulumiverse_unifi/firewall_rule.py -> build/lib/pulumiverse_unifi
copying pulumiverse_unifi/get_ap_group.py -> build/lib/pulumiverse_unifi
copying pulumiverse_unifi/setting_usg.py -> build/lib/pulumiverse_unifi
copying pulumiverse_unifi/outputs.py -> build/lib/pulumiverse_unifi
creating build/lib/pulumiverse_unifi/config
copying pulumiverse_unifi/config/vars.py -> build/lib/pulumiverse_unifi/config
copying pulumiverse_unifi/config/__init__.py -> build/lib/pulumiverse_unifi/config
copying pulumiverse_unifi/py.typed -> build/lib/pulumiverse_unifi
copying pulumiverse_unifi/pulumi-plugin.json -> build/lib/pulumiverse_unifi
running sdist
running egg_info
creating pulumiverse_unifi.egg-info
writing pulumiverse_unifi.egg-info/PKG-INFO
writing dependency_links to pulumiverse_unifi.egg-info/dependency_links.txt
writing requirements to pulumiverse_unifi.egg-info/requires.txt
writing top-level names to pulumiverse_unifi.egg-info/top_level.txt
writing manifest file 'pulumiverse_unifi.egg-info/SOURCES.txt'
reading manifest file 'pulumiverse_unifi.egg-info/SOURCES.txt'
writing manifest file 'pulumiverse_unifi.egg-info/SOURCES.txt'
running check
warning: check: missing meta-data: either (author and author_email) or (maintainer and maintainer_email) should be supplied

creating pulumiverse_unifi-0.0.1a1647554518+dirty
creating pulumiverse_unifi-0.0.1a1647554518+dirty/pulumiverse_unifi
creating pulumiverse_unifi-0.0.1a1647554518+dirty/pulumiverse_unifi.egg-info
creating pulumiverse_unifi-0.0.1a1647554518+dirty/pulumiverse_unifi/config
copying files to pulumiverse_unifi-0.0.1a1647554518+dirty...
copying README.md -> pulumiverse_unifi-0.0.1a1647554518+dirty
copying setup.py -> pulumiverse_unifi-0.0.1a1647554518+dirty
copying pulumiverse_unifi/__init__.py -> pulumiverse_unifi-0.0.1a1647554518+dirty/pulumiverse_unifi
copying pulumiverse_unifi/_inputs.py -> pulumiverse_unifi-0.0.1a1647554518+dirty/pulumiverse_unifi
copying pulumiverse_unifi/_utilities.py -> pulumiverse_unifi-0.0.1a1647554518+dirty/pulumiverse_unifi
copying pulumiverse_unifi/device.py -> pulumiverse_unifi-0.0.1a1647554518+dirty/pulumiverse_unifi
copying pulumiverse_unifi/dynamic_dns.py -> pulumiverse_unifi-0.0.1a1647554518+dirty/pulumiverse_unifi
copying pulumiverse_unifi/firewall_group.py -> pulumiverse_unifi-0.0.1a1647554518+dirty/pulumiverse_unifi
copying pulumiverse_unifi/firewall_rule.py -> pulumiverse_unifi-0.0.1a1647554518+dirty/pulumiverse_unifi
copying pulumiverse_unifi/get_ap_group.py -> pulumiverse_unifi-0.0.1a1647554518+dirty/pulumiverse_unifi
copying pulumiverse_unifi/get_network.py -> pulumiverse_unifi-0.0.1a1647554518+dirty/pulumiverse_unifi
copying pulumiverse_unifi/get_port_profile.py -> pulumiverse_unifi-0.0.1a1647554518+dirty/pulumiverse_unifi
copying pulumiverse_unifi/get_radius_profile.py -> pulumiverse_unifi-0.0.1a1647554518+dirty/pulumiverse_unifi
copying pulumiverse_unifi/get_user.py -> pulumiverse_unifi-0.0.1a1647554518+dirty/pulumiverse_unifi
copying pulumiverse_unifi/get_user_group.py -> pulumiverse_unifi-0.0.1a1647554518+dirty/pulumiverse_unifi
copying pulumiverse_unifi/network.py -> pulumiverse_unifi-0.0.1a1647554518+dirty/pulumiverse_unifi
copying pulumiverse_unifi/outputs.py -> pulumiverse_unifi-0.0.1a1647554518+dirty/pulumiverse_unifi
copying pulumiverse_unifi/port_forward.py -> pulumiverse_unifi-0.0.1a1647554518+dirty/pulumiverse_unifi
copying pulumiverse_unifi/port_profile.py -> pulumiverse_unifi-0.0.1a1647554518+dirty/pulumiverse_unifi
copying pulumiverse_unifi/provider.py -> pulumiverse_unifi-0.0.1a1647554518+dirty/pulumiverse_unifi
copying pulumiverse_unifi/pulumi-plugin.json -> pulumiverse_unifi-0.0.1a1647554518+dirty/pulumiverse_unifi
copying pulumiverse_unifi/py.typed -> pulumiverse_unifi-0.0.1a1647554518+dirty/pulumiverse_unifi
copying pulumiverse_unifi/setting_mgmt.py -> pulumiverse_unifi-0.0.1a1647554518+dirty/pulumiverse_unifi
copying pulumiverse_unifi/setting_usg.py -> pulumiverse_unifi-0.0.1a1647554518+dirty/pulumiverse_unifi
copying pulumiverse_unifi/site.py -> pulumiverse_unifi-0.0.1a1647554518+dirty/pulumiverse_unifi
copying pulumiverse_unifi/static_route.py -> pulumiverse_unifi-0.0.1a1647554518+dirty/pulumiverse_unifi
copying pulumiverse_unifi/user.py -> pulumiverse_unifi-0.0.1a1647554518+dirty/pulumiverse_unifi
copying pulumiverse_unifi/user_group.py -> pulumiverse_unifi-0.0.1a1647554518+dirty/pulumiverse_unifi
copying pulumiverse_unifi/wlan.py -> pulumiverse_unifi-0.0.1a1647554518+dirty/pulumiverse_unifi
copying pulumiverse_unifi.egg-info/PKG-INFO -> pulumiverse_unifi-0.0.1a1647554518+dirty/pulumiverse_unifi.egg-info
copying pulumiverse_unifi.egg-info/SOURCES.txt -> pulumiverse_unifi-0.0.1a1647554518+dirty/pulumiverse_unifi.egg-info
copying pulumiverse_unifi.egg-info/dependency_links.txt -> pulumiverse_unifi-0.0.1a1647554518+dirty/pulumiverse_unifi.egg-info
copying pulumiverse_unifi.egg-info/not-zip-safe -> pulumiverse_unifi-0.0.1a1647554518+dirty/pulumiverse_unifi.egg-info
copying pulumiverse_unifi.egg-info/requires.txt -> pulumiverse_unifi-0.0.1a1647554518+dirty/pulumiverse_unifi.egg-info
copying pulumiverse_unifi.egg-info/top_level.txt -> pulumiverse_unifi-0.0.1a1647554518+dirty/pulumiverse_unifi.egg-info
copying pulumiverse_unifi/config/__init__.py -> pulumiverse_unifi-0.0.1a1647554518+dirty/pulumiverse_unifi/config
copying pulumiverse_unifi/config/vars.py -> pulumiverse_unifi-0.0.1a1647554518+dirty/pulumiverse_unifi/config
Writing pulumiverse_unifi-0.0.1a1647554518+dirty/setup.cfg
creating dist
Creating tar archive
removing 'pulumiverse_unifi-0.0.1a1647554518+dirty' (and everything under it)
Time: 0h:00m:14s                                                        
```

Signed-off-by: Ringo De Smet <ringo@de-smet.name>