### PR TITLE
Improve lint, Go 1.20.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,12 @@ jobs:
     name: Build and Test Bridge
     strategy:
       matrix:
-        go-version: [1.19.x]
+        go-version: [1.20.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
       - name: Check out source code
@@ -40,9 +40,9 @@ jobs:
         provider: [ "gcp", "azure", "azuread", "random", ]
     steps:
       - name: Install Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.19.x
+          go-version: 1.20.x
       - name: Install Node.js
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,6 @@ jobs:
         run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)/bin" "${GOLANGCI_LINT_VERSION}"
       - name: Lint
         run: make lint
-      - name: Lint PF
-        run: cd pf && make lint
       - name: Test
         run: make test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  GOLANGCI_LINT_VERSION: v1.50.1
+  GOLANGCI_LINT_VERSION: v1.51.2
 name: Pull Request & Downstream Testing
 on: [pull_request]
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  GOLANGCI_LINT_VERSION: v1.51.2
+
 name: Pull Request & Downstream Testing
+
 on: [pull_request]
+
 jobs:
   build:
     name: Build and Test Bridge
@@ -25,7 +27,9 @@ jobs:
       - name: Build
         run: make build
       - name: Install golangci-lint
-        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)/bin" "${GOLANGCI_LINT_VERSION}"
+        uses: golangci/golangci-lint-action@v3
+        with:
+            version: v1.51.2
       - name: Lint
         run: make lint
       - name: Test

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -16,12 +16,12 @@ jobs:
     name: Build and Test Bridge
     strategy:
       matrix:
-        go-version: [1.19.x]
+        go-version: [1.20.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
       - name: Check out source code

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,6 +1,6 @@
 name: Master and Tag Builds
 env:
-  GOLANGCI_LINT_VERSION: v1.50.1
+  GOLANGCI_LINT_VERSION: v1.51.2
 on:
   push:
     branches:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,6 +1,5 @@
 name: Master and Tag Builds
-env:
-  GOLANGCI_LINT_VERSION: v1.51.2
+
 on:
   push:
     branches:
@@ -33,7 +32,9 @@ jobs:
       - name: Build
         run: make build
       - name: Install golangci-lint
-        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)/bin" "${GOLANGCI_LINT_VERSION}"
+        uses: golangci/golangci-lint-action@v3
+        with:
+            version: v1.51.2
       - name: Lint
         run: make lint
       - name: Test

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.19.x
+        - 1.20.x
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
@@ -22,7 +22,7 @@ jobs:
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ${{matrix.goversion}}
     - name: Download module dependencies

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -5,7 +5,6 @@ on:
   workflow_dispatch: {}
 env:
   GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
-  GOLANGCI_LINT_VERSION: v1.51.2
 jobs:
   weekly-pulumi-update:
     runs-on: ubuntu-latest
@@ -30,7 +29,9 @@ jobs:
         GOPROXY: "https://proxy.golang.org"
       run: go mod download
     - name: Install golangci-lint
-      run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)/bin" "${GOLANGCI_LINT_VERSION}"
+      uses: golangci/golangci-lint-action@v3
+      with:
+          version: v1.51.2
     - name: Update Pulumi/Pulumi
       id: gomod
       run: >-

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch: {}
 env:
   GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
-  GOLANGCI_LINT_VERSION: v1.50.1
+  GOLANGCI_LINT_VERSION: v1.51.2
 jobs:
   weekly-pulumi-update:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ fmt::
 	@gofmt -w -s .
 
 lint::
-	golangci-lint run
+	go run scripts/build.go lint
 
 test::
 	@mkdir -p bin

--- a/pf/Makefile
+++ b/pf/Makefile
@@ -67,6 +67,4 @@ tidy::
 	cd tests/internal/tlsshim && go mod tidy
 	cd tests/testdatagen/genrandom && go mod tidy
 
-.PHONY: lint todos
-lint:
-	golangci-lint run
+.PHONY: todos

--- a/pf/tests/.golangci.yml
+++ b/pf/tests/.golangci.yml
@@ -1,0 +1,18 @@
+run:
+  timeout: 10m
+
+linters:
+  enable-all: false
+  enable:
+    - errcheck
+    - gofmt
+    - gosec
+    - govet
+    - ineffassign
+    - megacheck
+    - misspell
+    - nakedret
+    - nolintlint
+    - revive
+    - unconvert
+    - unused

--- a/pf/tests/genupdate_test.go
+++ b/pf/tests/genupdate_test.go
@@ -30,7 +30,10 @@ import (
 //	PULUMI_DEBUG_GPRC=$PWD/grpc.json go test -run TestUpdateProgram
 //	jq -s . grpc.json
 func TestGenUpdates(t *testing.T) {
-	os.Mkdir("state", 0700)
+	err := os.Mkdir("state", 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	trace := "testdata/updateprogram.json"
 

--- a/pf/tests/integration/program_test.go
+++ b/pf/tests/integration/program_test.go
@@ -86,7 +86,7 @@ func prepareStateFolder(root string) error {
 
 func ensureTestBridgeProviderCompiled(wd string) error {
 	exe := "pulumi-resource-testbridge"
-	cmd := exec.Command("go", "build", "-o", filepath.Join("..", "..", "..", "bin", exe))
+	cmd := exec.Command("go", "build", "-o", filepath.Join("..", "..", "..", "bin", exe)) //nolint:gosec
 	cmd.Dir = filepath.Join(wd, "..", "internal", "cmd", exe)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/pf/tests/internal/cmd/pulumi-resource-tls/main.go
+++ b/pf/tests/internal/cmd/pulumi-resource-tls/main.go
@@ -30,5 +30,5 @@ var bridgeMetadata []byte
 
 func main() {
 	meta := tfbridge.ProviderMetadata{PackageSchema: schema, BridgeMetadata: bridgeMetadata}
-	tfbridge.Main(context.Background(), "tls", testprovider.TlsProvider(), meta)
+	tfbridge.Main(context.Background(), "tls", testprovider.TLSProvider(), meta)
 }

--- a/pf/tests/internal/cmd/pulumi-tfgen-tls/main.go
+++ b/pf/tests/internal/cmd/pulumi-tfgen-tls/main.go
@@ -20,5 +20,5 @@ import (
 )
 
 func main() {
-	tfgen.Main("tls", testprovider.TlsProvider())
+	tfgen.Main("tls", testprovider.TLSProvider())
 }

--- a/pf/tests/internal/testprovider/testbridge.go
+++ b/pf/tests/internal/testprovider/testbridge.go
@@ -78,7 +78,6 @@ func (p *syntheticProvider) Configure(ctx context.Context, req provider.Configur
 	if stringConfigProp != nil {
 		resp.ResourceData = stringConfigProp
 	}
-	return
 }
 
 func (p *syntheticProvider) DataSources(context.Context) []func() datasource.DataSource {

--- a/pf/tests/internal/testprovider/testbridge_resource_testcompres.go
+++ b/pf/tests/internal/testprovider/testbridge_resource_testcompres.go
@@ -64,7 +64,7 @@ func (e *testCompRes) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 }
 
 func (e *testCompRes) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	resourceId := "r1"
+	resourceID := "r1"
 
 	// Copy plan to state.
 	resp.State.Raw = req.Plan.Raw.Copy()
@@ -77,7 +77,7 @@ func (e *testCompRes) Create(ctx context.Context, req resource.CreateRequest, re
 		return
 	}
 
-	diags2 := resp.State.SetAttribute(ctx, path.Root("id"), resourceId)
+	diags2 := resp.State.SetAttribute(ctx, path.Root("id"), resourceID)
 	resp.Diagnostics.Append(diags2...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/pf/tests/internal/testprovider/tls.go
+++ b/pf/tests/internal/testprovider/tls.go
@@ -26,7 +26,7 @@ import (
 )
 
 // Adapts tls provider to tfbridge for testing tfbridge against another realistic provider.
-func TlsProvider() tfpf.ProviderInfo {
+func TLSProvider() tfpf.ProviderInfo {
 	tlsPkg := "tls"
 	tlsMod := "index"
 	tlsVersion := "4.0.4"

--- a/pf/tests/internal/testprovider/tuple_type.go
+++ b/pf/tests/internal/testprovider/tuple_type.go
@@ -156,22 +156,22 @@ type TupleValue struct {
 	val   []tftypes.Value
 }
 
-func (v TupleValue) Equal(o attr.Value) bool {
+func (c TupleValue) Equal(o attr.Value) bool {
 	oV, ok := o.(TupleValue)
 	if !ok {
 		return false
 	}
-	if !v.typ.Equal(oV.typ) {
+	if !c.typ.Equal(oV.typ) {
 		return false
 	}
-	if v.IsNull() && o.IsNull() {
+	if c.IsNull() && o.IsNull() {
 		return true
 	}
-	if v.IsUnknown() && o.IsUnknown() {
+	if c.IsUnknown() && o.IsUnknown() {
 		return true
 	}
-	for i := range v.val {
-		if !v.val[i].Equal(oV.val[i]) {
+	for i := range c.val {
+		if !c.val[i].Equal(oV.val[i]) {
 			return false
 		}
 	}

--- a/pf/tests/provider_diff_test.go
+++ b/pf/tests/provider_diff_test.go
@@ -203,7 +203,7 @@ func TestDiffVersionUpgrade(t *testing.T) {
 //
 // See https://github.com/pulumi/pulumi-tls/issues/173 for the details.
 func TestTlsResourceUpgrade(t *testing.T) {
-	server := newProviderServer(t, testprovider.TlsProvider())
+	server := newProviderServer(t, testprovider.TLSProvider())
 	testCase := `
 	{
 	  "method": "/pulumirpc.ResourceProvider/Diff",

--- a/pf/tests/provider_invoke_test.go
+++ b/pf/tests/provider_invoke_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestBasicInvoke(t *testing.T) {
-	server := newProviderServer(t, testprovider.TlsProvider())
+	server := newProviderServer(t, testprovider.TLSProvider())
 
 	testCase := `
         {
@@ -61,7 +61,7 @@ func TestBasicInvoke(t *testing.T) {
 }
 
 func TestInvokeWithInvalidData(t *testing.T) {
-	p := testprovider.TlsProvider()
+	p := testprovider.TLSProvider()
 	server := newProviderServer(t, p)
 
 	testCase := `

--- a/pf/tests/schema_test.go
+++ b/pf/tests/schema_test.go
@@ -25,7 +25,7 @@ func TestSchemaGen(t *testing.T) {
 		genMetadata(t, testprovider.RandomProvider())
 	})
 	t.Run("tls", func(t *testing.T) {
-		genMetadata(t, testprovider.TlsProvider())
+		genMetadata(t, testprovider.TLSProvider())
 	})
 	t.Run("testbridge", func(t *testing.T) {
 		genMetadata(t, testprovider.SyntheticTestBridgeProvider())

--- a/pkg/tests/.golangci.yml
+++ b/pkg/tests/.golangci.yml
@@ -1,0 +1,18 @@
+run:
+  timeout: 10m
+
+linters:
+  enable-all: false
+  enable:
+    - errcheck
+    - gofmt
+    - gosec
+    - govet
+    - ineffassign
+    - megacheck
+    - misspell
+    - nakedret
+    - nolintlint
+    - revive
+    - unconvert
+    - unused

--- a/scripts/build.go
+++ b/scripts/build.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	//"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func main() {
+	if len(os.Args) <= 1 {
+		usage()
+		return
+	}
+
+	switch os.Args[1] {
+	case "lint":
+		lintMain()
+	default:
+		usage()
+	}
+}
+
+func usage() {
+	fmt.Println("Usage: go run scripts/build.go CMD, supported commands: lint")
+	os.Exit(1)
+}
+
+func lintMain() {
+	roots := findGoModuleRoots()
+	failed := false
+	for _, m := range roots {
+		var stderr, stdout bytes.Buffer
+		cmd := exec.Command("golangci-lint", "run")
+		cmd.Dir = m
+		cmd.Stderr = &stderr
+		cmd.Stdout = &stdout
+		err := cmd.Run()
+		if err != nil {
+			fmt.Printf("cd %s && golangci-lint run\n", m)
+			fmt.Println(stdout.String())
+			fmt.Println(stderr.String())
+			fmt.Println(err)
+			fmt.Println()
+			failed = true
+		}
+	}
+	if failed {
+		log.Fatalf("lint failed")
+	}
+}
+
+// Finds directories containing go.mod files in the repository.
+func findGoModuleRoots() (result []string) {
+	var buf bytes.Buffer
+	cmd := exec.Command("git", "ls-files", "-z", "**/go.mod")
+	cmd.Dir = "."
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = &buf
+	if err := cmd.Run(); err != nil {
+		log.Fatal(err)
+	}
+	ms := strings.Split(buf.String(), string(rune(0)))
+	for _, m := range ms {
+		if m == "" {
+			continue
+		}
+		d := filepath.Dir(m)
+		result = append(result, d)
+	}
+	return result
+}


### PR DESCRIPTION
- Update go to 1.20.x
- Update setup-go to v3
- Update golangci-lint to a version compatible with 1.20.x
- Setup golangci-lint via official action
- `make lint` runs golangci-lint automatically on every module it finds in source (git ls-files go.mod search)
-  code is fixed up to pass the stricter lint checks
