### PR TITLE
Schema support for recognizing Int64 type

### DIFF
--- a/pkg/tfpfbridge/schemashim/object_pseudoresource.go
+++ b/pkg/tfpfbridge/schemashim/object_pseudoresource.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
@@ -27,12 +27,12 @@ import (
 // which assumes schema.Elem() would return either a Resource or a Schema. This struct packages the object field names
 // an types schema through a pseudo-Resource.
 type objectPseudoResource struct {
-	obj tftypes.Object
+	obj types.ObjectType
 
 	attrs map[string]attr
 }
 
-func newObjectPseudoResource(t tftypes.Object, attrs map[string]attr) *objectPseudoResource {
+func newObjectPseudoResource(t types.ObjectType, attrs map[string]attr) *objectPseudoResource {
 	return &objectPseudoResource{obj: t, attrs: attrs}
 }
 
@@ -65,7 +65,7 @@ func (*objectPseudoResource) DecodeTimeouts(
 }
 
 func (r *objectPseudoResource) Len() int {
-	return len(r.obj.AttributeTypes)
+	return len(r.obj.AttrTypes)
 }
 
 func (r *objectPseudoResource) Get(key string) shim.Schema {
@@ -81,7 +81,7 @@ func (r *objectPseudoResource) GetOk(key string) (shim.Schema, bool) {
 		return &attrSchema{key, attr}, true
 	}
 
-	if t, ok := r.obj.AttributeTypes[key]; ok {
+	if t, ok := r.obj.AttrTypes[key]; ok {
 		return newTypeSchema(t, nil), true
 	}
 
@@ -90,7 +90,7 @@ func (r *objectPseudoResource) GetOk(key string) (shim.Schema, bool) {
 
 func (r *objectPseudoResource) Range(each func(key string, value shim.Schema) bool) {
 	var attrs []string
-	for attr := range r.obj.AttributeTypes {
+	for attr := range r.obj.AttrTypes {
 		attrs = append(attrs, attr)
 	}
 	sort.Strings(attrs)

--- a/pkg/tfpfbridge/tests/internal/cmd/pulumi-resource-random/schema.json
+++ b/pkg/tfpfbridge/tests/internal/cmd/pulumi-resource-random/schema.json
@@ -37,7 +37,7 @@
                     "type": "string"
                 },
                 "byteLength": {
-                    "type": "number"
+                    "type": "integer"
                 },
                 "dec": {
                     "type": "string"
@@ -64,7 +64,7 @@
             ],
             "inputProperties": {
                 "byteLength": {
-                    "type": "number"
+                    "type": "integer"
                 },
                 "keepers": {
                     "type": "object",
@@ -89,7 +89,7 @@
                         "type": "string"
                     },
                     "byteLength": {
-                        "type": "number"
+                        "type": "integer"
                     },
                     "dec": {
                         "type": "string"
@@ -119,13 +119,13 @@
                     }
                 },
                 "max": {
-                    "type": "number"
+                    "type": "integer"
                 },
                 "min": {
-                    "type": "number"
+                    "type": "integer"
                 },
                 "result": {
-                    "type": "number"
+                    "type": "integer"
                 },
                 "seed": {
                     "type": "string"
@@ -144,10 +144,10 @@
                     }
                 },
                 "max": {
-                    "type": "number"
+                    "type": "integer"
                 },
                 "min": {
-                    "type": "number"
+                    "type": "integer"
                 },
                 "seed": {
                     "type": "string"
@@ -167,13 +167,13 @@
                         }
                     },
                     "max": {
-                        "type": "number"
+                        "type": "integer"
                     },
                     "min": {
-                        "type": "number"
+                        "type": "integer"
                     },
                     "result": {
-                        "type": "number"
+                        "type": "integer"
                     },
                     "seed": {
                         "type": "string"
@@ -195,22 +195,22 @@
                     }
                 },
                 "length": {
-                    "type": "number"
+                    "type": "integer"
                 },
                 "lower": {
                     "type": "boolean"
                 },
                 "minLower": {
-                    "type": "number"
+                    "type": "integer"
                 },
                 "minNumeric": {
-                    "type": "number"
+                    "type": "integer"
                 },
                 "minSpecial": {
-                    "type": "number"
+                    "type": "integer"
                 },
                 "minUpper": {
-                    "type": "number"
+                    "type": "integer"
                 },
                 "number": {
                     "type": "boolean",
@@ -255,22 +255,22 @@
                     }
                 },
                 "length": {
-                    "type": "number"
+                    "type": "integer"
                 },
                 "lower": {
                     "type": "boolean"
                 },
                 "minLower": {
-                    "type": "number"
+                    "type": "integer"
                 },
                 "minNumeric": {
-                    "type": "number"
+                    "type": "integer"
                 },
                 "minSpecial": {
-                    "type": "number"
+                    "type": "integer"
                 },
                 "minUpper": {
-                    "type": "number"
+                    "type": "integer"
                 },
                 "number": {
                     "type": "boolean",
@@ -306,22 +306,22 @@
                         }
                     },
                     "length": {
-                        "type": "number"
+                        "type": "integer"
                     },
                     "lower": {
                         "type": "boolean"
                     },
                     "minLower": {
-                        "type": "number"
+                        "type": "integer"
                     },
                     "minNumeric": {
-                        "type": "number"
+                        "type": "integer"
                     },
                     "minSpecial": {
-                        "type": "number"
+                        "type": "integer"
                     },
                     "minUpper": {
-                        "type": "number"
+                        "type": "integer"
                     },
                     "number": {
                         "type": "boolean",
@@ -356,7 +356,7 @@
                     }
                 },
                 "length": {
-                    "type": "number"
+                    "type": "integer"
                 },
                 "prefix": {
                     "type": "string"
@@ -377,7 +377,7 @@
                     }
                 },
                 "length": {
-                    "type": "number"
+                    "type": "integer"
                 },
                 "prefix": {
                     "type": "string"
@@ -396,7 +396,7 @@
                         }
                     },
                     "length": {
-                        "type": "number"
+                        "type": "integer"
                     },
                     "prefix": {
                         "type": "string"
@@ -423,7 +423,7 @@
                     }
                 },
                 "resultCount": {
-                    "type": "number"
+                    "type": "integer"
                 },
                 "results": {
                     "type": "array",
@@ -453,7 +453,7 @@
                     }
                 },
                 "resultCount": {
-                    "type": "number"
+                    "type": "integer"
                 },
                 "seed": {
                     "type": "string"
@@ -478,7 +478,7 @@
                         }
                     },
                     "resultCount": {
-                        "type": "number"
+                        "type": "integer"
                     },
                     "results": {
                         "type": "array",
@@ -502,22 +502,22 @@
                     }
                 },
                 "length": {
-                    "type": "number"
+                    "type": "integer"
                 },
                 "lower": {
                     "type": "boolean"
                 },
                 "minLower": {
-                    "type": "number"
+                    "type": "integer"
                 },
                 "minNumeric": {
-                    "type": "number"
+                    "type": "integer"
                 },
                 "minSpecial": {
-                    "type": "number"
+                    "type": "integer"
                 },
                 "minUpper": {
-                    "type": "number"
+                    "type": "integer"
                 },
                 "number": {
                     "type": "boolean",
@@ -560,22 +560,22 @@
                     }
                 },
                 "length": {
-                    "type": "number"
+                    "type": "integer"
                 },
                 "lower": {
                     "type": "boolean"
                 },
                 "minLower": {
-                    "type": "number"
+                    "type": "integer"
                 },
                 "minNumeric": {
-                    "type": "number"
+                    "type": "integer"
                 },
                 "minSpecial": {
-                    "type": "number"
+                    "type": "integer"
                 },
                 "minUpper": {
-                    "type": "number"
+                    "type": "integer"
                 },
                 "number": {
                     "type": "boolean",
@@ -607,22 +607,22 @@
                         }
                     },
                     "length": {
-                        "type": "number"
+                        "type": "integer"
                     },
                     "lower": {
                         "type": "boolean"
                     },
                     "minLower": {
-                        "type": "number"
+                        "type": "integer"
                     },
                     "minNumeric": {
-                        "type": "number"
+                        "type": "integer"
                     },
                     "minSpecial": {
-                        "type": "number"
+                        "type": "integer"
                     },
                     "minUpper": {
-                        "type": "number"
+                        "type": "integer"
                     },
                     "number": {
                         "type": "boolean",

--- a/pkg/tfpfbridge/tests/internal/cmd/pulumi-resource-testbridge/schema.json
+++ b/pkg/tfpfbridge/tests/internal/cmd/pulumi-resource-testbridge/schema.json
@@ -24,7 +24,7 @@
         "testbridge:index/TestresService:TestresService": {
             "properties": {
                 "intport": {
-                    "type": "number",
+                    "type": "integer",
                     "language": {
                         "python": {
                             "mapCase": false
@@ -72,7 +72,7 @@
                     }
                 },
                 "port": {
-                    "type": "number",
+                    "type": "integer",
                     "language": {
                         "python": {
                             "mapCase": false


### PR DESCRIPTION
On top of t0yv0/nested-optionals. 

This makes schema generation recognize int vs number. 

It turns out runtime support for integers may not be necessary. Both on PropertyValue side and on tftypes side the only numeric type is float64 and in case of TF it's big.Float, there's no dedicated int transport types.