### PR TITLE
Add gradle fields to JavaInfo

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -386,6 +386,15 @@ type CSharpInfo struct {
 
 type JavaInfo struct {
 	BasePackage string // the Base package for the Java SDK
+
+	// If set to "gradle" enables a generation of a basic set of
+	// Gradle build files.
+	BuildFiles string
+
+	// If non-empty and BuildFiles="gradle", enables the use of a
+	// given version of io.github.gradle-nexus.publish-plugin in
+	// the generated Gradle build files.
+	GradleNexusPublishPluginVersion string
 }
 
 // PreConfigureCallback is a function to invoke prior to calling the TF provider Configure

--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -380,7 +380,9 @@ func (g *schemaGenerator) genPackageSpec(pack *pkg) (pschema.PackageSpec, error)
 
 	if javai := g.info.Java; javai != nil {
 		spec.Language["java"] = rawMessage(map[string]interface{}{
-			"basePackage": javai.BasePackage,
+			"basePackage":                     javai.BasePackage,
+			"buildFiles":                      javai.BuildFiles,
+			"gradleNexusPublishPluginVersion": javai.GradleNexusPublishPluginVersion,
 		})
 	}
 


### PR DESCRIPTION
This lets us set the gradle params that gen-sdk needs to generate gradle files for java.