### PR TITLE
Fix a panic in renames module due to provider path confusion

### DIFF
--- a/pkg/tfgen/renames.go
+++ b/pkg/tfgen/renames.go
@@ -145,6 +145,8 @@ func (r renamesBuilder) findObjectTypeToken(path paths.TypePath) (tokens.Type, e
 	// As an implementation quirk, sometimes for a provider registerNamedObjectType gets called on an input propety
 	// but not the state property, though they represent the same thing and have the same type. Rewrite the path
 	// to replace state with inputs in this case and try the lookup again.
+	//
+	// See Test_ProviderWithObjectTypesInConfigCanGenerateRenames
 	path = r.normalizeProviderStateToProviderInputs(path)
 	if p, ok := r.objectTypes[path.String()]; ok {
 		return p, nil


### PR DESCRIPTION
Another quirky refinement to paths/renames functionality. Added a mini-repro as a unit test. If there's an object type involved in a config section of a provider, Pulumi generates a Provider type, and a named type for the object type, however it only registers it as provider.inputs.prop position, not provider.state.prop position, causing a later lookup that tries to find this object type to fail and panic. 

The current fix rewrites the provider.state.x to provider.inputs.x path during lookup. Another possible fix would be to perhaps rule out the distinction entirely - consider for the provider pseudo-resource the state and inputs paths to be the same. The current distinction only will be valuable if Pulumi ever generates distinct classes for provider.state.prop vs provider.inputs.prop in some target PL.