### PR TITLE
Ensure any customDiff detailed changes are not removed from the diff

### DIFF
--- a/pkg/tfbridge/diff.go
+++ b/pkg/tfbridge/diff.go
@@ -196,7 +196,8 @@ func makePropertyDiff(name, path string, v resource.PropertyValue, tfDiff shim.I
 			// These diffs are typically changes to output properties that we don't care about.
 			if finalize {
 				if hasOtherDiff &&
-					(other.Kind == pulumirpc.PropertyDiff_ADD || other.Kind == pulumirpc.PropertyDiff_ADD_REPLACE) {
+					(other.Kind == pulumirpc.PropertyDiff_ADD || other.Kind == pulumirpc.PropertyDiff_ADD_REPLACE) &&
+					!d.RequiresNew {
 					delete(diff, path)
 				}
 				return false


### PR DESCRIPTION
Fixes: #533

There was an extra iteration around the old values and it was removing
them from the diff map. This extra iteration was removing items from the
diff to ensure they were not state updates. We have changed this logic
to now not remove the diffs if they are forcing a new resource

After this change, we get the correct diff coming back from the provider:

```
Outputs:
  ~ cert-id: "319417831845702948372234168596306827381" => output<string>
```

This is based on the repro code in the original issue

This is what we get back from the TF Diff function:

```
       tfDiff=sdkv2.v2InstanceDiff{
           tf: &terraform.InstanceDiff{
               mu:         sync.Mutex{},
               Attributes: {
                   "ready_for_renewal": &terraform.ResourceAttrDiff{
                       Old:         "false",
                       New:         "true",
                       NewComputed: false,
                       NewRemoved:  false,
                       NewExtra:    nil,
                       RequiresNew: true,
                       Sensitive:   false,
                       Type:        0x0,
                   },
               },
               Destroy:        false,
               DestroyDeposed: false,
               DestroyTainted: false,
               RawConfig:      cty.Value{},
               RawState:       cty.Value{},
               RawPlan:        cty.Value{},
               Meta:           {},
           },
       }
```

We can see the diff before we hit the finalise function:

```
       diff=map[string]*pulumirpc.PropertyDiff{
           "readyForRenewal": &pulumirpc.PropertyDiff{
               Kind:                 1,
               InputDiff:            false,
               XXX_NoUnkeyedLiteral: struct {}{},
               XXX_unrecognized:     nil,
               XXX_sizecache:        0,
           },
       }
```

But in the final loop through the system we delete this diff from the list