### PR TITLE
Check For nil State and Return Error on Refresh

### DIFF
--- a/pkg/tfshim/tfplugin5/provider.go
+++ b/pkg/tfshim/tfplugin5/provider.go
@@ -455,6 +455,10 @@ func (p *provider) Refresh(t string, s shim.InstanceState) (shim.InstanceState, 
 		return nil, err
 	}
 
+	if resp.NewState == nil {
+		return nil, unmarshalErrors(resp.Diagnostics)
+	}
+
 	newStateVal, err := msgpack.Unmarshal(resp.NewState.Msgpack, resource.ctyType)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When refreshing a resource, the provider may return a `nil` value for `NewState` and the error will be in the `Diagnostics` field.  This PR accounts for this possibility and bubbles up the provider error rather than having the terraform bridge panic.

Relates to issue https://github.com/pulumi/pulumi-terraform-bridge/issues/503 