### PR TITLE
Enforce Bijection between `PulumiToTerraformName` and `TerraformToPulumiNameV2`

### DIFF
--- a/pkg/tf2pulumi/convert/tf12.go
+++ b/pkg/tf2pulumi/convert/tf12.go
@@ -1109,8 +1109,9 @@ func terraformToPulumiName(tfName string, schemas il.Schemas) string {
 	if schemas.Pulumi != nil && schemas.Pulumi.Name != "" {
 		return schemas.Pulumi.Name
 	}
-	return tfbridge.TerraformToPulumiName(
-		tfName, schemas.TF, schemas.Pulumi, false)
+	return tfbridge.TerraformToPulumiNameV2(
+		tfName, schema.SchemaMap{tfName: schemas.TF},
+		map[string]*tfbridge.SchemaInfo{tfName: schemas.Pulumi})
 }
 
 func (rr *resourceRewriter) terraformToPulumiName(tfName string) string {
@@ -1525,8 +1526,9 @@ func (b *tf12binder) rewriteScopeTraversal(n *model.ScopeTraversalExpression,
 			if schemas.Pulumi != nil && schemas.Pulumi.Name != "" {
 				traverser.Name = schemas.Pulumi.Name
 			} else {
-				traverser.Name = tfbridge.TerraformToPulumiName(
-					traverser.Name, schemas.TF, schemas.Pulumi, false)
+				traverser.Name = tfbridge.TerraformToPulumiNameV2(
+					traverser.Name, schema.SchemaMap{traverser.Name: schemas.TF},
+					map[string]*tfbridge.SchemaInfo{traverser.Name: schemas.Pulumi})
 			}
 			newTraversal = append(newTraversal, traverser)
 		case hcl.TraverseIndex:

--- a/pkg/tf2pulumi/convert/tf12.go
+++ b/pkg/tf2pulumi/convert/tf12.go
@@ -1109,7 +1109,8 @@ func terraformToPulumiName(tfName string, schemas il.Schemas) string {
 	if schemas.Pulumi != nil && schemas.Pulumi.Name != "" {
 		return schemas.Pulumi.Name
 	}
-	return tfbridge.TerraformToPulumiName(tfName, schemas.TF, schemas.Pulumi, false)
+	return tfbridge.TerraformToPulumiName(
+		tfName, schemas.TF, schemas.Pulumi, false)
 }
 
 func (rr *resourceRewriter) terraformToPulumiName(tfName string) string {
@@ -1524,7 +1525,8 @@ func (b *tf12binder) rewriteScopeTraversal(n *model.ScopeTraversalExpression,
 			if schemas.Pulumi != nil && schemas.Pulumi.Name != "" {
 				traverser.Name = schemas.Pulumi.Name
 			} else {
-				traverser.Name = tfbridge.TerraformToPulumiName(traverser.Name, schemas.TF, schemas.Pulumi, false)
+				traverser.Name = tfbridge.TerraformToPulumiName(
+					traverser.Name, schemas.TF, schemas.Pulumi, false)
 			}
 			newTraversal = append(newTraversal, traverser)
 		case hcl.TraverseIndex:

--- a/pkg/tf2pulumi/convert/tf12_names.go
+++ b/pkg/tf2pulumi/convert/tf12_names.go
@@ -82,7 +82,7 @@ func cleanName(name string) string {
 
 // pulumiName computes the Pulumi form of the given name.
 func (nt *nameTable) pulumiName(name string) string {
-	return camel(tfbridge.TerraformToPulumiName(name, nil, nil, false))
+	return camel(tfbridge.TerraformToPulumiNameV2(name, nil, nil))
 }
 
 // disambiguate ensures that the given name is unambiguous by appending an integer starting with 1 if necessary.

--- a/pkg/tf2pulumi/il/graph.go
+++ b/pkg/tf2pulumi/il/graph.go
@@ -746,7 +746,7 @@ func buildIgnoreChanges(tfIgnoreChanges []string, schemas Schemas) []string {
 					}
 				} else {
 					elementKey := tfbridge.TerraformToPulumiNameV2(element,
-						schema.SchemaMap{element: schemas.TF},
+						schema.SchemaMap{element: elemSchemas.TF},
 						map[string]*tfbridge.SchemaInfo{element: elemSchemas.Pulumi})
 					if path == "" {
 						path = elementKey

--- a/pkg/tf2pulumi/il/schemas.go
+++ b/pkg/tf2pulumi/il/schemas.go
@@ -26,6 +26,8 @@ import (
 // Schemas bundles a property's Terraform and Pulumi schema information into a single type. This information is then
 // used to determine type and name information for the property. If the Terraform property is of a composite type--a
 // map, list, or set--the property's schemas may also be used to access child schemas.
+//
+// TF and TFRes form a union, TF will be set for properties. TFRes will be set for resources.
 type Schemas struct {
 	TF     shim.Schema
 	TFRes  shim.Resource

--- a/pkg/tfbridge/names.go
+++ b/pkg/tfbridge/names.go
@@ -61,7 +61,7 @@ func PulumiToTerraformName(name string, tfs shim.SchemaMap, ps map[string]*Schem
 	return result
 }
 
-func checkTfMaxItems(tfs shim.Schema, maxItemsOne bool) bool {
+func isTfPlural(tfs shim.Schema) bool {
 	if tfs == nil {
 		return false
 	}
@@ -70,7 +70,7 @@ func checkTfMaxItems(tfs shim.Schema, maxItemsOne bool) bool {
 		return false
 	}
 
-	return (tfs.MaxItems() == 1) == maxItemsOne
+	return tfs.MaxItems() != 1
 }
 
 func isPulumiMaxItemsOne(ps *SchemaInfo) bool {
@@ -114,7 +114,7 @@ func terraformToPulumiName(name string, sch shim.SchemaMap, ps map[string]*Schem
 	}
 
 	// Pluralize names that will become array-shaped Pulumi values
-	if sch != nil && !isPulumiMaxItemsOne(psInfo) && checkTfMaxItems(sch.Get(name), false) {
+	if sch != nil && !isPulumiMaxItemsOne(psInfo) && isTfPlural(sch.Get(name)) {
 		candidate := inflector.Pluralize(name)
 
 		var conflict bool

--- a/pkg/tfbridge/names.go
+++ b/pkg/tfbridge/names.go
@@ -85,9 +85,21 @@ func TerraformToPulumiNameV2(name string, sch shim.SchemaMap, ps map[string]*Sch
 // string, from Terraform's underscore_casing to Pulumi's PascalCasing (if upper is true)
 // or camelCasing (if upper is false).
 //
-// Deprecated: Convert to TerraformToPulumiNameV2
+// Deprecated: Convert to TerraformToPulumiNameV2, see comment for conversion instructions.
 //
-// TODO: Playbook for transition
+// TerraformToPulumiNameV2 includes enough information for a bijective mapping between
+// Terraform attributes and Pulumi properties. If the full naming context cannot be
+// acquired, you can construct a partial naming context:
+//
+//	TerraformToPulumiNameV2(name,
+//		schema.SchemaMap(map[string]shim.Schema{name: sch}),
+//		map[string]*SchemaInfo{name: ps})
+//
+// If the previous (non-invertable) camel casing is necessary, it must be implemented
+// manually:
+//
+//	name := TerraformToPulumiNameV2(key, sch, ps)
+//	name = strings(uniode.ToUpper(rune(name[0]))) + name[1:]
 func TerraformToPulumiName(name string, sch shim.Schema, ps *SchemaInfo, upper bool) string {
 	return terraformToPulumiName(name,
 		schema.SchemaMap(map[string]shim.Schema{name: sch}),

--- a/pkg/tfbridge/names.go
+++ b/pkg/tfbridge/names.go
@@ -32,8 +32,6 @@ func PulumiToTerraformName(name string, tfs shim.SchemaMap, ps map[string]*Schem
 	var result string
 	// First, check if any tf name points to this one.
 	if tfs != nil {
-		// NOTE: TerraformToPulumiNameV2 is O(n) with n = # of properties. That makes
-		// PulumiToTerraformName O(n^2).
 		tfs.Range(func(key string, value shim.Schema) bool {
 			v := TerraformToPulumiNameV2(key, tfs, ps)
 			if v == name {
@@ -116,19 +114,7 @@ func terraformToPulumiName(name string, sch shim.SchemaMap, ps map[string]*Schem
 	// Pluralize names that will become array-shaped Pulumi values
 	if sch != nil && !isPulumiMaxItemsOne(psInfo) && isTfPlural(sch.Get(name)) {
 		candidate := inflector.Pluralize(name)
-
-		var conflict bool
-		sch.Range(func(key string, value shim.Schema) bool {
-			if key == name {
-				return true
-			}
-			if key == candidate {
-				conflict = true
-			}
-			return !conflict
-		})
-
-		if !conflict {
+		if _, conflict := sch.GetOk(candidate); !conflict {
 			name = candidate
 		}
 	}

--- a/pkg/tfbridge/names.go
+++ b/pkg/tfbridge/names.go
@@ -29,6 +29,13 @@ import (
 // PulumiToTerraformName performs a standard transformation on the given name string, from Pulumi's PascalCasing or
 // camelCasing, to Terraform's underscore_casing.
 func PulumiToTerraformName(name string, tfs shim.SchemaMap, ps map[string]*SchemaInfo) string {
+	// First, check if a .Name override applies
+	for k, v := range ps {
+		if v.Name == name {
+			return k
+		}
+	}
+
 	var result string
 	for i, c := range name {
 		if c >= 'A' && c <= 'Z' {
@@ -111,6 +118,12 @@ func terraformToPulumiName(name string, sch shim.SchemaMap, ps map[string]*Schem
 	var psInfo *SchemaInfo
 	if ps != nil {
 		psInfo = ps[name]
+	}
+
+	if psInfo != nil {
+		if name := psInfo.Name; name != "" {
+			return name
+		}
 	}
 
 	// Pluralize names that will become array-shaped Pulumi values

--- a/pkg/tfbridge/names.go
+++ b/pkg/tfbridge/names.go
@@ -115,12 +115,7 @@ func terraformToPulumiName(name string, sch shim.SchemaMap, ps map[string]*Schem
 
 	// Pluralize names that will become array-shaped Pulumi values
 	if sch != nil && !isPulumiMaxItemsOne(psInfo) && checkTfMaxItems(sch.Get(name), false) {
-		pluralized := inflector.Pluralize(name)
-		candidate := name
-		if inflector.Singularize(pluralized) == candidate {
-			candidate = pluralized
-		}
-		candidate = inflector.Pluralize(candidate)
+		candidate := inflector.Pluralize(name)
 
 		var conflict bool
 		sch.Range(func(key string, value shim.Schema) bool {

--- a/pkg/tfbridge/names_test.go
+++ b/pkg/tfbridge/names_test.go
@@ -223,6 +223,18 @@ func TestBijectiveNameConversion(t *testing.T) {
 				"plural":   "plural_property",
 			},
 		},
+		{ // Check number mapping
+			schema: map[string]*schemav2.Schema{
+				"base_32_string_seed": {Type: schemav2.TypeString},
+				"rfc_4180":            {Type: schemav2.TypeInt},
+				"ext_100_with200":     {Type: schemav2.TypeInt},
+			},
+			expected: map[string]string{
+				"base32StringSeed": "base_32_string_seed",
+				"rfc4180":          "rfc_4180",
+				"ext100With200":    "ext_100_with200",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/tfbridge/names_test.go
+++ b/pkg/tfbridge/names_test.go
@@ -66,7 +66,7 @@ func TestTerraformToPulumiNameWithSchemaInfoOverride(t *testing.T) {
 		},
 	}
 
-	name := TerraformToPulumiName("list_property", shimv1.NewSchema(tfs["list_property"]), ps["list_property"], false)
+	name := TerraformToPulumiNameV2("list_property", shimv1.NewSchemaMap(tfs), ps)
 	if name != "listProperty" {
 		t.Errorf("Expected `listProperty`, got %s", name)
 	}
@@ -180,24 +180,13 @@ func TestBijectiveNameConversion(t *testing.T) {
 		info     map[string]*SchemaInfo
 		expected map[string]string
 	}{
-		// NOTE:
-		//
-		// Cannot be fully bijective because TerraformToPulumiName does not have scope
-		// level information like PulumiToTerraformName. We should change the signature of
-		// TerraformToPulumiName so it's the inverse of PulumiToTerraformName.
-		//
-		// It's not that bad, since codegen will fail for these types of conflicts.
-		//
-		// Currently fails because "certificate_authority" maps to
-		// "certificateAuthorities" instead of "certificateAuthority".
-		//
-		// {
-		// 	schema: certSchema(),
-		// 	expected: map[string]string{
-		// 		"certificateAuthority":   "certificate_authority",
-		// 		"certificateAuthorities": "certificate_authorities",
-		// 	},
-		// },
+		{
+			schema: certSchema(),
+			expected: map[string]string{
+				"certificateAuthority":   "certificate_authority",
+				"certificateAuthorities": "certificate_authorities",
+			},
+		},
 		{
 			schema: certSchema(),
 			info: map[string]*SchemaInfo{
@@ -237,7 +226,7 @@ func TestBijectiveNameConversion(t *testing.T) {
 			for _, tf := range tfAttributes {
 				t.Run(tf+"->"+tfToPulumi[tf], func(t *testing.T) {
 					m := shimv2.NewSchemaMap(tt.schema)
-					assert.Equal(t, tfToPulumi[tf], TerraformToPulumiName(tf, m.Get(tf), tt.info[tf], false))
+					assert.Equal(t, tfToPulumi[tf], TerraformToPulumiNameV2(tf, m, tt.info))
 				})
 			}
 			for _, prop := range pulumiProps {

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -1147,7 +1147,7 @@ func getInfoFromTerraformName(key string,
 			name = key
 		} else {
 			// If no name override exists, use the default name mangling scheme.
-			name = TerraformToPulumiName(key, getSchema(tfs, key), ps[key], false)
+			name = TerraformToPulumiNameV2(key, tfs, ps)
 		}
 	}
 

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -1487,14 +1487,6 @@ func input(sch shim.Schema, info *tfbridge.SchemaInfo) bool {
 //	would need to understand how to unmarshal names in a language-idiomatic way (and specifically reverse the
 //	name transformation process).  This isn't impossible, but certainly complicates matters.
 func propertyName(key string, sch shim.SchemaMap, custom map[string]*tfbridge.SchemaInfo) string {
-	// Use the name override, if one exists, or use the standard name mangling otherwise.
-	if custom != nil {
-		v := custom[key]
-		if v != nil && v.Name != "" {
-			return v.Name
-		}
-	}
-
 	// BUGBUG: work around issue in the Elastic Transcoder where a field has a trailing ":".
 	key = strings.TrimSuffix(key, ":")
 

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -412,12 +412,7 @@ func (g *Generator) makeObjectPropertyType(typePath paths.TypePath,
 	}
 
 	for _, key := range stableSchemas(res.Schema()) {
-		propertySchema := res.Schema().Get(key)
-
-		var propertyInfo *tfbridge.SchemaInfo
-		if propertyInfos != nil {
-			propertyInfo = propertyInfos[key]
-		}
+		propertySchema := res.Schema()
 
 		// TODO: Figure out why counting whether this description came from the attributes seems wrong.
 		// With AWS, counting this takes the takes number of arg descriptions from attribs from about 170 to about 1400.
@@ -425,7 +420,7 @@ func (g *Generator) makeObjectPropertyType(typePath paths.TypePath,
 		doc, _ := getNestedDescriptionFromParsedDocs(entityDocs, objectName, key)
 
 		if v := g.propertyVariable(typePath, key,
-			propertySchema, propertyInfo, doc, "", out, entityDocs); v != nil {
+			propertySchema, propertyInfos, doc, "", out, entityDocs); v != nil {
 			t.properties = append(t.properties, v)
 		}
 	}
@@ -993,7 +988,7 @@ func (g *Generator) gatherConfig() *module {
 		// Generate a name and type to use for this key.
 		sch := cfg.Get(key)
 		prop := g.propertyVariable(cfgPath,
-			key, sch, custom[key], "", sch.Description(), true /*out*/, entityDocs{})
+			key, cfg, custom, "", sch.Description(), true /*out*/, entityDocs{})
 		if prop != nil {
 			prop.config = true
 			config.addMember(prop)
@@ -1008,9 +1003,15 @@ func (g *Generator) gatherConfig() *module {
 	}
 
 	// Now, if there are any extra config variables, that are Pulumi-only, add them.
+	extraConfigInfo := map[string]*tfbridge.SchemaInfo{}
+	extraConfigMap := schema.SchemaMap{}
 	for key, val := range g.info.ExtraConfig {
+		extraConfigInfo[key] = val.Info
+		extraConfigMap.Set(key, val.Schema)
+	}
+	for key := range g.info.ExtraConfig {
 		if prop := g.propertyVariable(cfgPath,
-			key, val.Schema, val.Info, "", "", true /*out*/, entityDocs{}); prop != nil {
+			key, extraConfigMap, extraConfigInfo, "", "", true /*out*/, entityDocs{}); prop != nil {
 			prop.config = true
 			config.addMember(prop)
 		}
@@ -1165,8 +1166,8 @@ func (g *Generator) gatherResource(rawname string,
 		if !isProvider {
 			// For all properties, generate the output property metadata. Note that this may differ slightly
 			// from the input in that the types may differ.
-			outprop := g.propertyVariable(resourcePath.Outputs(), key, propschema,
-				propinfo, doc, rawdoc, true /*out*/, entityDocs)
+			outprop := g.propertyVariable(resourcePath.Outputs(), key, schema.Schema(),
+				info.Fields, doc, rawdoc, true /*out*/, entityDocs)
 			if outprop != nil {
 				res.outprops = append(res.outprops, outprop)
 			}
@@ -1181,7 +1182,7 @@ func (g *Generator) gatherResource(rawname string,
 			}
 
 			inprop := g.propertyVariable(resourcePath.Inputs(),
-				key, propschema, propinfo, doc, rawdoc, false /*out*/, entityDocs)
+				key, schema.Schema(), info.Fields, doc, rawdoc, false /*out*/, entityDocs)
 			if inprop != nil {
 				res.inprops = append(res.inprops, inprop)
 				if !inprop.optional() {
@@ -1191,7 +1192,7 @@ func (g *Generator) gatherResource(rawname string,
 		}
 
 		// Make a state variable.  This is always optional and simply lets callers perform lookups.
-		stateVar := g.propertyVariable(resourcePath.State(), key, propschema, propinfo,
+		stateVar := g.propertyVariable(resourcePath.State(), key, schema.Schema(), info.Fields,
 			doc, rawdoc, false /*out*/, entityDocs)
 		stateVar.opt = true
 		stateVars = append(stateVars, stateVar)
@@ -1359,7 +1360,7 @@ func (g *Generator) gatherDataSource(rawname string,
 			}
 
 			argvar := g.propertyVariable(dataSourcePath.Args(),
-				arg, sch, cust, doc, "", false /*out*/, entityDocs)
+				arg, ds.Schema(), info.Fields, doc, "", false /*out*/, entityDocs)
 			fun.args = append(fun.args, argvar)
 			if !argvar.optional() {
 				fun.reqargs[argvar.name] = true
@@ -1370,18 +1371,20 @@ func (g *Generator) gatherDataSource(rawname string,
 		// Emit documentation for the property if available
 		fun.rets = append(fun.rets,
 			g.propertyVariable(dataSourcePath.Results(),
-				arg, sch, cust, entityDocs.Attributes[arg], "", true /*out*/, entityDocs))
+				arg, ds.Schema(), info.Fields, entityDocs.Attributes[arg], "", true /*out*/, entityDocs))
 	}
 
 	// If the data source's schema doesn't expose an id property, make one up since we'd like to expose it for data
 	// sources.
 	if id, has := ds.Schema().GetOk("id"); !has || id.Removed() != "" {
-		cust := &tfbridge.SchemaInfo{}
+		cust := map[string]*tfbridge.SchemaInfo{"id": {}}
 		rawdoc := "The provider-assigned unique ID for this managed resource."
-		idSchema := &schema.Schema{Type: shim.TypeString, Computed: true}
+		idSchema := schema.SchemaMap(map[string]shim.Schema{
+			"id": (&schema.Schema{Type: shim.TypeString, Computed: true}).Shim(),
+		})
 		fun.rets = append(fun.rets,
 			g.propertyVariable(dataSourcePath.Results(),
-				"id", idSchema.Shim(), cust, "", rawdoc, true /*out*/, entityDocs))
+				"id", idSchema, cust, "", rawdoc, true /*out*/, entityDocs))
 	}
 
 	// Produce the args/return types, if needed.
@@ -1483,18 +1486,19 @@ func input(sch shim.Schema, info *tfbridge.SchemaInfo) bool {
 //
 //	would need to understand how to unmarshal names in a language-idiomatic way (and specifically reverse the
 //	name transformation process).  This isn't impossible, but certainly complicates matters.
-func propertyName(key string, sch shim.Schema, custom *tfbridge.SchemaInfo) string {
+func propertyName(key string, sch shim.SchemaMap, custom map[string]*tfbridge.SchemaInfo) string {
 	// Use the name override, if one exists, or use the standard name mangling otherwise.
 	if custom != nil {
-		if custom.Name != "" {
-			return custom.Name
+		v := custom[key]
+		if v != nil && v.Name != "" {
+			return v.Name
 		}
 	}
 
 	// BUGBUG: work around issue in the Elastic Transcoder where a field has a trailing ":".
 	key = strings.TrimSuffix(key, ":")
 
-	return tfbridge.TerraformToPulumiName(key, sch, custom, false /*no to PascalCase; we want camelCase*/)
+	return tfbridge.TerraformToPulumiNameV2(key, sch, custom)
 }
 
 // propertyVariable creates a new property, with the Pulumi name, out of the given components.
@@ -1503,21 +1507,31 @@ func propertyName(key string, sch shim.Schema, custom *tfbridge.SchemaInfo) stri
 //
 // parentPath together with key uniquely locates the property in the Terraform schema.
 func (g *Generator) propertyVariable(parentPath paths.TypePath, key string,
-	sch shim.Schema, info *tfbridge.SchemaInfo,
+	sch shim.SchemaMap, info map[string]*tfbridge.SchemaInfo,
 	doc string, rawdoc string, out bool, entityDocs entityDocs) *variable {
 
 	if name := propertyName(key, sch, info); name != "" {
 		propName := paths.PropertyName{Key: key, Name: tokens.Name(name)}
 		typePath := paths.NewProperyPath(parentPath, propName)
 		g.renamesBuilder.registerProperty(parentPath, propName)
+
+		var schema shim.Schema
+		if sch != nil {
+			schema = sch.Get(key)
+		}
+		var varInfo *tfbridge.SchemaInfo
+		if info != nil {
+			varInfo = info[key]
+		}
+
 		return &variable{
 			name:         name,
 			out:          out,
 			doc:          doc,
 			rawdoc:       rawdoc,
-			schema:       sch,
-			info:         info,
-			typ:          g.makePropertyType(typePath, strings.ToLower(key), sch, info, out, entityDocs),
+			schema:       schema,
+			info:         varInfo,
+			typ:          g.makePropertyType(typePath, strings.ToLower(key), schema, varInfo, out, entityDocs),
 			parentPath:   parentPath,
 			propertyName: propName,
 		}
@@ -1530,8 +1544,8 @@ func dataSourceName(provider string, rawname string,
 	info *tfbridge.DataSourceInfo) (tokens.ModuleMemberName, tokens.ModuleName) {
 	if info == nil || info.Tok == "" {
 		// default transformations.
-		name := withoutPackageName(provider, rawname)                // strip off the pkg prefix.
-		name = tfbridge.TerraformToPulumiName(name, nil, nil, false) // camelCase
+		name := withoutPackageName(provider, rawname) // strip off the pkg prefix.
+		name = tfbridge.TerraformToPulumiNameV2(name, nil, nil)
 		return tokens.ModuleMemberName(name), tokens.ModuleName(name)
 	}
 	// otherwise, a custom transformation exists; use it.
@@ -1546,9 +1560,12 @@ func resourceName(provider string, rawname string,
 	}
 	if info == nil || info.Tok == "" {
 		// default transformations.
-		name := withoutPackageName(provider, rawname)                  // strip off the pkg prefix.
-		camel := tfbridge.TerraformToPulumiName(name, nil, nil, false) // camelCase the module name.
-		pascal := tfbridge.TerraformToPulumiName(name, nil, nil, true) // PascalCase the resource name.
+		name := withoutPackageName(provider, rawname)              // strip off the pkg prefix.
+		camel := tfbridge.TerraformToPulumiNameV2(name, nil, nil)  // camelCase the module name.
+		pascal := tfbridge.TerraformToPulumiNameV2(name, nil, nil) // PascalCase the resource name.
+		if pascal != "" {
+			pascal = string(unicode.ToUpper(rune(pascal[0]))) + pascal[1:]
+		}
 
 		modName := tokens.ModuleName(camel)
 		return tokens.TypeName(pascal), modName

--- a/pkg/tfgen/namecheck.go
+++ b/pkg/tfgen/namecheck.go
@@ -146,11 +146,7 @@ func validatePropertyNames(
 	errors := []nameError{}
 	mapping := map[string]string{}
 	schemaMap.Range(func(tfAttr string, tfAttrSchema shim.Schema) bool {
-		var info *tfbridge.SchemaInfo
-		if infos != nil {
-			info = infos[tfAttr]
-		}
-		pulumiName := tfbridge.TerraformToPulumiName(tfAttr, tfAttrSchema, info, false)
+		pulumiName := tfbridge.TerraformToPulumiNameV2(tfAttr, schemaMap, infos)
 
 		if oldAttr, exists := mapping[pulumiName]; exists {
 			errors = append(errors, newNameCollisionError(nc, tfKey, tfAttr, pulumiName, oldAttr))


### PR DESCRIPTION
Fixes #778

This PR adds `TerraformToPulumiNameV2`: A version of `TerraformToPulumiName` that captures the same amount of information as `PulumiToTerraformName`. 

This allows us ensure `TerraformToPulumiNameV2(PulumiToTerraformName(tfName)) == tfName` whenever possible[^1].

[^1]: The user can override this information. If there are manual overrides that conflict, we can't ensure the bijection.