### PR TITLE
Correctly identify more classes of nested properties

### DIFF
--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -396,9 +396,12 @@ var (
 	linkFooterRegexp = regexp.MustCompile(`(?m)^(\[\d+\]):\s(.*)`)
 
 	argumentBulletRegexp = regexp.MustCompile(
-		"^\\s*[*+-]\\s+`([a-zA-z0-9_]*)`\\s*(\\([a-zA-Z]*\\)\\s*)?[–-]?\\s+(\\([^\\)]*\\)\\s*)?(.*)")
+		"^\\s*[*+-]\\s*`([a-zA-z0-9_]*)`\\s*(\\([a-zA-Z]*\\)\\s*)?[–-]?\\s+(\\([^\\)]*\\)\\s*)?(.*)",
+	)
 
-	attributeBulletRegexp = regexp.MustCompile("^\\s*[*+-]\\s+`([a-zA-z0-9_]*)`\\s+[–-]?\\s+(.*)")
+	attributeBulletRegexp = regexp.MustCompile(
+		"^\\s*[*+-]\\s*`([a-zA-z0-9_]*)`\\s*[–-]?\\s+(.*)",
+	)
 
 	attributionFormatString = "This Pulumi package is based on the [`%[1]s` Terraform Provider](https://%[3]s/%[2]s/terraform-provider-%[1]s)."
 )
@@ -757,9 +760,6 @@ func (p *tfMarkdownParser) parseSchemaWithNestedSections(subsection []string) {
 // parseArgFromMarkdownLine takes a line of Markdown and attempts to parse it for a Terraform argument and its
 // description
 func parseArgFromMarkdownLine(line string) (string, string, bool) {
-	argumentBulletRegexp = regexp.MustCompile(
-		"^\\s*[*+-]\\s+`([a-zA-z0-9_]*)`\\s*(\\([a-zA-Z]*\\)\\s*)?[–-]?\\s+(\\([^\\)]*\\)\\s*)?(.*)")
-
 	matches := argumentBulletRegexp.FindStringSubmatch(line)
 
 	if len(matches) > 4 {

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -788,12 +788,24 @@ func getNestedBlockName(line string) string {
 		// For example:
 		// athena_workgroup.html.markdown: "#### result_configuration Argument Reference"
 		regexp.MustCompile("(?i)## ([a-z_]+).* argument reference"),
+
+		// For example:
+		// elasticsearch_domain.html.markdown: "### advanced_security_options"
+		regexp.MustCompile("#+ ([a-z_]+).*"),
+
+		// For example:
+		// dynamodb_table.html.markdown: "### `server_side_encryption`"
+		regexp.MustCompile("#+ `([a-z_]+).*`"),
+
+		// For example:
+		// route53_record.html.markdown: "### Failover Routing Policy"
+		regexp.MustCompile("#+ ([a-zA-Z_ ]+).*"),
 	}
 
 	for _, match := range nestedObjectRegexps {
 		matches := match.FindStringSubmatch(line)
 		if len(matches) >= 2 {
-			nested = strings.ToLower(matches[1])
+			nested = strings.Replace(strings.ToLower(matches[1]), " ", "_", -1)
 			break
 		}
 	}

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -791,15 +791,15 @@ func getNestedBlockName(line string) string {
 
 		// For example:
 		// elasticsearch_domain.html.markdown: "### advanced_security_options"
-		regexp.MustCompile("#+ ([a-z_]+).*"),
+		regexp.MustCompile("###+ ([a-z_]+).*"),
 
 		// For example:
 		// dynamodb_table.html.markdown: "### `server_side_encryption`"
-		regexp.MustCompile("#+ `([a-z_]+).*`"),
+		regexp.MustCompile("###+ `([a-z_]+).*`"),
 
 		// For example:
 		// route53_record.html.markdown: "### Failover Routing Policy"
-		regexp.MustCompile("#+ ([a-zA-Z_ ]+).*"),
+		regexp.MustCompile("###+ ([a-zA-Z_ ]+).*"),
 	}
 
 	for _, match := range nestedObjectRegexps {

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -1713,8 +1713,8 @@ func reformatText(g *Generator, text string, footerLinks map[string]string) (str
 		text = strings.Replace(text, "~> ", "> ", -1)
 
 		// Trim Prefixes we see when the description is spread across multiple lines.
-		text = strings.TrimPrefix(text, "-\n(Required)\n")
-		text = strings.TrimPrefix(text, "-\n(Optional)\n")
+		text = strings.TrimPrefix(text, "\n(Required)\n")
+		text = strings.TrimPrefix(text, "\n(Optional)\n")
 
 		// Find markdown Terraform docs site reference links.
 		text = markdownPageReferenceLink.ReplaceAllStringFunc(text, func(referenceLink string) string {

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -802,7 +802,8 @@ func getNestedBlockName(line string) string {
 		regexp.MustCompile("###+ ([a-zA-Z_ ]+).*"),
 
 		// For example:
-		// sql_database_instance.html.markdown: "The optional `settings.ip_configuration.authorized_networks[]`` sublist supports:"
+		// sql_database_instance.html.markdown:
+		// "The optional `settings.ip_configuration.authorized_networks[]`` sublist supports:"
 		regexp.MustCompile("`([a-zA-Z_.\\[\\]]+)`.*supports:"),
 	}
 

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -396,7 +396,7 @@ var (
 	linkFooterRegexp = regexp.MustCompile(`(?m)^(\[\d+\]):\s(.*)`)
 
 	argumentBulletRegexp = regexp.MustCompile(
-		"^\\s*[*+-]\\s*`([a-zA-z0-9_]*)`(\\([a-zA-Z]*\\)\\s*)?\\s*[:–-]?\\s*(\\([^\\)]*\\)[-\\s]*)?(.*)",
+		"^\\s*[*+-]\\s*`([a-zA-z0-9_]*)`\\s*(\\([a-zA-Z]*\\)\\s*)?\\s*[:–-]?\\s*(\\([^\\)]*\\)[-\\s]*)?(.*)",
 	)
 
 	attributeBulletRegexp = regexp.MustCompile(
@@ -800,12 +800,20 @@ func getNestedBlockName(line string) string {
 		// For example:
 		// route53_record.html.markdown: "### Failover Routing Policy"
 		regexp.MustCompile("###+ ([a-zA-Z_ ]+).*"),
+
+		// For example:
+		// sql_database_instance.html.markdown: "The optional `settings.ip_configuration.authorized_networks[]`` sublist supports:"
+		regexp.MustCompile("`([a-zA-Z_.\\[\\]]+)`.*supports:"),
 	}
 
 	for _, match := range nestedObjectRegexps {
 		matches := match.FindStringSubmatch(line)
 		if len(matches) >= 2 {
-			nested = strings.Replace(strings.ToLower(matches[1]), " ", "_", -1)
+			nested = strings.ToLower(matches[1])
+			nested = strings.Replace(nested, " ", "_", -1)
+			nested = strings.TrimSuffix(nested, "[]")
+			parts := strings.Split(nested, ".")
+			nested = parts[len(parts)-1]
 			break
 		}
 	}

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -396,11 +396,11 @@ var (
 	linkFooterRegexp = regexp.MustCompile(`(?m)^(\[\d+\]):\s(.*)`)
 
 	argumentBulletRegexp = regexp.MustCompile(
-		"^\\s*[*+-]\\s*`([a-zA-z0-9_]*)`\\s*(\\([a-zA-Z]*\\)\\s*)?[–-]?\\s+(\\([^\\)]*\\)\\s*)?(.*)",
+		"^\\s*[*+-]\\s*`([a-zA-z0-9_]*)`(\\([a-zA-Z]*\\)\\s*)?\\s*[:–-]?\\s*(\\([^\\)]*\\)[-\\s]*)?(.*)",
 	)
 
 	attributeBulletRegexp = regexp.MustCompile(
-		"^\\s*[*+-]\\s*`([a-zA-z0-9_]*)`\\s*[–-]?\\s+(.*)",
+		"^\\s*[*+-]\\s*`([a-zA-z0-9_]*)`\\s*[:–-]?\\s*(.*)",
 	)
 
 	attributionFormatString = "This Pulumi package is based on the [`%[1]s` Terraform Provider](https://%[3]s/%[2]s/terraform-provider-%[1]s)."

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -597,6 +597,9 @@ func TestParseArgFromMarkdownLine(t *testing.T) {
 		{"* `key_vault_key_id` - (Optional) The Key Vault key URI for CMK encryption. Changing this forces a new resource to be created.", "key_vault_key_id", "The Key Vault key URI for CMK encryption. Changing this forces a new resource to be created.", true},
 		{"* `urn` - The uniform resource name of the Droplet", "urn", "The uniform resource name of the Droplet", true},
 		{"* `name`- The name of the Droplet", "name", "The name of the Droplet", true},
+		{"* `jumbo_frame_capable` -Indicates whether jumbo frames (9001 MTU) are supported.", "jumbo_frame_capable", "Indicates whether jumbo frames (9001 MTU) are supported.", true},
+		{"* `ssl_support_method`: Specifies how you want CloudFront to serve HTTPS", "ssl_support_method", "Specifies how you want CloudFront to serve HTTPS", true},
+		{"* `principal_tags`: (Optional: []) - String to string map of variables.", "principal_tags", "String to string map of variables.", true},
 		// In rare cases, we may have a match where description is empty like the following, taken from https://github.com/hashicorp/terraform-provider-aws/blob/main/website/docs/r/spot_fleet_request.html.markdown
 		{"* `instance_pools_to_use_count` - (Optional; Default: 1)", "instance_pools_to_use_count", "", true},
 		{"", "", "", false},

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -595,6 +595,8 @@ func TestParseArgFromMarkdownLine(t *testing.T) {
 	}{
 		{"* `name` - (Required) A unique name to give the role.", "name", "A unique name to give the role.", true},
 		{"* `key_vault_key_id` - (Optional) The Key Vault key URI for CMK encryption. Changing this forces a new resource to be created.", "key_vault_key_id", "The Key Vault key URI for CMK encryption. Changing this forces a new resource to be created.", true},
+		{"* `urn` - The uniform resource name of the Droplet", "urn", "The uniform resource name of the Droplet", true},
+		{"* `name`- The name of the Droplet", "name", "The name of the Droplet", true},
 		// In rare cases, we may have a match where description is empty like the following, taken from https://github.com/hashicorp/terraform-provider-aws/blob/main/website/docs/r/spot_fleet_request.html.markdown
 		{"* `instance_pools_to_use_count` - (Optional; Default: 1)", "instance_pools_to_use_count", "", true},
 		{"", "", "", false},
@@ -607,6 +609,23 @@ func TestParseArgFromMarkdownLine(t *testing.T) {
 		assert.Equal(t, test.expectedDesc, desc)
 		assert.Equal(t, test.expectedFound, found)
 	}
+}
+
+func TestParseAttributesReferenceSection(t *testing.T) {
+	p := tfMarkdownParser{}
+	p.ret = entityDocs{
+		Arguments:  make(map[string]*argumentDocs),
+		Attributes: make(map[string]string),
+	}
+	p.parseAttributesReferenceSection([]string{
+		"The following attributes are exported:",
+		"",
+		"* `id` - The ID of the Droplet",
+		"* `urn` - The uniform resource name of the Droplet",
+		"* `name`- The name of the Droplet",
+		"* `region` - The region of the Droplet",
+	})
+	assert.Len(t, p.ret.Attributes, 4)
 }
 
 func TestGetNestedBlockName(t *testing.T) {

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -49,6 +49,10 @@ func TestURLRewrite(t *testing.T) {
 			Input:    "See google_container_node_pool for schema.",
 			Expected: "See google.container.NodePool for schema.",
 		},
+		{
+			Input:    "\n(Required)\nThe app_ip of name of the Firebase webApp.",
+			Expected: "The appIp of name of the Firebase webApp.",
+		},
 	}
 
 	g, err := NewGenerator(GeneratorOptions{

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -17,12 +17,12 @@ package tfgen
 
 import (
 	"bytes"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"strings"
 	"testing"
 	"text/template"
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -616,8 +616,15 @@ func TestGetNestedBlockName(t *testing.T) {
 		{"", ""},
 		{"The `website` object supports the following:", "website"},
 		{"#### result_configuration Argument Reference", "result_configuration"},
+		{"### advanced_security_options", "advanced_security_options"},
+		{"### `server_side_encryption`", "server_side_encryption"},
+		{"### Failover Routing Policy", "failover_routing_policy"},
+		{"##### `log_configuration`", "log_configuration"},
+		{"### data_format_conversion_configuration", "data_format_conversion_configuration"},
 		// This is a common starting line of base arguments, so should result in zero value:
 		{"The following arguments are supported:", ""},
+		{"* `kms_key_id` - ...", ""},
+		{"## Import", ""},
 	}
 
 	for _, tt := range tests {

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -637,6 +637,8 @@ func TestGetNestedBlockName(t *testing.T) {
 	}{
 		{"", ""},
 		{"The `website` object supports the following:", "website"},
+		{"The optional `settings.location_preference` subblock supports:", "location_preference"},
+		{"The optional `settings.ip_configuration.authorized_networks[]` sublist supports:", "authorized_networks"},
 		{"#### result_configuration Argument Reference", "result_configuration"},
 		{"### advanced_security_options", "advanced_security_options"},
 		{"### `server_side_encryption`", "server_side_encryption"},


### PR DESCRIPTION
Improve our attribute and argument parsing regexps to catch and extract more accurate results from additional common cases.

Fixes #529.
Fixes https://github.com/pulumi/pulumi-aws/issues/1993.
Fixes https://github.com/pulumi/pulumi-aws/issues/1879.
Fixes https://github.com/pulumi/pulumi-aws/issues/1994.
Fixes https://github.com/pulumi/pulumi-aws/issues/1992.
Fixes https://github.com/pulumi/pulumi-aws/issues/2050.
Fixes https://github.com/pulumi/pulumi-aws/issues/2119.
Fixes https://github.com/pulumi/pulumi-aws/issues/2163.
Fixes https://github.com/pulumi/pulumi-aws/issues/2164.
Fixes https://github.com/pulumi/pulumi-aws/issues/1603.
Fixes https://github.com/pulumi/pulumi-aws/issues/2034.
Fixes https://github.com/pulumi/pulumi-aws/issues/1315.
Fixes https://github.com/pulumi/pulumi-aws/issues/1616.
Fixes https://github.com/pulumi/pulumi-aws/issues/2253.
Fixes https://github.com/pulumi/pulumi-aws/issues/1678.
Fixes https://github.com/pulumi/docs/issues/6156.
Fixes https://github.com/pulumi/docs/issues/3384.
Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/214.
Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/550.
Fixes https://github.com/pulumi/pulumi-gcp/issues/784.
Fixes https://github.com/pulumi/pulumi-gcp/issues/852.
Fixes https://github.com/pulumi/pulumi-gcp/issues/393.
Fixes https://github.com/pulumi/pulumi-gcp/issues/953.
Fixes https://github.com/pulumi/docs/issues/3895.
Fixes https://github.com/pulumi/docs/issues/1626.
Fixes https://github.com/pulumi/pulumi-vsphere/issues/181.