### PR TITLE
Revert "Support different random char sets for autonames (#506)"

### DIFF
--- a/pkg/tfbridge/names_test.go
+++ b/pkg/tfbridge/names_test.go
@@ -145,30 +145,3 @@ func TestFromName(t *testing.T) {
 	assert.Len(t, out1, len("n1")+1+7+len(".fifo"))
 	assert.True(t, strings.HasSuffix(out1.(string), ".fifo"))
 }
-
-func TestFromNameRandchars(t *testing.T) {
-	res1 := &PulumiResource{
-		URN: "urn:pulumi:test::test::pkgA:index:t1::n1",
-		Properties: resource.PropertyMap{
-			"fifo": resource.NewBoolProperty(true),
-		},
-	}
-	f1 := FromName(AutoNameOptions{
-		Separator: "%",
-		Maxlen:    80,
-		Randlen:   7,
-		Randchars: []rune("a"),
-		PostTransform: func(res *PulumiResource, name string) (string, error) {
-			if fifo, hasfifo := res.Properties["fifo"]; hasfifo {
-				if fifo.IsBool() && fifo.BoolValue() {
-					return name + ".fifo", nil
-				}
-			}
-			return name, nil
-		},
-	})
-	out1, err := f1(res1)
-	outStr := out1.(string)
-	assert.NoError(t, err)
-	assert.Equal(t, "n1%aaaaaaa.fifo", outStr)
-}


### PR DESCRIPTION
This reverts commit e12baa8f06fbff32a08c25d93dd229b96dbdb682.