### PR TITLE
golangci-lint: Enable nolintlint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,6 +17,7 @@ linters:
     - megacheck
     - misspell
     - nakedret
+    - nolintlint
     - revive
     - unconvert
     - unused

--- a/pkg/tf2pulumi/convert/tf12.go
+++ b/pkg/tf2pulumi/convert/tf12.go
@@ -308,7 +308,7 @@ func (o *output) SyntaxNode() hclsyntax.Node {
 	return o.syntax
 }
 
-// nolint: structcheck, unused
+//nolint:structcheck, unused
 type module struct {
 	syntax *hclsyntax.Block
 
@@ -1076,7 +1076,7 @@ func (rr *resourceRewriter) pop() {
 	rr.stack = rr.stack[:len(rr.stack)-1]
 }
 
-// nolint: unused
+//nolint:unused
 func (rr *resourceRewriter) dumpStack() {
 	fmt.Printf("[")
 	for i, info := range rr.stack {

--- a/pkg/tf2pulumi/il/plugin_info.go
+++ b/pkg/tf2pulumi/il/plugin_info.go
@@ -186,7 +186,7 @@ func (pluginProviderInfoSource) GetProviderInfo(
 	}
 
 	// Run the plugin and decode its provider config.
-	// nolint: gas
+	//nolint:gas
 	cmd := exec.Command(path, "-get-provider-info")
 	out, err := cmd.StdoutPipe()
 	if err != nil {

--- a/pkg/tfbridge/diff_test.go
+++ b/pkg/tfbridge/diff_test.go
@@ -1573,7 +1573,7 @@ func TestCollectionsWithMultipleItems(t *testing.T) {
 		},
 	}
 
-	// nolint:lll
+	//nolint:lll
 	runTestCase := func(t *testing.T, name string, typ schema.ValueType, inputs, state []interface{}, expected map[string]DiffKind) {
 		t.Run(name, func(t *testing.T) {
 			diffTest(t,

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -43,7 +43,7 @@ const (
 // ProviderInfo contains information about a Terraform provider plugin that we will use to generate the Pulumi
 // metadata.  It primarily contains a pointer to the Terraform schema, but can also contain specific name translations.
 //
-// nolint: lll
+//nolint:lll
 type ProviderInfo struct {
 	P              shim.Provider // the TF provider/schema.
 	Name           string        // the TF provider name (e.g. terraform-provider-XXXX).

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -1344,7 +1344,7 @@ func isDefaultOrZeroValue(tfs shim.Schema, ps *SchemaInfo, v resource.PropertyVa
 	case v.IsNull():
 		return true
 	case v.IsBool():
-		//nolint this expression is clearer than !v.BoolValue()
+		//nolint:gosimple // This expression is clearer than !v.BoolValue()
 		return v.BoolValue() == false
 	case v.IsNumber():
 		return v.NumberValue() == 0

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -389,7 +389,7 @@ func readMarkdown(repo string, kind DocKind, possibleLocations []string) ([]byte
 	return nil, "", false
 }
 
-// nolint:lll
+//nolint:lll
 var (
 	// For example:
 	// [1]: https://docs.aws.amazon.com/lambda/latest/dg/welcome.html
@@ -1479,7 +1479,7 @@ func (g *Generator) convertHCL(hcl, path, exampleTitle string, languages []strin
 		}
 
 		// At least one language out of the given set has been generated, which is considered a success
-		// nolint:ineffassign
+		//nolint:ineffassign
 		err = nil
 	}
 
@@ -1603,7 +1603,6 @@ func cleanupDoc(name string, g *Generator, doc entityDocs, footerLinks map[strin
 	}, elidedDoc
 }
 
-//nolint:lll
 var (
 	// Match a [markdown](link)
 	markdownLink = regexp.MustCompile(`\[([^\]]*)\]\(([^\)]*)\)`)

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint: lll
+//nolint:lll
 package tfgen
 
 import (
@@ -34,16 +34,16 @@ type testcase struct {
 func TestURLRewrite(t *testing.T) {
 	tests := []testcase{
 		{
-			Input:    "The DNS name for the given subnet/AZ per [documented convention](http://docs.aws.amazon.com/efs/latest/ug/mounting-fs-mount-cmd-dns-name.html).", // nolint: lll
-			Expected: "The DNS name for the given subnet/AZ per [documented convention](http://docs.aws.amazon.com/efs/latest/ug/mounting-fs-mount-cmd-dns-name.html).", // nolint: lll
+			Input:    "The DNS name for the given subnet/AZ per [documented convention](http://docs.aws.amazon.com/efs/latest/ug/mounting-fs-mount-cmd-dns-name.html).", //nolint:lll
+			Expected: "The DNS name for the given subnet/AZ per [documented convention](http://docs.aws.amazon.com/efs/latest/ug/mounting-fs-mount-cmd-dns-name.html).", //nolint:lll
 		},
 		{
-			Input:    "It's recommended to specify `create_before_destroy = true` in a [lifecycle][1] block to replace a certificate which is currently in use (eg, by [`aws_lb_listener`](lb_listener.html)).", // nolint: lll
-			Expected: "It's recommended to specify `createBeforeDestroy = true` in a [lifecycle][1] block to replace a certificate which is currently in use (eg, by `awsLbListener`).",                         // nolint: lll
+			Input:    "It's recommended to specify `create_before_destroy = true` in a [lifecycle][1] block to replace a certificate which is currently in use (eg, by [`aws_lb_listener`](lb_listener.html)).", //nolint:lll
+			Expected: "It's recommended to specify `createBeforeDestroy = true` in a [lifecycle][1] block to replace a certificate which is currently in use (eg, by `awsLbListener`).",                         //nolint:lll
 		},
 		{
-			Input:    "The execution ARN to be used in [`lambda_permission`](/docs/providers/aws/r/lambda_permission.html)'s `source_arn`",                       // nolint: lll
-			Expected: "The execution ARN to be used in [`lambdaPermission`](https://www.terraform.io/docs/providers/aws/r/lambda_permission.html)'s `sourceArn`", // nolint: lll
+			Input:    "The execution ARN to be used in [`lambda_permission`](/docs/providers/aws/r/lambda_permission.html)'s `source_arn`",                       //nolint:lll
+			Expected: "The execution ARN to be used in [`lambdaPermission`](https://www.terraform.io/docs/providers/aws/r/lambda_permission.html)'s `sourceArn`", //nolint:lll
 		},
 		{
 			Input:    "See google_container_node_pool for schema.",
@@ -590,7 +590,7 @@ subtitle 2 content
 }
 
 func TestParseArgFromMarkdownLine(t *testing.T) {
-	// nolint:lll
+	//nolint:lll
 	tests := []struct {
 		input         string
 		expectedName  string

--- a/pkg/tfgen/examples_coverage_tracker.go
+++ b/pkg/tfgen/examples_coverage_tracker.go
@@ -129,8 +129,9 @@ func (ct *CoverageTracker) languageConversionSuccess(languageName string, progra
 	})
 }
 
-//nolint
 // Used when: generator has successfully converted current example, but threw out some warnings
+//
+//nolint:unused
 func (ct *CoverageTracker) languageConversionWarning(languageName string, warningDiagnostics hcl.Diagnostics) {
 	if ct == nil {
 		return

--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -15,7 +15,7 @@
 // Pulling out some of the repeated strings tokens into constants would harm readability, so we just ignore the
 // goconst linter's warning.
 //
-// nolint: goconst
+//nolint:goconst
 package tfgen
 
 import (

--- a/pkg/tfshim/sdk-v2/resource.go
+++ b/pkg/tfshim/sdk-v2/resource.go
@@ -28,7 +28,7 @@ func (r v2Resource) SchemaVersion() int {
 	return r.tf.SchemaVersion
 }
 
-// nolint: staticcheck
+//nolint:staticcheck
 func (r v2Resource) Importer() shim.ImportFunc {
 	if r.tf.Importer == nil {
 		return nil

--- a/pkg/tfshim/tfplugin5/resource.go
+++ b/pkg/tfshim/tfplugin5/resource.go
@@ -29,7 +29,6 @@ func (r *resource) SchemaVersion() int {
 	return r.schemaVersion
 }
 
-// nolint: staticcheck
 func (r *resource) Importer() shim.ImportFunc {
 	if r.provider == nil {
 		return nil


### PR DESCRIPTION
The nolintlint linter included with golangci-lint
finds bad usages of the `//nolint` directive
such as `// nolint:foo` (leading space).
Such incorrect usage ends up in the package's godocs (see #120).

This change enables the linter and fixes all occurrences
discovered by golangci-lint.

Depends on #716

Note that #716 is the base for this PR.
When that merges, the base branch for this will be updated.
