### PR TITLE
Support Configure calls

### DIFF
--- a/pkg/tfpfbridge/internal/convert/convert.go
+++ b/pkg/tfpfbridge/internal/convert/convert.go
@@ -43,6 +43,7 @@ type Encoding interface {
 
 // Subset of pschema.PackageSpec required for conversion.
 type PackageSpec interface {
+	Config() *pschema.ConfigSpec
 	Function(tok tokens.ModuleMember) *pschema.FunctionSpec
 	Resource(tok tokens.Type) *pschema.ResourceSpec
 	Type(tok tokens.Type) *pschema.ComplexTypeSpec
@@ -56,6 +57,36 @@ type PropertyNames interface {
 
 	// Same as PropertyKey but for provider-level configuration properties.
 	ConfigPropertyKey(property TerraformPropertyName, t tftypes.Type) resource.PropertyKey
+}
+
+// Like PropertyNames but specialized to either a type by token or config property.
+type LocalPropertyNames interface {
+	PropertyKey(property TerraformPropertyName, t tftypes.Type) resource.PropertyKey
+}
+
+type typeLocalPropertyNames struct {
+	propertyNames PropertyNames
+	typeToken     tokens.Token
+}
+
+func (l *typeLocalPropertyNames) PropertyKey(property TerraformPropertyName, t tftypes.Type) resource.PropertyKey {
+	return l.propertyNames.PropertyKey(l.typeToken, property, t)
+}
+
+func NewTypeLocalPropertyNames(pn PropertyNames, tok tokens.Token) LocalPropertyNames {
+	return &typeLocalPropertyNames{pn, tok}
+}
+
+type configLocalPropertyNames struct {
+	propertyNames PropertyNames
+}
+
+func (l *configLocalPropertyNames) PropertyKey(property TerraformPropertyName, t tftypes.Type) resource.PropertyKey {
+	return l.propertyNames.ConfigPropertyKey(property, t)
+}
+
+func NewConfigPropertyNames(pn PropertyNames) LocalPropertyNames {
+	return &configLocalPropertyNames{pn}
 }
 
 type Encoder interface {

--- a/pkg/tfpfbridge/internal/convert/convert.go
+++ b/pkg/tfpfbridge/internal/convert/convert.go
@@ -34,6 +34,7 @@ import (
 type TerraformPropertyName = string
 
 type Encoding interface {
+	NewConfigEncoder(tftypes.Object) (Encoder, error)
 	NewResourceDecoder(tokens.Type, tftypes.Object) (Decoder, error)
 	NewResourceEncoder(tokens.Type, tftypes.Object) (Encoder, error)
 	NewDataSourceDecoder(tokens.ModuleMember, tftypes.Object) (Decoder, error)
@@ -52,6 +53,9 @@ type PropertyNames interface {
 	//
 	// typeToken identifies the resource, data source, or named object type.
 	PropertyKey(typeToken tokens.Token, property TerraformPropertyName, t tftypes.Type) resource.PropertyKey
+
+	// Same as PropertyKey but for provider-level configuration properties.
+	ConfigPropertyKey(property TerraformPropertyName, t tftypes.Type) resource.PropertyKey
 }
 
 type Encoder interface {

--- a/pkg/tfpfbridge/internal/convert/encoding.go
+++ b/pkg/tfpfbridge/internal/convert/encoding.go
@@ -36,6 +36,10 @@ func NewEncoding(spec PackageSpec, propertyNames PropertyNames) Encoding {
 	return &encoding{spec: spec, propertyNames: propertyNames}
 }
 
+func (e *encoding) NewConfigEncoder(configType tftypes.Object) (Encoder, error) {
+	return nil, fmt.Errorf("TOO BAD")
+}
+
 func (e *encoding) NewResourceEncoder(resourceToken tokens.Type, objectType tftypes.Object) (Encoder, error) {
 	rspec := e.spec.Resource(resourceToken)
 	if rspec == nil {

--- a/pkg/tfpfbridge/internal/convert/encoding.go
+++ b/pkg/tfpfbridge/internal/convert/encoding.go
@@ -37,7 +37,17 @@ func NewEncoding(spec PackageSpec, propertyNames PropertyNames) Encoding {
 }
 
 func (e *encoding) NewConfigEncoder(configType tftypes.Object) (Encoder, error) {
-	return nil, fmt.Errorf("TOO BAD")
+	spec := specFinder(e.spec.Config().Variables)
+	propNames := NewConfigPropertyNames(e.propertyNames)
+	propertyEncoders, err := e.buildPropertyEncoders(propNames, spec, configType)
+	if err != nil {
+		return nil, fmt.Errorf("cannot derive an encoder for provider config: %w", err)
+	}
+	enc, err := newObjectEncoder(configType, propertyEncoders, propNames)
+	if err != nil {
+		return nil, fmt.Errorf("cannot derive an encoder for provider config: %w", err)
+	}
+	return enc, nil
 }
 
 func (e *encoding) NewResourceEncoder(resourceToken tokens.Type, objectType tftypes.Object) (Encoder, error) {
@@ -46,11 +56,12 @@ func (e *encoding) NewResourceEncoder(resourceToken tokens.Type, objectType tfty
 		return nil, fmt.Errorf("dangling resource token %q", string(resourceToken))
 	}
 	spec := specFinderWithID(rspec.Properties)
-	propertyEncoders, err := e.buildPropertyEncoders(tokens.Token(resourceToken), spec, objectType)
+	propNames := NewTypeLocalPropertyNames(e.propertyNames, tokens.Token(resourceToken))
+	propertyEncoders, err := e.buildPropertyEncoders(propNames, spec, objectType)
 	if err != nil {
 		return nil, fmt.Errorf("cannot derive an encoder for resource %q: %w", string(resourceToken), err)
 	}
-	enc, err := newObjectEncoder(tokens.Token(resourceToken), objectType, propertyEncoders, e.propertyNames)
+	enc, err := newObjectEncoder(objectType, propertyEncoders, propNames)
 	if err != nil {
 		return nil, fmt.Errorf("cannot derive an encoder for resource %q: %w", string(resourceToken), err)
 	}
@@ -63,12 +74,13 @@ func (e *encoding) NewResourceDecoder(resourceToken tokens.Type, objectType tfty
 		return nil, fmt.Errorf("dangling resource token %q", string(resourceToken))
 	}
 	spec := specFinderWithID(rspec.Properties)
-	propertyDecoders, err := e.buildPropertyDecoders(tokens.Token(resourceToken), spec, objectType)
+	propNames := NewTypeLocalPropertyNames(e.propertyNames, tokens.Token(resourceToken))
+	propertyDecoders, err := e.buildPropertyDecoders(propNames, spec, objectType)
 	if err != nil {
 		return nil, fmt.Errorf("cannot derive an decoder for resource %q: %w", string(resourceToken), err)
 	}
 	propertyDecoders["id"] = newStringDecoder()
-	dec, err := newObjectDecoder(tokens.Token(resourceToken), objectType, propertyDecoders, e.propertyNames)
+	dec, err := newObjectDecoder(objectType, propertyDecoders, propNames)
 	if err != nil {
 		return nil, fmt.Errorf("cannot derive a decoder for resource %q: %w", string(resourceToken), err)
 	}
@@ -82,11 +94,12 @@ func (e *encoding) NewDataSourceEncoder(functionToken tokens.ModuleMember, objec
 	}
 	token := tokens.Token(functionToken)
 	spec := specFinderWithFallback(specFinder(fspec.Inputs.Properties), specFinder(fspec.Outputs.Properties))
-	propertyEncoders, err := e.buildPropertyEncoders(token, spec, objectType)
+	propNames := NewTypeLocalPropertyNames(e.propertyNames, token)
+	propertyEncoders, err := e.buildPropertyEncoders(propNames, spec, objectType)
 	if err != nil {
 		return nil, fmt.Errorf("cannot derive an encoder for function %q: %w", string(token), err)
 	}
-	enc, err := newObjectEncoder(token, objectType, propertyEncoders, e.propertyNames)
+	enc, err := newObjectEncoder(objectType, propertyEncoders, propNames)
 	if err != nil {
 		return nil, fmt.Errorf("cannot derive an encoder for function %q: %w", string(token), err)
 	}
@@ -100,11 +113,12 @@ func (e *encoding) NewDataSourceDecoder(functionToken tokens.ModuleMember, objec
 		return nil, fmt.Errorf("dangling function token %q", string(token))
 	}
 	spec := specFinderWithFallback(specFinder(fspec.Outputs.Properties), specFinder(fspec.Inputs.Properties))
-	propertyDecoders, err := e.buildPropertyDecoders(token, spec, objectType)
+	propNames := NewTypeLocalPropertyNames(e.propertyNames, token)
+	propertyDecoders, err := e.buildPropertyDecoders(propNames, spec, objectType)
 	if err != nil {
 		return nil, fmt.Errorf("cannot derive an decoder for function %q: %w", string(token), err)
 	}
-	dec, err := newObjectDecoder(token, objectType, propertyDecoders, e.propertyNames)
+	dec, err := newObjectDecoder(objectType, propertyDecoders, propNames)
 	if err != nil {
 		return nil, fmt.Errorf("cannot derive a decoder for function %q: %w", string(token), err)
 	}
@@ -112,13 +126,13 @@ func (e *encoding) NewDataSourceDecoder(functionToken tokens.ModuleMember, objec
 }
 
 func (e *encoding) buildPropertyEncoders(
-	token tokens.Token,
+	propertyNames LocalPropertyNames,
 	propSpecs func(resource.PropertyKey) *pschema.PropertySpec,
 	objectType tftypes.Object,
 ) (map[TerraformPropertyName]Encoder, error) {
 	propertyEncoders := map[TerraformPropertyName]Encoder{}
 	for tfName, t := range objectType.AttributeTypes {
-		key := e.propertyNames.PropertyKey(token, tfName, t)
+		key := propertyNames.PropertyKey(tfName, t)
 		puSpec := propSpecs(key)
 		if puSpec == nil {
 			return nil, fmt.Errorf("missing property %q", string(key))
@@ -133,13 +147,13 @@ func (e *encoding) buildPropertyEncoders(
 }
 
 func (e *encoding) buildPropertyDecoders(
-	token tokens.Token,
+	propertyNames LocalPropertyNames,
 	propSpecs func(resource.PropertyKey) *pschema.PropertySpec,
 	objectType tftypes.Object,
 ) (map[TerraformPropertyName]Decoder, error) {
 	propertyEncoders := map[TerraformPropertyName]Decoder{}
 	for tfName, t := range objectType.AttributeTypes {
-		key := e.propertyNames.PropertyKey(token, tfName, t)
+		key := propertyNames.PropertyKey(tfName, t)
 		puSpec := propSpecs(key)
 		if puSpec == nil {
 			return nil, fmt.Errorf("missing property %q", string(key))
@@ -194,11 +208,12 @@ func (e *encoding) deriveEncoderForNamedObjectType(ref string, t tftypes.Object)
 	if refSpec.Enum != nil {
 		return nil, fmt.Errorf("enums are not supported: %q", ref)
 	}
-	propertyEncoders, err := e.buildPropertyEncoders(tok, specFinder(refSpec.Properties), t)
+	propNames := NewTypeLocalPropertyNames(e.propertyNames, tok)
+	propertyEncoders, err := e.buildPropertyEncoders(propNames, specFinder(refSpec.Properties), t)
 	if err != nil {
 		return nil, fmt.Errorf("issue deriving an encoder for %q: %w", ref, err)
 	}
-	return newObjectEncoder(tok, t, propertyEncoders, e.propertyNames)
+	return newObjectEncoder(t, propertyEncoders, propNames)
 }
 
 func (e *encoding) deriveDecoderForNamedObjectType(ref string, t tftypes.Object) (Decoder, error) {
@@ -209,11 +224,12 @@ func (e *encoding) deriveDecoderForNamedObjectType(ref string, t tftypes.Object)
 	if refSpec.Enum != nil {
 		return nil, fmt.Errorf("enums are not supported: %q", ref)
 	}
-	propertyDecoders, err := e.buildPropertyDecoders(tok, specFinder(refSpec.Properties), t)
+	propNames := NewTypeLocalPropertyNames(e.propertyNames, tok)
+	propertyDecoders, err := e.buildPropertyDecoders(propNames, specFinder(refSpec.Properties), t)
 	if err != nil {
 		return nil, fmt.Errorf("issue deriving an decoder for %q: %w", ref, err)
 	}
-	return newObjectDecoder(tok, t, propertyDecoders, e.propertyNames)
+	return newObjectDecoder(t, propertyDecoders, propNames)
 }
 
 func (e *encoding) deriveEncoder(typeSpec *pschema.TypeSpec, t tftypes.Type) (Encoder, error) {

--- a/pkg/tfpfbridge/provider.go
+++ b/pkg/tfpfbridge/provider.go
@@ -218,6 +218,10 @@ type packageSpec struct {
 
 var _ convert.PackageSpec = (*packageSpec)(nil)
 
+func (p packageSpec) Config() *pschema.ConfigSpec {
+	return &p.spec.Config
+}
+
 func (p packageSpec) Resource(tok tokens.Type) *pschema.ResourceSpec {
 	res, ok := p.spec.Resources[string(tok)]
 	if ok {

--- a/pkg/tfpfbridge/provider.go
+++ b/pkg/tfpfbridge/provider.go
@@ -23,6 +23,7 @@ import (
 	tfsdkprovider "github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
 	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
@@ -53,6 +54,8 @@ type Provider struct {
 	encoding      convert.Encoding
 	propertyNames convert.PropertyNames
 	diagSink      diag.Sink
+	configEncoder convert.Encoder
+	configType    tftypes.Object
 }
 
 var _ plugin.Provider = &Provider{}
@@ -87,6 +90,18 @@ func NewProvider(info info.ProviderInfo, pulumiSchema []byte, serializedRenames 
 	propertyNames := newPrecisePropertyNames(renames)
 	enc := convert.NewEncoding(packageSpec{&thePackageSpec}, propertyNames)
 
+	schema, diags := p.GetSchema(ctx)
+	if diags.HasError() {
+		panic(fmt.Errorf("GetSchema returned diagnostics with HasError"))
+	}
+
+	providerConfigType := schema.Type().TerraformType(ctx).(tftypes.Object)
+
+	configEncoder, err := enc.NewConfigEncoder(providerConfigType)
+	if err != nil {
+		panic(fmt.Errorf("NewConfigEncoder failed: %w", err))
+	}
+
 	return &Provider{
 		tfProvider:    p,
 		tfServer:      server6,
@@ -97,6 +112,8 @@ func NewProvider(info info.ProviderInfo, pulumiSchema []byte, serializedRenames 
 		packageSpec:   thePackageSpec,
 		propertyNames: propertyNames,
 		encoding:      enc,
+		configEncoder: configEncoder,
+		configType:    providerConfigType,
 	}
 }
 

--- a/pkg/tfpfbridge/tests/internal/cmd/pulumi-resource-testbridge/renames.json
+++ b/pkg/tfpfbridge/tests/internal/cmd/pulumi-resource-testbridge/renames.json
@@ -1,5 +1,6 @@
 {
   "resources": {
+    "testbridge:index/testres:TestConfigRes": "testbridge_testconfigres",
     "testbridge:index/testres:Testcompres": "testbridge_testcompres",
     "testbridge:index/testres:Testres": "testbridge_testres"
   },

--- a/pkg/tfpfbridge/tests/internal/cmd/pulumi-resource-testbridge/schema.json
+++ b/pkg/tfpfbridge/tests/internal/cmd/pulumi-resource-testbridge/schema.json
@@ -111,8 +111,21 @@
     },
     "resources": {
         "testbridge:index/testres:TestConfigRes": {
+            "properties": {
+                "configCopy": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "configCopy"
+            ],
             "stateInputs": {
                 "description": "Input properties used for looking up and filtering TestConfigRes resources.\n",
+                "properties": {
+                    "configCopy": {
+                        "type": "string"
+                    }
+                },
                 "type": "object"
             }
         },

--- a/pkg/tfpfbridge/tests/internal/cmd/pulumi-resource-testbridge/schema.json
+++ b/pkg/tfpfbridge/tests/internal/cmd/pulumi-resource-testbridge/schema.json
@@ -19,7 +19,16 @@
             "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-testbridge)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-testbridge` repo](https://github.com/pulumi/pulumi-terraform-bridge/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-testbridge` repo](https://github.com/terraform-providers/terraform-provider-testbridge/issues)."
         }
     },
-    "config": {},
+    "config": {
+        "variables": {
+            "stringConfigProp": {
+                "type": "string"
+            }
+        },
+        "defaults": [
+            "stringConfigProp"
+        ]
+    },
     "types": {
         "testbridge:index/TestresService:TestresService": {
             "properties": {
@@ -101,6 +110,12 @@
         "description": "The provider type for the testbridge package. By default, resources use package-wide configuration\nsettings, however an explicit `Provider` instance may be created and passed during resource\nconstruction to achieve fine-grained programmatic control over provider settings. See the\n[documentation](https://www.pulumi.com/docs/reference/programming-model/#providers) for more information.\n"
     },
     "resources": {
+        "testbridge:index/testres:TestConfigRes": {
+            "stateInputs": {
+                "description": "Input properties used for looking up and filtering TestConfigRes resources.\n",
+                "type": "object"
+            }
+        },
         "testbridge:index/testres:Testcompres": {
             "properties": {
                 "ecdsacurve": {

--- a/pkg/tfpfbridge/tests/internal/testing/replay.go
+++ b/pkg/tfpfbridge/tests/internal/testing/replay.go
@@ -44,6 +44,9 @@ func Replay(t *testing.T, server pulumirpc.ResourceProviderServer, jsonLog strin
 	case "/pulumirpc.ResourceProvider/Check":
 		replay(t, entry, new(pulumirpc.CheckRequest), server.Check)
 
+	case "/pulumirpc.ResourceProvider/Configure":
+		replay(t, entry, new(pulumirpc.ConfigureRequest), server.Configure)
+
 	case "/pulumirpc.ResourceProvider/Create":
 		replay(t, entry, new(pulumirpc.CreateRequest), server.Create)
 
@@ -64,6 +67,17 @@ func Replay(t *testing.T, server pulumirpc.ResourceProviderServer, jsonLog strin
 
 	default:
 		t.Errorf("Unknown method: %s", entry.Method)
+	}
+}
+
+func ReplaySequence(t *testing.T, server pulumirpc.ResourceProviderServer, jsonLog string) {
+	var entries []jsonLogEntry
+	err := json.Unmarshal([]byte(jsonLog), &entries)
+	assert.NoError(t, err)
+	for _, e := range entries {
+		bytes, err := json.Marshal(e)
+		assert.NoError(t, err)
+		Replay(t, server, string(bytes))
 	}
 }
 

--- a/pkg/tfpfbridge/tests/internal/testprovider/testbridge.go
+++ b/pkg/tfpfbridge/tests/internal/testprovider/testbridge.go
@@ -72,10 +72,12 @@ func (p *syntheticProvider) GetSchema(context.Context) (tfsdk.Schema, diag.Diagn
 }
 
 func (p *syntheticProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
-	var stringConfigProp string
+	var stringConfigProp *string
 	diags := req.Config.GetAttribute(ctx, path.Root("stringConfigProp"), &stringConfigProp)
 	resp.Diagnostics.Append(diags...)
-	resp.ResourceData = stringConfigProp
+	if stringConfigProp != nil {
+		resp.ResourceData = stringConfigProp
+	}
 	return
 }
 

--- a/pkg/tfpfbridge/tests/internal/testprovider/testbridge.go
+++ b/pkg/tfpfbridge/tests/internal/testprovider/testbridge.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2022, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,9 +19,11 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/pulumi/pulumi-terraform-bridge/pkg/tfpfbridge/info"
 )
@@ -42,8 +44,9 @@ func SyntheticTestBridgeProvider() info.ProviderInfo {
 		Repository:  "https://github.com/pulumi/pulumi-terraform-bridge",
 		Version:     "0.0.1",
 		Resources: map[string]*info.ResourceInfo{
-			"testbridge_testres":     {Tok: "testbridge:index/testres:Testres"},
-			"testbridge_testcompres": {Tok: "testbridge:index/testres:Testcompres"},
+			"testbridge_testres":       {Tok: "testbridge:index/testres:Testres"},
+			"testbridge_testcompres":   {Tok: "testbridge:index/testres:Testcompres"},
+			"testbridge_testconfigres": {Tok: "testbridge:index/testres:TestConfigRes"},
 		},
 	}
 }
@@ -59,10 +62,20 @@ func (p *syntheticProvider) Metadata(_ context.Context, _ provider.MetadataReque
 }
 
 func (p *syntheticProvider) GetSchema(context.Context) (tfsdk.Schema, diag.Diagnostics) {
-	return tfsdk.Schema{}, nil
+	return tfsdk.Schema{
+		Attributes: map[string]tfsdk.Attribute{
+			"stringConfigProp": {
+				Type: types.StringType,
+			},
+		},
+	}, nil
 }
 
-func (p *syntheticProvider) Configure(context.Context, provider.ConfigureRequest, *provider.ConfigureResponse) {
+func (p *syntheticProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
+	var stringConfigProp string
+	diags := req.Config.GetAttribute(ctx, path.Root("stringConfigProp"), &stringConfigProp)
+	resp.Diagnostics.Append(diags...)
+	resp.ResourceData = stringConfigProp
 	return
 }
 
@@ -74,5 +87,6 @@ func (p *syntheticProvider) Resources(context.Context) []func() resource.Resourc
 	return []func() resource.Resource{
 		newTestres,
 		newTestCompRes,
+		newTestConfigRes,
 	}
 }

--- a/pkg/tfpfbridge/tests/internal/testprovider/testbridge_resouce_testconfigres.go
+++ b/pkg/tfpfbridge/tests/internal/testprovider/testbridge_resouce_testconfigres.go
@@ -1,0 +1,83 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testprovider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type testconfigres struct {
+	config string
+}
+
+var _ resource.Resource = (*testconfigres)(nil)
+var _ resource.ResourceWithConfigure = (*testconfigres)(nil)
+
+func newTestConfigRes() resource.Resource {
+	return &testconfigres{}
+}
+
+func (*testconfigres) schema() tfsdk.Schema {
+	return tfsdk.Schema{
+		Description: `
+testbridge_testconfigres is built to test Configure support in the provider.
+`,
+		Attributes: map[string]tfsdk.Attribute{
+			"id": {
+				Type:     types.StringType,
+				Computed: true,
+			},
+			"configCopy": {
+				Type:     types.StringType,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func (e *testconfigres) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	e.config = req.ProviderData.(string)
+}
+
+func (e *testconfigres) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_testconfigres"
+}
+
+func (e *testconfigres) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {
+	return e.schema(), nil
+}
+
+func (e *testconfigres) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	resp.State.SetAttribute(ctx, path.Root("id"), "id-1")
+	resp.State.SetAttribute(ctx, path.Root("configCopy"), e.config)
+}
+
+func (e *testconfigres) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	panic("Read not implemented")
+}
+
+func (e *testconfigres) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	panic("Update not implemented")
+}
+
+func (e *testconfigres) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	panic("Delete not implemented")
+}

--- a/pkg/tfpfbridge/tests/internal/testprovider/testbridge_resouce_testconfigres.go
+++ b/pkg/tfpfbridge/tests/internal/testprovider/testbridge_resouce_testconfigres.go
@@ -54,7 +54,10 @@ testbridge_testconfigres is built to test Configure support in the provider.
 }
 
 func (e *testconfigres) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	e.config = req.ProviderData.(string)
+	cfg := req.ProviderData.(*string)
+	if cfg != nil {
+		e.config = *cfg
+	}
 }
 
 func (e *testconfigres) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {

--- a/pkg/tfpfbridge/tests/provider_configure_test.go
+++ b/pkg/tfpfbridge/tests/provider_configure_test.go
@@ -1,0 +1,65 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfbridgetests
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-terraform-bridge/pkg/tfpfbridge"
+
+	testutils "github.com/pulumi/pulumi-terraform-bridge/pkg/tfpfbridge/tests/internal/testing"
+	"github.com/pulumi/pulumi-terraform-bridge/pkg/tfpfbridge/tests/internal/testprovider"
+)
+
+func TestConfigure(t *testing.T) {
+	g := genTestBridgeSchemaBytes(t)
+	server := tfbridge.NewProviderServer(
+		testprovider.SyntheticTestBridgeProvider(),
+		g.pulumiSchema,
+		g.renames,
+	)
+	testCase := `
+[
+  {
+    "method": "/pulumirpc.ResourceProvider/Configure",
+    "request": {
+      "args": {
+        "stringConfigProp": "example"
+      }
+    },
+    "response": {
+      "acceptSecrets": true,
+      "supportsPreview": true,
+      "acceptResources": true
+    }
+  },
+  {
+    "method": "/pulumirpc.ResourceProvider/Create",
+    "request": {
+      "urn": "urn:pulumi:test-stack::basicprogram::testbridge:index/testres:TestConfigRes::r1",
+      "preview": false
+    },
+    "response": {
+      "id": "id-1",
+      "properties": {
+        "configCopy": "example",
+        "id": "id-1"
+      }
+    }
+  }
+]
+        `
+	testutils.ReplaySequence(t, server, testCase)
+}


### PR DESCRIPTION
Fixes https://github.com/pulumi/home/issues/2472

Having some success with this code enabling this program to work with `mitmproxy` running:


```go
package main

import (
	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"

	"github.com/pulumi/pulumi-tls/sdk/v4/go/tls"
)

func main() {
	pulumi.Run(func(ctx *pulumi.Context) error {
		prov, err := tls.NewProvider(ctx, "tlsprovider", &tls.ProviderArgs{
			Proxy: tls.ProviderProxyArgs{
				Url:     pulumi.String("http://localhost:8080"),
				FromEnv: pulumi.Bool(false),
			},
		})

		if err != nil {
			return err
		}

		url := "https://pulumi.com"
		verifyChain := false
		res, err := tls.GetCertificate(ctx, &tls.GetCertificateArgs{
			Url:         &url,
			VerifyChain: &verifyChain,
		}, pulumi.Provider(prov))
		if err != nil {
			return err
		}

		ctx.Export("issuer", pulumi.String(res.Certificates[0].Issuer))
		return nil
	})
}
```

It seems a bit heavyweight to require mitmproxy in integration test so still need to add some unit tests for the feature.