### PR TITLE
fix(bridge): default value initialization for ExactlyOneOf fields

### DIFF
--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -698,6 +698,10 @@ func (ctx *conversionContext) applyDefaults(result map[string]interface{}, olds,
 			}
 
 			for _, exactlyOneOfName := range sch.ExactlyOneOf() {
+				// If any *other* ExactlyOneOf keys have a default value, don't set the default for the current field
+				if exactlyOneOfName == name {
+					continue
+				}
 				if exactlyOneSchema, exists := tfs.GetOk(exactlyOneOfName); exists {
 					dv, _ := exactlyOneSchema.DefaultValue()
 					if dv != nil {

--- a/pkg/tfbridge/schema_provider_test.go
+++ b/pkg/tfbridge/schema_provider_test.go
@@ -83,6 +83,7 @@ func (f shimv1Factory) newSchema(m shim.Schema) *schemav1.Schema {
 		Deprecated:    m.Deprecated(),
 		Removed:       m.Removed(),
 		Sensitive:     m.Sensitive(),
+		ExactlyOneOf:  m.ExactlyOneOf(),
 	}
 }
 
@@ -189,6 +190,7 @@ func (f shimv2Factory) newSchema(m shim.Schema) *schemav2.Schema {
 		ConflictsWith: m.ConflictsWith(),
 		Deprecated:    m.Deprecated(),
 		Sensitive:     m.Sensitive(),
+		ExactlyOneOf:  m.ExactlyOneOf(),
 	}
 }
 


### PR DESCRIPTION
Fixes pulumi/pulumi-cloudflare#306

In the Cloudflare provider, three fields are set to ExactlyOneOf: `api_token`, `api_key`, and `api_user_service_key`. The subroutine in `applyDefaults` that iterates over TF schema and applies default values would return on line 705 when `name == "api_token"` because:

`sch.ExactlyOneOf()` returned `[]string{"api_token", "api_key", and "api_user_service_key"}`, and then the ExactlyOneOf check in the loop to set defaults (lines 701-708) would evaluate like so:

```go
676:  tfs.Range(func(name string, sch shim.Schema) bool {
      // in the loop iteration where name == "api_token"

// ...

701:  for _, exactlyOneOfName := range sch.ExactlyOneOf() {
        // exactlyOneOfName would eventually equal "api_token"
702:    if exactlyOneSchema, exists := tfs.GetOk(exactlyOneOfName); exists {
          // exactlyOneSchema == api_token's TF schema
          // exists == true
703:      dv, _ := exactlyOneSchema.DefaultValue()
          // dv := value of CLOUDFLARE_API_TOKEN env var
704:      if dv != nil {
            // dv != nil == true
705:        return true
          }
        }
      }
```

This caused any field with `ExactlyOneOf` and a default value func to skip default initialization: it would always find itself in this loop as the "other" key, discover that other key had a default value, and then exit the loop.

