### PR TITLE
Introduce a test case reproducing 611

### DIFF
--- a/internal/testing/schemas.go
+++ b/internal/testing/schemas.go
@@ -1,0 +1,50 @@
+package testing
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+)
+
+func AssertPackageSpecEquals(
+	t *testing.T,
+	expectedSchemaJsonFile string,
+	spec pschema.PackageSpec,
+) {
+
+	marshalSchema := func(s pschema.PackageSpec, w io.Writer) error {
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(s)
+	}
+
+	assertPackageSpecMatchesFile := func(spec pschema.PackageSpec, file string) {
+		expectedBytes, err := ioutil.ReadFile(file)
+		assert.NoError(t, err)
+		expected := string(expectedBytes)
+
+		buf := bytes.Buffer{}
+		err = marshalSchema(spec, &buf)
+		assert.NoError(t, err)
+		actual := string(buf.Bytes())
+
+		assert.Equal(t, expected, actual)
+	}
+
+	if os.Getenv("PULUMI_ACCEPT") != "" {
+		buf := bytes.Buffer{}
+		err := marshalSchema(spec, &buf)
+		assert.NoError(t, err)
+		err = ioutil.WriteFile(expectedSchemaJsonFile, buf.Bytes(), 0600)
+		assert.NoError(t, err)
+	}
+
+	assertPackageSpecMatchesFile(spec, expectedSchemaJsonFile)
+}

--- a/internal/testprovider/schema_regress_611.go
+++ b/internal/testprovider/schema_regress_611.go
@@ -1,0 +1,2029 @@
+package testprovider
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+)
+
+// Minified variant of pulumi-aws provider extracted from
+// pulumi/pulumi-terraform-bridge#611 issue.
+func ProviderRegress611() tfbridge.ProviderInfo {
+	awsMod := "index"
+	awsPkg := "aws"
+	iamMod := "Iam"
+
+	tfProvider := &schema.Provider{
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Description: `The region where AWS operations will take place. Examples
+are us-east-1, us-west-2, etc.`,
+			},
+			"skip_credentials_validation": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Skip the credentials validation via STS API. Used for AWS API implementations that do not have STS available/implemented.",
+			},
+			"skip_get_ec2_platforms": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Skip getting the supported EC2 platforms. Used by users that don't have ec2:DescribeAccountAttributes permissions.",
+			},
+			"skip_metadata_api_check": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Skip the AWS Metadata API check. Used for AWS API implementations that do not have a metadata api endpoint.",
+			},
+			"skip_region_validation": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Skip static validation of region name. Used by users of alternative AWS-like APIs or users w/ access to regions that are not public (yet).",
+			},
+		},
+		ResourcesMap: map[string]*schema.Resource{
+			"aws_iam_access_key": {Schema: map[string]*schema.Schema{
+				"create_date": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"encrypted_secret": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"encrypted_ses_smtp_password_v4": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"key_fingerprint": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"pgp_key": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+				},
+				"secret": {
+					Type:      schema.TypeString,
+					Computed:  true,
+					Sensitive: true,
+				},
+				"ses_smtp_password_v4": {
+					Type:      schema.TypeString,
+					Computed:  true,
+					Sensitive: true,
+				},
+				"status": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Default:  "Active",
+				},
+				"user": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}},
+			"aws_iam_account_alias": {Schema: map[string]*schema.Schema{"account_alias": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			}}},
+			"aws_iam_account_password_policy": {Schema: map[string]*schema.Schema{
+				"allow_users_to_change_password": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  true,
+				},
+				"expire_passwords": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				"hard_expiry": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Computed: true,
+				},
+				"max_password_age": {
+					Type:     schema.TypeInt,
+					Optional: true,
+					Computed: true,
+				},
+				"minimum_password_length": {
+					Type:     schema.TypeInt,
+					Optional: true,
+					Default:  6,
+				},
+				"password_reuse_prevention": {
+					Type:     schema.TypeInt,
+					Optional: true,
+					Computed: true,
+				},
+				"require_lowercase_characters": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Computed: true,
+				},
+				"require_numbers": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Computed: true,
+				},
+				"require_symbols": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Computed: true,
+				},
+				"require_uppercase_characters": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Computed: true,
+				},
+			}},
+			"aws_iam_group": {Schema: map[string]*schema.Schema{
+				"arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"name": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"path": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Default:  "/",
+				},
+				"unique_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}},
+			"aws_iam_group_membership": {Schema: map[string]*schema.Schema{
+				"group": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"name": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"users": {
+					Type:     schema.TypeSet,
+					Required: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+			}},
+			"aws_iam_group_policy": {Schema: map[string]*schema.Schema{
+				"group": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"name": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ForceNew:      true,
+					ConflictsWith: []string{"name_prefix"},
+				},
+				"name_prefix": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					ForceNew:      true,
+					ConflictsWith: []string{"name"},
+				},
+				"policy": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			}},
+			"aws_iam_group_policy_attachment": {Schema: map[string]*schema.Schema{
+				"group": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"policy_arn": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}},
+			"aws_iam_instance_profile": {Schema: map[string]*schema.Schema{
+				"arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"create_date": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"name": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ForceNew:      true,
+					ConflictsWith: []string{"name_prefix"},
+				},
+				"name_prefix": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					ForceNew:      true,
+					ConflictsWith: []string{"name"},
+				},
+				"path": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+					Default:  "/",
+				},
+				"role": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"tags": {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"tags_all": {
+					Type:     schema.TypeMap,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"unique_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}},
+			"aws_iam_openid_connect_provider": {Schema: map[string]*schema.Schema{
+				"arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"client_id_list": {
+					Type:     schema.TypeList,
+					Required: true,
+					ForceNew: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"tags": {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"tags_all": {
+					Type:     schema.TypeMap,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"thumbprint_list": {
+					Type:     schema.TypeList,
+					Required: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"url": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}},
+			"aws_iam_policy": {Schema: map[string]*schema.Schema{
+				"arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"description": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+				},
+				"name": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ForceNew:      true,
+					ConflictsWith: []string{"name_prefix"},
+				},
+				"name_prefix": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					ForceNew:      true,
+					ConflictsWith: []string{"name"},
+				},
+				"path": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+					Default:  "/",
+				},
+				"policy": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"policy_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"tags": {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"tags_all": {
+					Type:     schema.TypeMap,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+			}},
+			"aws_iam_policy_attachment": {Schema: map[string]*schema.Schema{
+				"groups": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"name": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"policy_arn": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"roles": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"users": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+			}},
+			"aws_iam_role": {Schema: map[string]*schema.Schema{
+				"arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"assume_role_policy": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"create_date": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"description": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"force_detach_policies": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				"inline_policy": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Computed: true,
+					Elem: &schema.Resource{Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"policy": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					}},
+				},
+				"managed_policy_arns": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"max_session_duration": {
+					Type:     schema.TypeInt,
+					Optional: true,
+					Default:  3600,
+				},
+				"name": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ForceNew:      true,
+					ConflictsWith: []string{"name_prefix"},
+				},
+				"name_prefix": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ForceNew:      true,
+					ConflictsWith: []string{"name"},
+				},
+				"path": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+					Default:  "/",
+				},
+				"permissions_boundary": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"tags": {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"tags_all": {
+					Type:     schema.TypeMap,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"unique_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}},
+			"aws_iam_role_policy": {Schema: map[string]*schema.Schema{
+				"name": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ForceNew:      true,
+					ConflictsWith: []string{"name_prefix"},
+				},
+				"name_prefix": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					ForceNew:      true,
+					ConflictsWith: []string{"name"},
+				},
+				"policy": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"role": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}},
+			"aws_iam_role_policy_attachment": {Schema: map[string]*schema.Schema{
+				"policy_arn": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"role": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}},
+			"aws_iam_saml_provider": {Schema: map[string]*schema.Schema{
+				"arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"name": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"saml_metadata_document": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"tags": {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"tags_all": {
+					Type:     schema.TypeMap,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"valid_until": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}},
+			"aws_iam_server_certificate": {Schema: map[string]*schema.Schema{
+				"arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"certificate_body": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"certificate_chain": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+				},
+				"expiration": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"name": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ForceNew:      true,
+					ConflictsWith: []string{"name_prefix"},
+				},
+				"name_prefix": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					ForceNew:      true,
+					ConflictsWith: []string{"name"},
+				},
+				"path": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+					Default:  "/",
+				},
+				"private_key": {
+					Type:      schema.TypeString,
+					Required:  true,
+					ForceNew:  true,
+					Sensitive: true,
+				},
+				"tags": {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"tags_all": {
+					Type:     schema.TypeMap,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"upload_date": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}},
+			"aws_iam_service_linked_role": {Schema: map[string]*schema.Schema{
+				"arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"aws_service_name": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"create_date": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"custom_suffix": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+				},
+				"description": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"path": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"tags": {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"tags_all": {
+					Type:     schema.TypeMap,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"unique_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}},
+			"aws_iam_service_specific_credential": {Schema: map[string]*schema.Schema{
+				"service_name": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"service_password": {
+					Type:      schema.TypeString,
+					Computed:  true,
+					Sensitive: true,
+				},
+				"service_specific_credential_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"service_user_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"status": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Default:  "Active",
+				},
+				"user_name": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}},
+			"aws_iam_signing_certificate": {Schema: map[string]*schema.Schema{
+				"certificate_body": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"certificate_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"status": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Default:  "Active",
+				},
+				"user_name": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}},
+			"aws_iam_user": {Schema: map[string]*schema.Schema{
+				"arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"force_destroy": {
+					Type:        schema.TypeBool,
+					Optional:    true,
+					Default:     false,
+					Description: "Delete user even if it has non-Terraform-managed IAM access keys, login profile or MFA devices",
+				},
+				"name": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"path": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Default:  "/",
+				},
+				"permissions_boundary": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"tags": {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"tags_all": {
+					Type:     schema.TypeMap,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"unique_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}},
+			"aws_iam_user_group_membership": {Schema: map[string]*schema.Schema{
+				"groups": {
+					Type:     schema.TypeSet,
+					Required: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"user": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}},
+			"aws_iam_user_login_profile": {Schema: map[string]*schema.Schema{
+				"encrypted_password": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"key_fingerprint": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"password": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"password_length": {
+					Type:     schema.TypeInt,
+					Optional: true,
+					ForceNew: true,
+					Default:  20,
+				},
+				"password_reset_required": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+				"pgp_key": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+				},
+				"user": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}},
+			"aws_iam_user_policy": {Schema: map[string]*schema.Schema{
+				"name": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ForceNew:      true,
+					ConflictsWith: []string{"name_prefix"},
+				},
+				"name_prefix": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					ForceNew:      true,
+					ConflictsWith: []string{"name"},
+				},
+				"policy": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"user": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}},
+			"aws_iam_user_policy_attachment": {Schema: map[string]*schema.Schema{
+				"policy_arn": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"user": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}},
+			"aws_iam_user_ssh_key": {Schema: map[string]*schema.Schema{
+				"encoding": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"fingerprint": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"public_key": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"ssh_public_key_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"status": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"username": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}},
+			"aws_iam_virtual_mfa_device": {Schema: map[string]*schema.Schema{
+				"arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"base_32_string_seed": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"path": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+					Default:  "/",
+				},
+				"qr_code_png": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"tags": {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"tags_all": {
+					Type:     schema.TypeMap,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"virtual_mfa_device_name": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+			}},
+		},
+		DataSourcesMap: map[string]*schema.Resource{
+			"aws_arn": {Schema: map[string]*schema.Schema{
+				"account": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"arn": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"partition": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"region": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"resource": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"service": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}},
+			"aws_availability_zone": {Schema: map[string]*schema.Schema{
+				"all_availability_zones": {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
+				"filter": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"values": {
+							Type:     schema.TypeSet,
+							Required: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					}},
+				},
+				"group_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"name": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"name_suffix": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"network_border_group": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"opt_in_status": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"parent_zone_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"parent_zone_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"region": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"state": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"zone_id": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"zone_type": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}},
+			"aws_availability_zones": {Schema: map[string]*schema.Schema{
+				"all_availability_zones": {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
+				"exclude_names": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"exclude_zone_ids": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"filter": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"values": {
+							Type:     schema.TypeSet,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					}},
+				},
+				"group_names": {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"names": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"state": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"zone_ids": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+			}},
+			"aws_billing_service_account": {Schema: map[string]*schema.Schema{"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			}}},
+			"aws_caller_identity": {Schema: map[string]*schema.Schema{
+				"account_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"user_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}},
+			"aws_default_tags": {Schema: map[string]*schema.Schema{"tags": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			}}},
+			"aws_iam_account_alias": {Schema: map[string]*schema.Schema{"account_alias": {
+				Type:     schema.TypeString,
+				Computed: true,
+			}}},
+			"aws_iam_group": {Schema: map[string]*schema.Schema{
+				"arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"group_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"group_name": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"path": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"users": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{Schema: map[string]*schema.Schema{
+						"arn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"path": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"user_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"user_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					}},
+				},
+			}},
+			"aws_iam_instance_profile": {Schema: map[string]*schema.Schema{
+				"arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"create_date": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"name": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"path": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"role_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"role_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"role_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}},
+			"aws_iam_instance_profiles": {Schema: map[string]*schema.Schema{
+				"arns": {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"names": {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"paths": {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"role_name": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			}},
+			"aws_iam_openid_connect_provider": {Schema: map[string]*schema.Schema{
+				"arn": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ExactlyOneOf: []string{
+						"arn",
+						"url",
+					},
+				},
+				"client_id_list": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"tags": {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"thumbprint_list": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"url": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ExactlyOneOf: []string{
+						"arn",
+						"url",
+					},
+				},
+			}},
+			"aws_iam_policy": {Schema: map[string]*schema.Schema{
+				"arn": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ConflictsWith: []string{
+						"name",
+						"path_prefix",
+					},
+				},
+				"description": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"name": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ConflictsWith: []string{"arn"},
+				},
+				"path": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"path_prefix": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					ConflictsWith: []string{"arn"},
+				},
+				"policy": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"policy_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"tags": {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+			}},
+			"aws_iam_policy_document": {Schema: map[string]*schema.Schema{
+				"json": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"override_json": {
+					Type:       schema.TypeString,
+					Optional:   true,
+					Deprecated: `Use the attribute "override_policy_documents" instead.`,
+				},
+				"override_policy_documents": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"policy_id": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"source_json": {
+					Type:       schema.TypeString,
+					Optional:   true,
+					Deprecated: `Use the attribute "source_policy_documents" instead.`,
+				},
+				"source_policy_documents": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"statement": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem: &schema.Resource{Schema: map[string]*schema.Schema{
+						"actions": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"condition": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Resource{Schema: map[string]*schema.Schema{
+								"test": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
+								"values": {
+									Type:     schema.TypeList,
+									Required: true,
+									Elem:     &schema.Schema{Type: schema.TypeString},
+								},
+								"variable": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
+							}},
+						},
+						"effect": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "Allow",
+						},
+						"not_actions": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"not_principals": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Resource{Schema: map[string]*schema.Schema{
+								"identifiers": {
+									Type:     schema.TypeSet,
+									Required: true,
+									Elem:     &schema.Schema{Type: schema.TypeString},
+								},
+								"type": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
+							}},
+						},
+						"not_resources": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"principals": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Resource{Schema: map[string]*schema.Schema{
+								"identifiers": {
+									Type:     schema.TypeSet,
+									Required: true,
+									Elem:     &schema.Schema{Type: schema.TypeString},
+								},
+								"type": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
+							}},
+						},
+						"resources": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"sid": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					}},
+				},
+				"version": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Default:  "2012-10-17",
+				},
+			}},
+			"aws_iam_role": {Schema: map[string]*schema.Schema{
+				"arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"assume_role_policy": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"create_date": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"description": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"max_session_duration": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"name": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"path": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"permissions_boundary": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"tags": {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"unique_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}},
+			"aws_iam_roles": {Schema: map[string]*schema.Schema{
+				"arns": {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"name_regex": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"names": {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"path_prefix": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			}},
+			"aws_iam_saml_provider": {Schema: map[string]*schema.Schema{
+				"arn": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"create_date": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"saml_metadata_document": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"tags": {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"valid_until": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}},
+			"aws_iam_server_certificate": {Schema: map[string]*schema.Schema{
+				"arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"certificate_body": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"certificate_chain": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"expiration_date": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"latest": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				"name": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Computed:      true,
+					ConflictsWith: []string{"name_prefix"},
+				},
+				"name_prefix": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					ConflictsWith: []string{"name"},
+				},
+				"path": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"path_prefix": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"upload_date": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}},
+			"aws_iam_session_context": {Schema: map[string]*schema.Schema{
+				"arn": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"issuer_arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"issuer_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"issuer_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"session_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}},
+			"aws_iam_user": {Schema: map[string]*schema.Schema{
+				"arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"path": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"permissions_boundary": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"tags": {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"user_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"user_name": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			}},
+			"aws_iam_user_ssh_key": {Schema: map[string]*schema.Schema{
+				"encoding": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"fingerprint": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"public_key": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"ssh_public_key_id": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"status": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"username": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			}},
+			"aws_iam_users": {Schema: map[string]*schema.Schema{
+				"arns": {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"name_regex": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"names": {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"path_prefix": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			}},
+			"aws_ip_ranges": {Schema: map[string]*schema.Schema{
+				"cidr_blocks": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"create_date": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"ipv6_cidr_blocks": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"regions": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"services": {
+					Type:     schema.TypeSet,
+					Required: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"sync_token": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"url": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Default:  "https://ip-ranges.amazonaws.com/ip-ranges.json",
+				},
+			}},
+			"aws_partition": {Schema: map[string]*schema.Schema{
+				"dns_suffix": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"partition": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"reverse_dns_prefix": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}},
+			"aws_region": {Schema: map[string]*schema.Schema{
+				"description": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"endpoint": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"name": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+			}},
+			"aws_regions": {Schema: map[string]*schema.Schema{
+				"all_regions": {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
+				"filter": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"values": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					}},
+				},
+				"names": {
+					Type:     schema.TypeSet,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+			}},
+			"aws_service": {Schema: map[string]*schema.Schema{
+				"dns_name": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ExactlyOneOf: []string{
+						"dns_name",
+						"reverse_dns_name",
+						"service_id",
+					},
+				},
+				"partition": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"region": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ConflictsWith: []string{
+						"dns_name",
+						"reverse_dns_name",
+					},
+				},
+				"reverse_dns_name": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ExactlyOneOf: []string{
+						"dns_name",
+						"reverse_dns_name",
+						"service_id",
+					},
+				},
+				"reverse_dns_prefix": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ConflictsWith: []string{
+						"dns_name",
+						"reverse_dns_name",
+					},
+				},
+				"service_id": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ExactlyOneOf: []string{
+						"dns_name",
+						"reverse_dns_name",
+						"service_id",
+					},
+				},
+				"supported": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+			}},
+		},
+	}
+
+	p := shimv2.NewProvider(tfProvider)
+
+	// awsMember manufactures a type token for the AWS package and
+	// the given module, file name, and type.
+	awsMember := func(moduleTitle string, fn string, mem string, experimental bool) tokens.ModuleMember {
+		if experimental {
+			moduleTitle = fmt.Sprintf("x/%s", moduleTitle)
+		}
+
+		moduleName := strings.ToLower(moduleTitle)
+		if fn != "" {
+			moduleName += "/" + fn
+		}
+		return tokens.ModuleMember(awsPkg + ":" + moduleName + ":" + mem)
+	}
+
+	// awsType manufactures a type token for the AWS package and
+	// the given module, file name, and type.
+	awsType := func(mod string, fn string, typ string) tokens.Type {
+		return tokens.Type(awsMember(mod, fn, typ, false))
+	}
+
+	// awsResource manufactures a standard resource token given a
+	// module and resource name. It automatically uses the AWS
+	// package and names the file by simply lower casing the
+	// type's first character.
+	awsTypeDefaultFile := func(mod string, typ string) tokens.Type {
+		fn := string(unicode.ToLower(rune(typ[0]))) + typ[1:]
+		return awsType(mod, fn, typ)
+	}
+
+	// awsResource manufactures a standard resource token given a
+	// module and resource name.
+	awsResource := func(mod string, res string) tokens.Type {
+		return awsTypeDefaultFile(mod, res)
+	}
+
+	// awsDataSource manufactures a standard resource token given
+	// a module and resource name. It automatically uses the AWS
+	// package and names the file by simply lower casing the data
+	// source's first character.
+	awsDataSource := func(mod string, res string) tokens.ModuleMember {
+		fn := string(unicode.ToLower(rune(res[0]))) + res[1:]
+		return awsMember(mod, fn, res, false)
+	}
+
+	awsExperimentalDataSource := func(mod string, res string) tokens.ModuleMember {
+		fn := string(unicode.ToLower(rune(res[0]))) + res[1:]
+		return awsMember(mod, fn, res, true)
+	}
+
+	prov := tfbridge.ProviderInfo{
+		P:           p,
+		Name:        "aws",
+		Description: "A Pulumi package for creating and managing Amazon Web Services (AWS) cloud resources.",
+		Keywords:    []string{"pulumi", "aws"},
+		License:     "Apache-2.0",
+		Homepage:    "https://pulumi.io",
+		Repository:  "https://github.com/phillipedwards/pulumi-aws",
+		Version:     "0.0.2",
+		GitHubOrg:   "hashicorp",
+		Config: map[string]*tfbridge.SchemaInfo{
+			"region": {
+				Type: awsTypeDefaultFile(awsMod, "Region"),
+				Default: &tfbridge.DefaultInfo{
+					EnvVars: []string{"AWS_REGION", "AWS_DEFAULT_REGION"},
+				},
+			},
+			"skip_get_ec2_platforms": {
+				Default: &tfbridge.DefaultInfo{
+					Value: true,
+				},
+			},
+			"skip_region_validation": {
+				Default: &tfbridge.DefaultInfo{
+					Value: true,
+				},
+			},
+			"skip_credentials_validation": {
+				Default: &tfbridge.DefaultInfo{
+					// This is required to now be false! When this is true, we defer
+					// the AWS credentials validation check to happen at resource
+					// creation time. Although it may be a little slower validating
+					// this upfront, we genuinely need to do this to ensure a good
+					// user experience. If we don't validate upfront, then we can
+					// be in a situation where a user can be waiting for a resource
+					// creation timeout (default up to 30mins) to find out that they
+					// have not got valid credentials
+					Value: false,
+				},
+			},
+			"skip_metadata_api_check": {
+				Type: "boolean",
+				Default: &tfbridge.DefaultInfo{
+					Value: true,
+				},
+			},
+		},
+		Resources: map[string]*tfbridge.ResourceInfo{
+
+			// Identity and Access Management (IAM)
+			"aws_iam_access_key": {Tok: awsResource(iamMod, "AccessKey")},
+			"aws_iam_account_alias": {
+				Tok: awsResource(iamMod, "AccountAlias"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"account_alias": {
+						CSharpName: "Alias",
+					},
+				},
+			},
+			"aws_iam_account_password_policy": {Tok: awsResource(iamMod, "AccountPasswordPolicy")},
+			"aws_iam_group_policy": {
+				Tok: awsResource(iamMod, "GroupPolicy"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"policy": {
+						Type:      "string",
+						AltTypes:  []tokens.Type{awsType(iamMod, "documents", "PolicyDocument")},
+						Transform: tfbridge.TransformJSONDocument,
+					},
+				},
+			},
+			"aws_iam_group":            {Tok: awsResource(iamMod, "Group")},
+			"aws_iam_group_membership": {Tok: awsResource(iamMod, "GroupMembership")},
+			"aws_iam_group_policy_attachment": {
+				Tok: awsResource(iamMod, "GroupPolicyAttachment"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"group": {
+						Type:     "string",
+						AltTypes: []tokens.Type{awsTypeDefaultFile(iamMod, "Group")},
+					},
+					"policy_arn": {
+						Name: "policyArn",
+						Type: awsTypeDefaultFile(awsMod, "ARN"),
+					},
+				},
+				// We pass delete-before-replace: this is a leaf node and a create followed by a delete actually
+				// deletes the same attachment we just created, since it is structurally equivalent!
+				DeleteBeforeReplace: true,
+			},
+			"aws_iam_instance_profile": {
+				Tok: awsResource(iamMod, "InstanceProfile"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"role": {
+						Type:     "string",
+						AltTypes: []tokens.Type{awsTypeDefaultFile(iamMod, "Role")},
+					},
+				},
+			},
+			"aws_iam_openid_connect_provider": {Tok: awsResource(iamMod, "OpenIdConnectProvider")},
+			"aws_iam_policy": {
+				Tok: awsResource(iamMod, "Policy"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"policy": {
+						Type:       "string",
+						AltTypes:   []tokens.Type{awsType(iamMod, "documents", "PolicyDocument")},
+						Transform:  tfbridge.TransformJSONDocument,
+						CSharpName: "PolicyDocument",
+					},
+				},
+			},
+			"aws_iam_policy_attachment": {
+				Tok: awsResource(iamMod, "PolicyAttachment"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"users": {
+						Elem: &tfbridge.SchemaInfo{
+							Type:     "string",
+							AltTypes: []tokens.Type{awsTypeDefaultFile(iamMod, "User")},
+						},
+					},
+					"roles": {
+						Elem: &tfbridge.SchemaInfo{
+							Type:     "string",
+							AltTypes: []tokens.Type{awsTypeDefaultFile(iamMod, "Role")},
+						},
+					},
+					"groups": {
+						Elem: &tfbridge.SchemaInfo{
+							Type:     "string",
+							AltTypes: []tokens.Type{awsTypeDefaultFile(iamMod, "Group")},
+						},
+					},
+					"policy_arn": {
+						Name: "policyArn",
+						Type: awsTypeDefaultFile(awsMod, "ARN"),
+					},
+				},
+				// We pass delete-before-replace: this is a leaf node and a create followed by a delete actually
+				// deletes the same attachment we just created, since it is structurally equivalent!
+				DeleteBeforeReplace: true,
+			},
+			"aws_iam_role_policy_attachment": {
+				Tok: awsResource(iamMod, "RolePolicyAttachment"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"role": {
+						Type:     "string",
+						AltTypes: []tokens.Type{awsTypeDefaultFile(iamMod, "Role")},
+					},
+					"policy_arn": {
+						Name: "policyArn",
+						Type: awsTypeDefaultFile(awsMod, "ARN"),
+					},
+				},
+				// We pass delete-before-replace: this is a leaf node and a create followed by a delete actually
+				// deletes the same attachment we just created, since it is structurally equivalent!
+				DeleteBeforeReplace: true,
+			},
+			"aws_iam_role_policy": {
+				Tok: awsResource(iamMod, "RolePolicy"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"role": {
+						Type:     "string",
+						AltTypes: []tokens.Type{awsTypeDefaultFile(iamMod, "Role")},
+					},
+					"policy": {
+						Type:      "string",
+						AltTypes:  []tokens.Type{awsType(iamMod, "documents", "PolicyDocument")},
+						Transform: tfbridge.TransformJSONDocument,
+					},
+				},
+			},
+			"aws_iam_role": {
+				Tok: awsResource(iamMod, "Role"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"name": tfbridge.AutoName("name", 64, "-"),
+					"assume_role_policy": {
+						Type:      "string",
+						AltTypes:  []tokens.Type{awsType(iamMod, "documents", "PolicyDocument")},
+						Transform: tfbridge.TransformJSONDocument,
+					},
+				},
+			},
+			"aws_iam_saml_provider":         {Tok: awsResource(iamMod, "SamlProvider")},
+			"aws_iam_server_certificate":    {Tok: awsResource(iamMod, "ServerCertificate")},
+			"aws_iam_service_linked_role":   {Tok: awsResource(iamMod, "ServiceLinkedRole")},
+			"aws_iam_user_group_membership": {Tok: awsResource(iamMod, "UserGroupMembership")},
+			"aws_iam_user_policy_attachment": {
+				Tok: awsResource(iamMod, "UserPolicyAttachment"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"user": {
+						Type:     "string",
+						AltTypes: []tokens.Type{awsTypeDefaultFile(iamMod, "User")},
+					},
+					"policy_arn": {
+						Name: "policyArn",
+						Type: awsTypeDefaultFile(awsMod, "ARN"),
+					},
+				},
+				// We pass delete-before-replace: this is a leaf node and a create followed by a delete actually
+				// deletes the same attachment we just created, since it is structurally equivalent!
+				DeleteBeforeReplace: true,
+			},
+			"aws_iam_user_policy": {
+				Tok: awsResource(iamMod, "UserPolicy"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"policy": {
+						Type:      "string",
+						AltTypes:  []tokens.Type{awsType(iamMod, "documents", "PolicyDocument")},
+						Transform: tfbridge.TransformJSONDocument,
+					},
+				},
+			},
+			"aws_iam_user_ssh_key":                {Tok: awsResource(iamMod, "SshKey")},
+			"aws_iam_user":                        {Tok: awsResource(iamMod, "User")},
+			"aws_iam_user_login_profile":          {Tok: awsResource(iamMod, "UserLoginProfile")},
+			"aws_iam_service_specific_credential": {Tok: awsResource(iamMod, "ServiceSpecificCredential")},
+			"aws_iam_signing_certificate":         {Tok: awsResource(iamMod, "SigningCertificate")},
+			"aws_iam_virtual_mfa_device":          {Tok: awsResource(iamMod, "VirtualMfaDevice")},
+		},
+		DataSources: map[string]*tfbridge.DataSourceInfo{
+			// AWS
+			"aws_arn":                     {Tok: awsDataSource(awsMod, "getArn")},
+			"aws_availability_zone":       {Tok: awsDataSource(awsMod, "getAvailabilityZone")},
+			"aws_availability_zones":      {Tok: awsDataSource(awsMod, "getAvailabilityZones")},
+			"aws_billing_service_account": {Tok: awsDataSource(awsMod, "getBillingServiceAccount")},
+			"aws_caller_identity":         {Tok: awsDataSource(awsMod, "getCallerIdentity")},
+			"aws_ip_ranges":               {Tok: awsDataSource(awsMod, "getIpRanges")},
+			"aws_partition":               {Tok: awsDataSource(awsMod, "getPartition")},
+			"aws_region":                  {Tok: awsDataSource(awsMod, "getRegion")},
+			"aws_regions":                 {Tok: awsDataSource(awsMod, "getRegions")},
+			"aws_default_tags":            {Tok: awsDataSource(awsMod, "getDefaultTags")},
+			"aws_service":                 {Tok: awsDataSource(awsMod, "getService")},
+
+			// IAM
+			"aws_iam_account_alias":           {Tok: awsDataSource(iamMod, "getAccountAlias")},
+			"aws_iam_group":                   {Tok: awsDataSource(iamMod, "getGroup")},
+			"aws_iam_instance_profile":        {Tok: awsDataSource(iamMod, "getInstanceProfile")},
+			"aws_iam_policy":                  {Tok: awsDataSource(iamMod, "getPolicy")},
+			"aws_iam_policy_document":         {Tok: awsExperimentalDataSource(iamMod, "getPolicyDocument")},
+			"aws_iam_role":                    {Tok: awsDataSource(iamMod, "getRole")},
+			"aws_iam_server_certificate":      {Tok: awsDataSource(iamMod, "getServerCertificate")},
+			"aws_iam_user":                    {Tok: awsDataSource(iamMod, "getUser")},
+			"aws_iam_users":                   {Tok: awsDataSource(iamMod, "getUsers")},
+			"aws_iam_session_context":         {Tok: awsDataSource(iamMod, "getSessionContext")},
+			"aws_iam_roles":                   {Tok: awsDataSource(iamMod, "getRoles")},
+			"aws_iam_user_ssh_key":            {Tok: awsDataSource(iamMod, "getUserSshKey")},
+			"aws_iam_openid_connect_provider": {Tok: awsDataSource(iamMod, "getOpenidConnectProvider")},
+			"aws_iam_saml_provider":           {Tok: awsDataSource(iamMod, "getSamlProvider")},
+			"aws_iam_instance_profiles":       {Tok: awsDataSource(iamMod, "getInstanceProfiles")},
+		},
+	}
+
+	prov.SetAutonaming(255, "-")
+
+	return prov
+}

--- a/pkg/tfgen/generate_schema_test.go
+++ b/pkg/tfgen/generate_schema_test.go
@@ -2,11 +2,22 @@ package tfgen
 
 import (
 	"bytes"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"text/template"
+
+	"github.com/stretchr/testify/assert"
+
+	bridgetesting "github.com/pulumi/pulumi-terraform-bridge/v3/internal/testing"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/internal/testprovider"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 )
+
+func TestRegress611(t *testing.T) {
+	provider := testprovider.ProviderRegress611()
+	schema, err := GenerateSchema(provider, nil)
+	assert.NoError(t, err)
+	bridgetesting.AssertPackageSpecEquals(t, "test_data/regress-611-schema.json", schema)
+}
 
 func TestAppendExample_InsertMiddle(t *testing.T) {
 	descTmpl := `Description text

--- a/pkg/tfgen/test_data/regress-611-schema.json
+++ b/pkg/tfgen/test_data/regress-611-schema.json
@@ -1,0 +1,4326 @@
+{
+  "name": "aws",
+  "version": "0.0.2",
+  "description": "A Pulumi package for creating and managing Amazon Web Services (AWS) cloud resources.",
+  "keywords": [
+    "pulumi",
+    "aws"
+  ],
+  "homepage": "https://pulumi.io",
+  "license": "Apache-2.0",
+  "attribution": "This Pulumi package is based on the [`aws` Terraform Provider](https://github.com/hashicorp/terraform-provider-aws).",
+  "repository": "https://github.com/phillipedwards/pulumi-aws",
+  "meta": {
+    "moduleFormat": "(.*)(?:/[^/]*)"
+  },
+  "language": {
+    "nodejs": {
+      "compatibility": "tfbridge20",
+      "disableUnionOutputTypes": true,
+      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/hashicorp/terraform-provider-aws)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-aws` repo](https://github.com/phillipedwards/pulumi-aws/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-aws` repo](https://github.com/hashicorp/terraform-provider-aws/issues)."
+    },
+    "python": {
+      "compatibility": "tfbridge20",
+      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/hashicorp/terraform-provider-aws)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-aws` repo](https://github.com/phillipedwards/pulumi-aws/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-aws` repo](https://github.com/hashicorp/terraform-provider-aws/issues)."
+    }
+  },
+  "config": {
+    "variables": {
+      "region": {
+        "type": "string",
+        "$ref": "#/types/aws:index/region:Region",
+        "description": "The region where AWS operations will take place. Examples are us-east-1, us-west-2, etc.\n",
+        "defaultInfo": {
+          "environment": [
+            "AWS_REGION",
+            "AWS_DEFAULT_REGION"
+          ]
+        }
+      },
+      "skipCredentialsValidation": {
+        "type": "boolean",
+        "description": "Skip the credentials validation via STS API. Used for AWS API implementations that do not have STS\navailable/implemented.\n",
+        "default": false
+      },
+      "skipGetEc2Platforms": {
+        "type": "boolean",
+        "description": "Skip getting the supported EC2 platforms. Used by users that don't have ec2:DescribeAccountAttributes permissions.\n",
+        "default": true
+      },
+      "skipMetadataApiCheck": {
+        "type": "boolean",
+        "description": "Skip the AWS Metadata API check. Used for AWS API implementations that do not have a metadata api endpoint.\n",
+        "default": true
+      },
+      "skipRegionValidation": {
+        "type": "boolean",
+        "description": "Skip static validation of region name. Used by users of alternative AWS-like APIs or users w/ access to regions that are\nnot public (yet).\n",
+        "default": true
+      }
+    }
+  },
+  "types": {
+    "aws:iam/RoleInlinePolicy:RoleInlinePolicy": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "policy": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        }
+      },
+      "type": "object"
+    },
+    "aws:iam/getGroupUser:getGroupUser": {
+      "properties": {
+        "arn": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "path": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "userId": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "userName": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        }
+      },
+      "type": "object",
+      "required": [
+        "arn",
+        "path",
+        "userId",
+        "userName"
+      ],
+      "language": {
+        "nodejs": {
+          "requiredInputs": []
+        }
+      }
+    },
+    "aws:index/getAvailabilityZoneFilter:getAvailabilityZoneFilter": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        }
+      },
+      "type": "object",
+      "required": [
+        "name",
+        "values"
+      ]
+    },
+    "aws:index/getAvailabilityZonesFilter:getAvailabilityZonesFilter": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        }
+      },
+      "type": "object",
+      "required": [
+        "name",
+        "values"
+      ]
+    },
+    "aws:index/getRegionsFilter:getRegionsFilter": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        }
+      },
+      "type": "object",
+      "required": [
+        "name",
+        "values"
+      ]
+    },
+    "aws:x/getPolicyDocumentStatement:getPolicyDocumentStatement": {
+      "properties": {
+        "actions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "conditions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/aws:x/getPolicyDocumentStatementCondition:getPolicyDocumentStatementCondition"
+          },
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "effect": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "notActions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "notPrincipals": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/aws:x/getPolicyDocumentStatementNotPrincipal:getPolicyDocumentStatementNotPrincipal"
+          },
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "notResources": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "principals": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/aws:x/getPolicyDocumentStatementPrincipal:getPolicyDocumentStatementPrincipal"
+          },
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "sid": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        }
+      },
+      "type": "object"
+    },
+    "aws:x/getPolicyDocumentStatementCondition:getPolicyDocumentStatementCondition": {
+      "properties": {
+        "test": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "variable": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        }
+      },
+      "type": "object",
+      "required": [
+        "test",
+        "values",
+        "variable"
+      ]
+    },
+    "aws:x/getPolicyDocumentStatementNotPrincipal:getPolicyDocumentStatementNotPrincipal": {
+      "properties": {
+        "identifiers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "type": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        }
+      },
+      "type": "object",
+      "required": [
+        "identifiers",
+        "type"
+      ]
+    },
+    "aws:x/getPolicyDocumentStatementPrincipal:getPolicyDocumentStatementPrincipal": {
+      "properties": {
+        "identifiers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "type": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        }
+      },
+      "type": "object",
+      "required": [
+        "identifiers",
+        "type"
+      ]
+    }
+  },
+  "provider": {
+    "description": "The provider type for the aws package. By default, resources use package-wide configuration\nsettings, however an explicit `Provider` instance may be created and passed during resource\nconstruction to achieve fine-grained programmatic control over provider settings. See the\n[documentation](https://www.pulumi.com/docs/reference/programming-model/#providers) for more information.\n",
+    "properties": {
+      "region": {
+        "type": "string",
+        "$ref": "#/types/aws:index/region:Region",
+        "description": "The region where AWS operations will take place. Examples are us-east-1, us-west-2, etc.\n"
+      },
+      "skipCredentialsValidation": {
+        "type": "boolean",
+        "description": "Skip the credentials validation via STS API. Used for AWS API implementations that do not have STS\navailable/implemented.\n"
+      },
+      "skipGetEc2Platforms": {
+        "type": "boolean",
+        "description": "Skip getting the supported EC2 platforms. Used by users that don't have ec2:DescribeAccountAttributes permissions.\n"
+      },
+      "skipMetadataApiCheck": {
+        "type": "boolean",
+        "description": "Skip the AWS Metadata API check. Used for AWS API implementations that do not have a metadata api endpoint.\n"
+      },
+      "skipRegionValidation": {
+        "type": "boolean",
+        "description": "Skip static validation of region name. Used by users of alternative AWS-like APIs or users w/ access to regions that are\nnot public (yet).\n"
+      }
+    },
+    "inputProperties": {
+      "region": {
+        "type": "string",
+        "$ref": "#/types/aws:index/region:Region",
+        "description": "The region where AWS operations will take place. Examples are us-east-1, us-west-2, etc.\n",
+        "defaultInfo": {
+          "environment": [
+            "AWS_REGION",
+            "AWS_DEFAULT_REGION"
+          ]
+        }
+      },
+      "skipCredentialsValidation": {
+        "type": "boolean",
+        "description": "Skip the credentials validation via STS API. Used for AWS API implementations that do not have STS\navailable/implemented.\n",
+        "default": false
+      },
+      "skipGetEc2Platforms": {
+        "type": "boolean",
+        "description": "Skip getting the supported EC2 platforms. Used by users that don't have ec2:DescribeAccountAttributes permissions.\n",
+        "default": true
+      },
+      "skipMetadataApiCheck": {
+        "type": "boolean",
+        "description": "Skip the AWS Metadata API check. Used for AWS API implementations that do not have a metadata api endpoint.\n",
+        "default": true
+      },
+      "skipRegionValidation": {
+        "type": "boolean",
+        "description": "Skip static validation of region name. Used by users of alternative AWS-like APIs or users w/ access to regions that are\nnot public (yet).\n",
+        "default": true
+      }
+    }
+  },
+  "resources": {
+    "aws:iam/accessKey:AccessKey": {
+      "properties": {
+        "createDate": {
+          "type": "string"
+        },
+        "encryptedSecret": {
+          "type": "string"
+        },
+        "encryptedSesSmtpPasswordV4": {
+          "type": "string"
+        },
+        "keyFingerprint": {
+          "type": "string"
+        },
+        "pgpKey": {
+          "type": "string"
+        },
+        "secret": {
+          "type": "string",
+          "secret": true
+        },
+        "sesSmtpPasswordV4": {
+          "type": "string",
+          "secret": true
+        },
+        "status": {
+          "type": "string"
+        },
+        "user": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "createDate",
+        "encryptedSecret",
+        "encryptedSesSmtpPasswordV4",
+        "keyFingerprint",
+        "secret",
+        "sesSmtpPasswordV4",
+        "user"
+      ],
+      "inputProperties": {
+        "pgpKey": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        },
+        "status": {
+          "type": "string"
+        },
+        "user": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        }
+      },
+      "requiredInputs": [
+        "user"
+      ],
+      "stateInputs": {
+        "description": "Input properties used for looking up and filtering AccessKey resources.\n",
+        "properties": {
+          "createDate": {
+            "type": "string"
+          },
+          "encryptedSecret": {
+            "type": "string"
+          },
+          "encryptedSesSmtpPasswordV4": {
+            "type": "string"
+          },
+          "keyFingerprint": {
+            "type": "string"
+          },
+          "pgpKey": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          },
+          "secret": {
+            "type": "string",
+            "secret": true
+          },
+          "sesSmtpPasswordV4": {
+            "type": "string",
+            "secret": true
+          },
+          "status": {
+            "type": "string"
+          },
+          "user": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          }
+        },
+        "type": "object"
+      }
+    },
+    "aws:iam/accountAlias:AccountAlias": {
+      "properties": {
+        "accountAlias": {
+          "type": "string",
+          "language": {
+            "csharp": {
+              "name": "Alias"
+            }
+          }
+        }
+      },
+      "required": [
+        "accountAlias"
+      ],
+      "inputProperties": {
+        "accountAlias": {
+          "type": "string",
+          "language": {
+            "csharp": {
+              "name": "Alias"
+            }
+          },
+          "willReplaceOnChanges": true
+        }
+      },
+      "requiredInputs": [
+        "accountAlias"
+      ],
+      "stateInputs": {
+        "description": "Input properties used for looking up and filtering AccountAlias resources.\n",
+        "properties": {
+          "accountAlias": {
+            "type": "string",
+            "language": {
+              "csharp": {
+                "name": "Alias"
+              }
+            },
+            "willReplaceOnChanges": true
+          }
+        },
+        "type": "object"
+      }
+    },
+    "aws:iam/accountPasswordPolicy:AccountPasswordPolicy": {
+      "properties": {
+        "allowUsersToChangePassword": {
+          "type": "boolean"
+        },
+        "expirePasswords": {
+          "type": "boolean"
+        },
+        "hardExpiry": {
+          "type": "boolean"
+        },
+        "maxPasswordAge": {
+          "type": "integer"
+        },
+        "minimumPasswordLength": {
+          "type": "integer"
+        },
+        "passwordReusePrevention": {
+          "type": "integer"
+        },
+        "requireLowercaseCharacters": {
+          "type": "boolean"
+        },
+        "requireNumbers": {
+          "type": "boolean"
+        },
+        "requireSymbols": {
+          "type": "boolean"
+        },
+        "requireUppercaseCharacters": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "expirePasswords",
+        "hardExpiry",
+        "maxPasswordAge",
+        "passwordReusePrevention",
+        "requireLowercaseCharacters",
+        "requireNumbers",
+        "requireSymbols",
+        "requireUppercaseCharacters"
+      ],
+      "inputProperties": {
+        "allowUsersToChangePassword": {
+          "type": "boolean"
+        },
+        "hardExpiry": {
+          "type": "boolean"
+        },
+        "maxPasswordAge": {
+          "type": "integer"
+        },
+        "minimumPasswordLength": {
+          "type": "integer"
+        },
+        "passwordReusePrevention": {
+          "type": "integer"
+        },
+        "requireLowercaseCharacters": {
+          "type": "boolean"
+        },
+        "requireNumbers": {
+          "type": "boolean"
+        },
+        "requireSymbols": {
+          "type": "boolean"
+        },
+        "requireUppercaseCharacters": {
+          "type": "boolean"
+        }
+      },
+      "stateInputs": {
+        "description": "Input properties used for looking up and filtering AccountPasswordPolicy resources.\n",
+        "properties": {
+          "allowUsersToChangePassword": {
+            "type": "boolean"
+          },
+          "expirePasswords": {
+            "type": "boolean"
+          },
+          "hardExpiry": {
+            "type": "boolean"
+          },
+          "maxPasswordAge": {
+            "type": "integer"
+          },
+          "minimumPasswordLength": {
+            "type": "integer"
+          },
+          "passwordReusePrevention": {
+            "type": "integer"
+          },
+          "requireLowercaseCharacters": {
+            "type": "boolean"
+          },
+          "requireNumbers": {
+            "type": "boolean"
+          },
+          "requireSymbols": {
+            "type": "boolean"
+          },
+          "requireUppercaseCharacters": {
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "aws:iam/group:Group": {
+      "properties": {
+        "arn": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "uniqueId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "arn",
+        "name",
+        "uniqueId"
+      ],
+      "inputProperties": {
+        "name": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        }
+      },
+      "stateInputs": {
+        "description": "Input properties used for looking up and filtering Group resources.\n",
+        "properties": {
+          "arn": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "uniqueId": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "aws:iam/groupMembership:GroupMembership": {
+      "properties": {
+        "group": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "group",
+        "name",
+        "users"
+      ],
+      "inputProperties": {
+        "group": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        },
+        "name": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "requiredInputs": [
+        "group",
+        "users"
+      ],
+      "stateInputs": {
+        "description": "Input properties used for looking up and filtering GroupMembership resources.\n",
+        "properties": {
+          "group": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          },
+          "name": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          },
+          "users": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "type": "object"
+      }
+    },
+    "aws:iam/groupPolicy:GroupPolicy": {
+      "properties": {
+        "group": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "namePrefix": {
+          "type": "string"
+        },
+        "policy": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "group",
+        "name",
+        "policy"
+      ],
+      "inputProperties": {
+        "group": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        },
+        "name": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        },
+        "namePrefix": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        },
+        "policy": {
+          "type": "string",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string",
+              "$ref": "#/types/aws:iam/documents:PolicyDocument"
+            }
+          ]
+        }
+      },
+      "requiredInputs": [
+        "group",
+        "policy"
+      ],
+      "stateInputs": {
+        "description": "Input properties used for looking up and filtering GroupPolicy resources.\n",
+        "properties": {
+          "group": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          },
+          "name": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          },
+          "namePrefix": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          },
+          "policy": {
+            "type": "string",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string",
+                "$ref": "#/types/aws:iam/documents:PolicyDocument"
+              }
+            ]
+          }
+        },
+        "type": "object"
+      }
+    },
+    "aws:iam/groupPolicyAttachment:GroupPolicyAttachment": {
+      "properties": {
+        "group": {
+          "type": "string"
+        },
+        "policyArn": {
+          "type": "string",
+          "$ref": "#/types/aws:index/aRN:ARN"
+        }
+      },
+      "required": [
+        "group",
+        "policyArn"
+      ],
+      "inputProperties": {
+        "group": {
+          "type": "string",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string",
+              "$ref": "#/types/aws:iam/group:Group"
+            }
+          ],
+          "willReplaceOnChanges": true
+        },
+        "policyArn": {
+          "type": "string",
+          "$ref": "#/types/aws:index/aRN:ARN",
+          "willReplaceOnChanges": true
+        }
+      },
+      "requiredInputs": [
+        "group",
+        "policyArn"
+      ],
+      "stateInputs": {
+        "description": "Input properties used for looking up and filtering GroupPolicyAttachment resources.\n",
+        "properties": {
+          "group": {
+            "type": "string",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string",
+                "$ref": "#/types/aws:iam/group:Group"
+              }
+            ],
+            "willReplaceOnChanges": true
+          },
+          "policyArn": {
+            "type": "string",
+            "$ref": "#/types/aws:index/aRN:ARN",
+            "willReplaceOnChanges": true
+          }
+        },
+        "type": "object"
+      }
+    },
+    "aws:iam/instanceProfile:InstanceProfile": {
+      "properties": {
+        "arn": {
+          "type": "string"
+        },
+        "createDate": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "namePrefix": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "role": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "tagsAll": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "uniqueId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "arn",
+        "createDate",
+        "name",
+        "tagsAll",
+        "uniqueId"
+      ],
+      "inputProperties": {
+        "name": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        },
+        "namePrefix": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        },
+        "path": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        },
+        "role": {
+          "type": "string",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string",
+              "$ref": "#/types/aws:iam/role:Role"
+            }
+          ]
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "stateInputs": {
+        "description": "Input properties used for looking up and filtering InstanceProfile resources.\n",
+        "properties": {
+          "arn": {
+            "type": "string"
+          },
+          "createDate": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          },
+          "namePrefix": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          },
+          "path": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          },
+          "role": {
+            "type": "string",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string",
+                "$ref": "#/types/aws:iam/role:Role"
+              }
+            ]
+          },
+          "tags": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "tagsAll": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "uniqueId": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "aws:iam/openIdConnectProvider:OpenIdConnectProvider": {
+      "properties": {
+        "arn": {
+          "type": "string"
+        },
+        "clientIdLists": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "tagsAll": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "thumbprintLists": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "arn",
+        "clientIdLists",
+        "tagsAll",
+        "thumbprintLists",
+        "url"
+      ],
+      "inputProperties": {
+        "clientIdLists": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "willReplaceOnChanges": true
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "thumbprintLists": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "url": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        }
+      },
+      "requiredInputs": [
+        "clientIdLists",
+        "thumbprintLists",
+        "url"
+      ],
+      "stateInputs": {
+        "description": "Input properties used for looking up and filtering OpenIdConnectProvider resources.\n",
+        "properties": {
+          "arn": {
+            "type": "string"
+          },
+          "clientIdLists": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "willReplaceOnChanges": true
+          },
+          "tags": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "tagsAll": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "thumbprintLists": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "url": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          }
+        },
+        "type": "object"
+      }
+    },
+    "aws:iam/policy:Policy": {
+      "properties": {
+        "arn": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "namePrefix": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "policy": {
+          "type": "string",
+          "language": {
+            "csharp": {
+              "name": "PolicyDocument"
+            }
+          }
+        },
+        "policyId": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "tagsAll": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "arn",
+        "name",
+        "policy",
+        "policyId",
+        "tagsAll"
+      ],
+      "inputProperties": {
+        "description": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        },
+        "name": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        },
+        "namePrefix": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        },
+        "path": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        },
+        "policy": {
+          "type": "string",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string",
+              "$ref": "#/types/aws:iam/documents:PolicyDocument"
+            }
+          ],
+          "language": {
+            "csharp": {
+              "name": "PolicyDocument"
+            }
+          }
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "requiredInputs": [
+        "policy"
+      ],
+      "stateInputs": {
+        "description": "Input properties used for looking up and filtering Policy resources.\n",
+        "properties": {
+          "arn": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          },
+          "name": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          },
+          "namePrefix": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          },
+          "path": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          },
+          "policy": {
+            "type": "string",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string",
+                "$ref": "#/types/aws:iam/documents:PolicyDocument"
+              }
+            ],
+            "language": {
+              "csharp": {
+                "name": "PolicyDocument"
+              }
+            }
+          },
+          "policyId": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "tagsAll": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        },
+        "type": "object"
+      }
+    },
+    "aws:iam/policyAttachment:PolicyAttachment": {
+      "properties": {
+        "groups": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "name": {
+          "type": "string"
+        },
+        "policyArn": {
+          "type": "string",
+          "$ref": "#/types/aws:index/aRN:ARN"
+        },
+        "roles": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "name",
+        "policyArn"
+      ],
+      "inputProperties": {
+        "groups": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string",
+                "$ref": "#/types/aws:iam/group:Group"
+              }
+            ]
+          }
+        },
+        "name": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        },
+        "policyArn": {
+          "type": "string",
+          "$ref": "#/types/aws:index/aRN:ARN",
+          "willReplaceOnChanges": true
+        },
+        "roles": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string",
+                "$ref": "#/types/aws:iam/role:Role"
+              }
+            ]
+          }
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string",
+                "$ref": "#/types/aws:iam/user:User"
+              }
+            ]
+          }
+        }
+      },
+      "requiredInputs": [
+        "policyArn"
+      ],
+      "stateInputs": {
+        "description": "Input properties used for looking up and filtering PolicyAttachment resources.\n",
+        "properties": {
+          "groups": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "$ref": "#/types/aws:iam/group:Group"
+                }
+              ]
+            }
+          },
+          "name": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          },
+          "policyArn": {
+            "type": "string",
+            "$ref": "#/types/aws:index/aRN:ARN",
+            "willReplaceOnChanges": true
+          },
+          "roles": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "$ref": "#/types/aws:iam/role:Role"
+                }
+              ]
+            }
+          },
+          "users": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string",
+                  "$ref": "#/types/aws:iam/user:User"
+                }
+              ]
+            }
+          }
+        },
+        "type": "object"
+      }
+    },
+    "aws:iam/role:Role": {
+      "properties": {
+        "arn": {
+          "type": "string"
+        },
+        "assumeRolePolicy": {
+          "type": "string"
+        },
+        "createDate": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "forceDetachPolicies": {
+          "type": "boolean"
+        },
+        "inlinePolicies": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/aws:iam/RoleInlinePolicy:RoleInlinePolicy"
+          }
+        },
+        "managedPolicyArns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "maxSessionDuration": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "namePrefix": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "permissionsBoundary": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "tagsAll": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "uniqueId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "arn",
+        "assumeRolePolicy",
+        "createDate",
+        "inlinePolicies",
+        "managedPolicyArns",
+        "name",
+        "namePrefix",
+        "tagsAll",
+        "uniqueId"
+      ],
+      "inputProperties": {
+        "assumeRolePolicy": {
+          "type": "string",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string",
+              "$ref": "#/types/aws:iam/documents:PolicyDocument"
+            }
+          ]
+        },
+        "description": {
+          "type": "string"
+        },
+        "forceDetachPolicies": {
+          "type": "boolean"
+        },
+        "inlinePolicies": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/aws:iam/RoleInlinePolicy:RoleInlinePolicy"
+          }
+        },
+        "managedPolicyArns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "maxSessionDuration": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        },
+        "namePrefix": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        },
+        "path": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        },
+        "permissionsBoundary": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "requiredInputs": [
+        "assumeRolePolicy"
+      ],
+      "stateInputs": {
+        "description": "Input properties used for looking up and filtering Role resources.\n",
+        "properties": {
+          "arn": {
+            "type": "string"
+          },
+          "assumeRolePolicy": {
+            "type": "string",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string",
+                "$ref": "#/types/aws:iam/documents:PolicyDocument"
+              }
+            ]
+          },
+          "createDate": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "forceDetachPolicies": {
+            "type": "boolean"
+          },
+          "inlinePolicies": {
+            "type": "array",
+            "items": {
+              "$ref": "#/types/aws:iam/RoleInlinePolicy:RoleInlinePolicy"
+            }
+          },
+          "managedPolicyArns": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "maxSessionDuration": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          },
+          "namePrefix": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          },
+          "path": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          },
+          "permissionsBoundary": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "tagsAll": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "uniqueId": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "aws:iam/rolePolicy:RolePolicy": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "namePrefix": {
+          "type": "string"
+        },
+        "policy": {
+          "type": "string"
+        },
+        "role": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "policy",
+        "role"
+      ],
+      "inputProperties": {
+        "name": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        },
+        "namePrefix": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        },
+        "policy": {
+          "type": "string",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string",
+              "$ref": "#/types/aws:iam/documents:PolicyDocument"
+            }
+          ]
+        },
+        "role": {
+          "type": "string",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string",
+              "$ref": "#/types/aws:iam/role:Role"
+            }
+          ],
+          "willReplaceOnChanges": true
+        }
+      },
+      "requiredInputs": [
+        "policy",
+        "role"
+      ],
+      "stateInputs": {
+        "description": "Input properties used for looking up and filtering RolePolicy resources.\n",
+        "properties": {
+          "name": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          },
+          "namePrefix": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          },
+          "policy": {
+            "type": "string",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string",
+                "$ref": "#/types/aws:iam/documents:PolicyDocument"
+              }
+            ]
+          },
+          "role": {
+            "type": "string",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string",
+                "$ref": "#/types/aws:iam/role:Role"
+              }
+            ],
+            "willReplaceOnChanges": true
+          }
+        },
+        "type": "object"
+      }
+    },
+    "aws:iam/rolePolicyAttachment:RolePolicyAttachment": {
+      "properties": {
+        "policyArn": {
+          "type": "string",
+          "$ref": "#/types/aws:index/aRN:ARN"
+        },
+        "role": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "policyArn",
+        "role"
+      ],
+      "inputProperties": {
+        "policyArn": {
+          "type": "string",
+          "$ref": "#/types/aws:index/aRN:ARN",
+          "willReplaceOnChanges": true
+        },
+        "role": {
+          "type": "string",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string",
+              "$ref": "#/types/aws:iam/role:Role"
+            }
+          ],
+          "willReplaceOnChanges": true
+        }
+      },
+      "requiredInputs": [
+        "policyArn",
+        "role"
+      ],
+      "stateInputs": {
+        "description": "Input properties used for looking up and filtering RolePolicyAttachment resources.\n",
+        "properties": {
+          "policyArn": {
+            "type": "string",
+            "$ref": "#/types/aws:index/aRN:ARN",
+            "willReplaceOnChanges": true
+          },
+          "role": {
+            "type": "string",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string",
+                "$ref": "#/types/aws:iam/role:Role"
+              }
+            ],
+            "willReplaceOnChanges": true
+          }
+        },
+        "type": "object"
+      }
+    },
+    "aws:iam/samlProvider:SamlProvider": {
+      "properties": {
+        "arn": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "samlMetadataDocument": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "tagsAll": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "validUntil": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "arn",
+        "name",
+        "samlMetadataDocument",
+        "tagsAll",
+        "validUntil"
+      ],
+      "inputProperties": {
+        "name": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        },
+        "samlMetadataDocument": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "requiredInputs": [
+        "samlMetadataDocument"
+      ],
+      "stateInputs": {
+        "description": "Input properties used for looking up and filtering SamlProvider resources.\n",
+        "properties": {
+          "arn": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          },
+          "samlMetadataDocument": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "tagsAll": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "validUntil": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "aws:iam/serverCertificate:ServerCertificate": {
+      "properties": {
+        "arn": {
+          "type": "string"
+        },
+        "certificateBody": {
+          "type": "string"
+        },
+        "certificateChain": {
+          "type": "string"
+        },
+        "expiration": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "namePrefix": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "privateKey": {
+          "type": "string",
+          "secret": true
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "tagsAll": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "uploadDate": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "arn",
+        "certificateBody",
+        "expiration",
+        "name",
+        "privateKey",
+        "tagsAll",
+        "uploadDate"
+      ],
+      "inputProperties": {
+        "certificateBody": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        },
+        "certificateChain": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        },
+        "name": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        },
+        "namePrefix": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        },
+        "path": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        },
+        "privateKey": {
+          "type": "string",
+          "secret": true,
+          "willReplaceOnChanges": true
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "requiredInputs": [
+        "certificateBody",
+        "privateKey"
+      ],
+      "stateInputs": {
+        "description": "Input properties used for looking up and filtering ServerCertificate resources.\n",
+        "properties": {
+          "arn": {
+            "type": "string"
+          },
+          "certificateBody": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          },
+          "certificateChain": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          },
+          "expiration": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          },
+          "namePrefix": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          },
+          "path": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          },
+          "privateKey": {
+            "type": "string",
+            "secret": true,
+            "willReplaceOnChanges": true
+          },
+          "tags": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "tagsAll": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "uploadDate": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "aws:iam/serviceLinkedRole:ServiceLinkedRole": {
+      "properties": {
+        "arn": {
+          "type": "string"
+        },
+        "awsServiceName": {
+          "type": "string"
+        },
+        "createDate": {
+          "type": "string"
+        },
+        "customSuffix": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "tagsAll": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "uniqueId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "arn",
+        "awsServiceName",
+        "createDate",
+        "name",
+        "path",
+        "tagsAll",
+        "uniqueId"
+      ],
+      "inputProperties": {
+        "awsServiceName": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        },
+        "customSuffix": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        },
+        "description": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "requiredInputs": [
+        "awsServiceName"
+      ],
+      "stateInputs": {
+        "description": "Input properties used for looking up and filtering ServiceLinkedRole resources.\n",
+        "properties": {
+          "arn": {
+            "type": "string"
+          },
+          "awsServiceName": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          },
+          "createDate": {
+            "type": "string"
+          },
+          "customSuffix": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "tagsAll": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "uniqueId": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "aws:iam/serviceSpecificCredential:ServiceSpecificCredential": {
+      "properties": {
+        "serviceName": {
+          "type": "string"
+        },
+        "servicePassword": {
+          "type": "string",
+          "secret": true
+        },
+        "serviceSpecificCredentialId": {
+          "type": "string"
+        },
+        "serviceUserName": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "userName": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "serviceName",
+        "servicePassword",
+        "serviceSpecificCredentialId",
+        "serviceUserName",
+        "userName"
+      ],
+      "inputProperties": {
+        "serviceName": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        },
+        "status": {
+          "type": "string"
+        },
+        "userName": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        }
+      },
+      "requiredInputs": [
+        "serviceName",
+        "userName"
+      ],
+      "stateInputs": {
+        "description": "Input properties used for looking up and filtering ServiceSpecificCredential resources.\n",
+        "properties": {
+          "serviceName": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          },
+          "servicePassword": {
+            "type": "string",
+            "secret": true
+          },
+          "serviceSpecificCredentialId": {
+            "type": "string"
+          },
+          "serviceUserName": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "userName": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          }
+        },
+        "type": "object"
+      }
+    },
+    "aws:iam/signingCertificate:SigningCertificate": {
+      "properties": {
+        "certificateBody": {
+          "type": "string"
+        },
+        "certificateId": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "userName": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "certificateBody",
+        "certificateId",
+        "userName"
+      ],
+      "inputProperties": {
+        "certificateBody": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        },
+        "status": {
+          "type": "string"
+        },
+        "userName": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        }
+      },
+      "requiredInputs": [
+        "certificateBody",
+        "userName"
+      ],
+      "stateInputs": {
+        "description": "Input properties used for looking up and filtering SigningCertificate resources.\n",
+        "properties": {
+          "certificateBody": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          },
+          "certificateId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "userName": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          }
+        },
+        "type": "object"
+      }
+    },
+    "aws:iam/sshKey:SshKey": {
+      "properties": {
+        "encoding": {
+          "type": "string"
+        },
+        "fingerprint": {
+          "type": "string"
+        },
+        "publicKey": {
+          "type": "string"
+        },
+        "sshPublicKeyId": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "encoding",
+        "fingerprint",
+        "publicKey",
+        "sshPublicKeyId",
+        "status",
+        "username"
+      ],
+      "inputProperties": {
+        "encoding": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        },
+        "publicKey": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        },
+        "status": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        }
+      },
+      "requiredInputs": [
+        "encoding",
+        "publicKey",
+        "username"
+      ],
+      "stateInputs": {
+        "description": "Input properties used for looking up and filtering SshKey resources.\n",
+        "properties": {
+          "encoding": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          },
+          "fingerprint": {
+            "type": "string"
+          },
+          "publicKey": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          },
+          "sshPublicKeyId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "username": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          }
+        },
+        "type": "object"
+      }
+    },
+    "aws:iam/user:User": {
+      "properties": {
+        "arn": {
+          "type": "string"
+        },
+        "forceDestroy": {
+          "type": "boolean",
+          "description": "Delete user even if it has non-Terraform-managed IAM access keys, login profile or MFA devices\n"
+        },
+        "name": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "permissionsBoundary": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "tagsAll": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "uniqueId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "arn",
+        "name",
+        "tagsAll",
+        "uniqueId"
+      ],
+      "inputProperties": {
+        "forceDestroy": {
+          "type": "boolean",
+          "description": "Delete user even if it has non-Terraform-managed IAM access keys, login profile or MFA devices\n"
+        },
+        "name": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "permissionsBoundary": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "stateInputs": {
+        "description": "Input properties used for looking up and filtering User resources.\n",
+        "properties": {
+          "arn": {
+            "type": "string"
+          },
+          "forceDestroy": {
+            "type": "boolean",
+            "description": "Delete user even if it has non-Terraform-managed IAM access keys, login profile or MFA devices\n"
+          },
+          "name": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "permissionsBoundary": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "tagsAll": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "uniqueId": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "aws:iam/userGroupMembership:UserGroupMembership": {
+      "properties": {
+        "groups": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "user": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "groups",
+        "user"
+      ],
+      "inputProperties": {
+        "groups": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "user": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        }
+      },
+      "requiredInputs": [
+        "groups",
+        "user"
+      ],
+      "stateInputs": {
+        "description": "Input properties used for looking up and filtering UserGroupMembership resources.\n",
+        "properties": {
+          "groups": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "user": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          }
+        },
+        "type": "object"
+      }
+    },
+    "aws:iam/userLoginProfile:UserLoginProfile": {
+      "properties": {
+        "encryptedPassword": {
+          "type": "string"
+        },
+        "keyFingerprint": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "passwordLength": {
+          "type": "integer"
+        },
+        "passwordResetRequired": {
+          "type": "boolean"
+        },
+        "pgpKey": {
+          "type": "string"
+        },
+        "user": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "encryptedPassword",
+        "keyFingerprint",
+        "password",
+        "passwordResetRequired",
+        "user"
+      ],
+      "inputProperties": {
+        "passwordLength": {
+          "type": "integer",
+          "willReplaceOnChanges": true
+        },
+        "passwordResetRequired": {
+          "type": "boolean",
+          "willReplaceOnChanges": true
+        },
+        "pgpKey": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        },
+        "user": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        }
+      },
+      "requiredInputs": [
+        "user"
+      ],
+      "stateInputs": {
+        "description": "Input properties used for looking up and filtering UserLoginProfile resources.\n",
+        "properties": {
+          "encryptedPassword": {
+            "type": "string"
+          },
+          "keyFingerprint": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          },
+          "passwordLength": {
+            "type": "integer",
+            "willReplaceOnChanges": true
+          },
+          "passwordResetRequired": {
+            "type": "boolean",
+            "willReplaceOnChanges": true
+          },
+          "pgpKey": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          },
+          "user": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          }
+        },
+        "type": "object"
+      }
+    },
+    "aws:iam/userPolicy:UserPolicy": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "namePrefix": {
+          "type": "string"
+        },
+        "policy": {
+          "type": "string"
+        },
+        "user": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "policy",
+        "user"
+      ],
+      "inputProperties": {
+        "name": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        },
+        "namePrefix": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        },
+        "policy": {
+          "type": "string",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string",
+              "$ref": "#/types/aws:iam/documents:PolicyDocument"
+            }
+          ]
+        },
+        "user": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        }
+      },
+      "requiredInputs": [
+        "policy",
+        "user"
+      ],
+      "stateInputs": {
+        "description": "Input properties used for looking up and filtering UserPolicy resources.\n",
+        "properties": {
+          "name": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          },
+          "namePrefix": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          },
+          "policy": {
+            "type": "string",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string",
+                "$ref": "#/types/aws:iam/documents:PolicyDocument"
+              }
+            ]
+          },
+          "user": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          }
+        },
+        "type": "object"
+      }
+    },
+    "aws:iam/userPolicyAttachment:UserPolicyAttachment": {
+      "properties": {
+        "policyArn": {
+          "type": "string",
+          "$ref": "#/types/aws:index/aRN:ARN"
+        },
+        "user": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "policyArn",
+        "user"
+      ],
+      "inputProperties": {
+        "policyArn": {
+          "type": "string",
+          "$ref": "#/types/aws:index/aRN:ARN",
+          "willReplaceOnChanges": true
+        },
+        "user": {
+          "type": "string",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string",
+              "$ref": "#/types/aws:iam/user:User"
+            }
+          ],
+          "willReplaceOnChanges": true
+        }
+      },
+      "requiredInputs": [
+        "policyArn",
+        "user"
+      ],
+      "stateInputs": {
+        "description": "Input properties used for looking up and filtering UserPolicyAttachment resources.\n",
+        "properties": {
+          "policyArn": {
+            "type": "string",
+            "$ref": "#/types/aws:index/aRN:ARN",
+            "willReplaceOnChanges": true
+          },
+          "user": {
+            "type": "string",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string",
+                "$ref": "#/types/aws:iam/user:User"
+              }
+            ],
+            "willReplaceOnChanges": true
+          }
+        },
+        "type": "object"
+      }
+    },
+    "aws:iam/virtualMfaDevice:VirtualMfaDevice": {
+      "properties": {
+        "arn": {
+          "type": "string"
+        },
+        "base32StringSeed": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "qrCodePng": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "tagsAll": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "virtualMfaDeviceName": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "arn",
+        "base32StringSeed",
+        "qrCodePng",
+        "tagsAll",
+        "virtualMfaDeviceName"
+      ],
+      "inputProperties": {
+        "path": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "virtualMfaDeviceName": {
+          "type": "string",
+          "willReplaceOnChanges": true
+        }
+      },
+      "requiredInputs": [
+        "virtualMfaDeviceName"
+      ],
+      "stateInputs": {
+        "description": "Input properties used for looking up and filtering VirtualMfaDevice resources.\n",
+        "properties": {
+          "arn": {
+            "type": "string"
+          },
+          "base32StringSeed": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          },
+          "qrCodePng": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "tagsAll": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "virtualMfaDeviceName": {
+            "type": "string",
+            "willReplaceOnChanges": true
+          }
+        },
+        "type": "object"
+      }
+    }
+  },
+  "functions": {
+    "aws:iam/getAccountAlias:getAccountAlias": {
+      "outputs": {
+        "description": "A collection of values returned by getAccountAlias.\n",
+        "properties": {
+          "accountAlias": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "description": "The provider-assigned unique ID for this managed resource.\n"
+          }
+        },
+        "type": "object",
+        "required": [
+          "accountAlias",
+          "id"
+        ]
+      }
+    },
+    "aws:iam/getGroup:getGroup": {
+      "inputs": {
+        "description": "A collection of arguments for invoking getGroup.\n",
+        "properties": {
+          "groupName": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": [
+          "groupName"
+        ]
+      },
+      "outputs": {
+        "description": "A collection of values returned by getGroup.\n",
+        "properties": {
+          "arn": {
+            "type": "string"
+          },
+          "groupId": {
+            "type": "string"
+          },
+          "groupName": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "description": "The provider-assigned unique ID for this managed resource.\n"
+          },
+          "path": {
+            "type": "string"
+          },
+          "users": {
+            "type": "array",
+            "items": {
+              "$ref": "#/types/aws:iam/getGroupUser:getGroupUser"
+            }
+          }
+        },
+        "type": "object",
+        "required": [
+          "arn",
+          "groupId",
+          "groupName",
+          "path",
+          "users",
+          "id"
+        ]
+      }
+    },
+    "aws:iam/getInstanceProfile:getInstanceProfile": {
+      "inputs": {
+        "description": "A collection of arguments for invoking getInstanceProfile.\n",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ]
+      },
+      "outputs": {
+        "description": "A collection of values returned by getInstanceProfile.\n",
+        "properties": {
+          "arn": {
+            "type": "string"
+          },
+          "createDate": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "description": "The provider-assigned unique ID for this managed resource.\n"
+          },
+          "name": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "roleArn": {
+            "type": "string"
+          },
+          "roleId": {
+            "type": "string"
+          },
+          "roleName": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": [
+          "arn",
+          "createDate",
+          "name",
+          "path",
+          "roleArn",
+          "roleId",
+          "roleName",
+          "id"
+        ]
+      }
+    },
+    "aws:iam/getInstanceProfiles:getInstanceProfiles": {
+      "inputs": {
+        "description": "A collection of arguments for invoking getInstanceProfiles.\n",
+        "properties": {
+          "roleName": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": [
+          "roleName"
+        ]
+      },
+      "outputs": {
+        "description": "A collection of values returned by getInstanceProfiles.\n",
+        "properties": {
+          "arns": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "id": {
+            "type": "string",
+            "description": "The provider-assigned unique ID for this managed resource.\n"
+          },
+          "names": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "paths": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "roleName": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": [
+          "arns",
+          "names",
+          "paths",
+          "roleName",
+          "id"
+        ]
+      }
+    },
+    "aws:iam/getOpenidConnectProvider:getOpenidConnectProvider": {
+      "inputs": {
+        "description": "A collection of arguments for invoking getOpenidConnectProvider.\n",
+        "properties": {
+          "arn": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "outputs": {
+        "description": "A collection of values returned by getOpenidConnectProvider.\n",
+        "properties": {
+          "arn": {
+            "type": "string"
+          },
+          "clientIdLists": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "id": {
+            "type": "string",
+            "description": "The provider-assigned unique ID for this managed resource.\n"
+          },
+          "tags": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "thumbprintLists": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": [
+          "arn",
+          "clientIdLists",
+          "tags",
+          "thumbprintLists",
+          "url",
+          "id"
+        ]
+      }
+    },
+    "aws:iam/getPolicy:getPolicy": {
+      "inputs": {
+        "description": "A collection of arguments for invoking getPolicy.\n",
+        "properties": {
+          "arn": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "pathPrefix": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        },
+        "type": "object"
+      },
+      "outputs": {
+        "description": "A collection of values returned by getPolicy.\n",
+        "properties": {
+          "arn": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "description": "The provider-assigned unique ID for this managed resource.\n"
+          },
+          "name": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "pathPrefix": {
+            "type": "string"
+          },
+          "policy": {
+            "type": "string"
+          },
+          "policyId": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        },
+        "type": "object",
+        "required": [
+          "arn",
+          "description",
+          "name",
+          "path",
+          "policy",
+          "policyId",
+          "tags",
+          "id"
+        ]
+      }
+    },
+    "aws:iam/getRole:getRole": {
+      "inputs": {
+        "description": "A collection of arguments for invoking getRole.\n",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ]
+      },
+      "outputs": {
+        "description": "A collection of values returned by getRole.\n",
+        "properties": {
+          "arn": {
+            "type": "string"
+          },
+          "assumeRolePolicy": {
+            "type": "string"
+          },
+          "createDate": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "description": "The provider-assigned unique ID for this managed resource.\n"
+          },
+          "maxSessionDuration": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "permissionsBoundary": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "uniqueId": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": [
+          "arn",
+          "assumeRolePolicy",
+          "createDate",
+          "description",
+          "maxSessionDuration",
+          "name",
+          "path",
+          "permissionsBoundary",
+          "tags",
+          "uniqueId",
+          "id"
+        ]
+      }
+    },
+    "aws:iam/getRoles:getRoles": {
+      "inputs": {
+        "description": "A collection of arguments for invoking getRoles.\n",
+        "properties": {
+          "nameRegex": {
+            "type": "string"
+          },
+          "pathPrefix": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "outputs": {
+        "description": "A collection of values returned by getRoles.\n",
+        "properties": {
+          "arns": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "id": {
+            "type": "string",
+            "description": "The provider-assigned unique ID for this managed resource.\n"
+          },
+          "nameRegex": {
+            "type": "string"
+          },
+          "names": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "pathPrefix": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": [
+          "arns",
+          "names",
+          "id"
+        ]
+      }
+    },
+    "aws:iam/getSamlProvider:getSamlProvider": {
+      "inputs": {
+        "description": "A collection of arguments for invoking getSamlProvider.\n",
+        "properties": {
+          "arn": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        },
+        "type": "object",
+        "required": [
+          "arn"
+        ]
+      },
+      "outputs": {
+        "description": "A collection of values returned by getSamlProvider.\n",
+        "properties": {
+          "arn": {
+            "type": "string"
+          },
+          "createDate": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "description": "The provider-assigned unique ID for this managed resource.\n"
+          },
+          "name": {
+            "type": "string"
+          },
+          "samlMetadataDocument": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "validUntil": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": [
+          "arn",
+          "createDate",
+          "name",
+          "samlMetadataDocument",
+          "tags",
+          "validUntil",
+          "id"
+        ]
+      }
+    },
+    "aws:iam/getServerCertificate:getServerCertificate": {
+      "inputs": {
+        "description": "A collection of arguments for invoking getServerCertificate.\n",
+        "properties": {
+          "latest": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "namePrefix": {
+            "type": "string"
+          },
+          "pathPrefix": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "outputs": {
+        "description": "A collection of values returned by getServerCertificate.\n",
+        "properties": {
+          "arn": {
+            "type": "string"
+          },
+          "certificateBody": {
+            "type": "string"
+          },
+          "certificateChain": {
+            "type": "string"
+          },
+          "expirationDate": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "description": "The provider-assigned unique ID for this managed resource.\n"
+          },
+          "latest": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "namePrefix": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "pathPrefix": {
+            "type": "string"
+          },
+          "uploadDate": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": [
+          "arn",
+          "certificateBody",
+          "certificateChain",
+          "expirationDate",
+          "name",
+          "path",
+          "uploadDate",
+          "id"
+        ]
+      }
+    },
+    "aws:iam/getSessionContext:getSessionContext": {
+      "inputs": {
+        "description": "A collection of arguments for invoking getSessionContext.\n",
+        "properties": {
+          "arn": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": [
+          "arn"
+        ]
+      },
+      "outputs": {
+        "description": "A collection of values returned by getSessionContext.\n",
+        "properties": {
+          "arn": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "description": "The provider-assigned unique ID for this managed resource.\n"
+          },
+          "issuerArn": {
+            "type": "string"
+          },
+          "issuerId": {
+            "type": "string"
+          },
+          "issuerName": {
+            "type": "string"
+          },
+          "sessionName": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": [
+          "arn",
+          "issuerArn",
+          "issuerId",
+          "issuerName",
+          "sessionName",
+          "id"
+        ]
+      }
+    },
+    "aws:iam/getUser:getUser": {
+      "inputs": {
+        "description": "A collection of arguments for invoking getUser.\n",
+        "properties": {
+          "tags": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "userName": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": [
+          "userName"
+        ]
+      },
+      "outputs": {
+        "description": "A collection of values returned by getUser.\n",
+        "properties": {
+          "arn": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "description": "The provider-assigned unique ID for this managed resource.\n"
+          },
+          "path": {
+            "type": "string"
+          },
+          "permissionsBoundary": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "userId": {
+            "type": "string"
+          },
+          "userName": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": [
+          "arn",
+          "path",
+          "permissionsBoundary",
+          "tags",
+          "userId",
+          "userName",
+          "id"
+        ]
+      }
+    },
+    "aws:iam/getUserSshKey:getUserSshKey": {
+      "inputs": {
+        "description": "A collection of arguments for invoking getUserSshKey.\n",
+        "properties": {
+          "encoding": {
+            "type": "string"
+          },
+          "sshPublicKeyId": {
+            "type": "string"
+          },
+          "username": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": [
+          "encoding",
+          "sshPublicKeyId",
+          "username"
+        ]
+      },
+      "outputs": {
+        "description": "A collection of values returned by getUserSshKey.\n",
+        "properties": {
+          "encoding": {
+            "type": "string"
+          },
+          "fingerprint": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "description": "The provider-assigned unique ID for this managed resource.\n"
+          },
+          "publicKey": {
+            "type": "string"
+          },
+          "sshPublicKeyId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "username": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": [
+          "encoding",
+          "fingerprint",
+          "publicKey",
+          "sshPublicKeyId",
+          "status",
+          "username",
+          "id"
+        ]
+      }
+    },
+    "aws:iam/getUsers:getUsers": {
+      "inputs": {
+        "description": "A collection of arguments for invoking getUsers.\n",
+        "properties": {
+          "nameRegex": {
+            "type": "string"
+          },
+          "pathPrefix": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "outputs": {
+        "description": "A collection of values returned by getUsers.\n",
+        "properties": {
+          "arns": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "id": {
+            "type": "string",
+            "description": "The provider-assigned unique ID for this managed resource.\n"
+          },
+          "nameRegex": {
+            "type": "string"
+          },
+          "names": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "pathPrefix": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": [
+          "arns",
+          "names",
+          "id"
+        ]
+      }
+    },
+    "aws:index/getArn:getArn": {
+      "inputs": {
+        "description": "A collection of arguments for invoking getArn.\n",
+        "properties": {
+          "arn": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": [
+          "arn"
+        ]
+      },
+      "outputs": {
+        "description": "A collection of values returned by getArn.\n",
+        "properties": {
+          "account": {
+            "type": "string"
+          },
+          "arn": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "description": "The provider-assigned unique ID for this managed resource.\n"
+          },
+          "partition": {
+            "type": "string"
+          },
+          "region": {
+            "type": "string"
+          },
+          "resource": {
+            "type": "string"
+          },
+          "service": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": [
+          "account",
+          "arn",
+          "partition",
+          "region",
+          "resource",
+          "service",
+          "id"
+        ]
+      }
+    },
+    "aws:index/getAvailabilityZone:getAvailabilityZone": {
+      "inputs": {
+        "description": "A collection of arguments for invoking getAvailabilityZone.\n",
+        "properties": {
+          "allAvailabilityZones": {
+            "type": "boolean"
+          },
+          "filters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/types/aws:index/getAvailabilityZoneFilter:getAvailabilityZoneFilter"
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          },
+          "zoneId": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "outputs": {
+        "description": "A collection of values returned by getAvailabilityZone.\n",
+        "properties": {
+          "allAvailabilityZones": {
+            "type": "boolean"
+          },
+          "filters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/types/aws:index/getAvailabilityZoneFilter:getAvailabilityZoneFilter"
+            }
+          },
+          "groupName": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "description": "The provider-assigned unique ID for this managed resource.\n"
+          },
+          "name": {
+            "type": "string"
+          },
+          "nameSuffix": {
+            "type": "string"
+          },
+          "networkBorderGroup": {
+            "type": "string"
+          },
+          "optInStatus": {
+            "type": "string"
+          },
+          "parentZoneId": {
+            "type": "string"
+          },
+          "parentZoneName": {
+            "type": "string"
+          },
+          "region": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          },
+          "zoneId": {
+            "type": "string"
+          },
+          "zoneType": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": [
+          "groupName",
+          "name",
+          "nameSuffix",
+          "networkBorderGroup",
+          "optInStatus",
+          "parentZoneId",
+          "parentZoneName",
+          "region",
+          "state",
+          "zoneId",
+          "zoneType",
+          "id"
+        ]
+      }
+    },
+    "aws:index/getAvailabilityZones:getAvailabilityZones": {
+      "inputs": {
+        "description": "A collection of arguments for invoking getAvailabilityZones.\n",
+        "properties": {
+          "allAvailabilityZones": {
+            "type": "boolean"
+          },
+          "excludeNames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "excludeZoneIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "filters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/types/aws:index/getAvailabilityZonesFilter:getAvailabilityZonesFilter"
+            }
+          },
+          "state": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "outputs": {
+        "description": "A collection of values returned by getAvailabilityZones.\n",
+        "properties": {
+          "allAvailabilityZones": {
+            "type": "boolean"
+          },
+          "excludeNames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "excludeZoneIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "filters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/types/aws:index/getAvailabilityZonesFilter:getAvailabilityZonesFilter"
+            }
+          },
+          "groupNames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "id": {
+            "type": "string",
+            "description": "The provider-assigned unique ID for this managed resource.\n"
+          },
+          "names": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "state": {
+            "type": "string"
+          },
+          "zoneIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "type": "object",
+        "required": [
+          "groupNames",
+          "names",
+          "zoneIds",
+          "id"
+        ]
+      }
+    },
+    "aws:index/getBillingServiceAccount:getBillingServiceAccount": {
+      "outputs": {
+        "description": "A collection of values returned by getBillingServiceAccount.\n",
+        "properties": {
+          "arn": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "description": "The provider-assigned unique ID for this managed resource.\n"
+          }
+        },
+        "type": "object",
+        "required": [
+          "arn",
+          "id"
+        ]
+      }
+    },
+    "aws:index/getCallerIdentity:getCallerIdentity": {
+      "outputs": {
+        "description": "A collection of values returned by getCallerIdentity.\n",
+        "properties": {
+          "accountId": {
+            "type": "string"
+          },
+          "arn": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "description": "The provider-assigned unique ID for this managed resource.\n"
+          },
+          "userId": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": [
+          "accountId",
+          "arn",
+          "userId",
+          "id"
+        ]
+      }
+    },
+    "aws:index/getDefaultTags:getDefaultTags": {
+      "inputs": {
+        "description": "A collection of arguments for invoking getDefaultTags.\n",
+        "properties": {
+          "tags": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        },
+        "type": "object"
+      },
+      "outputs": {
+        "description": "A collection of values returned by getDefaultTags.\n",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The provider-assigned unique ID for this managed resource.\n"
+          },
+          "tags": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        },
+        "type": "object",
+        "required": [
+          "tags",
+          "id"
+        ]
+      }
+    },
+    "aws:index/getIpRanges:getIpRanges": {
+      "inputs": {
+        "description": "A collection of arguments for invoking getIpRanges.\n",
+        "properties": {
+          "regions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "services": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": [
+          "services"
+        ]
+      },
+      "outputs": {
+        "description": "A collection of values returned by getIpRanges.\n",
+        "properties": {
+          "cidrBlocks": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "createDate": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "description": "The provider-assigned unique ID for this managed resource.\n"
+          },
+          "ipv6CidrBlocks": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "regions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "services": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "syncToken": {
+            "type": "integer"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": [
+          "cidrBlocks",
+          "createDate",
+          "ipv6CidrBlocks",
+          "services",
+          "syncToken",
+          "id"
+        ]
+      }
+    },
+    "aws:index/getPartition:getPartition": {
+      "outputs": {
+        "description": "A collection of values returned by getPartition.\n",
+        "properties": {
+          "dnsSuffix": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "description": "The provider-assigned unique ID for this managed resource.\n"
+          },
+          "partition": {
+            "type": "string"
+          },
+          "reverseDnsPrefix": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": [
+          "dnsSuffix",
+          "partition",
+          "reverseDnsPrefix",
+          "id"
+        ]
+      }
+    },
+    "aws:index/getRegion:getRegion": {
+      "inputs": {
+        "description": "A collection of arguments for invoking getRegion.\n",
+        "properties": {
+          "endpoint": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "outputs": {
+        "description": "A collection of values returned by getRegion.\n",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "endpoint": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "description": "The provider-assigned unique ID for this managed resource.\n"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": [
+          "description",
+          "endpoint",
+          "name",
+          "id"
+        ]
+      }
+    },
+    "aws:index/getRegions:getRegions": {
+      "inputs": {
+        "description": "A collection of arguments for invoking getRegions.\n",
+        "properties": {
+          "allRegions": {
+            "type": "boolean"
+          },
+          "filters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/types/aws:index/getRegionsFilter:getRegionsFilter"
+            }
+          }
+        },
+        "type": "object"
+      },
+      "outputs": {
+        "description": "A collection of values returned by getRegions.\n",
+        "properties": {
+          "allRegions": {
+            "type": "boolean"
+          },
+          "filters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/types/aws:index/getRegionsFilter:getRegionsFilter"
+            }
+          },
+          "id": {
+            "type": "string",
+            "description": "The provider-assigned unique ID for this managed resource.\n"
+          },
+          "names": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "type": "object",
+        "required": [
+          "names",
+          "id"
+        ]
+      }
+    },
+    "aws:index/getService:getService": {
+      "inputs": {
+        "description": "A collection of arguments for invoking getService.\n",
+        "properties": {
+          "dnsName": {
+            "type": "string"
+          },
+          "region": {
+            "type": "string"
+          },
+          "reverseDnsName": {
+            "type": "string"
+          },
+          "reverseDnsPrefix": {
+            "type": "string"
+          },
+          "serviceId": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "outputs": {
+        "description": "A collection of values returned by getService.\n",
+        "properties": {
+          "dnsName": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "description": "The provider-assigned unique ID for this managed resource.\n"
+          },
+          "partition": {
+            "type": "string"
+          },
+          "region": {
+            "type": "string"
+          },
+          "reverseDnsName": {
+            "type": "string"
+          },
+          "reverseDnsPrefix": {
+            "type": "string"
+          },
+          "serviceId": {
+            "type": "string"
+          },
+          "supported": {
+            "type": "boolean"
+          }
+        },
+        "type": "object",
+        "required": [
+          "dnsName",
+          "partition",
+          "region",
+          "reverseDnsName",
+          "reverseDnsPrefix",
+          "serviceId",
+          "supported",
+          "id"
+        ]
+      }
+    },
+    "aws:x/iam/getPolicyDocument:getPolicyDocument": {
+      "inputs": {
+        "description": "A collection of arguments for invoking getPolicyDocument.\n",
+        "properties": {
+          "overrideJson": {
+            "type": "string",
+            "deprecationMessage": "Use the attribute \"override_policy_documents\" instead."
+          },
+          "overridePolicyDocuments": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "policyId": {
+            "type": "string"
+          },
+          "sourceJson": {
+            "type": "string",
+            "deprecationMessage": "Use the attribute \"source_policy_documents\" instead."
+          },
+          "sourcePolicyDocuments": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "statements": {
+            "type": "array",
+            "items": {
+              "$ref": "#/types/aws:x/getPolicyDocumentStatement:getPolicyDocumentStatement"
+            }
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "outputs": {
+        "description": "A collection of values returned by getPolicyDocument.\n",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The provider-assigned unique ID for this managed resource.\n"
+          },
+          "json": {
+            "type": "string"
+          },
+          "overrideJson": {
+            "type": "string",
+            "deprecationMessage": "Use the attribute \"override_policy_documents\" instead."
+          },
+          "overridePolicyDocuments": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "policyId": {
+            "type": "string"
+          },
+          "sourceJson": {
+            "type": "string",
+            "deprecationMessage": "Use the attribute \"source_policy_documents\" instead."
+          },
+          "sourcePolicyDocuments": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "statements": {
+            "type": "array",
+            "items": {
+              "$ref": "#/types/aws:x/getPolicyDocumentStatement:getPolicyDocumentStatement"
+            }
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": [
+          "json",
+          "id"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Introduces a test case reproducing 611, in the [golden test style](https://ro-che.info/articles/2017-12-04-golden-tests) reminiscent of what Pulumi uses to test SDK generation ([example](https://github.com/pulumi/pulumi/blob/a2844f7b4436d67f980f6f5c514b99fd27e38646/pkg/codegen/testing/test/sdk_driver.go#L406)).

How this works:

- expected PackageSpec is stored in indented JSON
- the test asserts that there are no changes vs the indented JSON from the expected file
- you can run `PULUMI_ACCEPT=1 go test` to rewrite the expected file to actual value, check it with `git diff`, and commit if the new output makes sense to serve as the subsequent expected value

The test provider is extracted from a subset of AWS from #611 

Extracting the test provider subset is what caused most trouble. The values from "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema" Provider type that serve as a logical input to our schema generation process are not serializable as they contain funcs. Therefore it is difficult to write code that automatically computes subset. I got by with a semi-manual procedure that ended relying on "github.com/hexops/valast" package and some custom code to get back a Go literal that can be coaxed into an example provider value.
