### PR TITLE
GetMapping should only return for the 'tf' key

### DIFF
--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -1253,15 +1253,20 @@ func (p *Provider) Cancel(ctx context.Context, req *pbempty.Empty) (*pbempty.Emp
 func (p *Provider) GetMapping(
 	ctx context.Context, req *pulumirpc.GetMappingRequest) (*pulumirpc.GetMappingResponse, error) {
 
-	info := MarshalProviderInfo(&p.info)
-	mapping, err := json.Marshal(info)
-	if err != nil {
-		return nil, err
+	if req.Key == "tf" {
+		info := MarshalProviderInfo(&p.info)
+		mapping, err := json.Marshal(info)
+		if err != nil {
+			return nil, err
+		}
+		return &pulumirpc.GetMappingResponse{
+			Provider: p.info.Name,
+			Data:     mapping,
+		}, nil
 	}
-	return &pulumirpc.GetMappingResponse{
-		Provider: p.info.Name,
-		Data:     mapping,
-	}, nil
+
+	// An empty response is valid for GetMapping, it means we don't have a mapping for the given key
+	return &pulumirpc.GetMappingResponse{}, nil
 }
 
 func initializationError(id string, props *pbstruct.Struct, reasons []string) error {

--- a/pkg/tfgen/pluginHost.go
+++ b/pkg/tfgen/pluginHost.go
@@ -55,12 +55,15 @@ func (p *inmemoryProvider) GetSchema(version int) ([]byte, error) {
 }
 
 func (p *inmemoryProvider) GetMapping(key string) ([]byte, string, error) {
-	info := tfbridge.MarshalProviderInfo(&p.info)
-	mapping, err := json.Marshal(info)
-	if err != nil {
-		return nil, "", err
+	if key == "tf" {
+		info := tfbridge.MarshalProviderInfo(&p.info)
+		mapping, err := json.Marshal(info)
+		if err != nil {
+			return nil, "", err
+		}
+		return mapping, p.info.Name, nil
 	}
-	return mapping, p.info.Name, nil
+	return nil, "", nil
 }
 
 func (p *inmemoryProvider) GetPluginInfo() (workspace.PluginInfo, error) {


### PR DESCRIPTION
The engine will call GetMapping for other types of conversions in the future, we should only return for the "tf" plugin from the terraform-bridge.