### PR TITLE
Fix race on ID allocation causing flaky tests

### DIFF
--- a/pkg/tfpfbridge/Makefile
+++ b/pkg/tfpfbridge/Makefile
@@ -7,6 +7,7 @@ test::
 	go test
 	cd tests && rm -rf state && mkdir state
 	cd tests && go test
+	cd tests && rm -rf state && mkdir state
 
 test.integration::
 	cd tests/integration && go test -test.v


### PR DESCRIPTION
Adding a mutex and not relying on os.Stat to sync has fixed `make test.integration` target from being flaky. What was happening is id "2" was allocated to two resources simultaneously, confusing Read from pseudo-cloud-state.