### PR TITLE
Improve error message when a malformed version is given

### DIFF
--- a/pkg/tfpfbridge/main.go
+++ b/pkg/tfpfbridge/main.go
@@ -28,7 +28,8 @@ import (
 )
 
 // Main launches the tfbridge plugin for a given package pkg and provider prov.
-func Main(pkg, version string, prov info.ProviderInfo, pulumiSchema []byte, renames []byte) {
+func Main(pkg string, prov info.ProviderInfo, pulumiSchema []byte, renames []byte) {
+	version := prov.Version
 
 	// Look for a request to dump the provider info to stdout.
 	flags := flag.NewFlagSet("tf-provider-flags", flag.ContinueOnError)
@@ -75,7 +76,7 @@ func Main(pkg, version string, prov info.ProviderInfo, pulumiSchema []byte, rena
 	// TODO Initialize Terraform logging.
 	// prov.P.InitLogging()
 
-	if err := Serve(pkg, version, prov, pulumiSchema, renames); err != nil {
+	if err := Serve(pkg, prov, pulumiSchema, renames); err != nil {
 		cmdutil.ExitError(err.Error())
 	}
 }

--- a/pkg/tfpfbridge/serve.go
+++ b/pkg/tfpfbridge/serve.go
@@ -22,10 +22,7 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/pkg/tfpfbridge/info"
 )
 
-func Serve(pkg, version string, prov info.ProviderInfo, pulumiSchema []byte, renames []byte) error {
-	if prov.Version == "" {
-		prov.Version = version
-	}
+func Serve(pkg string, prov info.ProviderInfo, pulumiSchema []byte, renames []byte) error {
 	return provider.Main(pkg, func(host *provider.HostClient) (pulumirpc.ResourceProviderServer, error) {
 		return NewProviderServer(prov, pulumiSchema, renames)
 	})

--- a/pkg/tfpfbridge/serve.go
+++ b/pkg/tfpfbridge/serve.go
@@ -27,7 +27,6 @@ func Serve(pkg, version string, prov info.ProviderInfo, pulumiSchema []byte, ren
 		prov.Version = version
 	}
 	return provider.Main(pkg, func(host *provider.HostClient) (pulumirpc.ResourceProviderServer, error) {
-
-		return NewProviderServer(prov, pulumiSchema, renames), nil
+		return NewProviderServer(prov, pulumiSchema, renames)
 	})
 }

--- a/pkg/tfpfbridge/tests/genrandom_test.go
+++ b/pkg/tfpfbridge/tests/genrandom_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/pkg/tfpfbridge"
 	testutils "github.com/pulumi/pulumi-terraform-bridge/pkg/tfpfbridge/tests/internal/testing"
 	"github.com/pulumi/pulumi-terraform-bridge/pkg/tfpfbridge/tests/internal/testprovider"
+	"github.com/stretchr/testify/require"
 )
 
 // These tests replay gRPC logs from a well-behaved test program in testdatagen/genrandom to verify
@@ -47,7 +48,8 @@ func TestGenRandom(t *testing.T) {
 
 		t.Run(trace, func(t *testing.T) {
 			p := testprovider.RandomProvider()
-			server := tfbridge.NewProviderServer(p, schema.pulumiSchema, schema.renames)
+			server, err := tfbridge.NewProviderServer(p, schema.pulumiSchema, schema.renames)
+			require.NoError(t, err)
 			testutils.ReplayTraceFile(t, server, trace)
 		})
 	}

--- a/pkg/tfpfbridge/tests/genupdate_test.go
+++ b/pkg/tfpfbridge/tests/genupdate_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/pkg/tfpfbridge"
 	testutils "github.com/pulumi/pulumi-terraform-bridge/pkg/tfpfbridge/tests/internal/testing"
 	"github.com/pulumi/pulumi-terraform-bridge/pkg/tfpfbridge/tests/internal/testprovider"
+	"github.com/stretchr/testify/require"
 )
 
 // These tests replay Update gRPC logs to get some unit test coverage for Update.
@@ -37,10 +38,11 @@ func TestGenUpdates(t *testing.T) {
 
 	schemaBytes := genTestBridgeSchemaBytes(t)
 
-	server := tfbridge.NewProviderServer(
+	server, err := tfbridge.NewProviderServer(
 		testprovider.SyntheticTestBridgeProvider(),
 		schemaBytes.pulumiSchema,
 		schemaBytes.renames,
 	)
+	require.NoError(t, err)
 	testutils.ReplayTraceFile(t, server, trace)
 }

--- a/pkg/tfpfbridge/tests/internal/cmd/pulumi-resource-random/main.go
+++ b/pkg/tfpfbridge/tests/internal/cmd/pulumi-resource-random/main.go
@@ -30,7 +30,6 @@ var renames []byte
 func main() {
 	tfbridge.Main(
 		"random",
-		"4.8.2",
 		testprovider.RandomProvider(),
 		schema,
 		renames,

--- a/pkg/tfpfbridge/tests/internal/cmd/pulumi-resource-testbridge/main.go
+++ b/pkg/tfpfbridge/tests/internal/cmd/pulumi-resource-testbridge/main.go
@@ -30,7 +30,6 @@ var renames []byte
 func main() {
 	tfbridge.Main(
 		"testbridge",
-		"0.0.1",
 		testprovider.SyntheticTestBridgeProvider(),
 		schema,
 		renames,

--- a/pkg/tfpfbridge/tests/internal/cmd/pulumi-resource-tls/main.go
+++ b/pkg/tfpfbridge/tests/internal/cmd/pulumi-resource-tls/main.go
@@ -30,7 +30,6 @@ var renames []byte
 func main() {
 	tfbridge.Main(
 		"tls",
-		"4.0.4",
 		testprovider.TlsProvider(),
 		schema,
 		renames,

--- a/pkg/tfpfbridge/tests/internal/testprovider/tls.go
+++ b/pkg/tfpfbridge/tests/internal/testprovider/tls.go
@@ -96,5 +96,6 @@ func TlsProvider() tfbridge.ProviderInfo {
 				"tls": "Tls",
 			},
 		},
+		Version: tlsVersion,
 	}
 }

--- a/pkg/tfpfbridge/tests/provider_configure_test.go
+++ b/pkg/tfpfbridge/tests/provider_configure_test.go
@@ -17,6 +17,8 @@ package tfbridgetests
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi-terraform-bridge/pkg/tfpfbridge"
 
 	testutils "github.com/pulumi/pulumi-terraform-bridge/pkg/tfpfbridge/tests/internal/testing"
@@ -25,11 +27,12 @@ import (
 
 func TestConfigure(t *testing.T) {
 	g := genTestBridgeSchemaBytes(t)
-	server := tfbridge.NewProviderServer(
+	server, err := tfbridge.NewProviderServer(
 		testprovider.SyntheticTestBridgeProvider(),
 		g.pulumiSchema,
 		g.renames,
 	)
+	require.NoError(t, err)
 	testCase := `
 [
   {

--- a/pkg/tfpfbridge/tests/provider_create_test.go
+++ b/pkg/tfpfbridge/tests/provider_create_test.go
@@ -17,6 +17,8 @@ package tfbridgetests
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi-terraform-bridge/pkg/tfpfbridge"
 
 	testutils "github.com/pulumi/pulumi-terraform-bridge/pkg/tfpfbridge/tests/internal/testing"
@@ -25,11 +27,12 @@ import (
 
 func TestCreateWithComputedOptionals(t *testing.T) {
 	schemaBytes := genTestBridgeSchemaBytes(t)
-	server := tfbridge.NewProviderServer(
+	server, err := tfbridge.NewProviderServer(
 		testprovider.SyntheticTestBridgeProvider(),
 		schemaBytes.pulumiSchema,
 		schemaBytes.renames,
 	)
+	require.NoError(t, err)
 	testCase := `
         {
           "method": "/pulumirpc.ResourceProvider/Create",

--- a/pkg/tfpfbridge/tests/provider_diff_test.go
+++ b/pkg/tfpfbridge/tests/provider_diff_test.go
@@ -20,16 +20,18 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/pkg/tfpfbridge"
 	testutils "github.com/pulumi/pulumi-terraform-bridge/pkg/tfpfbridge/tests/internal/testing"
 	"github.com/pulumi/pulumi-terraform-bridge/pkg/tfpfbridge/tests/internal/testprovider"
+	"github.com/stretchr/testify/require"
 )
 
 // Test that preview diff in presence of computed attributes results in an empty diff.
 func TestEmptyTestresDiff(t *testing.T) {
 	schemaBytes := genTestBridgeSchemaBytes(t)
-	server := tfbridge.NewProviderServer(
+	server, err := tfbridge.NewProviderServer(
 		testprovider.SyntheticTestBridgeProvider(),
 		schemaBytes.pulumiSchema,
 		schemaBytes.renames,
 	)
+	require.NoError(t, err)
 	testCase := `
         {
           "method": "/pulumirpc.ResourceProvider/Diff",
@@ -58,11 +60,12 @@ func TestEmptyTestresDiff(t *testing.T) {
 // Test removing an optional input.
 func TestOptionRemovalTestresDiff(t *testing.T) {
 	schemaBytes := genTestBridgeSchemaBytes(t)
-	server := tfbridge.NewProviderServer(
+	server, err := tfbridge.NewProviderServer(
 		testprovider.SyntheticTestBridgeProvider(),
 		schemaBytes.pulumiSchema,
 		schemaBytes.renames,
 	)
+	require.NoError(t, err)
 	testCase := `
         {
           "method": "/pulumirpc.ResourceProvider/Diff",
@@ -95,11 +98,12 @@ func TestOptionRemovalTestresDiff(t *testing.T) {
 // Make sure optionalInputBoolCopy does not cause non-empty diff when not actually changing.
 func TestEmptyTestresDiffWithOptionalComputed(t *testing.T) {
 	schemaBytes := genTestBridgeSchemaBytes(t)
-	server := tfbridge.NewProviderServer(
+	server, err := tfbridge.NewProviderServer(
 		testprovider.SyntheticTestBridgeProvider(),
 		schemaBytes.pulumiSchema,
 		schemaBytes.renames,
 	)
+	require.NoError(t, err)
 	testCase := `
         {
           "method": "/pulumirpc.ResourceProvider/Diff",
@@ -129,11 +133,12 @@ func TestEmptyTestresDiffWithOptionalComputed(t *testing.T) {
 
 func TestDiffWithSecrets(t *testing.T) {
 	g := genRandomSchemaBytes(t)
-	server := tfbridge.NewProviderServer(
+	server, err := tfbridge.NewProviderServer(
 		testprovider.RandomProvider(),
 		g.pulumiSchema,
 		g.renames,
 	)
+	require.NoError(t, err)
 
 	testCase := `
         {

--- a/pkg/tfpfbridge/tests/provider_invoke_test.go
+++ b/pkg/tfpfbridge/tests/provider_invoke_test.go
@@ -17,6 +17,8 @@ package tfbridgetests
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi-terraform-bridge/pkg/tfpfbridge"
 
 	testutils "github.com/pulumi/pulumi-terraform-bridge/pkg/tfpfbridge/tests/internal/testing"
@@ -26,7 +28,9 @@ import (
 func TestBasicInvoke(t *testing.T) {
 	p := testprovider.TlsProvider()
 	g := genSchemaBytes(t, p)
-	server := tfbridge.NewProviderServer(p, g.pulumiSchema, g.renames)
+	server, err := tfbridge.NewProviderServer(p, g.pulumiSchema, g.renames)
+	require.NoError(t, err)
+
 	testCase := `
         {
           "method": "/pulumirpc.ResourceProvider/Invoke",
@@ -66,7 +70,9 @@ func TestBasicInvoke(t *testing.T) {
 func TestInvokeWithInvalidData(t *testing.T) {
 	p := testprovider.TlsProvider()
 	g := genSchemaBytes(t, p)
-	server := tfbridge.NewProviderServer(p, g.pulumiSchema, g.renames)
+	server, err := tfbridge.NewProviderServer(p, g.pulumiSchema, g.renames)
+	require.NoError(t, err)
+
 	testCase := `
         {
           "method": "/pulumirpc.ResourceProvider/Invoke",


### PR DESCRIPTION
Fixes #727 

Do not use version arg in favor of info.Verison.

Throw better errors.