### PR TITLE
Better namecheck

### DIFF
--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -865,6 +865,10 @@ func (g *Generator) Generate() error {
 			return errors.Wrapf(err, "failed to marshal schema")
 		}
 		files = map[string][]byte{"schema.json": bytes}
+
+		if err := nameCheck(g.info, pulumiPackageSpec, g.renamesBuilder, g.sink); err != nil {
+			return err
+		}
 	case PCL:
 		if g.skipExamples {
 			return fmt.Errorf("Cannot set skipExamples and get PCL")
@@ -915,7 +919,7 @@ func (g *Generator) Generate() error {
 
 // Remanes can be called after a successful call to Generate to extract name mappings.
 func (g *Generator) Renames() (Renames, error) {
-	return g.renamesBuilder.build(), nil
+	return g.renamesBuilder.BuildRenames()
 }
 
 // gatherPackage creates a package plus module structure for the entire set of members of this package.
@@ -1505,7 +1509,10 @@ func (g *Generator) propertyVariable(parentPath paths.TypePath, key string,
 	if name := propertyName(key, sch, info); name != "" {
 		propName := paths.PropertyName{Key: key, Name: tokens.Name(name)}
 		typePath := paths.NewProperyPath(parentPath, propName)
-		g.renamesBuilder.registerProperty(parentPath, propName)
+
+		if g.renamesBuilder != nil {
+			g.renamesBuilder.registerProperty(parentPath, propName)
+		}
 
 		var schema shim.Schema
 		if sch != nil {

--- a/pkg/tfgen/main.go
+++ b/pkg/tfgen/main.go
@@ -34,8 +34,6 @@ import (
 // Main executes the TFGen process for the given package pkg and provider prov.
 func Main(pkg string, version string, prov tfbridge.ProviderInfo) {
 	MainWithCustomGenerate(pkg, version, prov, func(opts GeneratorOptions) error {
-		validatePropertyNamesForProvider(prov).Report(opts.Sink)
-
 		// Create a generator with the specified settings.
 		g, err := NewGenerator(opts)
 		if err != nil {

--- a/pkg/tfgen/namecheck.go
+++ b/pkg/tfgen/namecheck.go
@@ -17,150 +17,355 @@ package tfgen
 import (
 	"fmt"
 	"os"
-	"sort"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+
+	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen/internal/paths"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
-type nameErrors []nameError
-
-func (ne nameErrors) Sort() {
-	sort.Slice(ne, func(i, j int) bool {
-		if ne[i].context < ne[j].context {
-			return true
-		}
-		if ne[i].tfKey < ne[j].tfKey {
-			return true
-		}
-		if ne[i].tfAttr < ne[j].tfAttr {
-			return true
-		}
-		if ne[i].message < ne[j].message {
-			return true
-		}
-		return false
-	})
+type nameCheckPropSet struct {
+	location  string
+	props     []paths.PropertyName
+	schemaMap shim.SchemaMap
+	infos     map[string]*tfbridge.SchemaInfo
 }
 
-func (ne nameErrors) Report(sink diag.Sink) {
-	if len(ne) == 0 {
-		return
-	}
-
+// Checks a generated schema to detect property name collisions and verify automatic naming.
+//
+// Bridged providers need to perform property name translation between Pulumi and Terraform names. Historically there
+// were two classes of issues with naming, both leading to confusing runtime errors:
+//
+//   - problems from customized ProviderInfo overrides, such as custom SchemaInfo.Name that picks a Pulumi property name
+//     that conflicts with another property
+//
+//   - automatic naming bugs in tfbridge code such as https://github.com/pulumi/pulumi-terraform-bridge/issues/778
+//
+// Best-effort attempt is made here to detect both classes of issues early (at schema generation aka provider build
+// time), decide which one it is.
+func nameCheck(
+	prov tfbridge.ProviderInfo,
+	spec pschema.PackageSpec,
+	renamesBuilder *renamesBuilder,
+	sink diag.Sink,
+) error {
 	if sink == nil {
 		sink = diag.DefaultSink(os.Stdout, os.Stderr, diag.FormatOptions{
 			Color: colors.Always,
 		})
 	}
 
-	ne.Sort()
-	sink.Warningf(&diag.Diag{Message: "Found %d naming error(s)"}, len(ne))
-	for _, n := range ne {
-		sink.Warningf(&diag.Diag{Message: "Naming error in Terraform %s %q attribute %q: %s"},
-			n.context, n.tfKey, n.tfAttr, n.message)
+	renames, err := renamesBuilder.BuildRenames()
+	if err != nil {
+		return err
+	}
+
+	props, err := renamesBuilder.BuildProperties()
+	if err != nil {
+		return err
+	}
+
+	all := []nameCheckPropSet{}
+
+	if len(spec.Config.Variables) > 0 {
+		configProps := renamesBuilder.BuildConfigProperties()
+		ps := nameCheckPropSet{
+			location:  "Config",
+			props:     configProps,
+			schemaMap: prov.P.Schema(),
+			infos:     prov.Config,
+		}
+		all = append(all, ps)
+	}
+
+	for tok := range spec.Resources {
+		key := renames.Resources[tokens.Type(tok)]
+		loc := fmt.Sprintf("Resource: %q\n    Token: %q", tok, key)
+		ps := nameCheckPropSet{
+			location:  loc,
+			props:     props[tokens.Token(tok)],
+			schemaMap: prov.P.ResourcesMap().Get(key).Schema(),
+			infos:     prov.Resources[key].Fields,
+		}
+		all = append(all, ps)
+	}
+
+	for tok := range spec.Functions {
+		key := renames.Functions[tokens.ModuleMember(tok)]
+		loc := fmt.Sprintf("Function: %q\n    Token: %q", key, tok)
+		ps := nameCheckPropSet{
+			location:  loc,
+			props:     props[tokens.Token(tok)],
+			schemaMap: prov.P.DataSourcesMap().Get(key).Schema(),
+			infos:     prov.DataSources[key].Fields,
+		}
+		all = append(all, ps)
+	}
+
+	for tok := range spec.Types {
+		typePaths := renamesBuilder.ObjectTypePaths(tokens.Type(tok))
+		for _, typePath := range typePaths.Paths() {
+			loc := fmt.Sprintf("Type: %q\n    TypePath: %s", tok, typePath.String())
+			p, err := locateTypByTypePath(prov, typePath)
+			if err != nil {
+				return err
+			}
+			schemaMap, err := p.SchemaMap()
+			if err != nil {
+				return err
+			}
+			infos, err := p.SchemaInfos()
+			if err != nil {
+				return err
+			}
+			ps := nameCheckPropSet{
+				location:  loc,
+				props:     props[tokens.Token(tok)],
+				schemaMap: schemaMap,
+				infos:     infos,
+			}
+			all = append(all, ps)
+		}
+	}
+
+	for _, props := range all {
+		nameCheckUniquePulumiNames(sink, props)
+		nameCheckUniqueTerraformNames(sink, props)
+		nameCheckTerraformToPulumiName(sink, props)
+		nameCheckPulumiToTerraformName(sink, props)
+	}
+
+	return nil
+}
+
+func nameCheckTerraformToPulumiName(sink diag.Sink, props nameCheckPropSet) {
+	for _, p := range props.props {
+		expected := p.Name
+		actual := tfbridge.TerraformToPulumiNameV2(p.Key, props.schemaMap, props.infos)
+		if actual == expected.String() {
+			continue
+		}
+		m := "TerraformToPulumiNameV2(%q) unexpectedly returns %q, expecting %q from schema generation.\n" +
+			"  Please report this as a bug to pulumi/pulumi-terraform-bridge.\n" +
+			"  Location:\n    %v\n"
+		sink.Warningf(&diag.Diag{Message: m}, p.Key, actual, expected, props.location)
 	}
 }
 
-type nameContext uint16
-
-const (
-	configPropertyNames     nameContext = 1
-	dataSourcePropertyNames nameContext = 2
-	resourcePropertyNames   nameContext = 3
-)
-
-func (nc nameContext) String() string {
-	switch nc {
-	case configPropertyNames:
-		return "Config"
-	case dataSourcePropertyNames:
-		return "DataSource"
-	case resourcePropertyNames:
-		return "Resource"
+func nameCheckPulumiToTerraformName(sink diag.Sink, props nameCheckPropSet) {
+	for _, p := range props.props {
+		expected := p.Key
+		actual := tfbridge.PulumiToTerraformName(p.Name.String(), props.schemaMap, props.infos)
+		if actual == expected {
+			continue
+		}
+		m := "PulumiToTerraformName(%q) unexpectedly returns %q, expecting %q from schema generation.\n" +
+			"  Please report this as a bug to pulumi/pulumi-terraform-bridge.\n" +
+			"  Location:\n    %v\n"
+		sink.Warningf(&diag.Diag{Message: m}, p.Key, actual, expected, props.location)
 	}
-	return "unknown"
 }
 
-type nameError struct {
-	context nameContext
-	tfKey   string
-	tfAttr  string
-	message string
-}
-
-func newNameTurnaroundError(nc nameContext, tfKey, tfAttr, pulumiName, tfAttrRecovered string) nameError {
-	m := fmt.Sprintf("Pulumi name %q incorrectly translates back to Terraform as %q",
-		pulumiName, tfAttrRecovered)
-	return nameError{context: nc, tfKey: tfKey, tfAttr: tfAttr, message: m}
-}
-
-func newNameCollisionError(nc nameContext, tfKey, tfAttr, pulumiName, tfAttrOther string) nameError {
-	m := fmt.Sprintf("Pulumi name %q already represents another Terraform name %q",
-		pulumiName, tfAttrOther)
-	return nameError{context: nc, tfKey: tfKey, tfAttr: tfAttr, message: m}
-}
-
-func validatePropertyNamesForProvider(prov tfbridge.ProviderInfo) nameErrors {
-	errors := []nameError{}
-
-	prov.P.Schema().Range(func(tfConfigKey string, sch shim.Schema) bool {
-		es := validatePropertyNames(configPropertyNames, tfConfigKey, prov.P.Schema(), prov.Config)
-		errors = append(errors, es...)
-		return true
-	})
-
-	prov.P.ResourcesMap().Range(func(tfResKey string, res shim.Resource) bool {
-		info := prov.Resources[tfResKey]
-		if info == nil {
-			info = &tfbridge.ResourceInfo{}
+func nameCheckUniquePulumiNames(sink diag.Sink, props nameCheckPropSet) {
+	index := map[tokens.Name][]string{}
+	for _, p := range props.props {
+		index[p.Name] = append(index[p.Name], p.Key)
+	}
+	for k, v := range index {
+		if len(v) <= 1 {
+			continue
 		}
-		res.Schema()
-		es := validatePropertyNames(resourcePropertyNames, tfResKey, res.Schema(), info.Fields)
-		errors = append(errors, es...)
-		return true
-	})
-
-	prov.P.DataSourcesMap().Range(func(tfDsKey string, ds shim.Resource) bool {
-		info := prov.DataSources[tfDsKey]
-		if info == nil {
-			info = &tfbridge.DataSourceInfo{}
-		}
-		es := validatePropertyNames(dataSourcePropertyNames, tfDsKey, ds.Schema(), info.Fields)
-		errors = append(errors, es...)
-		return true
-	})
-
-	return nameErrors(errors)
+		m := "Pulumi property %q maps to multiple Terraform properties %v.\n" +
+			"  This will cause runtime errors in the provider.\n" +
+			"  Please set SchemaInfo.Name to rename the Terraform properties.\n" +
+			"  Location:\n    %v\n"
+		sink.Warningf(&diag.Diag{Message: m}, k, v, props.location)
+	}
 }
 
-func validatePropertyNames(
-	nc nameContext,
-	tfKey string,
-	schemaMap shim.SchemaMap,
-	infos map[string]*tfbridge.SchemaInfo,
-) []nameError {
-	errors := []nameError{}
-	mapping := map[string]string{}
-	schemaMap.Range(func(tfAttr string, tfAttrSchema shim.Schema) bool {
-		pulumiName := tfbridge.TerraformToPulumiNameV2(tfAttr, schemaMap, infos)
-
-		if oldAttr, exists := mapping[pulumiName]; exists {
-			errors = append(errors, newNameCollisionError(nc, tfKey, tfAttr, pulumiName, oldAttr))
+func nameCheckUniqueTerraformNames(sink diag.Sink, props nameCheckPropSet) {
+	index := map[string][]tokens.Name{}
+	for _, p := range props.props {
+		index[p.Key] = append(index[p.Key], p.Name)
+	}
+	for k, v := range index {
+		if len(v) <= 1 {
+			continue
 		}
+		m := "Terraform property %q maps to multiple Pulumi properties %v.\n" +
+			"  This will cause runtime errors in the provider.\n" +
+			"  Please set SchemaInfo.Name to rename the Terraform properties.\n" +
+			"  Location:\n    %v\n"
+		sink.Warningf(&diag.Diag{Message: m}, k, v, props.location)
+	}
+}
 
-		mapping[pulumiName] = tfAttr
+// Internal helper family of types typ, objType, collectionType, scalarType assist nameCheck in the task of co-locating
+// SchemaInfo and shim.Schema in a provider by drilling down a TypePath. This is currently quite bespoke because of
+// convoluted encodings of types into shim.Schema (see documentation on shim.Schema.Elem), and wrinkles in TypePath
+// being confused about flattening where MaxItem=1 collections from Terraform are translated to scalars in Pulumi.
+type typ interface {
+	Property(pn paths.PropertyName) (typ, error)
+	Element() (typ, error)
+	SchemaMap() (shim.SchemaMap, error)
+	SchemaInfos() (map[string]*tfbridge.SchemaInfo, error)
+}
 
-		tfAttrRecovered := tfbridge.PulumiToTerraformName(pulumiName, schemaMap, infos)
-		if tfAttrRecovered != tfAttr {
-			errors = append(errors, newNameTurnaroundError(nc, tfKey, tfAttr, pulumiName, tfAttrRecovered))
+type objType struct {
+	fields shim.SchemaMap
+	infos  map[string]*tfbridge.SchemaInfo
+}
+
+func (x *objType) SchemaInfos() (map[string]*tfbridge.SchemaInfo, error) {
+	return x.infos, nil
+}
+
+func (x *objType) SchemaMap() (shim.SchemaMap, error) {
+	return x.fields, nil
+}
+
+func (x *objType) Property(pn paths.PropertyName) (typ, error) {
+	return newTyp(x.fields.Get(pn.Key), x.infos[pn.Key]), nil
+}
+
+func (x *objType) Element() (typ, error) {
+	return nil, fmt.Errorf("Element undefined on an objType")
+}
+
+var _ typ = (*objType)(nil)
+
+type collectionType struct {
+	elem typ
+}
+
+func (x *collectionType) Property(pn paths.PropertyName) (typ, error) {
+	if _, ok := x.elem.(*objType); ok {
+		// Because of flattening MaxItems=1, sometimes this logic is off by one and the collection of objects is
+		// asked to lookup a property, where in Pulumi projection it's no longer a collection but just an
+		// object.
+		return x.elem.Property(pn)
+	}
+	return nil, fmt.Errorf("Properties are undefined on an collectionType")
+}
+
+func (x *collectionType) SchemaInfos() (map[string]*tfbridge.SchemaInfo, error) {
+	// Also working around MaxItems=1
+	if _, ok := x.elem.(*objType); ok {
+		return x.elem.SchemaInfos()
+	}
+	return nil, fmt.Errorf("SchemaInfos are undefined on an collectionType")
+}
+
+func (x *collectionType) SchemaMap() (shim.SchemaMap, error) {
+	// Also working around MaxItems=1
+	if _, ok := x.elem.(*objType); ok {
+		return x.elem.SchemaMap()
+	}
+	return nil, fmt.Errorf("SchemaMap are undefined on an collectionType")
+}
+
+func (x *collectionType) Element() (typ, error) {
+	return x.elem, nil
+}
+
+var _ typ = (*collectionType)(nil)
+
+type scalarType struct{}
+
+func (x *scalarType) Element() (typ, error) {
+	return nil, fmt.Errorf("Element undefined on an scalarType")
+}
+
+func (x *scalarType) Property(pn paths.PropertyName) (typ, error) {
+	return nil, fmt.Errorf("Properties are undefined on an scalarType")
+}
+
+func (x *scalarType) SchemaMap() (shim.SchemaMap, error) {
+	return nil, fmt.Errorf("Fields are undefined on an scalarType")
+}
+
+func (x *scalarType) SchemaInfos() (map[string]*tfbridge.SchemaInfo, error) {
+	return nil, fmt.Errorf("Fields are undefined on an scalarType")
+}
+
+var _ typ = (*scalarType)(nil)
+
+func newTyp(s shim.Schema, info *tfbridge.SchemaInfo) typ {
+	switch sElem := s.Elem().(type) {
+	case shim.Resource:
+		switch s.Type() {
+		case shim.TypeMap:
+			t := &objType{fields: sElem.Schema()}
+			if info != nil {
+				t.infos = info.Fields
+			}
+			return t
+		case shim.TypeList, shim.TypeSet:
+			t := &objType{fields: sElem.Schema()}
+			if info != nil && info.Elem != nil {
+				t.infos = info.Elem.Fields
+			}
+			return &collectionType{t}
+		default:
+			panic("impossible: shim.Schema s with s.Elem() of type shim.Resource must have s.Type()" +
+				" be one of shim.TypeMap, shim.TypeSet, shim.TypeList. See Elem() doc comment.")
 		}
+	case shim.Schema:
+		var elem *tfbridge.SchemaInfo
+		if info != nil {
+			elem = info.Elem
+		}
+		parsed := newTyp(sElem, elem)
+		return &collectionType{parsed}
+	default:
+		return &scalarType{}
+	}
+}
 
-		return true
-
-	})
-	return errors
+func locateTypByTypePath(prov tfbridge.ProviderInfo, path paths.TypePath) (typ, error) {
+	switch p := path.(type) {
+	case *paths.DataSourceMemberPath:
+		key := p.DataSourcePath.Key()
+		return &objType{
+			fields: prov.P.DataSourcesMap().Get(key).Schema(),
+			infos:  prov.DataSources[key].Fields,
+		}, nil
+	case *paths.ResourceMemberPath:
+		if p.ResourcePath.IsProvider() {
+			return &objType{
+				fields: prov.P.Schema(),
+				infos:  prov.Config,
+			}, nil
+		}
+		key := p.ResourcePath.Key()
+		return &objType{
+			fields: prov.P.ResourcesMap().Get(key).Schema(),
+			infos:  prov.Resources[key].Fields,
+		}, nil
+	case *paths.ConfigPath:
+		return &objType{
+			fields: prov.P.Schema(),
+			infos:  prov.Config,
+		}, nil
+	case *paths.PropertyPath:
+		t, err := locateTypByTypePath(prov, p.Parent())
+		if err != nil {
+			return nil, err
+		}
+		return t.Property(p.PropertyName)
+	case *paths.ElementPath:
+		t, err := locateTypByTypePath(prov, p.Parent())
+		if err != nil {
+			return nil, err
+		}
+		return t.Element()
+	default:
+		panic("impossible match in locateTypByTypePath")
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/779

Name checks are now extended to cover object types, I think it covers everything now. Very reassuringly the name-checks pass on pulumi-aws as https://github.com/pulumi/pulumi-terraform-bridge/pull/782 took care of the missing bits. This double checks that the naming functions are indeed invertible for the entire provider after applying user-supplied Name overrides and pluralization.

- [x] check TF and Pulumi property name uniqueness for all objects
- [x] check object types (not just resources and functions)
- [x] cross-check that rename tables correspond to the renaming functions used at runtime
- [x] more actionable messages 
- [x] correlate SchemaInfo on object types

Example error presentation (note that's no longer an error anymore, it was a spurious warning due to a bug in namecheck, but it's here to illustrate the format):

```
warning: TerraformToPulumiNameV2("expiration") unexpectedly returns "expiration", expecting "expirations" from schema generation.
  Please report this as a bug to pulumi/pulumi-terraform-bridge.
  Location:
    Type: "aws:s3/BucketV2LifecycleRule:BucketV2LifecycleRule"
    TypePath: resource[key="aws_s3_bucket",token="aws:s3/bucketV2:BucketV2"].inputs.lifecycle_rule[pulumi:"lifecycleRules"].$
```
