### PR TITLE
Keep language metadata

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -20,11 +20,11 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
+	"github.com/blang/semver"
 	"golang.org/x/net/context"
 
-	"github.com/blang/semver"
 	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"

--- a/pkg/tfpfbridge/info/providerinfo.go
+++ b/pkg/tfpfbridge/info/providerinfo.go
@@ -21,6 +21,8 @@ import (
 	tfsdkprovider "github.com/hashicorp/terraform-plugin-framework/provider"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 )
 
 type ProviderInfo struct {
@@ -86,42 +88,19 @@ type OverlayInfo struct {
 }
 
 // JavaScriptInfo contains optional overlay information for Python code-generation.
-type JavaScriptInfo struct {
-	PackageName       string            // Custom name for the NPM package.
-	Dependencies      map[string]string // NPM dependencies to add to package.json.
-	DevDependencies   map[string]string // NPM dev-dependencies to add to package.json.
-	PeerDependencies  map[string]string // NPM peer-dependencies to add to package.json.
-	Resolutions       map[string]string // NPM resolutions to add to package.json.
-	Overlay           *OverlayInfo      // optional overlay information for augmented code-generation.
-	TypeScriptVersion string            // A specific version of TypeScript to include in package.json.
-}
+type JavaScriptInfo = tfbridge.JavaScriptInfo
 
 // PythonInfo contains optional overlay information for Python code-generation.
-type PythonInfo struct {
-	Requires      map[string]string // Pip install_requires information.
-	Overlay       *OverlayInfo      // optional overlay information for augmented code-generation.
-	UsesIOClasses bool              // Deprecated: No longer required, all providers use IO classes.
-	PackageName   string            // Name of the Python package to generate
-}
+type PythonInfo = tfbridge.PythonInfo
 
 // GolangInfo contains optional overlay information for Golang code-generation.
-type GolangInfo struct {
-	GenerateResourceContainerTypes bool         // Generate container types for resources e.g. arrays, maps, pointers etc.
-	ImportBasePath                 string       // Base import path for package.
-	Overlay                        *OverlayInfo // optional overlay information for augmented code-generation.
-}
+type GolangInfo = tfbridge.GolangInfo
 
 // CSharpInfo contains optional overlay information for C# code-generation.
-type CSharpInfo struct {
-	PackageReferences map[string]string // NuGet package reference information.
-	Overlay           *OverlayInfo      // optional overlay information for augmented code-generation.
-	Namespaces        map[string]string // Known .NET namespaces with proper capitalization.
-	RootNamespace     string            // The root namespace if setting to something other than Pulumi in the package name
-}
+type CSharpInfo = tfbridge.CSharpInfo
 
-type JavaInfo struct {
-	BasePackage string // the Base package for the Java SDK
-}
+// CSharpInfo contains optional overlay information for Java code-generation.
+type JavaInfo = tfbridge.JavaInfo
 
 // ResourceInfo is a top-level type exported by a provider.  This structure can override the type to generate.  It can
 // also give custom metadata for fields, using the SchemaInfo structure below.  Finally, a set of composite keys can be

--- a/pkg/tfpfbridge/schemashim/schemashim.go
+++ b/pkg/tfpfbridge/schemashim/schemashim.go
@@ -63,11 +63,13 @@ func ShimSchemaOnlyProviderInfo(ctx context.Context, provider info.ProviderInfo)
 		// TODO ExtraFunctionHclExamples: provider.ExtraFunctionHclExamples,
 		IgnoreMappings:    provider.IgnoreMappings,
 		PluginDownloadURL: provider.PluginDownloadURL,
-		// TODO JavaScript:              provider.JavaScript,
-		// TODO Python:                  provider.Python,
-		// TOOD Golang:                  provider.Golang,
-		// TODO CSharp:                  provider.CSharp,
-		// TODO Java:                    provider.Java,
+
+		JavaScript: provider.JavaScript,
+		Python:     provider.Python,
+		Golang:     provider.Golang,
+		CSharp:     provider.CSharp,
+		Java:       provider.Java,
+
 		TFProviderVersion: provider.TFProviderVersion,
 		// TODO TFProviderLicense:       provider.TFProviderLicense,
 		TFProviderModuleVersion: provider.TFProviderModuleVersion,

--- a/pkg/tfpfbridge/tests/internal/cmd/pulumi-resource-random/schema.json
+++ b/pkg/tfpfbridge/tests/internal/cmd/pulumi-resource-random/schema.json
@@ -13,14 +13,40 @@
         "moduleFormat": "(.*)(?:/[^/]*)"
     },
     "language": {
+        "csharp": {
+            "compatibility": "tfbridge20",
+            "namespaces": {
+                "random": "Random"
+            },
+            "packageReferences": {
+                "Pulumi": "3.*"
+            }
+        },
+        "go": {
+            "generateExtraInputTypes": true,
+            "generateResourceContainerTypes": true,
+            "importBasePath": "github.com/pulumi/pulumi-random/sdk/go/random"
+        },
         "nodejs": {
             "compatibility": "tfbridge20",
+            "dependencies": {
+                "@pulumi/pulumi": "^3.0.0"
+            },
+            "devDependencies": {
+                "@types/node": "^10.0.0"
+            },
             "disableUnionOutputTypes": true,
-            "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-random)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-random` repo](https://github.com/pulumi/pulumi-random/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-random` repo](https://github.com/terraform-providers/terraform-provider-random/issues)."
+            "packageDescription": "A Pulumi package to safely use randomness in Pulumi programs.",
+            "packageName": "",
+            "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-random)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-random` repo](https://github.com/pulumi/pulumi-random/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-random` repo](https://github.com/terraform-providers/terraform-provider-random/issues).",
+            "typescriptVersion": ""
         },
         "python": {
             "compatibility": "tfbridge20",
-            "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-random)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-random` repo](https://github.com/pulumi/pulumi-random/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-random` repo](https://github.com/terraform-providers/terraform-provider-random/issues)."
+            "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-random)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-random` repo](https://github.com/pulumi/pulumi-random/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-random` repo](https://github.com/terraform-providers/terraform-provider-random/issues).",
+            "requires": {
+                "pulumi": "\u003e=3.0.0,\u003c4.0.0"
+            }
         }
     },
     "config": {},


### PR DESCRIPTION
This turns out to be important for the random provider schema to continue working as before. 