### PR TITLE
Reproducable test case for pulumi/pulumi-azuredevops#52

### DIFF
--- a/internal/testprovider/schema.go
+++ b/internal/testprovider/schema.go
@@ -253,10 +253,23 @@ func ProviderV1() *schemav1.Provider {
 						Optional: true,
 					},
 					"set_property_value": {
-						Type:     schemav1.TypeSet,
-						Elem:     &schemav1.Schema{Type: schemav1.TypeString},
-						Optional: true,
-						ForceNew: true,
+						Type: schemav1.TypeSet,
+						Elem: &schemav1.Resource{
+							Schema: map[string]*schemav1.Schema{
+								"name": {
+									Type:     schemav1.TypeString,
+									Required: true,
+								},
+								"value": {
+									Type:          schemav1.TypeString,
+									Optional:      true,
+									Default:       "",
+									ConflictsWith: []string{"conflicting_property"},
+								},
+							},
+						},
+						Required: true,
+						MinItems: 1,
 					},
 					"string_with_bad_interpolation": {Type: schemav1.TypeString, Optional: true},
 					"conflicting_property": {
@@ -635,9 +648,23 @@ func ProviderV2() *schemav2.Provider {
 						Optional: true,
 					},
 					"set_property_value": {
-						Type:     schemav2.TypeSet,
-						Elem:     &schemav2.Schema{Type: schemav2.TypeString},
-						Optional: true,
+						Type: schemav2.TypeSet,
+						Elem: &schemav2.Resource{
+							Schema: map[string]*schemav2.Schema{
+								"name": {
+									Type:     schemav2.TypeString,
+									Required: true,
+								},
+								"value": {
+									Type:          schemav2.TypeString,
+									Optional:      true,
+									Default:       "",
+									ConflictsWith: []string{"conflicting_property"},
+								},
+							},
+						},
+						Required: true,
+						MinItems: 1,
 						ForceNew: true,
 					},
 					"string_with_bad_interpolation": {Type: schemav2.TypeString, Optional: true},

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -456,7 +456,16 @@ func testCheckFailures(t *testing.T, provider *Provider, typeName tokens.Type) [
 
 	pulumiIns, err := plugin.MarshalProperties(resource.PropertyMap{
 		"stringPropertyValue": resource.NewStringProperty("foo"),
-		"setPropertyValues":   resource.NewArrayProperty([]resource.PropertyValue{resource.NewStringProperty("foo")}),
+		"setPropertyValues": resource.NewArrayProperty(
+			[]resource.PropertyValue{
+				resource.NewObjectProperty(resource.PropertyMap{
+					"name": resource.NewStringProperty("somename"),
+					// On purpose not setting the value property here. `value` is optional,
+					// but `applyDefaults` sets the default value which will generate a conflict.
+					// Reproduces: https://github.com/pulumi/pulumi-azuredevops/issues/52
+				}),
+			},
+		),
 		"nestedResources": resource.NewObjectProperty(resource.PropertyMap{
 			"kind": unknown,
 			"configuration": resource.NewObjectProperty(resource.PropertyMap{


### PR DESCRIPTION
Added a test reproducing issue https://github.com/pulumi/pulumi-azuredevops/issues/52.

The `ConflictsWith` check contains a bug if this attribute is used on a property of an object within a collection, and conflicts with a top level property. When this nested property is optional but has a default value, `applyDefaults` in the bridge still applies the default value and it generates a conflict.

Test output:

```
=== RUN   TestProviderCheck
    provider_test.go:482: 
                Error Trace:    provider_test.go:482
                                                        provider_test.go:499
                Error:          "[reason:"\"conflicting_property\": conflicts with conflicting_property2"  reason:"\"conflicting_property2\": conflicts with conflicting_property"  reason:"Missing required property 'arrayPropertyValues'"  reason:"\"set_property_value.0.value\": conflicts with conflicting_property" ]" should have 3 item(s), but has 4
                Test:           TestProviderCheck
    provider_test.go:505: 
                Error Trace:    provider_test.go:505
                Error:          Not equal: 
                                expected: "Missing required property 'arrayPropertyValues'"
                                actual  : "\"set_property_value.0.value\": conflicts with conflicting_property"
                            
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -Missing required property 'arrayPropertyValues'
                                +"set_property_value.0.value": conflicts with conflicting_property
                Test:           TestProviderCheck
--- FAIL: TestProviderCheck (0.00s)
```
cc @stack72 
Signed-off-by: Ringo De Smet <ringo@de-smet.name>