### PR TITLE
[sdk/v2] Fill out RawConfig.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -208,4 +208,4 @@ require (
 	sourcegraph.com/sourcegraph/appdash v0.0.0-20211028080628-e2786a622600 // indirect
 )
 
-replace github.com/hashicorp/terraform-plugin-sdk/v2 => ../terraform-plugin-sdk
+replace github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20220722214815-c13e6bdd0f51

--- a/go.mod
+++ b/go.mod
@@ -208,4 +208,4 @@ require (
 	sourcegraph.com/sourcegraph/appdash v0.0.0-20211028080628-e2786a622600 // indirect
 )
 
-replace github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20220505215311-795430389fa7
+replace github.com/hashicorp/terraform-plugin-sdk/v2 => ../terraform-plugin-sdk

--- a/go.sum
+++ b/go.sum
@@ -792,8 +792,8 @@ github.com/pulumi/pulumi/sdk/v3 v3.36.0 h1:ErXvg+PXrVGvAVeLCgy/i2E0468+a/s5jURnM
 github.com/pulumi/pulumi/sdk/v3 v3.36.0/go.mod h1:e1xuPnh9aKzCesrFf96DEzcybLdRWRMhKeKVBmb2lm0=
 github.com/pulumi/terraform-diff-reader v0.0.0-20201211191010-ad4715e9285e h1:Dik4Qe/+xguB8JagPyXNlbOnRiXGmq/PSPQTGunYnTk=
 github.com/pulumi/terraform-diff-reader v0.0.0-20201211191010-ad4715e9285e/go.mod h1:sZ9FUzGO+yM41hsQHs/yIcj/Y993qMdBxBU5mpDmAfQ=
-github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20220505215311-795430389fa7 h1:RAiGj0GniixD+G+HuUzFWZh2VKdQ50nv5+EmkKG1u3E=
-github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20220505215311-795430389fa7/go.mod h1:TPjMXvpPNWagHzYOmVPzzRRIBTuaLVukR+esL08tgzg=
+github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20220722214815-c13e6bdd0f51 h1:pAdPMoXvWzH7yVgglaQRwM5remJ6Sdx6jOQoDT/boak=
+github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20220722214815-c13e6bdd0f51/go.mod h1:TPjMXvpPNWagHzYOmVPzzRRIBTuaLVukR+esL08tgzg=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rjeczalik/notify v0.9.2 h1:MiTWrPj55mNDHEiIX5YUSKefw/+lCQVoAFmD6oQm5w8=

--- a/pkg/tfshim/sdk-v2/cty.go
+++ b/pkg/tfshim/sdk-v2/cty.go
@@ -13,7 +13,7 @@ func makeResourceRawConfig(config *terraform.ResourceConfig, resource *schema.Re
 	original := schema.HCL2ValueFromConfigValue(config.Raw)
 	coerced, err := resource.CoreConfigSchema().CoerceValue(original)
 	if err != nil {
-		glog.V(9).Infof("failed to coerce config: %w", err)
+		glog.V(9).Infof("failed to coerce config: %v", err)
 		return original
 	}
 	return coerced

--- a/pkg/tfshim/sdk-v2/cty.go
+++ b/pkg/tfshim/sdk-v2/cty.go
@@ -7,6 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
+// makeResourceRawConfig converts the decoded Go values in a terraform.ResourceConfig into a cty.Value that is
+// appropriate for Instance{Diff,State}.RawConfig.
 func makeResourceRawConfig(config *terraform.ResourceConfig, resource *schema.Resource) cty.Value {
 	original := schema.HCL2ValueFromConfigValue(config.Raw)
 	coerced, err := resource.CoreConfigSchema().CoerceValue(original)

--- a/pkg/tfshim/sdk-v2/cty.go
+++ b/pkg/tfshim/sdk-v2/cty.go
@@ -1,0 +1,18 @@
+package sdkv2
+
+import (
+	"github.com/golang/glog"
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func makeResourceRawConfig(config *terraform.ResourceConfig, resource *schema.Resource) cty.Value {
+	original := schema.HCL2ValueFromConfigValue(config.Raw)
+	coerced, err := resource.CoreConfigSchema().CoerceValue(original)
+	if err != nil {
+		glog.V(9).Infof("failed to coerce config: %w", err)
+		return original
+	}
+	return coerced
+}

--- a/pkg/tfshim/sdk-v2/cty_test.go
+++ b/pkg/tfshim/sdk-v2/cty_test.go
@@ -1,0 +1,478 @@
+package sdkv2
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/assert"
+)
+
+var awsSSMParameterSchema = &schema.Resource{
+	Schema: map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+		"description": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"tier": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+		"type": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		"value": {
+			Type:      schema.TypeString,
+			Required:  true,
+			Sensitive: true,
+		},
+		"arn": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+		"key_id": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+		"data_type": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+		"overwrite": {
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
+		"allowed_pattern": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"version": {
+			Type:     schema.TypeInt,
+			Computed: true,
+		},
+		"tags": &schema.Schema{
+			Type:     schema.TypeMap,
+			Optional: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+		},
+		"tags_all": &schema.Schema{
+			Type:     schema.TypeMap,
+			Computed: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+		},
+	},
+}
+
+var auth0TenantSchema = &schema.Resource{
+	Schema: map[string]*schema.Schema{
+		"change_password": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Computed: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"enabled": {
+						Type:     schema.TypeBool,
+						Required: true,
+					},
+					"html": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+				},
+			},
+		},
+		"guardian_mfa_page": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Computed: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"enabled": {
+						Type:     schema.TypeBool,
+						Required: true,
+					},
+					"html": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+				},
+			},
+		},
+		"default_audience": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+		"default_directory": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+		"error_page": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Computed: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"html": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"show_log_link": {
+						Type:     schema.TypeBool,
+						Required: true,
+					},
+					"url": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+				},
+			},
+		},
+		"friendly_name": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+		"picture_url": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+		"support_email": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+		"support_url": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+		"allowed_logout_urls": {
+			Type:     schema.TypeList,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+			Optional: true,
+			Computed: true,
+		},
+		"sandbox_version": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+		"session_lifetime": {
+			Type:     schema.TypeFloat,
+			Optional: true,
+			Default:  168,
+		},
+		"idle_session_lifetime": {
+			Type:     schema.TypeFloat,
+			Optional: true,
+			Default:  72,
+		},
+		"enabled_locales": {
+			Type:     schema.TypeList,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+			Optional: true,
+			Computed: true,
+		},
+		"flags": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Computed: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"enable_client_connections": {
+						Type:     schema.TypeBool,
+						Optional: true,
+						Computed: true,
+					},
+					"enable_apis_section": {
+						Type:     schema.TypeBool,
+						Optional: true,
+						Computed: true,
+					},
+					"enable_pipeline2": {
+						Type:     schema.TypeBool,
+						Optional: true,
+						Computed: true,
+					},
+					"enable_dynamic_client_registration": {
+						Type:     schema.TypeBool,
+						Optional: true,
+						Computed: true,
+					},
+					"enable_custom_domain_in_emails": {
+						Type:     schema.TypeBool,
+						Optional: true,
+						Computed: true,
+					},
+					"universal_login": {
+						Type:     schema.TypeBool,
+						Optional: true,
+						Computed: true,
+					},
+					"enable_legacy_logs_search_v2": {
+						Type:     schema.TypeBool,
+						Optional: true,
+						Computed: true,
+					},
+					"disable_clickjack_protection_headers": {
+						Type:     schema.TypeBool,
+						Optional: true,
+						Computed: true,
+					},
+					"enable_public_signup_user_exists_error": {
+						Type:     schema.TypeBool,
+						Optional: true,
+						Computed: true,
+					},
+					"use_scope_descriptions_for_consent": {
+						Type:     schema.TypeBool,
+						Optional: true,
+						Computed: true,
+					},
+					"allow_legacy_delegation_grant_types": {
+						Type:     schema.TypeBool,
+						Optional: true,
+						Computed: true,
+					},
+					"allow_legacy_ro_grant_types": {
+						Type:     schema.TypeBool,
+						Optional: true,
+						Computed: true,
+					},
+					"allow_legacy_tokeninfo_endpoint": {
+						Type:     schema.TypeBool,
+						Optional: true,
+						Computed: true,
+					},
+					"enable_legacy_profile": {
+						Type:     schema.TypeBool,
+						Optional: true,
+						Computed: true,
+					},
+					"enable_idtoken_api2": {
+						Type:     schema.TypeBool,
+						Optional: true,
+						Computed: true,
+					},
+					"no_disclose_enterprise_connections": {
+						Type:     schema.TypeBool,
+						Optional: true,
+						Computed: true,
+					},
+					"disable_management_api_sms_obfuscation": {
+						Type:     schema.TypeBool,
+						Optional: true,
+						Computed: true,
+					},
+					"enable_adfs_waad_email_verification": {
+						Type:     schema.TypeBool,
+						Optional: true,
+						Computed: true,
+					},
+					"revoke_refresh_token_grant": {
+						Type:     schema.TypeBool,
+						Optional: true,
+						Computed: true,
+					},
+					"dashboard_log_streams_next": {
+						Type:     schema.TypeBool,
+						Optional: true,
+						Computed: true,
+					},
+					"dashboard_insights_view": {
+						Type:     schema.TypeBool,
+						Optional: true,
+						Computed: true,
+					},
+					"disable_fields_map_fix": {
+						Type:     schema.TypeBool,
+						Optional: true,
+						Computed: true,
+					},
+				},
+			},
+		},
+		"universal_login": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Computed: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"colors": {
+						Type:     schema.TypeList,
+						Optional: true,
+						MaxItems: 1,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"primary": {
+									Type:     schema.TypeString,
+									Optional: true,
+									Computed: true,
+								},
+								"page_background": {
+									Type:     schema.TypeString,
+									Optional: true,
+									Computed: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"default_redirection_uri": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+		"session_cookie": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Computed: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"mode": {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Description: "Behavior of tenant session cookie. Accepts either \"persistent\" or \"non-persistent\"",
+					},
+				},
+			},
+		},
+	},
+}
+
+func TestMakeResourceRawConfig(t *testing.T) {
+	cases := []struct {
+		name     string
+		schema   *schema.Resource
+		config   map[string]interface{}
+		expected cty.Value
+	}{
+		{
+			name:   "AWS SSM Parameter",
+			schema: awsSSMParameterSchema,
+			config: map[string]interface{}{
+				"name":  "/someParam",
+				"type":  "String",
+				"value": "foo",
+			},
+			expected: cty.ObjectVal(map[string]cty.Value{
+				"allowed_pattern": cty.NullVal(cty.String),
+				"tier":            cty.NullVal(cty.String),
+				"version":         cty.NullVal(cty.Number),
+				"data_type":       cty.NullVal(cty.String),
+				"key_id":          cty.NullVal(cty.String),
+				"name":            cty.StringVal("/someParam"),
+				"overwrite":       cty.NullVal(cty.Bool),
+				"tags_all":        cty.NullVal(cty.Map(cty.String)),
+				"tags":            cty.NullVal(cty.Map(cty.String)),
+				"type":            cty.StringVal("String"),
+				"arn":             cty.NullVal(cty.String),
+				"id":              cty.NullVal(cty.String),
+				"description":     cty.NullVal(cty.String),
+				"value":           cty.StringVal("foo"),
+			}),
+		},
+		{
+			name:   "Auth0 Tenant",
+			schema: auth0TenantSchema,
+			config: map[string]interface{}{
+				"friendly_name": "Tenant Name",
+			},
+			expected: cty.ObjectVal(map[string]cty.Value{
+				"allowed_logout_urls": cty.NullVal(cty.List(cty.String)),
+				"change_password": cty.ListValEmpty(cty.Object(map[string]cty.Type{
+					"enabled": cty.Bool,
+					"html":    cty.String,
+				})),
+				"default_audience":        cty.NullVal(cty.String),
+				"default_directory":       cty.NullVal(cty.String),
+				"default_redirection_uri": cty.NullVal(cty.String),
+				"enabled_locales":         cty.NullVal(cty.List(cty.String)),
+				"error_page": cty.ListValEmpty(cty.Object(map[string]cty.Type{
+					"html":          cty.String,
+					"show_log_link": cty.Bool,
+					"url":           cty.String,
+				})),
+				"flags": cty.ListValEmpty(cty.Object(map[string]cty.Type{
+					"allow_legacy_delegation_grant_types":    cty.Bool,
+					"allow_legacy_ro_grant_types":            cty.Bool,
+					"allow_legacy_tokeninfo_endpoint":        cty.Bool,
+					"dashboard_insights_view":                cty.Bool,
+					"dashboard_log_streams_next":             cty.Bool,
+					"disable_clickjack_protection_headers":   cty.Bool,
+					"disable_fields_map_fix":                 cty.Bool,
+					"disable_management_api_sms_obfuscation": cty.Bool,
+					"enable_adfs_waad_email_verification":    cty.Bool,
+					"enable_apis_section":                    cty.Bool,
+					"enable_client_connections":              cty.Bool,
+					"enable_custom_domain_in_emails":         cty.Bool,
+					"enable_dynamic_client_registration":     cty.Bool,
+					"enable_idtoken_api2":                    cty.Bool,
+					"enable_legacy_logs_search_v2":           cty.Bool,
+					"enable_legacy_profile":                  cty.Bool,
+					"enable_pipeline2":                       cty.Bool,
+					"enable_public_signup_user_exists_error": cty.Bool,
+					"no_disclose_enterprise_connections":     cty.Bool,
+					"revoke_refresh_token_grant":             cty.Bool,
+					"universal_login":                        cty.Bool,
+					"use_scope_descriptions_for_consent":     cty.Bool,
+				})),
+				"friendly_name": cty.StringVal("Tenant Name"),
+				"guardian_mfa_page": cty.ListValEmpty(cty.Object(map[string]cty.Type{
+					"enabled": cty.Bool,
+					"html":    cty.String,
+				})),
+				"id":                    cty.NullVal(cty.String),
+				"idle_session_lifetime": cty.NullVal(cty.Number),
+				"picture_url":           cty.NullVal(cty.String),
+				"sandbox_version":       cty.NullVal(cty.String),
+				"session_cookie": cty.ListValEmpty(cty.Object(map[string]cty.Type{
+					"mode": cty.String,
+				})),
+				"session_lifetime": cty.NullVal(cty.Number),
+				"support_email":    cty.NullVal(cty.String),
+				"support_url":      cty.NullVal(cty.String),
+				"universal_login": cty.ListValEmpty(cty.Object(map[string]cty.Type{
+					"colors": cty.List(cty.Object(map[string]cty.Type{
+						"page_background": cty.String,
+						"primary":         cty.String,
+					})),
+				})),
+			}),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			resourceConfig := &terraform.ResourceConfig{Raw: c.config}
+			config := makeResourceRawConfig(resourceConfig, c.schema)
+			if !assert.True(t, config.RawEquals(c.expected)) {
+				t.Log(config.GoString())
+				t.Log(c.expected.GoString())
+			}
+		})
+	}
+}

--- a/pkg/tfshim/sdk-v2/cty_test.go
+++ b/pkg/tfshim/sdk-v2/cty_test.go
@@ -61,12 +61,12 @@ var awsSSMParameterSchema = &schema.Resource{
 			Type:     schema.TypeInt,
 			Computed: true,
 		},
-		"tags": &schema.Schema{
+		"tags": {
 			Type:     schema.TypeMap,
 			Optional: true,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 		},
-		"tags_all": &schema.Schema{
+		"tags_all": {
 			Type:     schema.TypeMap,
 			Computed: true,
 			Elem:     &schema.Schema{Type: schema.TypeString},

--- a/pkg/tfshim/sdk-v2/cty_test.go
+++ b/pkg/tfshim/sdk-v2/cty_test.go
@@ -371,6 +371,13 @@ func TestMakeResourceRawConfig(t *testing.T) {
 		expected cty.Value
 	}{
 		{
+			// Equivalent TF config:
+			//
+			// resource "aws_ssm_parameter" "parameter" {
+			//     name = "/someParam"
+			//     type = "String"
+			//     value = "foo"
+			// }
 			name:   "AWS SSM Parameter",
 			schema: awsSSMParameterSchema,
 			config: map[string]interface{}{
@@ -396,6 +403,11 @@ func TestMakeResourceRawConfig(t *testing.T) {
 			}),
 		},
 		{
+			// Equivalent TF config:
+			//
+			// resource "auth0_tenant" "tenant" {
+			//     friendly_name = "Tenant Name"
+			// }
 			name:   "Auth0 Tenant",
 			schema: auth0TenantSchema,
 			config: map[string]interface{}{
@@ -461,6 +473,111 @@ func TestMakeResourceRawConfig(t *testing.T) {
 						"primary":         cty.String,
 					})),
 				})),
+			}),
+		},
+		{
+			// Equivalent TF config:
+			//
+			// resource "auth0_tenant" "tenant" {
+			//     friendly_name = "Tenant Name"
+			//
+			//     flags {
+			//         universal_login = true
+			//     }
+			//
+			//     universal_login {
+			//         colors {
+			//             primary = "#3385ff"
+			//             page_background = "#000000"
+			//         }
+			//     }
+			// }
+			name:   "Auth0 Tenant With Flags",
+			schema: auth0TenantSchema,
+			config: map[string]interface{}{
+				"friendly_name": "Tenant Name",
+				"flags": []interface{}{
+					map[string]interface{}{
+						"universal_login": true,
+					},
+				},
+				"universal_login": []interface{}{
+					map[string]interface{}{
+						"colors": []interface{}{
+							map[string]interface{}{
+								"primary":         "#3385ff",
+								"page_background": "#000000",
+							},
+						},
+					},
+				},
+			},
+			expected: cty.ObjectVal(map[string]cty.Value{
+				"allowed_logout_urls": cty.NullVal(cty.List(cty.String)),
+				"change_password": cty.ListValEmpty(cty.Object(map[string]cty.Type{
+					"enabled": cty.Bool,
+					"html":    cty.String,
+				})),
+				"default_audience":        cty.NullVal(cty.String),
+				"default_directory":       cty.NullVal(cty.String),
+				"default_redirection_uri": cty.NullVal(cty.String),
+				"enabled_locales":         cty.NullVal(cty.List(cty.String)),
+				"error_page": cty.ListValEmpty(cty.Object(map[string]cty.Type{
+					"html":          cty.String,
+					"show_log_link": cty.Bool,
+					"url":           cty.String,
+				})),
+				"flags": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"allow_legacy_delegation_grant_types":    cty.NullVal(cty.Bool),
+						"allow_legacy_ro_grant_types":            cty.NullVal(cty.Bool),
+						"allow_legacy_tokeninfo_endpoint":        cty.NullVal(cty.Bool),
+						"dashboard_insights_view":                cty.NullVal(cty.Bool),
+						"dashboard_log_streams_next":             cty.NullVal(cty.Bool),
+						"disable_clickjack_protection_headers":   cty.NullVal(cty.Bool),
+						"disable_fields_map_fix":                 cty.NullVal(cty.Bool),
+						"disable_management_api_sms_obfuscation": cty.NullVal(cty.Bool),
+						"enable_adfs_waad_email_verification":    cty.NullVal(cty.Bool),
+						"enable_apis_section":                    cty.NullVal(cty.Bool),
+						"enable_client_connections":              cty.NullVal(cty.Bool),
+						"enable_custom_domain_in_emails":         cty.NullVal(cty.Bool),
+						"enable_dynamic_client_registration":     cty.NullVal(cty.Bool),
+						"enable_idtoken_api2":                    cty.NullVal(cty.Bool),
+						"enable_legacy_logs_search_v2":           cty.NullVal(cty.Bool),
+						"enable_legacy_profile":                  cty.NullVal(cty.Bool),
+						"enable_pipeline2":                       cty.NullVal(cty.Bool),
+						"enable_public_signup_user_exists_error": cty.NullVal(cty.Bool),
+						"no_disclose_enterprise_connections":     cty.NullVal(cty.Bool),
+						"revoke_refresh_token_grant":             cty.NullVal(cty.Bool),
+						"universal_login":                        cty.True,
+						"use_scope_descriptions_for_consent":     cty.NullVal(cty.Bool),
+					}),
+				}),
+				"friendly_name": cty.StringVal("Tenant Name"),
+				"guardian_mfa_page": cty.ListValEmpty(cty.Object(map[string]cty.Type{
+					"enabled": cty.Bool,
+					"html":    cty.String,
+				})),
+				"id":                    cty.NullVal(cty.String),
+				"idle_session_lifetime": cty.NullVal(cty.Number),
+				"picture_url":           cty.NullVal(cty.String),
+				"sandbox_version":       cty.NullVal(cty.String),
+				"session_cookie": cty.ListValEmpty(cty.Object(map[string]cty.Type{
+					"mode": cty.String,
+				})),
+				"session_lifetime": cty.NullVal(cty.Number),
+				"support_email":    cty.NullVal(cty.String),
+				"support_url":      cty.NullVal(cty.String),
+				"universal_login": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"colors": cty.ListVal([]cty.Value{
+							cty.ObjectVal(map[string]cty.Value{
+								"page_background": cty.StringVal("#000000"),
+								"primary":         cty.StringVal("#3385ff"),
+							}),
+						}),
+					}),
+				}),
 			}),
 		},
 	}

--- a/pkg/tfshim/sdk-v2/upgrade_state.go
+++ b/pkg/tfshim/sdk-v2/upgrade_state.go
@@ -73,6 +73,7 @@ func upgradeResourceState(p *schema.Provider, res *schema.Resource,
 	if err != nil {
 		return nil, err
 	}
+	newState.RawConfig = instanceState.RawConfig
 
 	// Copy the original ID and meta to the new state and stamp in the new version.
 	newState.ID = instanceState.ID


### PR DESCRIPTION
These changes update the sdk/v2 shim to fill out the RawConfig field on
InstanceState and InstanceDiff. TF providers may inspect the value of
this field to determine the differences between an attribute that has
a default value because it is was not specified and an attribute that
has been explicitly set to its default value.

Fixes #548.