### PR TITLE
Allow the user to override upstream repo path

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -97,6 +97,8 @@ type ProviderInfo struct {
 
 	PreConfigureCallback           PreConfigureCallback // a provider-specific callback to invoke prior to TF Configure
 	PreConfigureCallbackWithLogger PreConfigureCallbackWithLogger
+
+	UpstreamRepoPath string // An optional path that overrides upstream location during docs lookup
 }
 
 // Describe the mapping from resource and datasource tokens to Pulumi resources and


### PR DESCRIPTION
Right now, the bridge assumes that it can find or download the upstream provider. This prohibits against building against submodules, since they are not found at their expected location in `GOPATH`. This adds an optional override.