### PR TITLE
Support latest tfplugindocs format

### DIFF
--- a/pkg/tfgen/parse_markdown_test.go
+++ b/pkg/tfgen/parse_markdown_test.go
@@ -99,6 +99,9 @@ func TestParseTopLevelSchema(t *testing.T) {
 
 	assert.Equal(t, "",
 		param(t, nested(t, schema, "widget.group_definition"), "title").desc)
+
+	assert.Equal(t, topParam(t, schema, "theme").desc,
+		"The theme of the dashboard.")
 }
 
 func TestParseNestedSchemaIntoDoc(t *testing.T) {

--- a/pkg/tfgen/test_data/mini.json
+++ b/pkg/tfgen/test_data/mini.json
@@ -1,7 +1,8 @@
 {
   "widget": {
     "Arguments": {
-      "group_definition": "The definition for a Group widget."
+      "theme": "The theme of the widget",
+      "group_definition": "The definition for a Group widget.",
     },
     "Description": "",
     "IsNested": true

--- a/pkg/tfgen/test_data/mini.md
+++ b/pkg/tfgen/test_data/mini.md
@@ -20,6 +20,7 @@ Preamble
 - **template_variable** (Block List) The list of template variables for this dashboard. (see [below for nested schema](#nestedblock--template_variable))
 - **template_variable_preset** (Block List) The list of selectable template variable presets for this dashboard. (see [below for nested schema](#nestedblock--template_variable_preset))
 - **url** (String) The URL of the dashboard.
+- `theme` (String) The theme of the dashboard.
 
 ### Read-Only
 
@@ -31,6 +32,7 @@ Preamble
 Optional:
 
 - **group_definition** (Block List, Max: 1) The definition for a Group widget. (see [below for nested schema](#nestedblock--widget--group_definition))
+- `theme` (String) The theme of the widget.
 
 ### Nested Schema for `widget.group_definition`
 


### PR DESCRIPTION
Fixes #580 by supporting both **strong** and `code` elements for the paramName when parsing schema documentation.

Sadly, because blackfriday doesn't handle strong and code elements in the same way (strong has children, code does not). We need to switch the logic and handle the `code` case directly.