### PR TITLE
Adds a new markdown representation of example conversion failures

### DIFF
--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -1406,7 +1406,6 @@ func (g *Generator) convertHCL(hcl, path, exampleTitle string, languages []strin
 		// At least one language out of the given set has been generated, which is considered a success
 		// nolint:ineffassign
 		err = nil
-
 	}
 
 	return result.String(), nil

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -1365,6 +1365,14 @@ func (g *Generator) convertHCL(hcl, path, exampleTitle string, languages []strin
 
 	if isCompleteFailure {
 		hclAllLangsConversionFailures++
+		if exampleTitle == "" {
+			g.warn(fmt.Sprintf("unable to convert HCL example for Pulumi entity '%s': %v. The example will be dropped "+
+				"from any generated docs or SDKs.", path, err))
+		} else {
+			g.warn(fmt.Sprintf("unable to convert HCL example '%s' for Pulumi entity '%s': %v. The example will be "+
+				"dropped from any generated docs or SDKs.", exampleTitle, path, err))
+		}
+
 		return "", err
 	}
 
@@ -1384,9 +1392,23 @@ func (g *Generator) convertHCL(hcl, path, exampleTitle string, languages []strin
 		case convert.LanguageGo:
 			hclGoPartialConversionFailures++
 		}
+
+		if exampleTitle == "" {
+			g.warn(fmt.Sprintf("unable to convert HCL example for Pulumi entity '%s' in the following language(s): "+
+				"%s. Examples for these languages will be dropped from any generated docs or SDKs.",
+				path, strings.Join(failedLangsStrings, ", ")))
+		} else {
+			g.warn(fmt.Sprintf("unable to convert HCL example '%s' for Pulumi entity '%s' in the following language(s): "+
+				"%s. Examples for these languages will be dropped from any generated docs or SDKs.",
+				exampleTitle, path, strings.Join(failedLangsStrings, ", ")))
+		}
+
+		// At least one language out of the given set has been generated, which is considered a success
+		// nolint:ineffassign
+		err = nil
+
 	}
 
-	// At least one language out of the given set has been generated, which is considered a success
 	return result.String(), nil
 }
 

--- a/pkg/tfgen/examples_coverage_exporter.go
+++ b/pkg/tfgen/examples_coverage_exporter.go
@@ -56,11 +56,11 @@ func (ce *coverageExportUtil) tryExport(outputDirectory string) error {
 	if err != nil {
 		return err
 	}
-	err = ce.exportHumanReadable(outputDirectory, "shortSummary.txt")
+	err = ce.exportMarkdown(outputDirectory, "summary.md")
 	if err != nil {
 		return err
 	}
-	return ce.exportMarkdown(outputDirectory, "summary.md")
+	return ce.exportHumanReadable(outputDirectory, "shortSummary.txt")
 }
 
 // Four different ways to export coverage data:
@@ -298,7 +298,10 @@ func (ce *coverageExportUtil) exportOverall(outputDirectory string, fileName str
 	return marshalAndWriteJSON(providerStatistic, jsonOutputLocation)
 }
 
-// The fourth mode, which simply gives the provider name, and success percentage.
+// The fifth mode, which provides outputs a markdown file with:
+// - the example's name
+// - the original HCL
+// - the conversion results for all languages
 func (ce *coverageExportUtil) exportMarkdown(outputDirectory string, fileName string) error {
 
 	// The Coverage Tracker data structure is flattened down to the example level, and they all
@@ -382,12 +385,15 @@ func (ce *coverageExportUtil) exportMarkdown(outputDirectory string, fileName st
 
 			errMsg := err.FailureInfo
 			if len(err.FailureInfo) > 1000 {
+				// truncate extremely long error messages
 				errMsg = err.FailureInfo[:1000]
 			}
 			out += errMsg
 			out += fmt.Sprintf("\n```\n")
 		}
+
 		if isCompleteFailure {
+			// it's a complete failure, no successes to print
 			continue
 		}
 

--- a/pkg/tfgen/examples_coverage_exporter.go
+++ b/pkg/tfgen/examples_coverage_exporter.go
@@ -368,20 +368,20 @@ func (ce *coverageExportUtil) exportMarkdown(outputDirectory string, fileName st
 			summaryText = "**complete failure**"
 		}
 
-		out += fmt.Sprintf("\n---\n")
+		out += "\n---\n"
 		out += fmt.Sprintf("\n## [%s] %s\n", summaryText, example.ExampleName)
 
 		// print original HCL
-		out += fmt.Sprintf("\n### HCL\n")
-		out += fmt.Sprintf("\n```terraform\n")
+		out += "\n### HCL\n"
+		out += "\n```terraform\n"
 		out += example.OriginalHCL + "\n"
-		out += fmt.Sprintf("\n```\n")
+		out += "\n```\n"
 
 		// print failures
-		out += fmt.Sprintf("\n### Failed Languages\n")
+		out += "\n### Failed Languages\n"
 		for lang, err := range failures {
 			out += fmt.Sprintf("\n#### %s\n", lang)
-			out += fmt.Sprintf("\n```text\n")
+			out += "\n```text\n"
 
 			errMsg := err.FailureInfo
 			if len(err.FailureInfo) > 1000 {
@@ -389,7 +389,7 @@ func (ce *coverageExportUtil) exportMarkdown(outputDirectory string, fileName st
 				errMsg = err.FailureInfo[:1000]
 			}
 			out += errMsg
-			out += fmt.Sprintf("\n```\n")
+			out += "\n```\n"
 		}
 
 		if isCompleteFailure {
@@ -398,14 +398,14 @@ func (ce *coverageExportUtil) exportMarkdown(outputDirectory string, fileName st
 		}
 
 		// print successes
-		out += fmt.Sprintf("\n### Successes\n")
+		out += "\n### Successes\n"
 		for lang, success := range successes {
-			out += fmt.Sprintf("\n<details>\n")
+			out += "\n<details>\n"
 			out += fmt.Sprintf("\n<summary>%s</summary>\n", lang)
 			out += fmt.Sprintf("\n```%s\n", lang)
 			out += success.Program
-			out += fmt.Sprintf("\n```\n")
-			out += fmt.Sprintf("\n</details>\n")
+			out += "\n```\n"
+			out += "\n</details>\n"
 		}
 	}
 

--- a/pkg/tfgen/examples_coverage_exporter.go
+++ b/pkg/tfgen/examples_coverage_exporter.go
@@ -365,6 +365,7 @@ func (ce *coverageExportUtil) exportMarkdown(outputDirectory string, fileName st
 			summaryText = "**complete failure**"
 		}
 
+		out += fmt.Sprintf("\n---\n")
 		out += fmt.Sprintf("\n## [%s] %s\n", summaryText, example.ExampleName)
 
 		// print original HCL

--- a/pkg/tfgen/examples_coverage_exporter.go
+++ b/pkg/tfgen/examples_coverage_exporter.go
@@ -379,7 +379,12 @@ func (ce *coverageExportUtil) exportMarkdown(outputDirectory string, fileName st
 		for lang, err := range failures {
 			out += fmt.Sprintf("\n#### %s\n", lang)
 			out += fmt.Sprintf("\n```text\n")
-			out += err.FailureInfo
+
+			errMsg := err.FailureInfo
+			if len(err.FailureInfo) > 1000 {
+				errMsg = err.FailureInfo[:1000]
+			}
+			out += errMsg
 			out += fmt.Sprintf("\n```\n")
 		}
 		if isCompleteFailure {

--- a/pkg/tfgen/examples_coverage_tracker.go
+++ b/pkg/tfgen/examples_coverage_tracker.go
@@ -76,6 +76,7 @@ type Example struct {
 type LanguageConversionResult struct {
 	FailureSeverity int    // This conversion's outcome: [Success, Warning, Failure, Fatal]
 	FailureInfo     string // Additional in-depth information
+	Program         string // Converted program
 
 	// How many times this example has been converted to this language.
 	// It is expected that this will be equal to 1.
@@ -116,7 +117,7 @@ func (ct *CoverageTracker) foundExample(pageName string, hcl string) {
 }
 
 // Used when: current example has been successfully converted to a certain language
-func (ct *CoverageTracker) languageConversionSuccess(languageName string) {
+func (ct *CoverageTracker) languageConversionSuccess(languageName string, program string) {
 	if ct == nil {
 		return
 	}
@@ -124,10 +125,11 @@ func (ct *CoverageTracker) languageConversionSuccess(languageName string) {
 		FailureSeverity:  Success,
 		FailureInfo:      "",
 		TranslationCount: 1,
+		Program:          program,
 	})
 }
 
-//nolint
+// nolint
 // Used when: generator has successfully converted current example, but threw out some warnings
 func (ct *CoverageTracker) languageConversionWarning(languageName string, warningDiagnostics hcl.Diagnostics) {
 	if ct == nil {

--- a/pkg/tfgen/examples_coverage_tracker.go
+++ b/pkg/tfgen/examples_coverage_tracker.go
@@ -129,7 +129,7 @@ func (ct *CoverageTracker) languageConversionSuccess(languageName string, progra
 	})
 }
 
-// nolint
+//nolint
 // Used when: generator has successfully converted current example, but threw out some warnings
 func (ct *CoverageTracker) languageConversionWarning(languageName string, warningDiagnostics hcl.Diagnostics) {
 	if ct == nil {


### PR DESCRIPTION
Provides a human-friendly markdown version of translation errors.

context: https://github.com/pulumi/home/issues/2344

part of https://github.com/pulumi/home/issues/2462