### PR TITLE
Make explicit the tuple type for strategies

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -104,7 +104,7 @@ type ProviderInfo struct {
 //
 // NOTE: Experimental; We are still iterating on the design of this function, and it is
 // subject to change without warning.
-type ComputeDefaultInfo struct {
+type DefaultStrategy struct {
 	Resource   ResourceStrategy
 	DataSource DataSourceStrategy
 }
@@ -113,7 +113,7 @@ type ComputeDefaultInfo struct {
 //
 // NOTE: Experimental; We are still iterating on the design of this function, and it is
 // subject to change without warning.
-func (info *ProviderInfo) ComputeDefaults(opts ComputeDefaultInfo) error {
+func (info *ProviderInfo) ComputeDefaults(opts DefaultStrategy) error {
 	var errs multierror.Error
 	err := info.computeDefaultResources(opts.Resource)
 	if err != nil {

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -99,39 +99,47 @@ type ProviderInfo struct {
 	PreConfigureCallbackWithLogger PreConfigureCallbackWithLogger
 }
 
+// Describe the mapping from resource and datasource tokens to Pulumi resources and
+// datasources.
+//
+// NOTE: Experimental; We are still iterating on the design of this function, and it is
+// subject to change without warning.
+type ComputeDefaultInfo struct {
+	Resource   ResourceStrategy
+	DataSource DataSourceStrategy
+}
+
 // Add mapped resources and datasources according to the given strategies.
 //
 // NOTE: Experimental; We are still iterating on the design of this function, and it is
 // subject to change without warning.
-func (info *ProviderInfo) ComputeDefaults(r ResourceStrategy, d DatasourceStrategy) error {
+func (info *ProviderInfo) ComputeDefaults(opts ComputeDefaultInfo) error {
 	var errs multierror.Error
-	err := info.ComputeDefaultResources(r)
+	err := info.computeDefaultResources(opts.Resource)
 	if err != nil {
 		errs.Errors = append(errs.Errors, fmt.Errorf("resources:\n%w", err))
 	}
-	err = info.ComputeDefaultDataSources(d)
+	err = info.computeDefaultDataSources(opts.DataSource)
 	if err != nil {
 		errs.Errors = append(errs.Errors, fmt.Errorf("datasources:\n%w", err))
 	}
 	return errs.ErrorOrNil()
 }
 
-// Apply strategy to generate missing resources.
-//
-// NOTE: Experimental; We are still iterating on the design of this function, and it is
-// subject to change without warning.
-func (info *ProviderInfo) ComputeDefaultResources(strategy ResourceStrategy) error {
+func (info *ProviderInfo) computeDefaultResources(strategy ResourceStrategy) error {
+	if strategy == nil {
+		return nil
+	}
 	if info.Resources == nil {
 		info.Resources = map[string]*ResourceInfo{}
 	}
 	return applyComputedTokens(info.P.ResourcesMap(), info.Resources, strategy)
 }
 
-// Apply strategy to generate missing datsources.
-//
-// NOTE: Experimental; We are still iterating on the design of this function, and it is
-// subject to change without warning.
-func (info *ProviderInfo) ComputeDefaultDataSources(strategy DatasourceStrategy) error {
+func (info *ProviderInfo) computeDefaultDataSources(strategy DataSourceStrategy) error {
+	if strategy == nil {
+		return nil
+	}
 	if info.DataSources == nil {
 		info.DataSources = map[string]*DataSourceInfo{}
 	}
@@ -157,7 +165,7 @@ func applyComputedTokens[T ResourceInfo | DataSourceInfo](
 			// Skipping, since there is already a non-nil resource there.
 			continue
 		}
-		v, err := tks(k, keys)
+		v, err := tks(k)
 		if err != nil {
 			errs.Errors = append(errs.Errors, err)
 			continue

--- a/pkg/tfbridge/token.go
+++ b/pkg/tfbridge/token.go
@@ -34,13 +34,13 @@ type ResourceStrategy = Strategy[ResourceInfo]
 //
 // NOTE: Experimental; We are still iterating on the design of this type, and it is
 // subject to change without warning.
-type DatasourceStrategy = Strategy[DataSourceInfo]
+type DataSourceStrategy = Strategy[DataSourceInfo]
 
 // A generic remapping strategy.
 //
 // NOTE: Experimental; We are still iterating on the design of this type, and it is
 // subject to change without warning.
-type Strategy[T ResourceInfo | DataSourceInfo] func(tfToken string, tfTokens []string) (*T, error)
+type Strategy[T ResourceInfo | DataSourceInfo] func(tfToken string) (*T, error)
 
 // A function that joins a module and name into a pulumi type token.
 //
@@ -87,14 +87,14 @@ func camelCase(s string) string {
 // subject to change without warning.
 func TokensSingleModule(
 	tfPackagePrefix, moduleName string, finalize MakeToken,
-) (ResourceStrategy, DatasourceStrategy) {
+) ComputeDefaultInfo {
 	return TokensKnownModules(tfPackagePrefix, moduleName, nil, finalize)
 }
 
 func tokensKnownModules[T ResourceInfo | DataSourceInfo](
 	prefix, defaultModule string, modules []string, new func(string, string) (*T, error),
 ) Strategy[T] {
-	return func(tfToken string, _ []string) (*T, error) {
+	return func(tfToken string) (*T, error) {
 		tk := strings.TrimPrefix(tfToken, prefix)
 		if len(tk) == len(tfToken) {
 			return nil, fmt.Errorf("token '%s' missing package prefix '%s'", tfToken, prefix)
@@ -121,40 +121,55 @@ func tokensKnownModules[T ResourceInfo | DataSourceInfo](
 // subject to change without warning.
 func TokensKnownModules(
 	tfPackagePrefix, defaultModule string, modules []string, finalize MakeToken,
-) (ResourceStrategy, DatasourceStrategy) {
+) ComputeDefaultInfo {
 	// NOTE: We could turn this from a sort + linear lookup into a radix tree to recover
 	// O(log(n)) performance (current is O(n*m)) where n = number of modules and m =
 	// number of mappings.
 	sort.Sort(sort.Reverse(sort.StringSlice(modules)))
 
-	return tokensKnownModules(tfPackagePrefix, defaultModule, modules, func(mod, tk string) (*ResourceInfo, error) {
-			tk, err := finalize(mod, tk)
-			if err != nil {
-				return nil, err
-			}
-			return &ResourceInfo{Tok: tokens.Type(tk)}, nil
-		}), tokensKnownModules(tfPackagePrefix, defaultModule, modules, func(mod, tk string) (*DataSourceInfo, error) {
-			tk, err := finalize(mod, "get"+tk)
-			if err != nil {
-				return nil, err
-			}
-			return &DataSourceInfo{Tok: tokens.ModuleMember(tk)}, nil
-		})
+	return ComputeDefaultInfo{
+		Resource: tokensKnownModules(tfPackagePrefix, defaultModule, modules,
+			func(mod, tk string) (*ResourceInfo, error) {
+				tk, err := finalize(mod, tk)
+				if err != nil {
+					return nil, err
+				}
+				return &ResourceInfo{Tok: tokens.Type(tk)}, nil
+			}),
+		DataSource: tokensKnownModules(tfPackagePrefix, defaultModule, modules,
+			func(mod, tk string) (*DataSourceInfo, error) {
+				tk, err := finalize(mod, "get"+tk)
+				if err != nil {
+					return nil, err
+				}
+				return &DataSourceInfo{Tok: tokens.ModuleMember(tk)}, nil
+			}),
+	}
+}
+
+func (ts ComputeDefaultInfo) Unmappable(substring, reason string) ComputeDefaultInfo {
+	ts.DataSource = ts.DataSource.Unmappable(substring, reason)
+	ts.Resource = ts.Resource.Unmappable(substring, reason)
+	return ts
 }
 
 // Mark that a strategy cannot handle a sub-string.
 //
 // NOTE: Experimental; We are still iterating on the design of this function, and it is
 // subject to change without warning.
-func (ts Strategy[T]) Unmappable(substring string) Strategy[T] {
-	return func(tfToken string, tfTokens []string) (*T, error) {
+func (ts Strategy[T]) Unmappable(substring, reason string) Strategy[T] {
+	msg := fmt.Sprintf("cannot map tokens that contains '%s'", substring)
+	if reason != "" {
+		msg += ": " + reason
+	}
+	return func(tfToken string) (*T, error) {
 		if strings.Contains(tfToken, substring) {
 			return nil, UnmappableError{
 				TfToken: tfToken,
-				Reason:  fmt.Errorf("contains unmapable sub-string '%s'", substring),
+				Reason:  fmt.Errorf(msg),
 			}
 		}
-		return ts(tfToken, tfTokens)
+		return ts(tfToken)
 	}
 }
 

--- a/pkg/tfbridge/token.go
+++ b/pkg/tfbridge/token.go
@@ -87,7 +87,7 @@ func camelCase(s string) string {
 // subject to change without warning.
 func TokensSingleModule(
 	tfPackagePrefix, moduleName string, finalize MakeToken,
-) ComputeDefaultInfo {
+) DefaultStrategy {
 	return TokensKnownModules(tfPackagePrefix, moduleName, nil, finalize)
 }
 
@@ -121,13 +121,13 @@ func tokensKnownModules[T ResourceInfo | DataSourceInfo](
 // subject to change without warning.
 func TokensKnownModules(
 	tfPackagePrefix, defaultModule string, modules []string, finalize MakeToken,
-) ComputeDefaultInfo {
+) DefaultStrategy {
 	// NOTE: We could turn this from a sort + linear lookup into a radix tree to recover
 	// O(log(n)) performance (current is O(n*m)) where n = number of modules and m =
 	// number of mappings.
 	sort.Sort(sort.Reverse(sort.StringSlice(modules)))
 
-	return ComputeDefaultInfo{
+	return DefaultStrategy{
 		Resource: tokensKnownModules(tfPackagePrefix, defaultModule, modules,
 			func(mod, tk string) (*ResourceInfo, error) {
 				tk, err := finalize(mod, tk)
@@ -147,7 +147,7 @@ func TokensKnownModules(
 	}
 }
 
-func (ts ComputeDefaultInfo) Unmappable(substring, reason string) ComputeDefaultInfo {
+func (ts DefaultStrategy) Unmappable(substring, reason string) DefaultStrategy {
 	ts.DataSource = ts.DataSource.Unmappable(substring, reason)
 	ts.Resource = ts.Resource.Unmappable(substring, reason)
 	return ts

--- a/pkg/tfbridge/token_test.go
+++ b/pkg/tfbridge/token_test.go
@@ -64,7 +64,7 @@ func TestTokensSingleModule(t *testing.T) {
 	info.Resources = map[string]*tfbridge.ResourceInfo{
 		"foo_bar_hello_world": {Tok: "foo:index:BarHelloPulumi"},
 	}
-	err = info.ComputeDefaults(tfbridge.ComputeDefaultInfo{
+	err = info.ComputeDefaults(tfbridge.DefaultStrategy{
 		Resource: opts.Resource,
 	})
 	require.NoError(t, err)
@@ -90,7 +90,7 @@ func TestTokensKnownModules(t *testing.T) {
 		},
 	}
 
-	err := info.ComputeDefaults(tfbridge.ComputeDefaultInfo{
+	err := info.ComputeDefaults(tfbridge.DefaultStrategy{
 		Resource: tfbridge.TokensKnownModules("cs101_", "index", []string{
 			"fizz_", "buzz_", "fizz_buzz_",
 		}, func(module, name string) (string, error) {


### PR DESCRIPTION
Even though this is technically a breaking change, I only expect the `datadog` provider to require a fix.