### PR TITLE
Ensure tf2pulumi works with windows path

### DIFF
--- a/pkg/tf2pulumi/convert/tf12.go
+++ b/pkg/tf2pulumi/convert/tf12.go
@@ -32,7 +32,6 @@ func parseFile(parser *syntax.Parser, fs afero.Fs, path string) error {
 	}
 	defer contract.IgnoreClose(f)
 
-	contract.Assert(path[0] == '/')
 	return parser.ParseFile(f, path[1:])
 }
 


### PR DESCRIPTION
Remove the contract.Assert that will error on windows file paths

This will resolve https://github.com/pulumi/tf2pulumi/issues/261 when we make a release of tf2pulumi with the fix in