### PR TITLE
Support TypeObject

### DIFF
--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -334,6 +334,8 @@ func makePropertyType(objectName string, sch shim.Schema, info *tfbridge.SchemaI
 		t.kind = kindMap
 	case shim.TypeSet:
 		t.kind = kindSet
+	case shim.TypeObject:
+		t.kind = kindObject
 	}
 
 	// We should carry across any of the deprecation messages, to Pulumi, as per Terraform schema
@@ -345,9 +347,12 @@ func makePropertyType(objectName string, sch shim.Schema, info *tfbridge.SchemaI
 	case shim.Schema:
 		t.element = makePropertyType(objectName, elem, elemInfo, out, entityDocs)
 	case shim.Resource:
-		t.element = makeObjectPropertyType(objectName, elem, elemInfo, out, entityDocs)
+		if t.kind == kindObject {
+			t.properties = makeObjectProperties(objectName, elem.Schema(), elemInfo, out, entityDocs)
+		} else {
+			t.element = makeObjectPropertyType(objectName, elem.Schema(), elemInfo, out, entityDocs)
+		}
 	}
-
 	switch t.kind {
 	case kindList, kindSet:
 		if tfbridge.IsMaxItemsOne(sch, info) {
@@ -364,7 +369,7 @@ func makePropertyType(objectName string, sch shim.Schema, info *tfbridge.SchemaI
 	return t
 }
 
-func makeObjectPropertyType(objectName string, res shim.Resource, info *tfbridge.SchemaInfo, out bool,
+func makeObjectPropertyType(objectName string, objectSchema shim.SchemaMap, info *tfbridge.SchemaInfo, out bool,
 	entityDocs entityDocs) *propertyType {
 
 	t := &propertyType{
@@ -377,14 +382,19 @@ func makeObjectPropertyType(objectName string, res shim.Resource, info *tfbridge
 		t.altTypes = info.AltTypes
 		t.asset = info.Asset
 	}
+	t.properties = makeObjectProperties(objectName, objectSchema, info, out, entityDocs)
+	return t
+}
 
+func makeObjectProperties(objectName string, objectSchema shim.SchemaMap, info *tfbridge.SchemaInfo, out bool,
+	entityDocs entityDocs) []*variable {
+	var properties []*variable
 	var propertyInfos map[string]*tfbridge.SchemaInfo
 	if info != nil {
 		propertyInfos = info.Fields
 	}
-
-	for _, key := range stableSchemas(res.Schema()) {
-		propertySchema := res.Schema().Get(key)
+	for _, key := range stableSchemas(objectSchema) {
+		propertySchema := objectSchema.Get(key)
 
 		var propertyInfo *tfbridge.SchemaInfo
 		if propertyInfos != nil {
@@ -397,11 +407,10 @@ func makeObjectPropertyType(objectName string, res shim.Resource, info *tfbridge
 		doc, _ := getNestedDescriptionFromParsedDocs(entityDocs, objectName, key)
 
 		if v := propertyVariable(key, propertySchema, propertyInfo, doc, "", out, entityDocs); v != nil {
-			t.properties = append(t.properties, v)
+			properties = append(properties, v)
 		}
 	}
-
-	return t
+	return properties
 }
 
 func (t *propertyType) equals(other *propertyType) bool {

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -336,6 +336,8 @@ func makePropertyType(objectName string, sch shim.Schema, info *tfbridge.SchemaI
 		t.kind = kindSet
 	case shim.TypeObject:
 		t.kind = kindObject
+		objSchema := sch.(shim.ObjectTypeSchema)
+		t.properties = makeObjectProperties(objectName, objSchema.Fields(), elemInfo, out, entityDocs)
 	}
 
 	// We should carry across any of the deprecation messages, to Pulumi, as per Terraform schema
@@ -347,12 +349,9 @@ func makePropertyType(objectName string, sch shim.Schema, info *tfbridge.SchemaI
 	case shim.Schema:
 		t.element = makePropertyType(objectName, elem, elemInfo, out, entityDocs)
 	case shim.Resource:
-		if t.kind == kindObject {
-			t.properties = makeObjectProperties(objectName, elem.Schema(), elemInfo, out, entityDocs)
-		} else {
-			t.element = makeObjectPropertyType(objectName, elem.Schema(), elemInfo, out, entityDocs)
-		}
+		t.element = makeObjectPropertyType(objectName, elem.Schema(), elemInfo, out, entityDocs)
 	}
+
 	switch t.kind {
 	case kindList, kindSet:
 		if tfbridge.IsMaxItemsOne(sch, info) {

--- a/pkg/tfgen/test_data/test-object-type-schema.json
+++ b/pkg/tfgen/test_data/test-object-type-schema.json
@@ -1,0 +1,70 @@
+{
+  "name": "myprov",
+  "attribution": "This Pulumi package is based on the [`myprov` Terraform Provider](https://github.com/terraform-providers/terraform-provider-myprov).",
+  "meta": {
+    "moduleFormat": "(.*)(?:/[^/]*)"
+  },
+  "language": {
+    "nodejs": {
+      "compatibility": "tfbridge20",
+      "disableUnionOutputTypes": true,
+      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-myprov)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-myprov` repo](/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-myprov` repo](https://github.com/terraform-providers/terraform-provider-myprov/issues)."
+    },
+    "python": {
+      "compatibility": "tfbridge20",
+      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-myprov)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-myprov` repo](/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-myprov` repo](https://github.com/terraform-providers/terraform-provider-myprov/issues)."
+    }
+  },
+  "config": {},
+  "types": {
+    "myprov:index/ResObjField:ResObjField": {
+      "properties": {
+        "x": {
+          "type": "string",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        },
+        "y": {
+          "type": "integer",
+          "language": {
+            "python": {
+              "mapCase": false
+            }
+          }
+        }
+      },
+      "type": "object",
+      "required": [
+        "x",
+        "y"
+      ]
+    }
+  },
+  "provider": {
+    "description": "The provider type for the myprov package. By default, resources use package-wide configuration\nsettings, however an explicit `Provider` instance may be created and passed during resource\nconstruction to achieve fine-grained programmatic control over provider settings. See the\n[documentation](https://www.pulumi.com/docs/reference/programming-model/#providers) for more information.\n"
+  },
+  "resources": {
+    "myprov:index/res:Res": {
+      "properties": {
+        "objField": {
+          "$ref": "#/types/myprov:index/ResObjField:ResObjField"
+        }
+      },
+      "required": [
+        "objField"
+      ],
+      "stateInputs": {
+        "description": "Input properties used for looking up and filtering Res resources.\n",
+        "properties": {
+          "objField": {
+            "$ref": "#/types/myprov:index/ResObjField:ResObjField"
+          }
+        },
+        "type": "object"
+      }
+    }
+  }
+}

--- a/pkg/tfshim/shim.go
+++ b/pkg/tfshim/shim.go
@@ -58,6 +58,7 @@ const (
 	TypeList
 	TypeMap
 	TypeSet
+	TypeObject // TypeObject is only used for Terraform Plugin Framework support.
 )
 
 type SchemaDefaultFunc func() (interface{}, error)
@@ -75,7 +76,19 @@ type Schema interface {
 	Computed() bool
 	ForceNew() bool
 	StateFunc() SchemaStateFunc
+
+	// Elem may return a nil, a *Schema value, or a *Resource value.
+	//
+	// If this Schema value represents a compound type such (List[T] or Map[String,T]), Elem() returns a *Schema
+	// representing the element type T.
+	//
+	// TODO explain the *Resource case.
+	//
+	// If Type() == ObjectType, this Schema value represents an Object type and type Elem().(*Resource).Schema()
+	// returns the SchemaMap with the types of the Object fields. Although Elem() returns a *Resource in this case
+	// it is not a real Resource but simply an encoding for the SchemaMap.
 	Elem() interface{}
+
 	MaxItems() int
 	MinItems() int
 	ConflictsWith() []string

--- a/pkg/tfshim/shim.go
+++ b/pkg/tfshim/shim.go
@@ -77,16 +77,17 @@ type Schema interface {
 	ForceNew() bool
 	StateFunc() SchemaStateFunc
 
-	// Elem may return a nil, a *Schema value, or a *Resource value.
+	// s.Elem() may return a nil, a Schema value, or a Resource value.
 	//
-	// If this Schema value represents a compound type such (List[T] or Map[String,T]), Elem() returns a *Schema
-	// representing the element type T.
+	// If s represents an element or block of a compound type such TypeList, TypeSet or TypeMap, s.Elem() returns a
+	// Schema value representing its element type. That is, if s ~ List[String] then s.Elem() ~ String.
 	//
-	// TODO explain the *Resource case.
+	// If s.Elem() returns a Resource, s represens a configuration block, and s.Elem() Resource only implements the
+	// Schema field, denoting the schema of the block.
 	//
-	// If Type() == ObjectType, this Schema value represents an Object type and type Elem().(*Resource).Schema()
-	// returns the SchemaMap with the types of the Object fields. Although Elem() returns a *Resource in this case
-	// it is not a real Resource but simply an encoding for the SchemaMap.
+	// The design of Elem() follows Terraform Plugin SDK directly.
+	//
+	// See also: https://github.com/hashicorp/terraform-plugin-sdk/blob/main/helper/schema/schema.go#L231
 	Elem() interface{}
 
 	MaxItems() int
@@ -101,6 +102,14 @@ type Schema interface {
 
 	SetElement(config interface{}) (interface{}, error)
 	SetHash(v interface{}) int
+}
+
+// Represents Object types. A value of type Schema that represents an Object type (s.Type() == TypeObject) can be cast
+// down to ObjectTypeSchema. This interface can be used to retrieve the types of the fields.
+type ObjectTypeSchema interface {
+	Schema
+
+	Fields() SchemaMap
 }
 
 type SchemaMap interface {


### PR DESCRIPTION
With Terraform Plugin Framework arises a need for nested Object types. With this minor modification tfgen can start supporting these and generating Pulumi Schema for these types. It is a bit quirky to overload Elem() to return a pseudo-resource for TypeObject, but it keeps the change minimal without digging further into errors in MashalSchema. Open to feedback on that, if we want a cleaner encoding I can dig deeper and try to work it out.

The change should be backwards-compatible since TypeObject entries are not yet generated by any of the production providers. 