### PR TITLE
Override docs repo path resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,4 @@ tfgen, the command that generates Pulumi schema/code for a bridged provider supp
 * `PULUMI_SKIP_MISSING_MAPPING_ERROR`: If truthy, tfgen will not fail if a data source or resource in the TF provider is not mapped to the Pulumi provider. Instead, a warning is printed. Default is `false`.
 * `PULUMI_SKIP_EXTRA_MAPPING_ERROR`: If truthy, tfgen will not fail if a mapped data source or resource does not exist in the TF provider. Instead, warning is printed. Default is `false`.
 * `PULUMI_MISSING_DOCS_ERROR`: If truthy, tfgen will fail if docs cannot be found for a data source or resource. Default is `false`.
+* `PULUMI_REPO_PATHS`: Override the paths to where to locate specific repos e.g. "github.com/foo/terraform-provider-bar=./terraform-provider-bar"

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -141,6 +141,13 @@ func getRepoPath(gitHost string, org string, provider string, version string) (s
 		moduleCoordinates = fmt.Sprintf("%s/%s", moduleCoordinates, version)
 	}
 
+	if repoPathsEnvVar, has := os.LookupEnv("PULUMI_REPO_PATHS"); has {
+		path := findRepoPath(repoPathsEnvVar, moduleCoordinates)
+		if path != "" {
+			return path, nil
+		}
+	}
+
 	if path, ok := repoPaths.Load(moduleCoordinates); ok {
 		return path.(string), nil
 	}
@@ -178,6 +185,19 @@ func getRepoPath(gitHost string, org string, provider string, version string) (s
 	repoPaths.Store(moduleCoordinates, target.Dir)
 
 	return target.Dir, nil
+}
+
+// findRepoPath returns the value associated first match of the module coordinates.
+// repoPathsEnvVar is in the format "github.com/foo/terraform-provider-bar=./terraform-provider-bar"
+func findRepoPath(repoPathsEnvVar string, moduleCoordinates string) string {
+	for _, provider := range strings.Split(repoPathsEnvVar, ",") {
+		parts := strings.SplitN(provider, "=", 2)
+
+		if parts[0] == moduleCoordinates {
+			return parts[1]
+		}
+	}
+	return ""
 }
 
 func getMarkdownDetails(sink diag.Sink, org string, provider string,

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -839,6 +839,13 @@ func TestParseImports_WithOverride(t *testing.T) {
 	assert.Equal(t, "## Import\n\noverridden import details", parser.ret.Import)
 }
 
+func TestFindRepoPath(t *testing.T) {
+	env := "domain.test/foo/bar=./baz,github.com/foo/terraform-provider-bar=./terraform-provider-bar,"
+	actual := findRepoPath(env, "github.com/foo/terraform-provider-bar")
+
+	assert.Equal(t, "./terraform-provider-bar", actual)
+}
+
 type mockResource struct {
 	docs  tfbridge.DocInfo
 	token tokens.Token


### PR DESCRIPTION
Use an environment variable to override the resolution of specific repos during docs discovery.

Set `PULUMI_REPO_PATHS` to override the paths to where to locate specific repos e.g. 

```
PULUMI_REPO_PATHS="github.com/foo/terraform-provider-bar=./terraform-provider-bar"
```

This is required for when we are checking out the provider as a submodule then using a replace directive in our go.mod. 