### PR TITLE
Port all the tests

### DIFF
--- a/pkg/tfpfbridge/Makefile
+++ b/pkg/tfpfbridge/Makefile
@@ -4,7 +4,7 @@ build.tests::
 	cd tests/integration && go test -test.run NONE
 
 test::
-	go test
+	go test . ./pfutils ./internal/convert
 	cd tests && rm -rf state && mkdir state
 	cd tests && go test
 	cd tests && rm -rf state && mkdir state

--- a/pkg/tfpfbridge/pfutils/block.go
+++ b/pkg/tfpfbridge/pfutils/block.go
@@ -36,6 +36,7 @@ type Block interface {
 	NestedBlocks() map[string]Block
 	GetMaxItems() int64
 	GetMinItems() int64
+	HasNestedObject() bool
 }
 
 type BlockLike interface {
@@ -105,6 +106,15 @@ type blockAdapter struct {
 	minItems     int64
 	maxItems     int64
 	BlockLike
+}
+
+func (b *blockAdapter) HasNestedObject() bool {
+	switch b.NestingMode() {
+	case BlockNestingModeList, BlockNestingModeSet:
+		return true
+	default:
+		return false
+	}
 }
 
 func (b *blockAdapter) GetMinItems() int64 {

--- a/pkg/tfpfbridge/pfutils/eq.go
+++ b/pkg/tfpfbridge/pfutils/eq.go
@@ -57,7 +57,7 @@ func replaceComputedAttributesWithNull(schema Schema,
 	offset *tftypes.AttributePath, val tftypes.Value) (tftypes.Value, error) {
 	return tftypes.Transform(val, func(p *tftypes.AttributePath, v tftypes.Value) (tftypes.Value, error) {
 		realPath := joinPaths(offset, p)
-		if attr, err := AttributeAtTerraformPath(schema, realPath); err == nil && attr.IsComputed() {
+		if ab, err := LookupTerraformPath(schema, realPath); err == nil && ab.IsAttr && ab.Attr.IsComputed() {
 			return tftypes.NewValue(v.Type(), nil), nil
 		}
 		return v, nil


### PR DESCRIPTION
- make test was not running all the unit tests
- some of the tests need further mechanical work to port to Plugin Framework v1.1.1
- there is a change around how Plugin Framework handles attribute path walking - it introduces intermediate type NestedObjet that needs to be accounted for