### PR TITLE
Add support for ExactlyOneOf

### DIFF
--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -352,28 +352,34 @@ func (ctx *conversionContext) MakeTerraformInputs(olds, news resource.PropertyMa
 
 }
 
-func (ctx *conversionContext) applyDefaults(result map[string]interface{}, olds, news resource.PropertyMap,
-	tfs shim.SchemaMap, ps map[string]*SchemaInfo, rawNames bool) error {
-
-	if !ctx.ApplyDefaults {
-		return nil
+func buildExactlyOneOfsWith(result map[string]interface{}, tfs shim.SchemaMap) map[string]struct{} {
+	exactlyOneOf := make(map[string]struct{})
+	if tfs != nil {
+		tfs.Range(func(name string, sch shim.Schema) bool {
+			if _, has := result[name]; has {
+				// `name` is present, so mark any names that are declared to
+				// exactlyOneOf with `name` for exclusion.
+				for _, exclusion := range sch.ExactlyOneOf() {
+					exactlyOneOf[exclusion] = struct{}{}
+				}
+			} else {
+				// `name` is not present, so mark it for exclusion if any fields
+				// that exactlyOneOf with `name` are present.
+				for _, exclusion := range sch.ExactlyOneOf() {
+					if _, has := result[exclusion]; has {
+						exactlyOneOf[name] = struct{}{}
+						break
+					}
+				}
+			}
+			return true
+		})
 	}
 
-	// Create an array to track which properties are defaults.
-	newDefaults := []interface{}{}
+	return exactlyOneOf
+}
 
-	// Pull the list of old defaults if any. If there is no list, then we will treat all old values as being usable
-	// for new defaults. If there is a list, we will only propagate defaults that were themselves defaults.
-	useOldDefault := func(key resource.PropertyKey) bool { return true }
-	if oldDefaults, ok := olds[defaultsKey]; ok {
-		oldDefaultSet := make(map[resource.PropertyKey]bool)
-		for _, k := range oldDefaults.ArrayValue() {
-			oldDefaultSet[resource.PropertyKey(k.StringValue())] = true
-		}
-		useOldDefault = func(key resource.PropertyKey) bool { return oldDefaultSet[key] }
-	}
-
-	// Compute any names for which setting a default would cause a conflict.
+func buildConflictsWith(result map[string]interface{}, tfs shim.SchemaMap) map[string]struct{} {
 	conflictsWith := make(map[string]struct{})
 	if tfs != nil {
 		tfs.Range(func(name string, sch shim.Schema) bool {
@@ -397,12 +403,43 @@ func (ctx *conversionContext) applyDefaults(result map[string]interface{}, olds,
 		})
 	}
 
+	return conflictsWith
+}
+
+func (ctx *conversionContext) applyDefaults(result map[string]interface{}, olds, news resource.PropertyMap,
+	tfs shim.SchemaMap, ps map[string]*SchemaInfo, rawNames bool) error {
+
+	if !ctx.ApplyDefaults {
+		return nil
+	}
+
+	// Create an array to track which properties are defaults.
+	newDefaults := []interface{}{}
+
+	// Pull the list of old defaults if any. If there is no list, then we will treat all old values as being usable
+	// for new defaults. If there is a list, we will only propagate defaults that were themselves defaults.
+	useOldDefault := func(key resource.PropertyKey) bool { return true }
+	if oldDefaults, ok := olds[defaultsKey]; ok {
+		oldDefaultSet := make(map[resource.PropertyKey]bool)
+		for _, k := range oldDefaults.ArrayValue() {
+			oldDefaultSet[resource.PropertyKey(k.StringValue())] = true
+		}
+		useOldDefault = func(key resource.PropertyKey) bool { return oldDefaultSet[key] }
+	}
+
+	// Compute any names for which setting a default would cause a conflict.
+	conflictsWith := buildConflictsWith(result, tfs)
+	exactlyOneOf := buildExactlyOneOfsWith(result, tfs)
+
 	// First, attempt to use the overlays.
 	for name, info := range ps {
 		if info.Removed {
 			continue
 		}
 		if _, conflicts := conflictsWith[name]; conflicts {
+			continue
+		}
+		if _, exactlyOneOfConflicts := exactlyOneOf[name]; exactlyOneOfConflicts {
 			continue
 		}
 		sch := getSchema(tfs, name)
@@ -480,10 +517,14 @@ func (ctx *conversionContext) applyDefaults(result map[string]interface{}, olds,
 				result[name] = defaultValue
 				newDefaults = append(newDefaults, key)
 
-				// Expand the conflicts map
+				// Expand the conflicts and exactlyOneOf map
 				if sch != nil {
 					for _, conflictingName := range sch.ConflictsWith() {
 						conflictsWith[conflictingName] = struct{}{}
+					}
+
+					for _, exactlyOneOfName := range sch.ExactlyOneOf() {
+						exactlyOneOf[exactlyOneOfName] = struct{}{}
 					}
 				}
 			}
@@ -504,10 +545,23 @@ func (ctx *conversionContext) applyDefaults(result map[string]interface{}, olds,
 				return true
 			}
 
+			if _, exactlyOneOfConflict := exactlyOneOf[name]; exactlyOneOfConflict {
+				return true
+			}
+
 			// If a conflicting field has a default value, don't set the default for the current field
 			for _, conflictingName := range sch.ConflictsWith() {
 				if conflictingSchema, exists := tfs.GetOk(conflictingName); exists {
 					dv, _ := conflictingSchema.DefaultValue()
+					if dv != nil {
+						return true
+					}
+				}
+			}
+
+			for _, exactlyOneOfName := range sch.ExactlyOneOf() {
+				if exactlyOneSchema, exists := tfs.GetOk(exactlyOneOfName); exists {
+					dv, _ := exactlyOneSchema.DefaultValue()
 					if dv != nil {
 						return true
 					}

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -723,6 +723,7 @@ func sortDefaultsList(m resource.PropertyMap) {
 	m[defaultsKey] = resource.NewArrayProperty(defs)
 }
 
+//
 func TestDefaults(t *testing.T) {
 	for _, f := range factories {
 		t.Run(f.SDKVersion(), func(t *testing.T) {
@@ -755,6 +756,8 @@ func TestDefaults(t *testing.T) {
 			asset, err := resource.NewTextAsset("hello")
 			assert.Nil(t, err)
 			tfs := f.NewSchemaMap(map[string]*schema.Schema{
+				"xyz": {Type: shim.TypeString, ExactlyOneOf: []string{"xyz", "abc"}},
+				"abc": {Type: shim.TypeString, Default: "ABC", ExactlyOneOf: []string{"xyz", "abc"}},
 				"ccc": {Type: shim.TypeString, Default: "CCC"},
 				"cc2": {Type: shim.TypeString, DefaultFunc: func() (interface{}, error) { return "CC2", nil }},
 				"ddd": {Type: shim.TypeString, Default: "TFD"},
@@ -826,10 +829,12 @@ func TestDefaults(t *testing.T) {
 
 			// sort the defaults list before the equality test below.
 			sortDefaultsList(outputs)
+
 			assert.Equal(t, resource.NewPropertyMapFromMap(map[string]interface{}{
 				defaultsKey: []interface{}{
-					"cc2", "ccc", "ee2", "eee", "ggg", "iii", "ll2", "lll", "mm2", "mmm", "oo2", "uuu", "vvv", "www",
+					"abc", "cc2", "ccc", "ee2", "eee", "ggg", "iii", "ll2", "lll", "mm2", "mmm", "oo2", "uuu", "vvv", "www",
 				},
+				"abc": "ABC",
 				"bbb": "BBB",
 				"ccc": "CCC",
 				"cc2": "CC2",
@@ -850,6 +855,7 @@ func TestDefaults(t *testing.T) {
 				"uuu": "PSU",
 				"vvv": 1337,
 				"www": "OLW",
+				// xzy is NOT set as it's either that or abc
 				"zzz": asset,
 			}), outputs)
 
@@ -860,12 +866,13 @@ func TestDefaults(t *testing.T) {
 			assert.NoError(t, err)
 			outputs = MakeTerraformOutputs(f.NewTestProvider(), inputs, tfs, ps, assets, false, true)
 
-			// sort the defaults list before the equality test below.
+			//sort the defaults list before the equality test below.
 			sortDefaultsList(outputs)
 			assert.Equal(t, resource.NewPropertyMapFromMap(map[string]interface{}{
 				defaultsKey: []interface{}{
-					"cc2", "ccc", "ee2", "eee", "ggg", "iii", "ll2", "lll", "mm2", "mmm", "oo2", "uuu", "vvv", "www",
+					"abc", "cc2", "ccc", "ee2", "eee", "ggg", "iii", "ll2", "lll", "mm2", "mmm", "oo2", "uuu", "vvv", "www",
 				},
+				"abc": "ABC",
 				"bbb": "BBB",
 				"ccc": "CCC",
 				"cc2": "CC2",
@@ -888,6 +895,7 @@ func TestDefaults(t *testing.T) {
 				"uuu": "PSU",
 				"vvv": 1337,
 				"www": "OLW",
+				// xyz is NOT set as it has ExactlyOneOf with abc
 				"zzz": asset,
 			}), outputs)
 		})

--- a/pkg/tfshim/schema/schema.go
+++ b/pkg/tfshim/schema/schema.go
@@ -26,6 +26,7 @@ type Schema struct {
 	MaxItems      int
 	MinItems      int
 	ConflictsWith []string
+	ExactlyOneOf  []string
 	Removed       string
 	Deprecated    string
 	Sensitive     bool
@@ -106,6 +107,10 @@ func (s SchemaShim) MinItems() int {
 
 func (s SchemaShim) ConflictsWith() []string {
 	return s.V.ConflictsWith
+}
+
+func (s SchemaShim) ExactlyOneOf() []string {
+	return s.V.ExactlyOneOf
 }
 
 func (s SchemaShim) Removed() string {

--- a/pkg/tfshim/sdk-v1/schema.go
+++ b/pkg/tfshim/sdk-v1/schema.go
@@ -103,6 +103,10 @@ func (s v1Schema) ConflictsWith() []string {
 	return s.tf.ConflictsWith
 }
 
+func (s v1Schema) ExactlyOneOf() []string {
+	return s.tf.ExactlyOneOf
+}
+
 func (s v1Schema) Removed() string {
 	return s.tf.Removed
 }

--- a/pkg/tfshim/sdk-v2/schema.go
+++ b/pkg/tfshim/sdk-v2/schema.go
@@ -103,6 +103,10 @@ func (s v2Schema) ConflictsWith() []string {
 	return s.tf.ConflictsWith
 }
 
+func (s v2Schema) ExactlyOneOf() []string {
+	return s.tf.ExactlyOneOf
+}
+
 func (s v2Schema) Removed() string {
 	return ""
 }

--- a/pkg/tfshim/shim.go
+++ b/pkg/tfshim/shim.go
@@ -79,6 +79,7 @@ type Schema interface {
 	MaxItems() int
 	MinItems() int
 	ConflictsWith() []string
+	ExactlyOneOf() []string
 	Deprecated() string
 	Removed() string
 	Sensitive() bool

--- a/pkg/tfshim/tfplugin5/schema.go
+++ b/pkg/tfshim/tfplugin5/schema.go
@@ -84,6 +84,14 @@ func (s *attributeSchema) ConflictsWith() []string {
 	return nil
 }
 
+func (s *attributeSchema) ExactlyOneOf() []string {
+	return nil
+}
+
+func (s *attributeSchema) AtLeastOneOf() []string {
+	return nil
+}
+
 func (s *attributeSchema) Removed() string {
 	return ""
 }


### PR DESCRIPTION
Fixes: #384

this will exclude any default values when exactlyOneOf is set in
the TF Schema and will stop programs like:

```
import pulumi
import pulumi_tls as tls

cert = tls.get_certificate(url="https://oidc.eks.us-west-2.amazonaws.com/id/<redacted>")

pulumi.export("cert", cert)
```

getting errors like

```
      File "./__main__.py", line 6, in <module>
        cert = tls.get_certificate(url="https://oidc.eks.us-west-2.amazonaws.com/id/<redacted>")
      File "/Users/stack72/code/test-tls/test-py-lookup/venv/lib/python3.8/site-packages/pulumi_tls/get_certificate.py", line 95, in get_certificate
        __ret__ = pulumi.runtime.invoke('tls:index/getCertificate:getCertificate', __args__, opts=opts, typ=GetCertificateResult).value
      File "/Users/stack72/code/test-tls/test-py-lookup/venv/lib/python3.8/site-packages/pulumi/runtime/invoke.py", line 166, in invoke
        raise invoke_error
    Exception: invoke of tls:index/getCertificate:getCertificate failed: Invalid combination of arguments: "url": only one of `content,url` can be specified, but `content,url` were specified. ()
    error: an unhandled error occurred: Program exited with non-zero exit code: 1
```
