### PR TITLE
Introduce PreStateUpgradeHook for Plugin Framework

### DIFF
--- a/pf/tests/prestateupgradehook_test.go
+++ b/pf/tests/prestateupgradehook_test.go
@@ -1,0 +1,72 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfbridgetests
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-terraform-bridge/pf/tests/internal/testprovider"
+	testutils "github.com/pulumi/pulumi-terraform-bridge/testing/x"
+	tfbridge "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
+func TestPreStateUpgradeHook(t *testing.T) {
+	info := testprovider.RandomProvider()
+	info.ProviderInfo.Resources["random_string"].PreStateUpgradeHook = func(args tfbridge.PreStateUpgradeHookArgs) (int64, resource.PropertyMap, error) {
+		// Assume that if prior state is missing a schema version marker, it really is a corrupt state at version 2.
+		if args.PriorStateSchemaVersion == 0 {
+			return 2, args.PriorState, nil
+		}
+		// Otherwise proceed as ususal without modification.
+		return args.PriorStateSchemaVersion, args.PriorState, nil
+	}
+
+	server := newProviderServer(t, info)
+	testutils.Replay(t, server, `
+	{
+	  "method": "/pulumirpc.ResourceProvider/Update",
+	  "request": {
+	    "id": "0",
+	    "urn": "urn:pulumi:dev::repro-pulumi-random::random:index/randomString:RandomString::s",
+	    "olds": {
+	      "length": 1,
+	      "result": "x"
+	    },
+	    "news": {
+	      "length": 2
+	    }
+	  },
+	  "response": {
+	    "properties": {
+	      "__meta": "{\"schema_version\":\"2\"}",
+	      "id": "*",
+	      "length": 2,
+	      "lower": true,
+	      "minLower": 0,
+	      "minNumeric": 0,
+	      "minSpecial": 0,
+	      "minUpper": 0,
+	      "number": true,
+	      "numeric": true,
+	      "result": "*",
+	      "special": true,
+	      "upper": true
+	    }
+	  }
+	}
+        `)
+
+}

--- a/pf/tfbridge/resource_state.go
+++ b/pf/tfbridge/resource_state.go
@@ -156,7 +156,12 @@ func updateTFSchemaVersion(m resource.PropertyMap, version int64) (resource.Prop
 	} else {
 		meta = map[string]interface{}{}
 	}
-	meta["schema_version"] = version
+	if version != 0 {
+		meta["schema_version"] = fmt.Sprintf("%d", version)
+	}
+	if len(meta) == 0 {
+		return m, nil
+	}
 	updatedMeta, err := json.Marshal(meta)
 	if err != nil {
 		return nil, err

--- a/pf/tfbridge/resource_state.go
+++ b/pf/tfbridge/resource_state.go
@@ -159,21 +159,22 @@ func parseTFSchemaVersion(m resource.PropertyMap) (int64, error) {
 }
 
 func updateTFSchemaVersion(m resource.PropertyMap, version int64) (resource.PropertyMap, error) {
+	var meta map[string]interface{}
 	if metaProperty, hasMeta := m[metaKey]; hasMeta && metaProperty.IsString() {
-		var meta map[string]interface{}
 		if err := json.Unmarshal([]byte(metaProperty.StringValue()), &meta); err != nil {
 			err = fmt.Errorf("expected %q special property to be a JSON-marshalled string: %w",
 				metaKey, err)
 			return nil, err
 		}
-		meta["schema_version"] = version
-		updatedMeta, err := json.Marshal(meta)
-		if err != nil {
-			return nil, err
-		}
-		c := m.Copy()
-		c[metaKey] = resource.NewStringProperty(string(updatedMeta))
-		return c, nil
+	} else {
+		meta = map[string]interface{}{}
 	}
-	return nil, nil
+	meta["schema_version"] = version
+	updatedMeta, err := json.Marshal(meta)
+	if err != nil {
+		return nil, err
+	}
+	c := m.Copy()
+	c[metaKey] = resource.NewStringProperty(string(updatedMeta))
+	return c, nil
 }

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -180,8 +180,8 @@ type ResourceInfo struct {
 	DeprecationMessage  string      // message to use in deprecation warning
 	CSharpName          string      // .NET-specific name
 
-	// Optional hook to run before upgrading the state. This is currently only supported for Plugin-Framework based
-	// providers.
+	// Optional hook to run before upgrading the state. TODO[pulumi/pulumi-terraform-bridge#864] this is currently
+	// only supported for Plugin-Framework based providers.
 	PreStateUpgradeHook PreStateUpgradeHook
 }
 

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -180,6 +180,8 @@ type ResourceInfo struct {
 	DeprecationMessage  string      // message to use in deprecation warning
 	CSharpName          string      // .NET-specific name
 
+	// Optional hook to run before upgrading the state.
+	PreStateUpgradeHook PreStateUpgradeHook
 }
 
 // GetTok returns a resource type token
@@ -955,4 +957,16 @@ func ConfigBoolValue(vars resource.PropertyMap, prop resource.PropertyKey, envs 
 		}
 	}
 	return false
+}
+
+// If specified, the hook will run just prior to executing Terraform state upgrades to transform the resource state as
+// stored in Pulumi. It can be used to perform idempotent corrections on corrupt state and to compensate for
+// Terraform-level state upgrade not working as expected. Returns the corrected resource state and version. To be used
+// with care.
+type PreStateUpgradeHook = func(PreStateUpgradeHookArgs) (int64, resource.PropertyMap, error)
+
+type PreStateUpgradeHookArgs struct {
+	PriorState              resource.PropertyMap
+	PriorStateSchemaVersion int64
+	ResourceSchemaVersion   int64
 }

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -964,6 +964,8 @@ func ConfigBoolValue(vars resource.PropertyMap, prop resource.PropertyKey, envs 
 // stored in Pulumi. It can be used to perform idempotent corrections on corrupt state and to compensate for
 // Terraform-level state upgrade not working as expected. Returns the corrected resource state and version. To be used
 // with care.
+//
+// See also: https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#Schema.Version
 type PreStateUpgradeHook = func(PreStateUpgradeHookArgs) (int64, resource.PropertyMap, error)
 
 type PreStateUpgradeHookArgs struct {

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -180,7 +180,8 @@ type ResourceInfo struct {
 	DeprecationMessage  string      // message to use in deprecation warning
 	CSharpName          string      // .NET-specific name
 
-	// Optional hook to run before upgrading the state.
+	// Optional hook to run before upgrading the state. This is currently only supported for Plugin-Framework based
+	// providers.
 	PreStateUpgradeHook PreStateUpgradeHook
 }
 


### PR DESCRIPTION
PreStateUpgradeHook seems useful in a few recent exceptional situations:

- pulumi-random provider versions to an early version of PF that contaminated users's state do not let us ship an easy upgrade that just works; writing some logic in PreStateUpgradeHook could be used to auto-fix it

- pulumi-tls provider updates to FP are breaking because upstream did not code up state migrations properly, but using this hook can let us compensate at Pulumi level: https://github.com/pulumi/pulumi-tls/pull/190

Open to suggestions on alternative mechanism and/or API design.