### PR TITLE
Accommodate conflict remaps

### DIFF
--- a/pkg/tfbridge/names_test.go
+++ b/pkg/tfbridge/names_test.go
@@ -235,6 +235,19 @@ func TestBijectiveNameConversion(t *testing.T) {
 				"ext100With200":    "ext_100_with200",
 			},
 		},
+		{ // Check manually overwritten remaps
+			schema: map[string]*schemav2.Schema{
+				"plural_type":  {Type: schemav2.TypeList},
+				"plural_types": {Type: schemav2.TypeList},
+			},
+			info: map[string]*SchemaInfo{
+				"plural_types": {Name: "remaped"},
+			},
+			expected: map[string]string{
+				"pluralTypes": "plural_type",
+				"remaped":     "plural_types",
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/790

We were keeping fields singular when they would cause a conflict, even if the conflict was manually remapped. This caused a breaking change in the azurerm_frontdoor resource. 

The problem was discovered via https://github.com/pulumi/pulumi-azure/actions/runs/4078132838/jobs/7048043503. 