### PR TITLE
Add facilities for automatic token mapping

### DIFF
--- a/pkg/tfbridge/token.go
+++ b/pkg/tfbridge/token.go
@@ -1,0 +1,117 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfbridge
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/cgstrings"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+)
+
+// A strategy for generating missing resources.
+type ResourceTokenStrategy = TokenStrategy[ResourceInfo]
+
+// A strategy for generating missing datasources.
+type DataSourceTokenStrategy = TokenStrategy[DataSourceInfo]
+
+// A function that joins a module and name into a pulumi type token.
+//
+// For example:
+//
+//	func(module, name string) (string, error) {
+//	 return fmt.Sprintf("pkgName:%s:%s", module, name), nil
+//	}
+type FinalizeToken func(module, name string) (string, error)
+
+type TokenStrategy[T any] func(tfToken string, tfTokens []string) (*T, error)
+
+func upperCamelCase(s string) string { return cgstrings.UppercaseFirst(camelCase(s)) }
+
+func camelCase(s string) string {
+	return cgstrings.ModifyStringAroundDelimeter(s, "_", cgstrings.UppercaseFirst)
+}
+
+// A strategy that assigns all tokens to the same module.
+//
+// For example:
+//
+//	rStrat, dStrat := TokensSingleModule("pkgName_", "index", finalize)
+//
+// The above example would transform "pkgName_foo" into "pkgName:index:Foo".
+func TokensSingleModule(
+	tfPackagePrefix, moduleName string, finalize FinalizeToken,
+) (ResourceTokenStrategy, DataSourceTokenStrategy) {
+	return TokensKnownModules(tfPackagePrefix, moduleName, nil, finalize)
+}
+
+func tokensKnownModules[T any](
+	prefix, defaultModule string, modules []string, new func(string, string) (*T, error),
+) TokenStrategy[T] {
+	return func(tfToken string, _ []string) (*T, error) {
+		tk := strings.TrimPrefix(tfToken, prefix)
+		if len(tk) == len(tfToken) {
+			return nil, fmt.Errorf("token '%s' missing package prefix '%s'", tfToken, prefix)
+		}
+		mod := defaultModule
+		for _, m := range modules {
+			if strings.HasPrefix(tk, m) {
+				mod = m
+				break
+			}
+		}
+		if mod == "" {
+			return nil, fmt.Errorf("could not find a module that prefixes '%s' in '%#v'", tk, modules)
+		}
+		return new(camelCase(mod), upperCamelCase(strings.TrimPrefix(tk, mod)))
+	}
+}
+
+// A strategy for assigning tokens to a hand generated set of modules.
+//
+// If defaultModule is "", then the returned strategies will error on not encountering a matching module.
+func TokensKnownModules(
+	tfPackagePrefix, defaultModule string, modules []string, finalize FinalizeToken,
+) (ResourceTokenStrategy, DataSourceTokenStrategy) {
+	// NOTE: We could turn this from a sort + linear lookup into a radix tree to recover
+	// O(log(n)) performance (current is O(n*m)) where n = number of modules and m =
+	// number of mappings.
+	sort.Sort(sort.Reverse(sort.StringSlice(modules)))
+
+	return tokensKnownModules(tfPackagePrefix, defaultModule, modules, func(mod, tk string) (*ResourceInfo, error) {
+			tk, err := finalize(mod, tk)
+			if err != nil {
+				return nil, err
+			}
+			return &ResourceInfo{Tok: tokens.Type(tk)}, nil
+		}), tokensKnownModules(tfPackagePrefix, defaultModule, modules, func(mod, tk string) (*DataSourceInfo, error) {
+			tk, err := finalize(mod, "get"+tk)
+			if err != nil {
+				return nil, err
+			}
+			return &DataSourceInfo{Tok: tokens.ModuleMember(tk)}, nil
+		})
+}
+
+func (ts TokenStrategy[T]) Unmappable(substring string) TokenStrategy[T] {
+	return func(tfToken string, tfTokens []string) (*T, error) {
+		if strings.Contains(tfToken, substring) {
+			return nil, fmt.Errorf("token '%s' contains un-map-able sub-string '%s'", tfToken, substring)
+		}
+		return ts(tfToken, tfTokens)
+	}
+}

--- a/pkg/tfbridge/token.go
+++ b/pkg/tfbridge/token.go
@@ -133,8 +133,28 @@ func TokensKnownModules(
 func (ts Strategy[T]) Unmappable(substring string) Strategy[T] {
 	return func(tfToken string, tfTokens []string) (*T, error) {
 		if strings.Contains(tfToken, substring) {
-			return nil, fmt.Errorf("token '%s' contains un-map-able sub-string '%s'", tfToken, substring)
+			return nil, UnmappableError{
+				TfToken: tfToken,
+				Reason:  fmt.Errorf("contains unmapable sub-string '%s'", substring),
+			}
 		}
 		return ts(tfToken, tfTokens)
 	}
+}
+
+// Indicate that a token cannot be mapped.
+//
+// NOTE: Experimental; We are still iterating on the design of this type, and it is
+// subject to change without warning.
+type UnmappableError struct {
+	TfToken string
+	Reason  error
+}
+
+func (err UnmappableError) Error() string {
+	return fmt.Sprintf("'%s' unmappable: %s", err.TfToken, err.Reason)
+}
+
+func (err UnmappableError) Unwrap() error {
+	return err.Reason
 }

--- a/pkg/tfbridge/token_test.go
+++ b/pkg/tfbridge/token_test.go
@@ -44,7 +44,7 @@ func TestTokensSingleModule(t *testing.T) {
 		return fmt.Sprintf("foo:%s:%s", module, name), nil
 	})
 
-	err := info.DefaultTokens(rTokens, dTokens)
+	err := info.ComputeDefaults(rTokens, dTokens)
 	require.NoError(t, err)
 
 	expectedResources := map[string]*tfbridge.ResourceInfo{
@@ -64,7 +64,7 @@ func TestTokensSingleModule(t *testing.T) {
 	info.Resources = map[string]*tfbridge.ResourceInfo{
 		"foo_bar_hello_world": {Tok: "foo:index:BarHelloPulumi"},
 	}
-	err = info.DefaultResourceTokens(rTokens)
+	err = info.ComputeDefaultResources(rTokens)
 	require.NoError(t, err)
 
 	assert.Equal(t, map[string]*tfbridge.ResourceInfo{
@@ -93,7 +93,7 @@ func TestTokensKnownModules(t *testing.T) {
 	}, func(module, name string) (string, error) {
 		return fmt.Sprintf("cs101:%s:%s", module, name), nil
 	})
-	err := info.DefaultResourceTokens(rTokens)
+	err := info.ComputeDefaultResources(rTokens)
 	require.NoError(t, err)
 
 	assert.Equal(t, map[string]*tfbridge.ResourceInfo{
@@ -126,7 +126,7 @@ func TestUnmappable(t *testing.T) {
 		return fmt.Sprintf("cs101:%s:%s", module, name), nil
 	})
 	strategy = strategy.Unmappable("five")
-	err := info.DefaultResourceTokens(strategy)
+	err := info.ComputeDefaultResources(strategy)
 	assert.ErrorContains(t, err, "contains un-map-able sub-string")
 
 	// Override the unmappable resources
@@ -135,7 +135,7 @@ func TestUnmappable(t *testing.T) {
 		"cs101_fizz_buzz_one_five": {Tok: "cs101:fizzBuzz:One5"},
 		"cs101_buzz_five":          {Tok: "cs101:buzz:Five"},
 	}
-	err = info.DefaultResourceTokens(strategy)
+	err = info.ComputeDefaultResources(strategy)
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]*tfbridge.ResourceInfo{
 		"cs101_fizz_buzz_one_five": {Tok: "cs101:fizzBuzz:One5"},

--- a/pkg/tfbridge/token_test.go
+++ b/pkg/tfbridge/token_test.go
@@ -127,7 +127,7 @@ func TestUnmappable(t *testing.T) {
 	})
 	strategy = strategy.Unmappable("five")
 	err := info.ComputeDefaultResources(strategy)
-	assert.ErrorContains(t, err, "contains un-map-able sub-string")
+	assert.ErrorContains(t, err, "contains unmapable sub-string")
 
 	// Override the unmappable resources
 	info.Resources = map[string]*tfbridge.ResourceInfo{

--- a/pkg/tfbridge/token_test.go
+++ b/pkg/tfbridge/token_test.go
@@ -1,0 +1,192 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfbridge_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokensSingleModule(t *testing.T) {
+	info := tfbridge.ProviderInfo{
+		P: Provider{
+			resources: map[string]struct{}{
+				"foo_fizz_buzz":       {},
+				"foo_bar_hello_world": {},
+				"foo_bar":             {},
+			},
+			datasources: map[string]struct{}{
+				"foo_source1":             {},
+				"foo_very_special_source": {},
+			},
+		},
+	}
+
+	rTokens, dTokens := tfbridge.TokensSingleModule("foo_", "index", func(module, name string) (string, error) {
+		return fmt.Sprintf("foo:%s:%s", module, name), nil
+	})
+
+	err := info.DefaultTokens(rTokens, dTokens)
+	require.NoError(t, err)
+
+	expectedResources := map[string]*tfbridge.ResourceInfo{
+		"foo_fizz_buzz":       {Tok: "foo:index:FizzBuzz"},
+		"foo_bar_hello_world": {Tok: "foo:index:BarHelloWorld"},
+		"foo_bar":             {Tok: "foo:index:Bar"},
+	}
+	expectedDatasources := map[string]*tfbridge.DataSourceInfo{
+		"foo_source1":             {Tok: "foo:index:getSource1"},
+		"foo_very_special_source": {Tok: "foo:index:getVerySpecialSource"},
+	}
+
+	assert.Equal(t, expectedResources, info.Resources)
+	assert.Equal(t, expectedDatasources, info.DataSources)
+
+	// Now test that overrides still work
+	info.Resources = map[string]*tfbridge.ResourceInfo{
+		"foo_bar_hello_world": {Tok: "foo:index:BarHelloPulumi"},
+	}
+	err = info.DefaultResourceTokens(rTokens)
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]*tfbridge.ResourceInfo{
+		"foo_fizz_buzz":       {Tok: "foo:index:FizzBuzz"},
+		"foo_bar_hello_world": {Tok: "foo:index:BarHelloPulumi"},
+		"foo_bar":             {Tok: "foo:index:Bar"},
+	}, info.Resources)
+}
+
+func TestTokensKnownModules(t *testing.T) {
+	info := tfbridge.ProviderInfo{
+		P: Provider{
+			resources: map[string]struct{}{
+				"cs101_fizz_buzz_one_five": {},
+				"cs101_fizz_three":         {},
+				"cs101_fizz_three_six":     {},
+				"cs101_buzz_five":          {},
+				"cs101_buzz_ten":           {},
+				"cs101_game":               {},
+			},
+		},
+	}
+
+	rTokens, _ := tfbridge.TokensKnownModules("cs101_", "index", []string{
+		"fizz_", "buzz_", "fizz_buzz_",
+	}, func(module, name string) (string, error) {
+		return fmt.Sprintf("cs101:%s:%s", module, name), nil
+	})
+	err := info.DefaultResourceTokens(rTokens)
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]*tfbridge.ResourceInfo{
+		"cs101_fizz_buzz_one_five": {Tok: "cs101:fizzBuzz:OneFive"},
+		"cs101_fizz_three":         {Tok: "cs101:fizz:Three"},
+		"cs101_fizz_three_six":     {Tok: "cs101:fizz:ThreeSix"},
+		"cs101_buzz_five":          {Tok: "cs101:buzz:Five"},
+		"cs101_buzz_ten":           {Tok: "cs101:buzz:Ten"},
+		"cs101_game":               {Tok: "cs101:index:Game"},
+	}, info.Resources)
+}
+
+func TestUnmappable(t *testing.T) {
+	info := tfbridge.ProviderInfo{
+		P: Provider{
+			resources: map[string]struct{}{
+				"cs101_fizz_buzz_one_five": {},
+				"cs101_fizz_three":         {},
+				"cs101_fizz_three_six":     {},
+				"cs101_buzz_five":          {},
+				"cs101_buzz_ten":           {},
+				"cs101_game":               {},
+			},
+		},
+	}
+
+	strategy, _ := tfbridge.TokensKnownModules("cs101_", "index", []string{
+		"fizz_", "buzz_", "fizz_buzz_",
+	}, func(module, name string) (string, error) {
+		return fmt.Sprintf("cs101:%s:%s", module, name), nil
+	})
+	strategy = strategy.Unmappable("five")
+	err := info.DefaultResourceTokens(strategy)
+	assert.ErrorContains(t, err, "contains un-map-able sub-string")
+
+	// Override the unmappable resources
+	info.Resources = map[string]*tfbridge.ResourceInfo{
+		// When "five" comes after another number, we print it as "5"
+		"cs101_fizz_buzz_one_five": {Tok: "cs101:fizzBuzz:One5"},
+		"cs101_buzz_five":          {Tok: "cs101:buzz:Five"},
+	}
+	err = info.DefaultResourceTokens(strategy)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]*tfbridge.ResourceInfo{
+		"cs101_fizz_buzz_one_five": {Tok: "cs101:fizzBuzz:One5"},
+		"cs101_fizz_three":         {Tok: "cs101:fizz:Three"},
+		"cs101_fizz_three_six":     {Tok: "cs101:fizz:ThreeSix"},
+		"cs101_buzz_five":          {Tok: "cs101:buzz:Five"},
+		"cs101_buzz_ten":           {Tok: "cs101:buzz:Ten"},
+		"cs101_game":               {Tok: "cs101:index:Game"},
+	}, info.Resources)
+}
+
+type Provider struct {
+	util.UnimplementedProvider
+
+	// We are only concerned with tokens, so that's all we support
+	datasources map[string]struct{}
+	resources   map[string]struct{}
+}
+
+func (p Provider) ResourcesMap() shim.ResourceMap   { return ResourceMap{p.resources} }
+func (p Provider) DataSourcesMap() shim.ResourceMap { return ResourceMap{p.datasources} }
+
+type ResourceMap struct{ m map[string]struct{} }
+type Resource struct{ t string }
+
+func (m ResourceMap) Len() int                     { return len(m.m) }
+func (m ResourceMap) Get(key string) shim.Resource { return Resource{key} }
+func (m ResourceMap) GetOk(key string) (shim.Resource, bool) {
+	_, ok := m.m[key]
+	if !ok {
+		return nil, false
+	}
+	return Resource{key}, true
+}
+func (m ResourceMap) Range(each func(key string, value shim.Resource) bool) {
+	for k := range m.m {
+		each(k, Resource{k})
+	}
+}
+func (m ResourceMap) Set(key string, value shim.Resource) {
+	m.m[key] = struct{}{}
+}
+
+func (r Resource) Schema() shim.SchemaMap          { panic("unimplemented") }
+func (r Resource) SchemaVersion() int              { panic("unimplemented") }
+func (r Resource) Importer() shim.ImportFunc       { panic("unimplemented") }
+func (r Resource) DeprecationMessage() string      { panic("unimplemented") }
+func (r Resource) Timeouts() *shim.ResourceTimeout { panic("unimplemented") }
+func (r Resource) InstanceState(id string, object, meta map[string]interface{}) (shim.InstanceState, error) {
+	panic("unimplemented")
+}
+func (r Resource) DecodeTimeouts(config shim.ResourceConfig) (*shim.ResourceTimeout, error) {
+	panic("unimplemented")
+}

--- a/pkg/tfshim/util/util.go
+++ b/pkg/tfshim/util/util.go
@@ -1,0 +1,66 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+)
+
+var _ = (shim.Provider)((*UnimplementedProvider)(nil))
+
+// An embed-able unimplemented Provider for use in testing.
+type UnimplementedProvider struct{}
+
+func (UnimplementedProvider) Schema() shim.SchemaMap           { panic("unimplemented") }
+func (UnimplementedProvider) ResourcesMap() shim.ResourceMap   { panic("unimplemented") }
+func (UnimplementedProvider) DataSourcesMap() shim.ResourceMap { panic("unimplemented") }
+
+func (UnimplementedProvider) Validate(c shim.ResourceConfig) ([]string, []error) {
+	panic("unimplemented")
+}
+func (UnimplementedProvider) ValidateResource(t string, c shim.ResourceConfig) ([]string, []error) {
+	panic("unimplemented")
+}
+func (UnimplementedProvider) ValidateDataSource(t string, c shim.ResourceConfig) ([]string, []error) {
+	panic("unimplemented")
+}
+
+func (UnimplementedProvider) Configure(c shim.ResourceConfig) error { panic("unimplemented") }
+func (UnimplementedProvider) Diff(t string, s shim.InstanceState, c shim.ResourceConfig) (shim.InstanceDiff, error) {
+	panic("unimplemented")
+}
+func (UnimplementedProvider) Apply(t string, s shim.InstanceState, d shim.InstanceDiff) (shim.InstanceState, error) {
+	panic("unimplemented")
+}
+func (UnimplementedProvider) Refresh(t string, s shim.InstanceState) (shim.InstanceState, error) {
+	panic("unimplemented")
+}
+
+func (UnimplementedProvider) ReadDataDiff(t string, c shim.ResourceConfig) (shim.InstanceDiff, error) {
+	panic("unimplemented")
+}
+func (UnimplementedProvider) ReadDataApply(t string, d shim.InstanceDiff) (shim.InstanceState, error) {
+	panic("unimplemented")
+}
+
+func (UnimplementedProvider) Meta() interface{} { panic("unimplemented") }
+func (UnimplementedProvider) Stop() error       { panic("unimplemented") }
+
+func (UnimplementedProvider) InitLogging()                      { panic("unimplemented") }
+func (UnimplementedProvider) NewDestroyDiff() shim.InstanceDiff { panic("unimplemented") }
+func (UnimplementedProvider) NewResourceConfig(object map[string]interface{}) shim.ResourceConfig {
+	panic("unimplemented")
+}
+func (UnimplementedProvider) IsSet(v interface{}) ([]interface{}, bool) { panic("unimplemented") }


### PR DESCRIPTION
This PR adds methods on `tfbridge.ProviderInfo` to apply naming strategies to missing tokens, as well as two common and simple strategies: single module and picking from a curated list of modules.

Token strategies are designed for an additive path from manual to automatic mapping, so there is no need to change any old code to start using automatic mapping. Strategies support an `Unmappable` method, which marks a substring as illegal to map, and thus for a human to map manually. This is for difficult to map or inconsistently mapped strings like `db => DB` or `flowlogs => FlowLogs`.

Example usage:
```go
// For a already defined `*tfbridge.ProviderInfo` called `info`
err := info.DefaultTokens(tfbridge.TokensSingleModule("pkgname_", "index", 
  func(module, name string) (string, error) {
    modulePostfix := lowerFirstChar(name)
    return fmt.Sprintf("pkgName:%s/%s:%s", module, modulePostfix, name), nil
  }))
```