### PR TITLE
Fixes #720: ignore invalid defaults

### DIFF
--- a/pkg/tfshim/sdk-v2/defaults.go
+++ b/pkg/tfshim/sdk-v2/defaults.go
@@ -30,14 +30,12 @@ func withPatchedDefaults(s *schema.Schema) *schema.Schema {
 }
 
 func hasInvalidDefault(s *schema.Schema) bool {
-	if s.Default == nil && s.ValidateFunc == nil {
+	if s.Default == nil || s.ValidateFunc == nil {
 		return false
 	}
 	_, errors := s.ValidateFunc(s.Default, "field")
 	for _, err := range errors {
-		glog.V(9).Infof("ignoring a Default value %v that does not validate with ValidateFunc: %v",
-			s.Default,
-			err)
+		glog.V(9).Infof("ignoring an invalid (per ValidateFunc) Default %v: %v", s.Default, err)
 	}
 	return len(errors) > 0
 }

--- a/pkg/tfshim/sdk-v2/defaults.go
+++ b/pkg/tfshim/sdk-v2/defaults.go
@@ -1,0 +1,45 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sdkv2
+
+import (
+	"github.com/golang/glog"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func withPatchedDefaults(s *schema.Schema) *schema.Schema {
+	if hasInvalidDefault(s) {
+		var schema schema.Schema = *s
+		schema.Default = nil
+		return &schema
+	}
+	return s
+}
+
+func hasInvalidDefault(s *schema.Schema) bool {
+	if s.Default != nil && s.ValidateFunc != nil {
+		_, errors := s.ValidateFunc(s.Default, "field")
+		if len(errors) > 0 {
+			for _, err := range errors {
+				glog.V(9).Infof("ignoring a Default value %v that does not validate with ValidateFunc: %v",
+					s.Default,
+					err)
+			}
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/tfshim/sdk-v2/defaults.go
+++ b/pkg/tfshim/sdk-v2/defaults.go
@@ -30,16 +30,14 @@ func withPatchedDefaults(s *schema.Schema) *schema.Schema {
 }
 
 func hasInvalidDefault(s *schema.Schema) bool {
-	if s.Default != nil && s.ValidateFunc != nil {
-		_, errors := s.ValidateFunc(s.Default, "field")
-		if len(errors) > 0 {
-			for _, err := range errors {
-				glog.V(9).Infof("ignoring a Default value %v that does not validate with ValidateFunc: %v",
-					s.Default,
-					err)
-			}
-			return true
-		}
+	if s.Default == nil && s.ValidateFunc == nil {
+		return false
 	}
-	return false
+	_, errors := s.ValidateFunc(s.Default, "field")
+	for _, err := range errors {
+		glog.V(9).Infof("ignoring a Default value %v that does not validate with ValidateFunc: %v",
+			s.Default,
+			err)
+	}
+	return len(errors) > 0
 }

--- a/pkg/tfshim/sdk-v2/defaults_test.go
+++ b/pkg/tfshim/sdk-v2/defaults_test.go
@@ -1,0 +1,54 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sdkv2_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
+)
+
+// Regressing an issue in the wild where a default value is given that does not validate. Currently pkg/tfbridge may
+// call DefaultValue() at runtime, but ignores Validators. In the case of invalid defaults, it may send an invalid value
+// to the provider, which will run validators and fail. The quick fix applied in defaults.go tested here is to detect
+// invalid defaults and drop them, pretending they were never set.
+//
+// See pulumi/pulumi-terraform-bridge#720
+func TestDroppingInvalidDefaults(t *testing.T) {
+	suspectSchema := sdkv2.NewSchema(&schema.Schema{
+		Type:         schema.TypeInt,
+		Optional:     true,
+		Default:      -1,
+		ValidateFunc: validation.IntBetween(0, 99999),
+	})
+	dv, err := suspectSchema.DefaultValue()
+	assert.Nil(t, dv)
+	assert.NoError(t, err)
+
+	goodSchema := sdkv2.NewSchema(&schema.Schema{
+		Type:         schema.TypeInt,
+		Optional:     true,
+		Default:      -1,
+		ValidateFunc: validation.IntBetween(-1, 99999),
+	})
+	dv, err = goodSchema.DefaultValue()
+	assert.Equal(t, -1, dv)
+	assert.NoError(t, err)
+
+}

--- a/pkg/tfshim/sdk-v2/schema.go
+++ b/pkg/tfshim/sdk-v2/schema.go
@@ -53,15 +53,15 @@ func (s v2Schema) Required() bool {
 }
 
 func (s v2Schema) Default() interface{} {
-	return s.tf.Default
+	return withPatchedDefaults(s.tf).Default
 }
 
 func (s v2Schema) DefaultFunc() shim.SchemaDefaultFunc {
-	return shim.SchemaDefaultFunc(s.tf.DefaultFunc)
+	return shim.SchemaDefaultFunc(withPatchedDefaults(s.tf).DefaultFunc)
 }
 
 func (s v2Schema) DefaultValue() (interface{}, error) {
-	return s.tf.DefaultValue()
+	return withPatchedDefaults(s.tf).DefaultValue()
 }
 
 func (s v2Schema) Description() string {


### PR DESCRIPTION
Fixes #720 

When an upstream provider defines a schema with a non-nil Default value and a non-nil ValidateFunc check such that the DefaultValue does not pass the validations according to ValidateFunc, the bridge will now ignore the DefaultValue and proceed as if it has been unset or nil. This works around issues in creating azure.storage.ManagementPolicy.