### PR TITLE
Add ability to control deleteBeforeReplace semantics

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -148,14 +148,17 @@ type ResourceOrDataSourceInfo interface {
 // also give custom metadata for fields, using the SchemaInfo structure below.  Finally, a set of composite keys can be
 // given; this is used when Terraform needs more than just the ID to uniquely identify and query for a resource.
 type ResourceInfo struct {
-	Tok                 tokens.Type            // a type token to override the default; "" uses the default.
-	Fields              map[string]*SchemaInfo // a map of custom field names; if a type is missing, uses the default.
-	IDFields            []string               // an optional list of ID alias fields.
-	Docs                *DocInfo               // overrides for finding and mapping TF docs.
-	DeleteBeforeReplace bool                   // if true, Pulumi will delete before creating new replacement resources.
-	Aliases             []AliasInfo            // aliases for this resources, if any.
-	DeprecationMessage  string                 // message to use in deprecation warning
-	CSharpName          string                 // .NET-specific name
+	Tok      tokens.Type            // a type token to override the default; "" uses the default.
+	Fields   map[string]*SchemaInfo // a map of custom field names; if a type is missing, uses the default.
+	IDFields []string               // an optional list of ID alias fields.
+	// list of parameters that we can trust that any change will allow a createBeforeDelete
+	UniqueNameFields    []string
+	Docs                *DocInfo    // overrides for finding and mapping TF docs.
+	DeleteBeforeReplace bool        // if true, Pulumi will delete before creating new replacement resources.
+	Aliases             []AliasInfo // aliases for this resources, if any.
+	DeprecationMessage  string      // message to use in deprecation warning
+	CSharpName          string      // .NET-specific name
+
 }
 
 // GetTok returns a resource type token

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -805,7 +805,7 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 	})
 
 	deleteBeforeReplace := len(replaces) > 0 &&
-		(res.Schema.DeleteBeforeReplace || nameRequiresDeleteBeforeReplace(news, res.TF.Schema(), res.Schema.Fields))
+		(res.Schema.DeleteBeforeReplace || nameRequiresDeleteBeforeReplace(news, olds, res.TF.Schema(), res.Schema))
 
 	return &pulumirpc.DiffResponse{
 		Changes:             changes,

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -76,18 +76,18 @@ func nameRequiresDeleteBeforeReplace(news resource.PropertyMap, olds resource.Pr
 	// and override the deleteBeforeReplace e.g. name or namePrefix
 	// if any of these values change then we can assume we can
 	if len(resourceInfo.UniqueNameFields) > 0 {
-		// we are explicitly trying to force functionality here
-		for _, idField := range resourceInfo.UniqueNameFields {
-			_, _, psi := getInfoFromPulumiName(resource.PropertyKey(idField), tfs, fields, false)
+		for _, name := range resourceInfo.UniqueNameFields {
+			key := resource.PropertyKey(name)
+			_, _, psi := getInfoFromPulumiName(key, tfs, fields, false)
 
-			oldVal := olds[resource.PropertyKey(idField)]
-			newVal := news[resource.PropertyKey(idField)]
+			oldVal := olds[key]
+			newVal := news[key]
 
 			if !oldVal.DeepEquals(newVal) {
 				return false
 			}
 
-			if psi != nil && psi.HasDefault() && psi.Default.AutoNamed && hasDefault[resource.PropertyKey(idField)] {
+			if psi != nil && psi.HasDefault() && psi.Default.AutoNamed && hasDefault[key] {
 				return false
 			}
 		}


### PR DESCRIPTION
In the situation where a resource cannot have the same name AND is
explicitly named (e.g. GPC InstanceTemplate or AWS Autoscaling Group)
the resource would default to deleteBeforeReplace. This wouldn't work
if the resource was attached to another resource

Pulumi wasn't taking into account the fact that a physical name field
was being updated and still defaulted to deleteBeforeReplace

We can now specific a list of physicalNameFields in the provider that
will override the deleteBeforeReplace semantics and it will force the
creation of a new resource (because the name is changing) before it
deletes the old one

[![asciicast](https://asciinema.org/a/DPDWU14QgamK6z026BvIgLwx3.svg)](https://asciinema.org/a/DPDWU14QgamK6z026BvIgLwx3)