### PR TITLE
Include stacktrace in error message

### DIFF
--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -1191,7 +1191,7 @@ type ConversionError struct {
 // construct a new ConversionError. The argument is expected to be
 // the value that was recovered from the panic.
 func newConversionError(panicArg interface{}, trace string) *ConversionError {
-	var err = fmt.Errorf("panic converting HCL: %s.", panicArg)
+	var err = fmt.Errorf("panic converting HCL: %s", panicArg)
 	return &ConversionError{
 		panicArg:   panicArg,
 		trace:      trace,

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -26,6 +26,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime/debug"
 	"sort"
 	"strings"
 	"sync"
@@ -1174,6 +1175,43 @@ func (g *Generator) convertExamples(docs, name string, stripSubsectionsWithError
 	return output.String()
 }
 
+// A ConversionError occurs when convert.Convert yields a panic.
+// This can be removed when https://github.com/pulumi/pulumi-terraform-bridge/issues/477
+// is resolved. ConversionError exposes the stacktrace of the panic so callers
+// can choose to pass the trace along to the user or swallow it.
+type ConversionError struct {
+	// panicArg is the argument that was passed to panic() during conversion.
+	panicArg interface{}
+	// trace is the captured stacktrace.
+	trace string
+	// wrappedErr is the error message provided by this struct.
+	wrappedErr error
+}
+
+// construct a new ConversionError. The argument is expected to be
+// the value that was recovered from the panic.
+func newConversionError(panicArg interface{}, trace string) *ConversionError {
+	var err = fmt.Errorf("panic converting HCL: %s.", panicArg)
+	return &ConversionError{
+		panicArg:   panicArg,
+		trace:      trace,
+		wrappedErr: err,
+	}
+}
+
+// StackTrace returns the stacktrace of the error.
+func (err *ConversionError) StackTrace() string {
+	return err.trace
+}
+
+// Return the err-representation of this struct.
+func (err *ConversionError) Error() string {
+	return err.wrappedErr.Error()
+}
+
+// Statically enforce that ConversionError implements the Error interface.
+var _ error = &ConversionError{}
+
 // convert wraps convert.Convert so that it returns an error in the event of a panic in convert.Convert
 //
 // Note: If this issue is fixed, the call to convert.Convert can be unwrapped and this function can be deleted:
@@ -1185,8 +1223,8 @@ func (g *Generator) convert(input afero.Fs, languageName string) (files map[stri
 		if v != nil {
 			files = map[string][]byte{}
 			diags = convert.Diagnostics{}
-			err = fmt.Errorf("panic converting HCL: %v", v)
-
+			var trace = string(debug.Stack())
+			err = newConversionError(v, trace)
 			g.coverageTracker.languageConversionPanic(languageName, fmt.Sprintf("%v", v))
 		}
 	}()
@@ -1226,6 +1264,9 @@ func (g *Generator) convertHCLToString(hcl, path, languageName string) (string, 
 	if err != nil {
 		// Because this condition is presumably the result of a panic that we wrap as an error, we do not need to add
 		// anything to g.coverageTracker - that's covered in the panic recovery above.
+		if convErr, ok := err.(*ConversionError); ok {
+			g.debug("Printing stack trace for panic: %v", convErr.StackTrace)
+		}
 		return "", fmt.Errorf("failed to convert HCL for %s to %v: %w", path, languageName, err)
 	}
 	if diags.All.HasErrors() {


### PR DESCRIPTION
In TFGen, HCL conversion is allowed to panic. Panics are recovered and converted into errors, which are then displayed to the user.

Currently, these panics don't provide a way to inspect the stacktrace, making it very hard to debug P1s. This PR captures the stacktrace, and logs traces when `debug` is enabled.

# Related

* https://github.com/pulumi/pulumi-terraform-bridge/issues/477
