### PR TITLE
Relax secret encoder checks

### DIFF
--- a/pkg/tfpfbridge/internal/convert/secret.go
+++ b/pkg/tfpfbridge/internal/convert/secret.go
@@ -15,8 +15,6 @@
 package convert
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -51,10 +49,15 @@ func (enc *secretEncoder) FromPropertyValue(p resource.PropertyValue) (tftypes.V
 	if p.IsNull() {
 		return tftypes.NewValue(enc.tfType, nil), nil
 	}
+	var v resource.PropertyValue
 	if !p.IsSecret() {
-		return tftypes.Value{}, fmt.Errorf("PropertyValue should be secret but is not")
+		// Relaxing the strict check due to https://github.com/pulumi/pulumi/issues/11971
+		//
+		// return tftypes.Value{}, fmt.Errorf("PropertyValue should be secret but is not")
+		v = p
+	} else {
+		v = p.SecretValue().Element
 	}
-	v := p.SecretValue().Element
 	return enc.elementEncoder.FromPropertyValue(v)
 }
 

--- a/pkg/tfpfbridge/internal/convert/secret_test.go
+++ b/pkg/tfpfbridge/internal/convert/secret_test.go
@@ -1,0 +1,36 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package convert
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
+// Due to https://github.com/pulumi/pulumi/issues/11971 provider may receive secret values that are not explicitly
+// wrapped, and should tolerate it.
+func TestRelaxedSecretHandling(t *testing.T) {
+	encoder, err := newSecretEncoder(newStringEncoder(), tftypes.String)
+	require.NoError(t, err)
+
+	v, err := encoder.FromPropertyValue(resource.NewStringProperty("OK"))
+	require.NoError(t, err)
+
+	require.Equal(t, tftypes.NewValue(tftypes.String, "OK"), v)
+}


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/729

Instead of erroring, automatically coerce secrets to secret form if they are not wrapped already.