### PR TITLE
Check whether object properties' fields are outputs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 PROJECT          := github.com/pulumi/pulumi-terraform-bridge
 TESTPARALLELISM  := 10
 
+.PHONY: default
+default: build lint test
+
 build::
 	go mod tidy
 	go build ${PROJECT}/v3/pkg/...

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -803,26 +803,3 @@ func TestParseImports_WithOverride(t *testing.T) {
 
 	assert.Equal(t, "## Import\n\noverridden import details", parser.ret.Import)
 }
-
-type mockResource struct {
-	docs  tfbridge.DocInfo
-	token tokens.Token
-}
-
-func (r *mockResource) GetFields() map[string]*tfbridge.SchemaInfo {
-	//TODO implement me
-	panic("implement me")
-}
-
-func (r *mockResource) ReplaceExamplesSection() bool {
-	//TODO implement me
-	panic("implement me")
-}
-
-func (r *mockResource) GetDocs() *tfbridge.DocInfo {
-	return &r.docs
-}
-
-func (r *mockResource) GetTok() tokens.Token {
-	return r.token
-}

--- a/pkg/tfgen/generate_test.go
+++ b/pkg/tfgen/generate_test.go
@@ -2,7 +2,6 @@ package tfgen
 
 import (
 	schemav2 "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
 	"sort"
 	"testing"
@@ -133,42 +132,4 @@ func TestMakeObjectPropertyType_InputTypes(t *testing.T) {
 	assert.Equal(t, false, inputResult.properties[1].out)
 	assert.Equal(t, "vpcId", inputResult.properties[2].name)
 	assert.Equal(t, true, inputResult.properties[2].out)
-}
-
-type mockResource struct {
-	schema shim.SchemaMap
-}
-
-func (m mockResource) Schema() shim.SchemaMap {
-	return m.schema
-}
-
-func (m mockResource) SchemaVersion() int {
-	//TODO implement me
-	panic("implement me")
-}
-
-func (m mockResource) Importer() shim.ImportFunc {
-	//TODO implement me
-	panic("implement me")
-}
-
-func (m mockResource) DeprecationMessage() string {
-	//TODO implement me
-	panic("implement me")
-}
-
-func (m mockResource) Timeouts() *shim.ResourceTimeout {
-	//TODO implement me
-	panic("implement me")
-}
-
-func (m mockResource) InstanceState(id string, object, meta map[string]interface{}) (shim.InstanceState, error) {
-	//TODO implement me
-	panic("implement me")
-}
-
-func (m mockResource) DecodeTimeouts(config shim.ResourceConfig) (*shim.ResourceTimeout, error) {
-	//TODO implement me
-	panic("implement me")
 }

--- a/pkg/tfgen/generate_test.go
+++ b/pkg/tfgen/generate_test.go
@@ -1,6 +1,10 @@
 package tfgen
 
 import (
+	schemav2 "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
+	"sort"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -75,4 +79,96 @@ func Test_ForceNew(t *testing.T) {
 			assert.Equal(t, test.ShouldForceNew, actuallyForcesNew)
 		})
 	}
+}
+
+func TestMakeObjectPropertyType_InputTypes(t *testing.T) {
+
+	vpcConfig := mockResource{
+		schema: shimv2.NewSchemaMap(map[string]*schemav2.Schema{
+			"security_group_ids": {
+				Type:     7,
+				Required: true,
+				Optional: false,
+				Computed: false,
+				Elem: &schema.Schema{
+					Type:     4,
+					Required: false,
+					Optional: false,
+					Computed: false,
+				},
+			},
+			"subnet_ids": {
+				Type:     7,
+				Required: true,
+				Optional: false,
+				Computed: false,
+				Elem: &schema.Schema{
+					Type:       4,
+					ConfigMode: 0,
+					Required:   false,
+					Optional:   false,
+					Computed:   false,
+				},
+			},
+			// This should only appear in the output type, not the input type:
+			"vpc_id": {
+				Type:       4,
+				ConfigMode: 0,
+				Required:   false,
+				Optional:   false,
+				Computed:   true,
+			},
+		}),
+	}
+
+	inputResult := makeObjectPropertyType("vpc_config", vpcConfig, nil, false, entityDocs{}, "")
+	sort.Slice(inputResult.properties, func(i, j int) bool {
+		return inputResult.properties[i].name < inputResult.properties[j].name
+	})
+
+	assert.Equal(t, 3, len(inputResult.properties))
+	assert.Equal(t, "securityGroupIds", inputResult.properties[0].name)
+	assert.Equal(t, false, inputResult.properties[0].out)
+	assert.Equal(t, "subnetIds", inputResult.properties[1].name)
+	assert.Equal(t, false, inputResult.properties[1].out)
+	assert.Equal(t, "vpcId", inputResult.properties[2].name)
+	assert.Equal(t, true, inputResult.properties[2].out)
+}
+
+type mockResource struct {
+	schema shim.SchemaMap
+}
+
+func (m mockResource) Schema() shim.SchemaMap {
+	return m.schema
+}
+
+func (m mockResource) SchemaVersion() int {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m mockResource) Importer() shim.ImportFunc {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m mockResource) DeprecationMessage() string {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m mockResource) Timeouts() *shim.ResourceTimeout {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m mockResource) InstanceState(id string, object, meta map[string]interface{}) (shim.InstanceState, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m mockResource) DecodeTimeouts(config shim.ResourceConfig) (*shim.ResourceTimeout, error) {
+	//TODO implement me
+	panic("implement me")
 }

--- a/pkg/tfgen/mocks_test.go
+++ b/pkg/tfgen/mocks_test.go
@@ -1,0 +1,65 @@
+package tfgen
+
+import (
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+)
+
+type mockResource struct {
+	schema shim.SchemaMap
+	docs   tfbridge.DocInfo
+	token  tokens.Token
+}
+
+func (r *mockResource) GetFields() map[string]*tfbridge.SchemaInfo {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (r *mockResource) ReplaceExamplesSection() bool {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (r *mockResource) GetDocs() *tfbridge.DocInfo {
+	return &r.docs
+}
+
+func (r *mockResource) GetTok() tokens.Token {
+	return r.token
+}
+
+func (r mockResource) Schema() shim.SchemaMap {
+	return r.schema
+}
+
+func (r mockResource) SchemaVersion() int {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (r mockResource) Importer() shim.ImportFunc {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (r mockResource) DeprecationMessage() string {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (r mockResource) Timeouts() *shim.ResourceTimeout {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (r mockResource) InstanceState(id string, object, meta map[string]interface{}) (shim.InstanceState, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (r mockResource) DecodeTimeouts(config shim.ResourceConfig) (*shim.ResourceTimeout, error) {
+	//TODO implement me
+	panic("implement me")
+}


### PR DESCRIPTION
**STATUS:** I believe this PR correctly sets whether the intermediate representation of the property (`propertyType`) is an output, but it's not producing the desired output in schema (as verified by generating the SDKs).

I need some help with someone familiar with the Pulumi schema to get this across the finish line. I believe we need additional changes to the logic that maps `propertyType` to the final Pulumi schema type.

Will fix https://github.com/pulumi/pulumi-terraform-bridge/issues/493

* Add tests for makeObjectPropertyType.
* Add doc comments.
* Add rawname as a parameter for debugging. (It's very difficult to get
  enough context to debug the affected functions without it.)
