### PR TITLE
Add workflow to update providers on release

### DIFF
--- a/.github/workflows/update-providers-ci-mgmt.yml
+++ b/.github/workflows/update-providers-ci-mgmt.yml
@@ -1,11 +1,19 @@
 name: Update Providers with new bridge version via ci-mgmt
 on:
   workflow_dispatch:
+  release:
+    types: [published]
+env:
+  GH_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
-  update-providers:
-    name: update-providers
+  upgrade_provider:
+    name: upgrade-provider
     runs-on: ubuntu-latest
     steps:
-      - name: Check out source code
-        uses: actions/checkout@master
-    # TBD
+    - name: Call upgrade provider action
+      uses: pulumi/pulumi-upgrade-provider-action@v0.0.4
+      with:
+        slack-channel: provider-upgrade-status
+        slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+        kind: "bridge"


### PR DESCRIPTION
Fixes https://github.com/pulumi/home/issues/2589
Automatically trigger [update-bridge-all-providers](https://github.com/pulumi/ci-mgmt/blob/master/.github/workflows/update-bridge-all-providers.yml) in `pulumi/ci-mgmt` on release