### PR TITLE
`namecheck` resilient to unmapped resources/functions

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -186,7 +186,12 @@ type ResourceInfo struct {
 func (info *ResourceInfo) GetTok() tokens.Token { return tokens.Token(info.Tok) }
 
 // GetFields returns information about the resource's custom fields
-func (info *ResourceInfo) GetFields() map[string]*SchemaInfo { return info.Fields }
+func (info *ResourceInfo) GetFields() map[string]*SchemaInfo {
+	if info == nil {
+		return nil
+	}
+	return info.Fields
+}
 
 // GetDocs returns a resource docs override from the Pulumi provider
 func (info *ResourceInfo) GetDocs() *DocInfo { return info.Docs }
@@ -208,7 +213,12 @@ type DataSourceInfo struct {
 func (info *DataSourceInfo) GetTok() tokens.Token { return tokens.Token(info.Tok) }
 
 // GetFields returns information about the datasource's custom fields
-func (info *DataSourceInfo) GetFields() map[string]*SchemaInfo { return info.Fields }
+func (info *DataSourceInfo) GetFields() map[string]*SchemaInfo {
+	if info == nil {
+		return nil
+	}
+	return info.Fields
+}
 
 // GetDocs returns a datasource docs override from the Pulumi provider
 func (info *DataSourceInfo) GetDocs() *DocInfo { return info.Docs }

--- a/pkg/tfgen/namecheck_test.go
+++ b/pkg/tfgen/namecheck_test.go
@@ -1,0 +1,80 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfgen
+
+import (
+	"testing"
+
+	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/internal/testprovider"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
+)
+
+// We are testing that there are no panics when checking valid resources, even when the
+// resource is missing in the schema.
+func TestNameCheckMissingResource(t *testing.T) {
+	p := testprovider.ProviderMiniRandom()
+	info := tfbridge.ProviderInfo{
+		P: shim.NewProvider(p),
+	}
+
+	properties := func(names ...string) map[string]pschema.PropertySpec {
+		props := make(map[string]pschema.PropertySpec)
+		for _, name := range names {
+			props[name] = pschema.PropertySpec{}
+		}
+		return props
+	}
+
+	randomIntegerProps := properties("keepers", "min",
+		"max", "seed", "result")
+
+	for _, resources := range []map[string]pschema.ResourceSpec{
+		{},
+		{
+			"random/index:integer:Integer": {
+				InputProperties: randomIntegerProps,
+				ObjectTypeSpec: pschema.ObjectTypeSpec{
+					Properties: randomIntegerProps,
+				}},
+		},
+	} {
+		schema := pschema.PackageSpec{
+			Name:      "random",
+			Resources: resources,
+		}
+		err := nameCheck(info, schema, newRenamesBuilder("random", "random_"), NoErrorSink(t))
+		assert.NoError(t, err)
+	}
+}
+
+func NoErrorSink(t *testing.T) diag.Sink {
+	e := errOnWrite{t}
+	return diag.DefaultSink(e, e, diag.FormatOptions{
+		Color: colors.Never,
+	})
+}
+
+type errOnWrite struct{ t *testing.T }
+
+func (e errOnWrite) Write(p []byte) (int, error) {
+	e.t.Fatalf("Attempted to write %s", string(p))
+	return 0, nil
+}


### PR DESCRIPTION
This allows pulumi-docker/v4 to build. Previously, it crashed with

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x200ca6d]

goroutine 1 [running]:
github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen.nameCheck({{0x2c91018, 0xc000948d80}, {0x2667432, 0x6}, {0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}, ...}, ...)
        $HOME/go/pkg/mod/github.com/pulumi/pulumi-terraform-bridge/v3@v3.41.0/pkg/tfgen/namecheck.go:93 +0x48d
github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen.(*Generator).Generate(0xc0007498c0)
        $HOME/go/pkg/mod/github.com/pulumi/pulumi-terraform-bridge/v3@v3.41.0/pkg/tfgen/generate.go:890 +0x6d8
github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen.Main.func1({{0x2667432, 0x6}, {0x2c581a0, 0x1f}, {0x7ffc70d971fd, 0x6}, {{0x2c91018, 0xc000948d80}, {0x2667432, 0x6}, ...}, ...})
```