### PR TITLE
Add the ability to inject specific language examples for a resource

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -151,6 +151,7 @@ type ResourceOrDataSourceInfo interface {
 	GetTok() tokens.Token              // a type token to override the default; "" uses the default.
 	GetFields() map[string]*SchemaInfo // a map of custom field names; if a type is missing, uses the default.
 	GetDocs() *DocInfo                 // overrides for finding and mapping TF docs.
+	ReplaceExamplesSection() bool      // whether we are replacing the upstream TF examples generation
 }
 
 // ResourceInfo is a top-level type exported by a provider.  This structure can override the type to generate.  It can
@@ -179,6 +180,11 @@ func (info *ResourceInfo) GetFields() map[string]*SchemaInfo { return info.Field
 // GetDocs returns a resource docs override from the Pulumi provider
 func (info *ResourceInfo) GetDocs() *DocInfo { return info.Docs }
 
+// ReplaceExamplesSection returns whether to replace the upstream examples with our own source
+func (info *ResourceInfo) ReplaceExamplesSection() bool {
+	return info.Docs != nil && info.Docs.ReplaceExamplesSection
+}
+
 // DataSourceInfo can be used to override a data source's standard name mangling and argument/return information.
 type DataSourceInfo struct {
 	Tok                tokens.ModuleMember
@@ -195,6 +201,11 @@ func (info *DataSourceInfo) GetFields() map[string]*SchemaInfo { return info.Fie
 
 // GetDocs returns a datasource docs override from the Pulumi provider
 func (info *DataSourceInfo) GetDocs() *DocInfo { return info.Docs }
+
+// ReplaceExamplesSection returns whether to replace the upstream examples with our own source
+func (info *DataSourceInfo) ReplaceExamplesSection() bool {
+	return info.Docs != nil && info.Docs.ReplaceExamplesSection
+}
 
 // SchemaInfo contains optional name transformations to apply.
 type SchemaInfo struct {
@@ -283,6 +294,11 @@ type DocInfo struct {
 	IncludeArgumentsFrom           string // optionally include arguments from another raw resource for docs.
 	IncludeAttributesFromArguments string // optionally include attributes from another raw resource's arguments.
 	ImportDetails                  string // Overwrite for import instructions
+
+	// Replace examples with the contents of a specific document
+	// this document will satisfy the criteria `docs/pulumiToken.md`
+	// The examples need to wrapped in the correct shortcodes
+	ReplaceExamplesSection bool
 }
 
 // GetImportDetails returns a string of import instructions defined in the Pulumi provider. Defaults to empty.

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -456,7 +456,7 @@ const (
 )
 
 func (p *tfMarkdownParser) parseSupplementaryExamples() (string, error) {
-	examplesFileName := fmt.Sprintf("docs/%s/%s.md", p.kind, p.rawname)
+	examplesFileName := fmt.Sprintf("docs/%s/%s.examples.md", p.kind, p.rawname)
 	absPath, err := filepath.Abs(examplesFileName)
 	if err != nil {
 		return "", err
@@ -492,7 +492,7 @@ func (p *tfMarkdownParser) parse() (entityDocs, error) {
 	}
 
 	// we are explicitly overwriting the Terraform examples here
-	if p.info.ReplaceExamplesSection() {
+	if p.info.GetDocs() != nil && p.info.ReplaceExamplesSection() {
 		for i, section := range sections {
 			// Let's remove any existing examples usage we have in our parsed documentation
 			if len(section) > 0 && strings.Contains(section[0], "Example Usage") {

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -486,13 +486,13 @@ func (p *tfMarkdownParser) parse() (entityDocs, error) {
 	sections := splitGroupLines(markdown, "## ")
 
 	// we are using the Terraform docs as the source of the examples for this resource
-	if p.info.GetDocs() != nil && !p.info.GetDocs().ReplaceExamplesSection {
+	if p.info != nil && p.info.GetDocs() != nil && !p.info.GetDocs().ReplaceExamplesSection {
 		// Reparent examples that are peers of the "Example Usage" section (if any) and fixup some example titles.
 		sections = reformatExamples(sections)
 	}
 
 	// we are explicitly overwriting the Terraform examples here
-	if p.info.GetDocs() != nil && p.info.ReplaceExamplesSection() {
+	if p.info != nil && p.info.GetDocs() != nil && p.info.ReplaceExamplesSection() {
 		for i, section := range sections {
 			// Let's remove any existing examples usage we have in our parsed documentation
 			if len(section) > 0 && strings.Contains(section[0], "Example Usage") {

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -455,6 +455,21 @@ const (
 	sectionImports             = 5
 )
 
+func (p *tfMarkdownParser) parseSupplementaryExamples() (string, error) {
+	examplesFileName := fmt.Sprintf("docs/%s/%s.md", p.kind, p.rawname)
+	absPath, err := filepath.Abs(examplesFileName)
+	if err != nil {
+		return "", err
+	}
+	fileBytes, err := os.ReadFile(absPath)
+	if err != nil {
+		p.g.error("explicitly marked resource documention for replacement, but found no file at %q", examplesFileName)
+		return "", err
+	}
+
+	return string(fileBytes), nil
+}
+
 func (p *tfMarkdownParser) parse() (entityDocs, error) {
 	p.ret = entityDocs{
 		Arguments:  make(map[string]*argumentDocs),
@@ -470,8 +485,29 @@ func (p *tfMarkdownParser) parse() (entityDocs, error) {
 	// Split the sections by H2 topics in the Markdown file.
 	sections := splitGroupLines(markdown, "## ")
 
-	// Reparent examples that are peers of the "Example Usage" section (if any) and fixup some example titles.
-	sections = reformatExamples(sections)
+	// we are using the Terraform docs as the source of the examples for this resource
+	if p.info.GetDocs() != nil && !p.info.GetDocs().ReplaceExamplesSection {
+		// Reparent examples that are peers of the "Example Usage" section (if any) and fixup some example titles.
+		sections = reformatExamples(sections)
+	}
+
+	// we are explicitly overwriting the Terraform examples here
+	if p.info.ReplaceExamplesSection() {
+		for i, section := range sections {
+			// Let's remove any existing examples usage we have in our parsed documentation
+			if len(section) > 0 && strings.Contains(section[0], "Example Usage") {
+				sections = append(sections[:i], sections[i+1:]...)
+			}
+
+			// now we are going to inject the new source of examples
+			newExamples, err := p.parseSupplementaryExamples()
+			if err != nil {
+				return entityDocs{}, err
+			}
+			newSection := strings.Split(newExamples, "\n")
+			sections = append(sections, newSection)
+		}
+	}
 
 	for _, section := range sections {
 		if err := p.parseSection(section); err != nil {
@@ -647,7 +683,8 @@ func (p *tfMarkdownParser) parseSection(h2Section []string) error {
 			// Skip empty subsections (they just add unnecessary padding and headers).
 			continue
 		}
-		if hasExamples && sectionKind != sectionExampleUsage && sectionKind != sectionImports {
+		if hasExamples && sectionKind != sectionExampleUsage && sectionKind != sectionImports &&
+			!p.info.ReplaceExamplesSection() {
 			p.g.warn("Unexpected code snippets in section '%v' for %v '%v'. The HCL code will be converted if possible, "+
 				"but may not display correctly in the generated docs.", header, p.kind, p.rawname)
 			unexpectedSnippets++
@@ -993,6 +1030,14 @@ func (p *tfMarkdownParser) reformatSubsection(lines []string) ([]string, bool, b
 func (g *Generator) convertExamples(docs, name string, stripSubsectionsWithErrors bool) string {
 	if docs == "" {
 		return ""
+	}
+
+	if strings.Contains(docs, "```typescript") || strings.Contains(docs, "```python") ||
+		strings.Contains(docs, "```go") || strings.Contains(docs, "```yaml") ||
+		strings.Contains(docs, "```csharp") {
+		// we have explicitly rewritten these examples and need to just return them directly rather than trying
+		// to reconvert them
+		return docs
 	}
 
 	output := &bytes.Buffer{}


### PR DESCRIPTION
This will allow us to change the examples that come from the TF
resource. Currently, the functionality we have in place is to allow
us to enhance the examples. That doesn't help when we have incorrect
examples in our docs - we want to replace the TF based examples
completely
