### PR TITLE
Ensure that Read preserves schema version

### DIFF
--- a/pf/tests/provider_read_test.go
+++ b/pf/tests/provider_read_test.go
@@ -28,9 +28,32 @@ func TestReadFromRefresh(t *testing.T) {
 	// Specifically testing for:
 	//
 	// - __meta writing out the schema version
+	// - implicit upgrade from version 1 to version 3 is performed ("numeric": true) appears
 	// - inputs being populated
+
 	server := newProviderServer(t, testprovider.RandomProvider())
-	testCase := `
+
+	testCase := `[
+	{
+	  "method": "/pulumirpc.ResourceProvider/Configure",
+	  "request": {
+	    "args": {
+	      "version": "4.8.0"
+	    },
+	    "acceptSecrets": true,
+	    "acceptResources": true
+	  },
+	  "response": {
+	    "acceptSecrets": true,
+	    "supportsPreview": true,
+	    "acceptResources": true
+	  },
+	  "metadata": {
+	    "kind": "resource",
+	    "mode": "client",
+	    "name": "random"
+	  }
+	},
 	{
 	  "method": "/pulumirpc.ResourceProvider/Read",
 	  "request": {
@@ -77,7 +100,7 @@ func TestReadFromRefresh(t *testing.T) {
 	  "response": {
 	    "id": "none",
 	    "properties": {
-	      "__meta": "{\"schema_version\":\"1\"}",
+	      "__meta": "{\"schema_version\":\"3\"}",
 	      "bcryptHash": {
 		"4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
 		"value": "$2a$10$HHwx0gQztkpPIc7WkE4Wt.v7ibWT9Ug24/F5XLa6xNm/gOuyS5WRa"
@@ -90,6 +113,7 @@ func TestReadFromRefresh(t *testing.T) {
 	      "minSpecial": 0,
 	      "minUpper": 0,
 	      "number": true,
+              "numeric": true,
 	      "overrideSpecial": "_%@:",
 	      "result": {
 		"4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
@@ -98,28 +122,32 @@ func TestReadFromRefresh(t *testing.T) {
 	      "special": true,
 	      "upper": true
 	    },
-	    "inputs": {
-	      "__defaults": [
-		"lower",
-		"minLower",
-		"minNumeric",
-		"minSpecial",
-		"minUpper",
-		"number",
-		"upper"
-	      ],
-	      "length": 8,
-	      "lower": true,
-	      "minLower": 0,
-	      "minNumeric": 0,
-	      "minSpecial": 0,
-	      "minUpper": 0,
-	      "number": true,
-	      "overrideSpecial": "_%@:",
-	      "special": true,
-	      "upper": true
-	    }
+            "inputs": {}
 	  }
-	}`
-	testutils.Replay(t, server, testCase)
+	}]`
+
+	// TODO populate inputs
+	// "inputs": {
+	//   "__defaults": [
+	// 	"lower",
+	// 	"minLower",
+	// 	"minNumeric",
+	// 	"minSpecial",
+	// 	"minUpper",
+	// 	"number",
+	// 	"upper"
+	//   ],
+	//   "length": 8,
+	//   "lower": true,
+	//   "minLower": 0,
+	//   "minNumeric": 0,
+	//   "minSpecial": 0,
+	//   "minUpper": 0,
+	//   "number": true,
+	//   "overrideSpecial": "_%@:",
+	//   "special": true,
+	//   "upper": true
+	// }
+
+	testutils.ReplaySequence(t, server, testCase)
 }

--- a/pf/tests/provider_read_test.go
+++ b/pf/tests/provider_read_test.go
@@ -1,0 +1,125 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfbridgetests
+
+import (
+	"testing"
+
+	testutils "github.com/pulumi/pulumi-terraform-bridge/pf/tests/internal/testing"
+
+	"github.com/pulumi/pulumi-terraform-bridge/pf/tests/internal/testprovider"
+)
+
+func TestReadFromRefresh(t *testing.T) {
+	// This test case was obtained by running `pulumi refresh` on a simple stack with one RandomPassword.
+	//
+	// Specifically testing for:
+	//
+	// - __meta writing out the schema version
+	// - inputs being populated
+	server := newProviderServer(t, testprovider.RandomProvider())
+	testCase := `
+	{
+	  "method": "/pulumirpc.ResourceProvider/Read",
+	  "request": {
+	    "id": "none",
+	    "urn": "urn:pulumi:dev::repro-pulumi-random-258::random:index/randomPassword:RandomPassword::access-token-",
+	    "properties": {
+	      "__meta": "{\"schema_version\":\"1\"}",
+	      "bcryptHash": "$2a$10$HHwx0gQztkpPIc7WkE4Wt.v7ibWT9Ug24/F5XLa6xNm/gOuyS5WRa",
+	      "id": "none",
+	      "length": 8,
+	      "lower": true,
+	      "minLower": 0,
+	      "minNumeric": 0,
+	      "minSpecial": 0,
+	      "minUpper": 0,
+	      "number": true,
+	      "overrideSpecial": "_%@:",
+	      "result": "Ps7XGKxa",
+	      "special": true,
+	      "upper": true
+	    },
+	    "inputs": {
+	      "__defaults": [
+		"lower",
+		"minLower",
+		"minNumeric",
+		"minSpecial",
+		"minUpper",
+		"number",
+		"upper"
+	      ],
+	      "length": 8,
+	      "lower": true,
+	      "minLower": 0,
+	      "minNumeric": 0,
+	      "minSpecial": 0,
+	      "minUpper": 0,
+	      "number": true,
+	      "overrideSpecial": "_%@:",
+	      "special": true,
+	      "upper": true
+	    }
+	  },
+	  "response": {
+	    "id": "none",
+	    "properties": {
+	      "__meta": "{\"schema_version\":\"1\"}",
+	      "bcryptHash": {
+		"4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
+		"value": "$2a$10$HHwx0gQztkpPIc7WkE4Wt.v7ibWT9Ug24/F5XLa6xNm/gOuyS5WRa"
+	      },
+	      "id": "none",
+	      "length": 8,
+	      "lower": true,
+	      "minLower": 0,
+	      "minNumeric": 0,
+	      "minSpecial": 0,
+	      "minUpper": 0,
+	      "number": true,
+	      "overrideSpecial": "_%@:",
+	      "result": {
+		"4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
+		"value": "Ps7XGKxa"
+	      },
+	      "special": true,
+	      "upper": true
+	    },
+	    "inputs": {
+	      "__defaults": [
+		"lower",
+		"minLower",
+		"minNumeric",
+		"minSpecial",
+		"minUpper",
+		"number",
+		"upper"
+	      ],
+	      "length": 8,
+	      "lower": true,
+	      "minLower": 0,
+	      "minNumeric": 0,
+	      "minSpecial": 0,
+	      "minUpper": 0,
+	      "number": true,
+	      "overrideSpecial": "_%@:",
+	      "special": true,
+	      "upper": true
+	    }
+	  }
+	}`
+	testutils.Replay(t, server, testCase)
+}

--- a/pf/tfbridge/provider_create.go
+++ b/pf/tfbridge/provider_create.go
@@ -54,7 +54,7 @@ func (p *provider) Create(
 	}
 
 	// TODO handle planResp.Diagnostics
-	// TODO handle planResp.PlannedPrivate
+	// TODO[pulumi/pulumi-terraform-bridge#747] handle planResp.PlannedPrivate
 	// TODO handle planResp.RequiresReplace - probably can be ignored in Create
 
 	if preview {
@@ -77,8 +77,8 @@ func (p *provider) Create(
 		PlannedState: planResp.PlannedState,
 		Config:       &configValue,
 
-		// TODO PlannedPrivate []byte{},
-		// TODO Set ProviderMeta
+		// TODO[pulumi/pulumi-terraform-bridge#747] PlannedPrivate []byte{},
+		// TODO[pulumi/pulumi-terraform-bridge#794] set ProviderMeta
 		//
 		// See https://www.terraform.io/internals/provider-meta
 	}
@@ -92,7 +92,7 @@ func (p *provider) Create(
 		return "", nil, 0, err
 	}
 
-	// TODO handle resp.Private field to save that state inside Pulumi state.
+	// TODO[pulumi/pulumi-terraform-bridge#747] handle resp.Private field to save that state inside Pulumi state.
 
 	createdState, err := parseResourceStateFromTF(ctx, &rh, resp.NewState)
 	if err != nil {

--- a/pf/tfbridge/provider_delete.go
+++ b/pf/tfbridge/provider_delete.go
@@ -54,7 +54,7 @@ func (p *provider) Delete(urn resource.URN, id resource.ID,
 	if err != nil {
 		return resource.StatusOK, err
 	}
-	// TODO handle resp.Private
+	// TODO[pulumi/pulumi-terraform-bridge#747] handle resp.Private
 
 	if err := p.processDiagnostics(resp.Diagnostics); err != nil {
 		return resource.StatusPartialFailure, err

--- a/pf/tfbridge/provider_diff.go
+++ b/pf/tfbridge/provider_diff.go
@@ -73,7 +73,7 @@ func (p *provider) Diff(
 		return plugin.DiffResult{}, err
 	}
 
-	// TODO handle planResp.PlannedPrivate
+	// TODO[pulumi/pulumi-terraform-bridge#747] handle planResp.PlannedPrivate
 
 	// TODO detect errors in planResp.Diagnostics
 

--- a/pf/tfbridge/provider_invoke.go
+++ b/pf/tfbridge/provider_invoke.go
@@ -74,7 +74,7 @@ func (p *provider) readDataSource(ctx context.Context, handle datasourceHandle,
 	req := &tfprotov6.ReadDataSourceRequest{
 		Config:   config,
 		TypeName: handle.terraformDataSourceName,
-		// TODO ProviderMeta
+		// TODO[pulumi/pulumi-terraform-bridge#794] set ProviderMeta
 	}
 
 	resp, err := p.tfServer.ReadDataSource(ctx, req)

--- a/pf/tfbridge/provider_plan.go
+++ b/pf/tfbridge/provider_plan.go
@@ -59,8 +59,8 @@ func (p *provider) plan(
 		ProposedNewState: &proposedNewStateV,
 		Config:           &configV,
 
-		// TODO PriorPrivate
-		// TODO ProviderMeta
+		// TODO[pulumi/pulumi-terraform-bridge#747] PriorPrivate
+		// TODO[pulumi/pulumi-terraform-bridge#794] set ProviderMeta
 	}
 
 	planResp, err := p.tfServer.PlanResourceChange(ctx, &planReq)

--- a/pf/tfbridge/provider_read.go
+++ b/pf/tfbridge/provider_read.go
@@ -32,7 +32,7 @@ func (p *provider) Read(
 	inputs,
 	currentStateMap resource.PropertyMap,
 ) (plugin.ReadResult, resource.Status, error) {
-	// TODO test for a resource that is not found
+	// TODO[pulumi/pulumi-terraform-bridge#793] Add a test for Read handling a not-found resource
 
 	ctx := context.TODO()
 

--- a/pf/tfbridge/provider_read.go
+++ b/pf/tfbridge/provider_read.go
@@ -61,8 +61,8 @@ func (p *provider) Read(
 		CurrentState: &currentStateDV,
 	}
 
-	// TODO Set ProviderMeta
-	// TODO Set Private
+	// TODO[pulumi/pulumi-terraform-bridge#794] set ProviderMeta
+	// TODO[pulumi/pulumi-terraform-bridge#747] set Private
 
 	resp, err := p.tfServer.ReadResource(ctx, &req)
 	if err != nil {
@@ -73,8 +73,7 @@ func (p *provider) Read(
 		return plugin.ReadResult{}, 0, err
 	}
 
-	// TODO handle resp.Private
-
+	// TODO[pulumi/pulumi-terraform-bridge#747] handle resp.Private
 	if resp.NewState == nil {
 		return plugin.ReadResult{}, resource.StatusUnknown, nil
 	}
@@ -96,7 +95,7 @@ func (p *provider) Read(
 
 	return plugin.ReadResult{
 		ID: readID,
-		// TODO support populating inputs, see extractInputsFromOutputs in the prod bridge.
+		// TODO[pulumi/pulumi-terraform-bridge#795] populate Inputs
 		Inputs:  nil,
 		Outputs: readStateMap,
 	}, resource.StatusOK, nil

--- a/pf/tfbridge/provider_update.go
+++ b/pf/tfbridge/provider_update.go
@@ -95,7 +95,7 @@ func (p *provider) Update(
 		return nil, 0, err
 	}
 
-	// TODO handle resp.Private
+	// TODO[pulumi/pulumi-terraform-bridge#747] handle resp.Private
 	updatedState, err := parseResourceStateFromTF(ctx, &rh, resp.NewState)
 	if err != nil {
 		return nil, 0, err

--- a/pf/tfbridge/resource_state.go
+++ b/pf/tfbridge/resource_state.go
@@ -45,6 +45,7 @@ func (u *upgradedResourceState) ToPropertyMap(rh *resourceHandle) (resource.Prop
 	if err != nil {
 		return nil, err
 	}
+
 	return addTFSchemaVersion(propMap, u.state.TFSchemaVersion)
 }
 


### PR DESCRIPTION
Make sure Read():

- performs state upgrades (this seems to be part of sdk-v2 behavior, we probably have to)
- notes the state version in what it returns to the Pulumi CLI

The test was extracted from a `pulumi refresh`. We might need to test "get not refresh" scenario based on some if-then-else code I've seen in the v3/tfbridge.  Not sure yet which high-level Pulumi command it corresponds to.

I've also not had time make sure the input pieces are implemented, need to ticket that.
