### PR TITLE
golangci-lint: Upgrade to v1.50.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  GOLANGCI_LINT_VERSION: v1.46.2
+  GOLANGCI_LINT_VERSION: v1.50.1
 name: Pull Request & Downstream Testing
 on: [pull_request]
 jobs:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,6 +1,6 @@
 name: Master and Tag Builds
 env:
-  GOLANGCI_LINT_VERSION: v1.46.2
+  GOLANGCI_LINT_VERSION: v1.50.1
 on:
   push:
     branches:

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch: {}
 env:
   GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
-  GOLANGCI_LINT_VERSION: v1.46.2
+  GOLANGCI_LINT_VERSION: v1.50.1
 jobs:
   weekly-pulumi-update:
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,6 @@ run:
 linters:
   enable-all: false
   enable:
-    - deadcode
     - errcheck
     - gofmt
     - gosec
@@ -19,6 +18,5 @@ linters:
     - misspell
     - nakedret
     - revive
-    - structcheck
     - unconvert
-    - varcheck
+    - unused


### PR DESCRIPTION
Upgrades the repository to the most current version of golangci-lint.

Since v1.49, a few linters were disabled/replaced.
Per golangci-lint's startup message:

    WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
    WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
    WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.

This change complies with the suggestion by dropping those linters from
the configuration, and adding in 'unused'.
