### PR TITLE
Link up converters with rename tables

### DIFF
--- a/pkg/tfgen/internal/paths/paths.go
+++ b/pkg/tfgen/internal/paths/paths.go
@@ -21,10 +21,10 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 )
 
-// TypePath values uniquely identify locations within a Pulumi Package Schema that necessite generating types in a
-// target programming language when a provider SDK for that language is being built. Examples of such types include
-// resources (see ResourcePath), data sources (DataSourcePath), provider configuration (ConfigPath), and nested object
-// types that are used to describe the type of resource properties.
+// TypePath values uniquely identify locations within a Pulumi Package Schema that require generating types in a target
+// programming language when a provider SDK for that language is being built. Examples of such types include resources
+// (see ResourcePath), data sources (DataSourcePath), provider configuration (ConfigPath), and nested object types that
+// are used to describe the type of resource properties.
 type TypePath interface {
 	// Parent path, can be nil for root paths.
 	Parent() TypePath

--- a/pkg/tfgen/internal/paths/paths.go
+++ b/pkg/tfgen/internal/paths/paths.go
@@ -21,6 +21,10 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 )
 
+// TypePath values uniquely identify locations within a Pulumi Package Schema that necessite generating types in a
+// target programming language when a provider SDK for that language is being built. Examples of such types include
+// resources (see ResourcePath), data sources (DataSourcePath), provider configuration (ConfigPath), and nested object
+// types that are used to describe the type of resource properties.
 type TypePath interface {
 	// Parent path, can be nil for root paths.
 	Parent() TypePath

--- a/pkg/tfgen/internal/paths/paths.go
+++ b/pkg/tfgen/internal/paths/paths.go
@@ -39,15 +39,15 @@ type ResourcePath struct {
 	isProvider bool
 }
 
-func NewResourcePath(key string, resourceToken tokens.Type, isProvider bool) *ResourcePath {
-	if isProvider && key != "" {
-		panic("key should be empty when isProvider=true")
+func NewResourcePath(terraformResourceKey string, resourceToken tokens.Type, isProvider bool) *ResourcePath {
+	if isProvider && terraformResourceKey != "" {
+		panic("terraformResourceKey should be empty when isProvider=true")
 	}
-	if !isProvider && key == "" {
-		panic("key should not be empty when isProvider=false")
+	if !isProvider && terraformResourceKey == "" {
+		panic("terraformResourceKey should not be empty when isProvider=false")
 	}
 	return &ResourcePath{
-		key:        key,
+		key:        terraformResourceKey,
 		token:      resourceToken,
 		isProvider: isProvider,
 	}

--- a/pkg/tfpfbridge/internal/convert/encoding.go
+++ b/pkg/tfpfbridge/internal/convert/encoding.go
@@ -66,7 +66,7 @@ func (e *encoding) NewResourceDecoder(resourceToken tokens.Type, objectType tfty
 	propertyDecoders["id"] = newStringDecoder()
 	dec, err := newObjectDecoder(tokens.Token(resourceToken), objectType, propertyDecoders, e.propertyNames)
 	if err != nil {
-		return nil, fmt.Errorf("cannot derive an encoder for resource %q: %w", string(resourceToken), err)
+		return nil, fmt.Errorf("cannot derive a decoder for resource %q: %w", string(resourceToken), err)
 	}
 	return dec, nil
 }

--- a/pkg/tfpfbridge/main.go
+++ b/pkg/tfpfbridge/main.go
@@ -28,7 +28,7 @@ import (
 )
 
 // Main launches the tfbridge plugin for a given package pkg and provider prov.
-func Main(pkg, version string, prov info.ProviderInfo, pulumiSchema []byte) {
+func Main(pkg, version string, prov info.ProviderInfo, pulumiSchema []byte, renames []byte) {
 
 	// Look for a request to dump the provider info to stdout.
 	flags := flag.NewFlagSet("tf-provider-flags", flag.ContinueOnError)
@@ -75,7 +75,7 @@ func Main(pkg, version string, prov info.ProviderInfo, pulumiSchema []byte) {
 	// TODO Initialize Terraform logging.
 	// prov.P.InitLogging()
 
-	if err := Serve(pkg, version, prov, pulumiSchema); err != nil {
+	if err := Serve(pkg, version, prov, pulumiSchema, renames); err != nil {
 		cmdutil.ExitError(err.Error())
 	}
 }

--- a/pkg/tfpfbridge/provider.go
+++ b/pkg/tfpfbridge/provider.go
@@ -173,7 +173,7 @@ func (p *Provider) GetMapping(key string) ([]byte, string, error) {
 }
 
 func setupEncoding(p pschema.PackageSpec, renames tfgen.Renames) convert.Encoding {
-	return convert.NewEncoding(packageSpec{&p}, &PrecisePropertyNames{renames})
+	return convert.NewEncoding(packageSpec{&p}, newPrecisePropertyNames(renames))
 }
 
 type packageSpec struct {

--- a/pkg/tfpfbridge/serve.go
+++ b/pkg/tfpfbridge/serve.go
@@ -22,9 +22,9 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/pkg/tfpfbridge/info"
 )
 
-func Serve(pkg, version string, prov info.ProviderInfo, pulumiSchema []byte) error {
+func Serve(pkg, version string, prov info.ProviderInfo, pulumiSchema []byte, renames []byte) error {
 	return provider.Main(pkg, func(host *provider.HostClient) (pulumirpc.ResourceProviderServer, error) {
 
-		return NewProviderServer(prov, pulumiSchema), nil
+		return NewProviderServer(prov, pulumiSchema, renames), nil
 	})
 }

--- a/pkg/tfpfbridge/tests/genrandom_test.go
+++ b/pkg/tfpfbridge/tests/genrandom_test.go
@@ -47,7 +47,7 @@ func TestGenRandom(t *testing.T) {
 
 		t.Run(trace, func(t *testing.T) {
 			p := testprovider.RandomProvider()
-			server := tfbridge.NewProviderServer(p, schema)
+			server := tfbridge.NewProviderServer(p, schema.pulumiSchema, schema.renames)
 			testutils.ReplayTraceFile(t, server, trace)
 		})
 	}

--- a/pkg/tfpfbridge/tests/genupdate_test.go
+++ b/pkg/tfpfbridge/tests/genupdate_test.go
@@ -27,16 +27,20 @@ import (
 //
 // To re-capture try:
 //
-//    cd tests/integration
-//    PULUMI_DEBUG_GPRC=$PWD/grpc.json go test -run TestUpdateProgram
-//    jq -s . grpc.json
+//	cd tests/integration
+//	PULUMI_DEBUG_GPRC=$PWD/grpc.json go test -run TestUpdateProgram
+//	jq -s . grpc.json
 func TestGenUpdates(t *testing.T) {
 	os.Mkdir("state", 0700)
 
 	trace := "testdata/updateprogram.json"
+
+	schemaBytes := genTestBridgeSchemaBytes(t)
+
 	server := tfbridge.NewProviderServer(
 		testprovider.SyntheticTestBridgeProvider(),
-		genTestBridgeSchemaBytes(t),
+		schemaBytes.pulumiSchema,
+		schemaBytes.renames,
 	)
 	testutils.ReplayTraceFile(t, server, trace)
 }

--- a/pkg/tfpfbridge/tests/internal/cmd/pulumi-resource-random/main.go
+++ b/pkg/tfpfbridge/tests/internal/cmd/pulumi-resource-random/main.go
@@ -24,11 +24,15 @@ import (
 //go:embed schema.json
 var schema []byte
 
+//go:embed renames.json
+var renames []byte
+
 func main() {
 	tfbridge.Main(
 		"random",
 		"4.8.2",
 		testprovider.RandomProvider(),
 		schema,
+		renames,
 	)
 }

--- a/pkg/tfpfbridge/tests/internal/cmd/pulumi-resource-random/renames.json
+++ b/pkg/tfpfbridge/tests/internal/cmd/pulumi-resource-random/renames.json
@@ -1,0 +1,38 @@
+{
+  "resources": {
+    "random:index/randomId:RandomId": "random_id",
+    "random:index/randomInteger:RandomInteger": "random_integer",
+    "random:index/randomPassword:RandomPassword": "random_password",
+    "random:index/randomPet:RandomPet": "random_pet",
+    "random:index/randomShuffle:RandomShuffle": "random_shuffle",
+    "random:index/randomString:RandomString": "random_string",
+    "random:index/randomUuid:RandomUuid": "random_uuid"
+  },
+  "renamedProperties": {
+    "random:index/randomId:RandomId": {
+      "b64Std": "b64_std",
+      "b64Url": "b64_url",
+      "byteLength": "byte_length"
+    },
+    "random:index/randomPassword:RandomPassword": {
+      "bcryptHash": "bcrypt_hash",
+      "minLower": "min_lower",
+      "minNumeric": "min_numeric",
+      "minSpecial": "min_special",
+      "minUpper": "min_upper",
+      "overrideSpecial": "override_special"
+    },
+    "random:index/randomShuffle:RandomShuffle": {
+      "inputs": "input",
+      "resultCount": "result_count",
+      "results": "result"
+    },
+    "random:index/randomString:RandomString": {
+      "minLower": "min_lower",
+      "minNumeric": "min_numeric",
+      "minSpecial": "min_special",
+      "minUpper": "min_upper",
+      "overrideSpecial": "override_special"
+    }
+  }
+}

--- a/pkg/tfpfbridge/tests/internal/cmd/pulumi-resource-testbridge/main.go
+++ b/pkg/tfpfbridge/tests/internal/cmd/pulumi-resource-testbridge/main.go
@@ -24,11 +24,15 @@ import (
 //go:embed schema.json
 var schema []byte
 
+//go:embed renames.json
+var renames []byte
+
 func main() {
 	tfbridge.Main(
 		"testbridge",
 		"0.0.1",
 		testprovider.SyntheticTestBridgeProvider(),
 		schema,
+		renames,
 	)
 }

--- a/pkg/tfpfbridge/tests/internal/cmd/pulumi-resource-testbridge/renames.json
+++ b/pkg/tfpfbridge/tests/internal/cmd/pulumi-resource-testbridge/renames.json
@@ -1,0 +1,11 @@
+{
+  "resources": {
+    "testbridge:index/testres:Testres": "testbridge_testres"
+  },
+  "renamedProperties": {
+    "testbridge:index/testres:Testres": {
+      "optionalInputStringListCopies": "optionalInputStringListCopy",
+      "optionalInputStringLists": "optionalInputStringList"
+    }
+  }
+}

--- a/pkg/tfpfbridge/tests/provider_diff_test.go
+++ b/pkg/tfpfbridge/tests/provider_diff_test.go
@@ -24,9 +24,11 @@ import (
 
 // Test that preview diff in presence of computed attributes results in an empty diff.
 func TestEmptyTestresDiff(t *testing.T) {
+	schemaBytes := genTestBridgeSchemaBytes(t)
 	server := tfbridge.NewProviderServer(
 		testprovider.SyntheticTestBridgeProvider(),
-		genTestBridgeSchemaBytes(t),
+		schemaBytes.pulumiSchema,
+		schemaBytes.renames,
 	)
 	testCase := `
         {
@@ -55,9 +57,11 @@ func TestEmptyTestresDiff(t *testing.T) {
 
 // Test removing an optional input.
 func TestOptionRemovalTestresDiff(t *testing.T) {
+	schemaBytes := genTestBridgeSchemaBytes(t)
 	server := tfbridge.NewProviderServer(
 		testprovider.SyntheticTestBridgeProvider(),
-		genTestBridgeSchemaBytes(t),
+		schemaBytes.pulumiSchema,
+		schemaBytes.renames,
 	)
 	testCase := `
         {
@@ -90,9 +94,11 @@ func TestOptionRemovalTestresDiff(t *testing.T) {
 
 // Make sure optionalInputBoolCopy does not cause non-empty diff when not actually changing.
 func TestEmptyTestresDiffWithOptionalComputed(t *testing.T) {
+	schemaBytes := genTestBridgeSchemaBytes(t)
 	server := tfbridge.NewProviderServer(
 		testprovider.SyntheticTestBridgeProvider(),
-		genTestBridgeSchemaBytes(t),
+		schemaBytes.pulumiSchema,
+		schemaBytes.renames,
 	)
 	testCase := `
         {

--- a/pkg/tfpfbridge/tfgen/main.go
+++ b/pkg/tfpfbridge/tfgen/main.go
@@ -16,6 +16,7 @@ package tfgen
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/pulumi/pulumi-terraform-bridge/pkg/tfpfbridge/info"
 	"github.com/pulumi/pulumi-terraform-bridge/pkg/tfpfbridge/schemashim"
@@ -30,5 +31,50 @@ import (
 func Main(provider, version string, info info.ProviderInfo) {
 	ctx := context.Background()
 	shimInfo := schemashim.ShimSchemaOnlyProviderInfo(ctx, info)
-	tfgen.Main(provider, version, shimInfo)
+
+	tfgen.MainWithCustomGenerate(provider, version, shimInfo, func(opts tfgen.GeneratorOptions) error {
+		g, err := tfgen.NewGenerator(opts)
+		if err != nil {
+			return err
+		}
+
+		if err := g.Generate(); err != nil {
+			return err
+		}
+
+		if opts.Language == tfgen.Schema {
+			if err := writeRenames(g, opts); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+}
+
+func writeRenames(g *tfgen.Generator, opts tfgen.GeneratorOptions) error {
+	renames, err := g.Renames()
+	if err != nil {
+		return err
+	}
+
+	renamesFile, err := opts.Root.Create("renames.json")
+	if err != nil {
+		return err
+	}
+
+	renamesBytes, err := json.MarshalIndent(renames, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	if _, err := renamesFile.Write(renamesBytes); err != nil {
+		return err
+	}
+
+	if err := renamesFile.Close(); err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
"Use precise rename" commit is relevant, the base is in the other PRs. What's happening here:

- TFPF converters use rename tables from #649 to be able to understand TF-Pu name mapping precisely
- The version of tfgen.Main that ships with TFPF is acquiring an ability to write those out as renames.json
- Just like the schema, renames are computed during the tfgen pass and simply accessed as a database at runtime   