### PR TITLE
Update releases link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ This repo on its own isn't particularly interesting, until it is used to create 
 
 ### Releasing
 
-We use git tags and [GitHub Releases](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases).
+We use git tags and [GitHub Releases](https://github.com/pulumi/pulumi-terraform-bridge/releases).
 Maintainers will push a new semver tag when appropriate.
 
 ### Adapting a New Terraform Provider


### PR DESCRIPTION
this link was linking to the github feature docs, thought it might be worth updating the link to link to the releases for this repo. up to yall to decide.