### PR TITLE
Include examples with errors

### DIFF
--- a/pkg/tf2pulumi/convert/convert.go
+++ b/pkg/tf2pulumi/convert/convert.go
@@ -128,9 +128,6 @@ func Convert(opts Options) (map[string][]byte, Diagnostics, error) {
 	if err != nil {
 		return nil, Diagnostics{All: diagnostics, files: tfFiles}, err
 	}
-	if diagnostics.HasErrors() {
-		return nil, Diagnostics{All: diagnostics, files: tfFiles}, nil
-	}
 
 	return generatedFiles, Diagnostics{All: diagnostics, files: tfFiles}, nil
 }


### PR DESCRIPTION
We generate a huge number of examples with the majority of examples correct.

From the perspective of `pulumi/pkg/codegen` authors, the examples that are not correct can be split into two catagories:

1. Examples where the PCL is syntactically correct but does not describe a valid program.

2. Examples where the PCL describes a valid program but the resulting example is not valid.

(2) is a bug in program-gen. I think we all agree that valid PCL should result in a valid program.

(1) is more complicated. Right now, programgen tries to produce an output file that is as close to a valid program as possible. If it believes the output program will not be correct, an error diagnostic explaining why the result will not be valid is emmited with the file.

We need to decide if we want to include examples that are known to be incorrect, but could still be directionally helpful.