### PR TITLE
Use NewUniqueName

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -308,10 +308,11 @@ type DefaultInfo struct {
 	EnvVars []string
 }
 
-// PulumiResource is just a little bundle that carries URN and properties around.
+// PulumiResource is just a little bundle that carries URN, seed and properties around.
 type PulumiResource struct {
 	URN        resource.URN
 	Properties resource.PropertyMap
+	Seed       []byte
 }
 
 // OverlayInfo contains optional overlay information.  Each info has a 1:1 correspondence with a module and

--- a/pkg/tfbridge/names.go
+++ b/pkg/tfbridge/names.go
@@ -198,7 +198,8 @@ func FromName(options AutoNameOptions) func(res *PulumiResource) (interface{}, e
 			vs = options.Transform(vs)
 		}
 		if options.Randlen > 0 {
-			uniqueHex, err := resource.NewUniqueName(res.Seed, vs+options.Separator, options.Randlen, options.Maxlen, options.Charset)
+			uniqueHex, err := resource.NewUniqueName(
+				res.Seed, vs+options.Separator, options.Randlen, options.Maxlen, options.Charset)
 			if err != nil {
 				return uniqueHex, errors.Wrapf(err, "could not make instance of '%v'", res.URN.Type())
 			}

--- a/pkg/tfbridge/names.go
+++ b/pkg/tfbridge/names.go
@@ -132,8 +132,10 @@ type AutoNameOptions struct {
 	Separator string
 	// Maximum length of the generated name
 	Maxlen int
-	// Number of characters of random hex digits to add to the name
+	// Number of random characters to add to the name
 	Randlen int
+	// What characters to use for the random portion of the name, defaults to hex digits
+	Charset []rune
 	// A transform to apply to the name prior to adding random characters
 	Transform func(string) string
 	// A transform to apply after the auto naming has been computed
@@ -196,7 +198,7 @@ func FromName(options AutoNameOptions) func(res *PulumiResource) (interface{}, e
 			vs = options.Transform(vs)
 		}
 		if options.Randlen > 0 {
-			uniqueHex, err := resource.NewUniqueHex(vs+options.Separator, options.Randlen, options.Maxlen)
+			uniqueHex, err := resource.NewUniqueName(res.Seed, vs+options.Separator, options.Randlen, options.Maxlen, options.Charset)
 			if err != nil {
 				return uniqueHex, errors.Wrapf(err, "could not make instance of '%v'", res.URN.Type())
 			}

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -686,7 +686,8 @@ func (p *Provider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (*pul
 	// includes the default values.  Otherwise, the provider wouldn't be presented with its own defaults.
 	tfname := res.TFName
 	inputs, assets, err := MakeTerraformInputs(
-		&PulumiResource{URN: urn, Properties: news, Seed: req.RandomSeed}, p.configValues, olds, news, res.TF.Schema(), res.Schema.Fields)
+		&PulumiResource{URN: urn, Properties: news, Seed: req.RandomSeed},
+		p.configValues, olds, news, res.TF.Schema(), res.Schema.Fields)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -686,7 +686,7 @@ func (p *Provider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (*pul
 	// includes the default values.  Otherwise, the provider wouldn't be presented with its own defaults.
 	tfname := res.TFName
 	inputs, assets, err := MakeTerraformInputs(
-		&PulumiResource{URN: urn, Properties: news}, p.configValues, olds, news, res.TF.Schema(), res.Schema.Fields)
+		&PulumiResource{URN: urn, Properties: news, Seed: req.RandomSeed}, p.configValues, olds, news, res.TF.Schema(), res.Schema.Fields)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Same as for the other provider updates, this is the new naming system for update plans. I've put the seed on PulumiResource  rather than as a parameter on the naming function because that signature is used in a lot of downstream repos.

This also extends AutoNameOptions to have a Charset option (as NewUniqueName supports that) which should allow a lot of the transform functions in downstream repos to be switch to just autonames instead.