### PR TITLE
Basic secret transcoding

### DIFF
--- a/pkg/tfpfbridge/internal/convert/encoding.go
+++ b/pkg/tfpfbridge/internal/convert/encoding.go
@@ -118,15 +118,23 @@ func (e *encoding) newPropertyEncoder(name string, propSpec pschema.PropertySpec
 	if err != nil {
 		return nil, fmt.Errorf("Cannot derive an encoder for property %q: %w", name, err)
 	}
-	return enc, err
+
+	if propSpec.Secret {
+		return newSecretEncoder(enc, t)
+	}
+
+	return enc, nil
 }
 
 func (e *encoding) newPropertyDecoder(name string, propSpec pschema.PropertySpec, t tftypes.Type) (Decoder, error) {
-	enc, err := e.deriveDecoder(&propSpec.TypeSpec, t)
+	dec, err := e.deriveDecoder(&propSpec.TypeSpec, t)
 	if err != nil {
 		return nil, fmt.Errorf("Cannot derive a decoder for property %q: %w", name, err)
 	}
-	return enc, err
+	if propSpec.Secret {
+		return newSecretDecoder(dec)
+	}
+	return dec, nil
 }
 
 func (e *encoding) resolveRef(ref string) (tokens.Token, *pschema.ComplexTypeSpec, error) {

--- a/pkg/tfpfbridge/internal/convert/object.go
+++ b/pkg/tfpfbridge/internal/convert/object.go
@@ -83,8 +83,7 @@ func (enc *objectEncoder) FromPropertyValue(p resource.PropertyValue) (tftypes.V
 			v, err := attrEncoder.FromPropertyValue(pv)
 			if err != nil {
 				return tftypes.NewValue(enc.objectType, nil),
-					fmt.Errorf("encObj failed on property %s (%v): %w",
-						attr, pv, err)
+					fmt.Errorf("objectEncoder failed on property %q: %w", attr, err)
 			}
 			values[attr] = v
 		} else {

--- a/pkg/tfpfbridge/internal/convert/secret.go
+++ b/pkg/tfpfbridge/internal/convert/secret.go
@@ -1,0 +1,72 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package convert
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
+type secretEncoder struct {
+	elementEncoder Encoder
+	tfType         tftypes.Type
+}
+
+type secretDecoder struct {
+	elementDecoder Decoder
+}
+
+func newSecretEncoder(elementEncoder Encoder, tfType tftypes.Type) (Encoder, error) {
+	return &secretEncoder{
+		elementEncoder: elementEncoder,
+		tfType:         tfType,
+	}, nil
+}
+
+func newSecretDecoder(elementDecoder Decoder) (Decoder, error) {
+	return &secretDecoder{
+		elementDecoder: elementDecoder,
+	}, nil
+}
+
+func (enc *secretEncoder) FromPropertyValue(p resource.PropertyValue) (tftypes.Value, error) {
+	if propertyValueIsUnkonwn(p) {
+		return tftypes.NewValue(enc.tfType, tftypes.UnknownValue), nil
+	}
+	if p.IsNull() {
+		return tftypes.NewValue(enc.tfType, nil), nil
+	}
+	if !p.IsSecret() {
+		return tftypes.Value{}, fmt.Errorf("PropertyValue should be secret but is not")
+	}
+	v := p.SecretValue().Element
+	return enc.elementEncoder.FromPropertyValue(v)
+}
+
+func (dec *secretDecoder) ToPropertyValue(v tftypes.Value) (resource.PropertyValue, error) {
+	encoded, err := dec.elementDecoder.ToPropertyValue(v)
+	if err != nil {
+		return resource.PropertyValue{}, err
+	}
+	// Not entirely certain here if Pulumi needs nil and unknown secerts to wrapped in resource.MakeSecret or not,
+	// assuming they do not need to be wrapped.
+	if !v.IsKnown() || v.IsNull() {
+		return encoded, nil
+	}
+	return resource.MakeSecret(encoded), nil
+}

--- a/pkg/tfpfbridge/tests/provider_diff_test.go
+++ b/pkg/tfpfbridge/tests/provider_diff_test.go
@@ -126,3 +126,49 @@ func TestEmptyTestresDiffWithOptionalComputed(t *testing.T) {
         }`
 	testutils.Replay(t, server, testCase)
 }
+
+func TestDiffWithSecrets(t *testing.T) {
+	g := genRandomSchemaBytes(t)
+	server := tfbridge.NewProviderServer(
+		testprovider.RandomProvider(),
+		g.pulumiSchema,
+		g.renames,
+	)
+
+	testCase := `
+        {
+          "method": "/pulumirpc.ResourceProvider/Diff",
+          "request": {
+            "id": "none",
+            "urn": "urn:pulumi:p-it-antons-mac-ts-c25899e1::simple-random::random:index/randomPassword:RandomPassword::password",
+            "olds": {
+              "bcryptHash": {
+                "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
+                "value": "$2a$10$kO5OLyiYS.C1IA/Es/wJPugt9F9GM4jKMLmZW5gjUwP5RB4OJ6WTK"
+              },
+              "id": "none",
+              "length": 32,
+              "lower": true,
+              "minLower": 0,
+              "minNumeric": 0,
+              "minSpecial": 0,
+              "minUpper": 0,
+              "number": true,
+              "numeric": true,
+              "result": {
+                "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
+                "value": ":7WJQW2-7D%*fp:s$L!8ABF}_$A{L8>j"
+              },
+              "special": true,
+              "upper": true
+            },
+            "news": {
+              "length": 32
+            }
+          },
+          "response": {
+            "changes": "DIFF_NONE"
+          }
+        }`
+	testutils.Replay(t, server, testCase)
+}


### PR DESCRIPTION
Quick support for dealing with Secret values on the wire. Pulumi passes these values for properties marked as secret in the schema. This change is necessary to scale up to passing Random provider tests.