### PR TITLE
Exclude AWS downstream broken test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        provider: [ "aws", "gcp", "azure", "azuread", "random", ]
+        provider: [ "gcp", "azure", "azuread", "random", ]
     steps:
       - name: Install Go
         uses: actions/setup-go@v1


### PR DESCRIPTION
We don't have the capacity to address underlying issue yet, so it is better to exclude the red failing check from CI for now, so that we do not get desensitized and actually react to failing checks properly.