### PR TITLE
Flattened encoder support

### DIFF
--- a/pkg/tfpfbridge/internal/convert/encoding.go
+++ b/pkg/tfpfbridge/internal/convert/encoding.go
@@ -177,15 +177,20 @@ func (e *encoding) deriveDecoderForNamedObjectType(ref string, t tftypes.Object)
 }
 
 func (e *encoding) deriveEncoder(typeSpec *pschema.TypeSpec, t tftypes.Type) (Encoder, error) {
-	// TODO also detect set flattening.
-	if t.Is(tftypes.List{}) && typeSpec.Type != "array" {
-		// In case of IsMaxItemOne lists or sets, Pulumi flattens List[T] to T. The encoder needs to compensate.
-		encoder, err := e.deriveEncoder(typeSpec, t.(tftypes.List).ElementType)
+	if (t.Is(tftypes.List{}) || t.Is(tftypes.Set{})) && typeSpec.Type != "array" {
+		// For IsMaxItemOne lists or sets, Pulumi flattens List[T] or Set[T] to T.
+		var elementType tftypes.Type
+		if t.Is(tftypes.List{}) {
+			elementType = t.(tftypes.List).ElementType
+		} else {
+			elementType = t.(tftypes.Set).ElementType
+		}
+		encoder, err := e.deriveEncoder(typeSpec, elementType)
 		if err != nil {
 			return nil, err
 		}
-		return &flattenedListEncoder{
-			listType:       t,
+		return &flattenedEncoder{
+			collectionType: t,
 			elementEncoder: encoder,
 		}, nil
 	}
@@ -236,14 +241,19 @@ func (e *encoding) deriveEncoder(typeSpec *pschema.TypeSpec, t tftypes.Type) (En
 }
 
 func (e *encoding) deriveDecoder(typeSpec *pschema.TypeSpec, t tftypes.Type) (Decoder, error) {
-	// TODO also detect set flattening.
-	if t.Is(tftypes.List{}) && typeSpec.Type != "array" {
-		// In case of IsMaxItemOne lists or sets, Pulumi flattens List[T] to T. The decoder needs to compensate.
-		decoder, err := e.deriveDecoder(typeSpec, t.(tftypes.List).ElementType)
+	if (t.Is(tftypes.List{}) || t.Is(tftypes.Set{})) && typeSpec.Type != "array" {
+		// In case of IsMaxItemOne lists or sets, Pulumi flattens List[T] or Set[T] to T.
+		var elementType tftypes.Type
+		if t.Is(tftypes.List{}) {
+			elementType = t.(tftypes.List).ElementType
+		} else {
+			elementType = t.(tftypes.Set).ElementType
+		}
+		decoder, err := e.deriveDecoder(typeSpec, elementType)
 		if err != nil {
 			return nil, err
 		}
-		return &flattenedListDecoder{
+		return &flattenedDecoder{
 			elementDecoder: decoder,
 		}, nil
 	}

--- a/pkg/tfpfbridge/internal/convert/flattened.go
+++ b/pkg/tfpfbridge/internal/convert/flattened.go
@@ -21,12 +21,12 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
-type flattenedListEncoder struct {
-	listType       tftypes.Type
+type flattenedEncoder struct {
+	collectionType tftypes.Type
 	elementEncoder Encoder
 }
 
-func (enc *flattenedListEncoder) FromPropertyValue(v resource.PropertyValue) (tftypes.Value, error) {
+func (enc *flattenedEncoder) FromPropertyValue(v resource.PropertyValue) (tftypes.Value, error) {
 	encoded, err := enc.elementEncoder.FromPropertyValue(v)
 	if err != nil {
 		return tftypes.Value{}, nil
@@ -37,14 +37,14 @@ func (enc *flattenedListEncoder) FromPropertyValue(v resource.PropertyValue) (tf
 		list = append(list, encoded)
 	}
 
-	return tftypes.NewValue(enc.listType, list), nil
+	return tftypes.NewValue(enc.collectionType, list), nil
 }
 
-type flattenedListDecoder struct {
+type flattenedDecoder struct {
 	elementDecoder Decoder
 }
 
-func (dec *flattenedListDecoder) ToPropertyValue(v tftypes.Value) (resource.PropertyValue, error) {
+func (dec *flattenedDecoder) ToPropertyValue(v tftypes.Value) (resource.PropertyValue, error) {
 	var list []tftypes.Value
 	if err := v.As(&list); err != nil {
 		return resource.PropertyValue{}, nil
@@ -55,7 +55,7 @@ func (dec *flattenedListDecoder) ToPropertyValue(v tftypes.Value) (resource.Prop
 	case 1:
 		return dec.elementDecoder.ToPropertyValue(list[0])
 	default:
-		msg := "IsMaxItemsOne list has too many (%d) values"
+		msg := "IsMaxItemsOne list or set has too many (%d) values"
 		err := fmt.Errorf(msg, len(list))
 		return resource.PropertyValue{}, err
 	}

--- a/pkg/tfpfbridge/internal/convert/flattened.go
+++ b/pkg/tfpfbridge/internal/convert/flattened.go
@@ -1,0 +1,62 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package convert
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
+type flattenedListEncoder struct {
+	listType       tftypes.Type
+	elementEncoder Encoder
+}
+
+func (enc *flattenedListEncoder) FromPropertyValue(v resource.PropertyValue) (tftypes.Value, error) {
+	encoded, err := enc.elementEncoder.FromPropertyValue(v)
+	if err != nil {
+		return tftypes.Value{}, nil
+	}
+
+	list := []tftypes.Value{}
+	if !encoded.IsNull() {
+		list = append(list, encoded)
+	}
+
+	return tftypes.NewValue(enc.listType, list), nil
+}
+
+type flattenedListDecoder struct {
+	elementDecoder Decoder
+}
+
+func (dec *flattenedListDecoder) ToPropertyValue(v tftypes.Value) (resource.PropertyValue, error) {
+	var list []tftypes.Value
+	if err := v.As(&list); err != nil {
+		return resource.PropertyValue{}, nil
+	}
+	switch len(list) {
+	case 0:
+		return resource.NewNullProperty(), nil
+	case 1:
+		return dec.elementDecoder.ToPropertyValue(list[0])
+	default:
+		msg := "IsMaxItemsOne list has too many (%d) values"
+		err := fmt.Errorf(msg, len(list))
+		return resource.PropertyValue{}, err
+	}
+}

--- a/pkg/tfpfbridge/internal/convert/flattened_test.go
+++ b/pkg/tfpfbridge/internal/convert/flattened_test.go
@@ -25,60 +25,92 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
-func TestFlattenedListEncoder(t *testing.T) {
+func TestFlattenedEncoder(t *testing.T) {
 	enc := &encoding{nil, nil}
-	encoder, err := enc.newPropertyEncoder("p", schema.PropertySpec{
-		TypeSpec: schema.TypeSpec{
-			Type: "string",
-		},
+
+	listEncoder, err := enc.newPropertyEncoder("p", schema.PropertySpec{
+		TypeSpec: schema.TypeSpec{Type: "string"},
 	}, tftypes.List{ElementType: tftypes.String})
 	require.NoError(t, err)
 
+	setEncoder, err := enc.newPropertyEncoder("p", schema.PropertySpec{
+		TypeSpec: schema.TypeSpec{Type: "string"},
+	}, tftypes.Set{ElementType: tftypes.String})
+	require.NoError(t, err)
+
 	t.Run("singleton-list", func(t *testing.T) {
-		actual, err := encoder.FromPropertyValue(resource.NewStringProperty("foo"))
+		actual, err := listEncoder.FromPropertyValue(resource.NewStringProperty("foo"))
 		require.NoError(t, err)
-		expected := tftypes.NewValue(
-			tftypes.List{ElementType: tftypes.String},
-			[]tftypes.Value{
-				tftypes.NewValue(tftypes.String, "foo"),
-			})
+		expected := tftypes.NewValue(tftypes.List{ElementType: tftypes.String},
+			[]tftypes.Value{tftypes.NewValue(tftypes.String, "foo")})
 		assert.Equal(t, expected, actual)
 	})
 
 	t.Run("empty-list", func(t *testing.T) {
-		actual, err := encoder.FromPropertyValue(resource.NewNullProperty())
+		actual, err := listEncoder.FromPropertyValue(resource.NewNullProperty())
 		require.NoError(t, err)
 		expected := tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{})
 		assert.Equal(t, expected, actual)
 	})
+
+	t.Run("singleton-set", func(t *testing.T) {
+		actual, err := setEncoder.FromPropertyValue(resource.NewStringProperty("foo"))
+		require.NoError(t, err)
+		expected := tftypes.NewValue(tftypes.Set{ElementType: tftypes.String},
+			[]tftypes.Value{tftypes.NewValue(tftypes.String, "foo")})
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("empty-set", func(t *testing.T) {
+		actual, err := setEncoder.FromPropertyValue(resource.NewNullProperty())
+		require.NoError(t, err)
+		expected := tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, []tftypes.Value{})
+		assert.Equal(t, expected, actual)
+	})
 }
 
-func TestFlattenedListDecoder(t *testing.T) {
+func TestFlattenedDecoder(t *testing.T) {
 	enc := &encoding{nil, nil}
-	encoder, err := enc.newPropertyDecoder("p", schema.PropertySpec{
-		TypeSpec: schema.TypeSpec{
-			Type: "string",
-		},
+
+	listDecoder, err := enc.newPropertyDecoder("p", schema.PropertySpec{
+		TypeSpec: schema.TypeSpec{Type: "string"},
 	}, tftypes.List{ElementType: tftypes.String})
 	require.NoError(t, err)
 
+	setDecoder, err := enc.newPropertyDecoder("p", schema.PropertySpec{
+		TypeSpec: schema.TypeSpec{Type: "string"},
+	}, tftypes.Set{ElementType: tftypes.String})
+	require.NoError(t, err)
+
 	t.Run("singleton-list", func(t *testing.T) {
-		tfValue := tftypes.NewValue(
-			tftypes.List{ElementType: tftypes.String},
-			[]tftypes.Value{
-				tftypes.NewValue(tftypes.String, "foo"),
-			})
-		actual, err := encoder.ToPropertyValue(tfValue)
+		tfValue := tftypes.NewValue(tftypes.List{ElementType: tftypes.String},
+			[]tftypes.Value{tftypes.NewValue(tftypes.String, "foo")})
+		actual, err := listDecoder.ToPropertyValue(tfValue)
 		require.NoError(t, err)
 		expected := resource.NewStringProperty("foo")
 		assert.Equal(t, expected, actual)
 	})
 
 	t.Run("empty-list", func(t *testing.T) {
-		tfValue := tftypes.NewValue(
-			tftypes.List{ElementType: tftypes.String},
-			[]tftypes.Value{})
-		actual, err := encoder.ToPropertyValue(tfValue)
+		tfValue := tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{})
+		actual, err := listDecoder.ToPropertyValue(tfValue)
+		require.NoError(t, err)
+		expected := resource.NewNullProperty()
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("singleton-set", func(t *testing.T) {
+		tfValue := tftypes.NewValue(tftypes.Set{ElementType: tftypes.String},
+			[]tftypes.Value{tftypes.NewValue(tftypes.String, "foo")})
+		actual, err := setDecoder.ToPropertyValue(tfValue)
+		require.NoError(t, err)
+		expected := resource.NewStringProperty("foo")
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("empty-set", func(t *testing.T) {
+		tfValue := tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, []tftypes.Value{})
+		actual, err := setDecoder.ToPropertyValue(tfValue)
 		require.NoError(t, err)
 		expected := resource.NewNullProperty()
 		assert.Equal(t, expected, actual)

--- a/pkg/tfpfbridge/internal/convert/flattened_test.go
+++ b/pkg/tfpfbridge/internal/convert/flattened_test.go
@@ -1,0 +1,86 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package convert
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
+func TestFlattenedListEncoder(t *testing.T) {
+	enc := &encoding{nil, nil}
+	encoder, err := enc.newPropertyEncoder("p", schema.PropertySpec{
+		TypeSpec: schema.TypeSpec{
+			Type: "string",
+		},
+	}, tftypes.List{ElementType: tftypes.String})
+	require.NoError(t, err)
+
+	t.Run("singleton-list", func(t *testing.T) {
+		actual, err := encoder.FromPropertyValue(resource.NewStringProperty("foo"))
+		require.NoError(t, err)
+		expected := tftypes.NewValue(
+			tftypes.List{ElementType: tftypes.String},
+			[]tftypes.Value{
+				tftypes.NewValue(tftypes.String, "foo"),
+			})
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("empty-list", func(t *testing.T) {
+		actual, err := encoder.FromPropertyValue(resource.NewNullProperty())
+		require.NoError(t, err)
+		expected := tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{})
+		assert.Equal(t, expected, actual)
+	})
+}
+
+func TestFlattenedListDecoder(t *testing.T) {
+	enc := &encoding{nil, nil}
+	encoder, err := enc.newPropertyDecoder("p", schema.PropertySpec{
+		TypeSpec: schema.TypeSpec{
+			Type: "string",
+		},
+	}, tftypes.List{ElementType: tftypes.String})
+	require.NoError(t, err)
+
+	t.Run("singleton-list", func(t *testing.T) {
+		tfValue := tftypes.NewValue(
+			tftypes.List{ElementType: tftypes.String},
+			[]tftypes.Value{
+				tftypes.NewValue(tftypes.String, "foo"),
+			})
+		actual, err := encoder.ToPropertyValue(tfValue)
+		require.NoError(t, err)
+		expected := resource.NewStringProperty("foo")
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("empty-list", func(t *testing.T) {
+		tfValue := tftypes.NewValue(
+			tftypes.List{ElementType: tftypes.String},
+			[]tftypes.Value{})
+		actual, err := encoder.ToPropertyValue(tfValue)
+		require.NoError(t, err)
+		expected := resource.NewNullProperty()
+		assert.Equal(t, expected, actual)
+	})
+}


### PR DESCRIPTION
When Pulumi detects MaxItems=1 blocks in TF, it translates them to flat models. This needs to carry over to the convert package so it can work with translating these values appropriately.