### PR TITLE
Suggested aliasing strategy tweaks

### DIFF
--- a/pkg/tfbridge/x/token_test.go
+++ b/pkg/tfbridge/x/token_test.go
@@ -202,13 +202,16 @@ func TestAliasing(t *testing.T) {
 	}, simple.Resources)
 
 	modules := provider()
+
 	knownModules := TokensKnownModules("pkg_", "",
 		[]string{"mod1", "mod2"}, MakeStandardToken("pkg"))
-	aliasing, finish, err := Aliasing(metadata, knownModules)
+
+	err = ComputeDefaults(modules, knownModules)
 	require.NoError(t, err)
-	err = ComputeDefaults(modules, aliasing)
+
+	err = AutoAliasing(metadata, modules)
 	require.NoError(t, err)
-	finish(modules)
+
 	hist2 := md.Clone(metadata)
 	ref := func(s string) *string { return &s }
 	assert.Equal(t, map[string]*tfbridge.ResourceInfo{
@@ -242,7 +245,7 @@ func TestAliasing(t *testing.T) {
 	}, modules.Resources)
 
 	modules2 := provider()
-	aliasing, finish, err = Aliasing(metadata, knownModules)
+	aliasing, finish, err := Aliasing(metadata, knownModules)
 	require.NoError(t, err)
 	err = ComputeDefaults(modules2, aliasing)
 	require.NoError(t, err)

--- a/pkg/tfbridge/x/token_test.go
+++ b/pkg/tfbridge/x/token_test.go
@@ -245,11 +245,13 @@ func TestAliasing(t *testing.T) {
 	}, modules.Resources)
 
 	modules2 := provider()
-	aliasing, finish, err := Aliasing(metadata, knownModules)
+
+	err = ComputeDefaults(modules2, knownModules)
 	require.NoError(t, err)
-	err = ComputeDefaults(modules2, aliasing)
+
+	err = AutoAliasing(metadata, modules2)
 	require.NoError(t, err)
-	finish(modules2)
+
 	hist3 := md.Clone(metadata)
 	assert.Equal(t, hist2, hist3, "No changes should imply no change in history")
 	assert.Equal(t, modules, modules2)

--- a/pkg/tfbridge/x/token_test.go
+++ b/pkg/tfbridge/x/token_test.go
@@ -189,13 +189,12 @@ func TestAliasing(t *testing.T) {
 	metadata, err := metadata.New(nil)
 	require.NoError(t, err)
 
-	aliasing, finish, err := Aliasing(metadata,
-		TokensSingleModule("pkg_", "index", MakeStandardToken("pkg")))
-	require.NoError(t, err)
-	err = ComputeDefaults(simple, aliasing)
+	err = ComputeDefaults(simple, TokensSingleModule("pkg_", "index", MakeStandardToken("pkg")))
 	require.NoError(t, err)
 
-	finish(simple)
+	err = AutoAliasing(metadata, simple)
+	require.NoError(t, err)
+
 	assert.Equal(t, map[string]*tfbridge.ResourceInfo{
 		"pkg_mod1_r1": {Tok: "pkg:index/mod1R1:Mod1R1"},
 		"pkg_mod1_r2": {Tok: "pkg:index/mod1R2:Mod1R2"},
@@ -205,7 +204,7 @@ func TestAliasing(t *testing.T) {
 	modules := provider()
 	knownModules := TokensKnownModules("pkg_", "",
 		[]string{"mod1", "mod2"}, MakeStandardToken("pkg"))
-	aliasing, finish, err = Aliasing(metadata, knownModules)
+	aliasing, finish, err := Aliasing(metadata, knownModules)
 	require.NoError(t, err)
 	err = ComputeDefaults(modules, aliasing)
 	require.NoError(t, err)

--- a/pkg/tfbridge/x/token_test.go
+++ b/pkg/tfbridge/x/token_test.go
@@ -192,7 +192,7 @@ func TestAliasing(t *testing.T) {
 	err = ComputeDefaults(simple, TokensSingleModule("pkg_", "index", MakeStandardToken("pkg")))
 	require.NoError(t, err)
 
-	err = AutoAliasing(metadata, simple)
+	err = AutoAliasing(simple, metadata)
 	require.NoError(t, err)
 
 	assert.Equal(t, map[string]*tfbridge.ResourceInfo{
@@ -209,7 +209,7 @@ func TestAliasing(t *testing.T) {
 	err = ComputeDefaults(modules, knownModules)
 	require.NoError(t, err)
 
-	err = AutoAliasing(metadata, modules)
+	err = AutoAliasing(modules, metadata)
 	require.NoError(t, err)
 
 	hist2 := md.Clone(metadata)
@@ -249,7 +249,7 @@ func TestAliasing(t *testing.T) {
 	err = ComputeDefaults(modules2, knownModules)
 	require.NoError(t, err)
 
-	err = AutoAliasing(metadata, modules2)
+	err = AutoAliasing(modules2, metadata)
 	require.NoError(t, err)
 
 	hist3 := md.Clone(metadata)

--- a/pkg/tfbridge/x/tokens.go
+++ b/pkg/tfbridge/x/tokens.go
@@ -143,7 +143,7 @@ type aliasHistory struct {
 // updating the passed ProviderInfo passed to ComputeDefault.
 type FinishAlias = func(*b.ProviderInfo)
 
-func AutoAliasing(artifact metadata.Provider, providerInfo *b.ProviderInfo) error {
+func AutoAliasing(providerInfo *b.ProviderInfo, artifact metadata.Provider) error {
 	remaps := &[]func(*b.ProviderInfo){}
 
 	hist, err := getHistory(artifact)

--- a/pkg/tfbridge/x/tokens.go
+++ b/pkg/tfbridge/x/tokens.go
@@ -154,6 +154,17 @@ func AutoAliasing(artifact metadata.Provider, providerInfo *b.ProviderInfo) erro
 	for tfToken, computed := range providerInfo.Resources {
 		aliasResource(hist.Resources, computed, tfToken, remaps)
 	}
+
+	for _, r := range *remaps {
+		r(providerInfo)
+	}
+
+	if err := md.Set(artifact, artifactKey, hist); err != nil {
+		// Set fails only when `hist` is not serializable. Because `hist` is
+		// composed of marshallable, non-cyclic types, this is impossible.
+		contract.AssertNoErrorf(err, "History failed to serialize")
+	}
+
 	return nil
 }
 

--- a/pkg/tfbridge/x/tokens.go
+++ b/pkg/tfbridge/x/tokens.go
@@ -155,6 +155,10 @@ func AutoAliasing(artifact metadata.Provider, providerInfo *b.ProviderInfo) erro
 		aliasResource(hist.Resources, computed, tfToken, remaps)
 	}
 
+	for tfToken, computed := range providerInfo.DataSources {
+		aliasDataSource(hist.DataSources, computed, tfToken, remaps)
+	}
+
 	for _, r := range *remaps {
 		r(providerInfo)
 	}

--- a/pkg/tfbridge/x/tokens.go
+++ b/pkg/tfbridge/x/tokens.go
@@ -217,7 +217,8 @@ func aliasResources(
 		if err != nil {
 			return nil, err
 		}
-		return aliasResource(hist, res, tfToken, remaps)
+		aliasResource(hist, res, tfToken, remaps)
+		return res, nil
 	}
 }
 
@@ -226,7 +227,7 @@ func aliasResource(
 	computed *b.ResourceInfo,
 	tfToken string,
 	remaps *[]func(*b.ProviderInfo),
-) (*b.ResourceInfo, error) {
+) {
 	prev, hasPrev := hist[tfToken]
 	if !hasPrev {
 		// It's not in the history, so it must be new. Stick it in the history for
@@ -244,7 +245,6 @@ func aliasResource(
 		})
 
 	}
-	return computed, nil
 }
 
 func aliasOrRenameResource(p *b.ProviderInfo, tfToken string, hist *tokenHistory[tokens.Type]) {


### PR DESCRIPTION
I've played with making auto-aliasing not a strategy. In this PR it's a side-effecting function to be called after ComputeDefaults. This cleans up the Go API.