### PR TITLE
Prevent mutating existing 'id' property on schema

### DIFF
--- a/pkg/tf2pulumi/convert/tf12.go
+++ b/pkg/tf2pulumi/convert/tf12.go
@@ -1754,7 +1754,9 @@ func (b *tf12binder) resourceType(addr addrs.Resource,
 	if schemas.TFRes == nil {
 		schemas.TFRes = (&schema.Resource{Schema: schema.SchemaMap{}}).Shim()
 	}
-	schemas.TFRes.Schema().Set("id", (&schema.Schema{Type: shim.TypeString, Computed: true}).Shim())
+	if _, ok := schemas.TFRes.Schema().GetOk("id"); !ok {
+		schemas.TFRes.Schema().Set("id", (&schema.Schema{Type: shim.TypeString, Computed: true}).Shim())
+	}
 
 	return token, schemas, schemas.ModelType(), nil
 }


### PR DESCRIPTION
Fixes pulumi/pulumi#9611 which was a bug caused by this roundabout sequence.

# Bug

Examples code generation should be deterministic. Instead, for the Hetzner Cloud (hcloud) provider, the `id` properties on several functions flapped between a string or numeric representation in the docs.

# Root cause analysis

The Hetzner Cloud `hcloud_network` & `hcloud_networks` upstream examples contain a bug, the latter docs refer to `hcloud_network` (singular) in the examples and not plural. 

This is relevant because our own code has a data race. We intermingle schema binding (and mutating the schema) with example code generation. Depending on whether `getExample` or `getExamples` runs first, we either:

  1. Generate example code for `getExample` (correctly)
  2. Generate example code for `getExamples` (broken due to upstream)
  3. Mutate `getExample` to have an `id: string` output.

Or:

  1. Generate example code for `getExamples` (broken due to upstream)
  2. Mutate `getExample` to have an `id: string` output.
  3. Generate example code for `getExample` (**incorrectly, due to mutation of id property**)

The change in this PR ensures that if an "id" is present, it is not overridden. Here's the mutation: 

https://github.com/pulumi/pulumi-terraform-bridge/blob/6d583a65000454b4c745c1b443e056cae34203a0/pkg/tf2pulumi/convert/tf12.go#L1757

While root causing this, I found this earlier code which seems to make that line redundant, because we also "make up" a string output if one doesn't prior to doing any code generation, up front:

https://github.com/pulumi/pulumi-terraform-bridge/blob/6d583a65000454b4c745c1b443e056cae34203a0/pkg/tfgen/generate.go#L1235-L1243

As I'm new to this code base, I don't know why either of these blocks is needed, as I think they create phantom "id" properties on functions that do not have an "id" output, such as in the `getNetworks` example.

If either or both of the quoted code blocks can be safely removed, I think we should favor doing so over this PR.