### PR TITLE
Fix unknown value encoding in Plugin Framework

### DIFF
--- a/pf/internal/convert/bool.go
+++ b/pf/internal/convert/bool.go
@@ -49,8 +49,7 @@ func (*boolEncoder) FromPropertyValue(p resource.PropertyValue) (tftypes.Value, 
 
 func (*boolDecoder) ToPropertyValue(v tftypes.Value) (resource.PropertyValue, error) {
 	if !v.IsKnown() {
-		c := resource.Computed{Element: resource.NewBoolProperty(false)}
-		unknown := resource.NewComputedProperty(c)
+		unknown := resource.NewOutputProperty(resource.Output{Known: false})
 		return unknown, nil
 	}
 	if v.IsNull() {

--- a/pf/internal/convert/bool.go
+++ b/pf/internal/convert/bool.go
@@ -49,8 +49,7 @@ func (*boolEncoder) FromPropertyValue(p resource.PropertyValue) (tftypes.Value, 
 
 func (*boolDecoder) ToPropertyValue(v tftypes.Value) (resource.PropertyValue, error) {
 	if !v.IsKnown() {
-		unknown := resource.NewOutputProperty(resource.Output{Known: false})
-		return unknown, nil
+		return unknownProperty(), nil
 	}
 	if v.IsNull() {
 		return resource.NewPropertyValue(nil), nil

--- a/pf/internal/convert/convert_test.go
+++ b/pf/internal/convert/convert_test.go
@@ -156,7 +156,7 @@ func convertTurnaroundUnknownTestCase(ty tftypes.Type, zeroValue resource.Proper
 		name: ty.String() + "/unknown",
 		ty:   ty,
 		val:  tftypesNewValue(ty, tftypes.UnknownValue),
-		prop: resource.NewComputedProperty(resource.Computed{Element: zeroValue}),
+		prop: resource.NewOutputProperty(resource.Output{Known: false}),
 	}
 }
 

--- a/pf/internal/convert/convert_test.go
+++ b/pf/internal/convert/convert_test.go
@@ -156,7 +156,7 @@ func convertTurnaroundUnknownTestCase(ty tftypes.Type, zeroValue resource.Proper
 		name: ty.String() + "/unknown",
 		ty:   ty,
 		val:  tftypesNewValue(ty, tftypes.UnknownValue),
-		prop: resource.NewOutputProperty(resource.Output{Known: false}),
+		prop: unknownProperty(),
 	}
 }
 

--- a/pf/internal/convert/list.go
+++ b/pf/internal/convert/list.go
@@ -72,7 +72,7 @@ func (enc *listEncoder) FromPropertyValue(p resource.PropertyValue) (tftypes.Val
 
 func (dec *listDecoder) ToPropertyValue(v tftypes.Value) (resource.PropertyValue, error) {
 	if !v.IsKnown() {
-		return resource.NewOutputProperty(resource.Output{Known: false}), nil
+		return unknownProperty(), nil
 	}
 	if v.IsNull() {
 		return resource.NewPropertyValue(nil), nil

--- a/pf/internal/convert/list.go
+++ b/pf/internal/convert/list.go
@@ -72,8 +72,7 @@ func (enc *listEncoder) FromPropertyValue(p resource.PropertyValue) (tftypes.Val
 
 func (dec *listDecoder) ToPropertyValue(v tftypes.Value) (resource.PropertyValue, error) {
 	if !v.IsKnown() {
-		zero := resource.NewArrayProperty([]resource.PropertyValue{})
-		return resource.NewComputedProperty(resource.Computed{Element: zero}), nil
+		return resource.NewOutputProperty(resource.Output{Known: false}), nil
 	}
 	if v.IsNull() {
 		return resource.NewPropertyValue(nil), nil

--- a/pf/internal/convert/map.go
+++ b/pf/internal/convert/map.go
@@ -70,7 +70,7 @@ func (enc *mapEncoder) FromPropertyValue(p resource.PropertyValue) (tftypes.Valu
 
 func (dec *mapDecoder) ToPropertyValue(v tftypes.Value) (resource.PropertyValue, error) {
 	if !v.IsKnown() {
-		return resource.NewOutputProperty(resource.Output{Known: false}), nil
+		return unknownProperty(), nil
 	}
 	if v.IsNull() {
 		return resource.NewPropertyValue(nil), nil

--- a/pf/internal/convert/map.go
+++ b/pf/internal/convert/map.go
@@ -70,8 +70,7 @@ func (enc *mapEncoder) FromPropertyValue(p resource.PropertyValue) (tftypes.Valu
 
 func (dec *mapDecoder) ToPropertyValue(v tftypes.Value) (resource.PropertyValue, error) {
 	if !v.IsKnown() {
-		zero := resource.NewObjectProperty(make(resource.PropertyMap))
-		return resource.NewComputedProperty(resource.Computed{Element: zero}), nil
+		return resource.NewOutputProperty(resource.Output{Known: false}), nil
 	}
 	if v.IsNull() {
 		return resource.NewPropertyValue(nil), nil

--- a/pf/internal/convert/number.go
+++ b/pf/internal/convert/number.go
@@ -50,8 +50,7 @@ func (*numberEncoder) FromPropertyValue(p resource.PropertyValue) (tftypes.Value
 
 func (*numberDecoder) ToPropertyValue(v tftypes.Value) (resource.PropertyValue, error) {
 	if !v.IsKnown() {
-		unknown := resource.NewOutputProperty(resource.Output{Known: false})
-		return unknown, nil
+		return unknownProperty(), nil
 	}
 	if v.IsNull() {
 		return resource.NewPropertyValue(nil), nil

--- a/pf/internal/convert/number.go
+++ b/pf/internal/convert/number.go
@@ -50,7 +50,7 @@ func (*numberEncoder) FromPropertyValue(p resource.PropertyValue) (tftypes.Value
 
 func (*numberDecoder) ToPropertyValue(v tftypes.Value) (resource.PropertyValue, error) {
 	if !v.IsKnown() {
-		unknown := resource.NewComputedProperty(resource.Computed{Element: resource.NewNumberProperty(0)})
+		unknown := resource.NewOutputProperty(resource.Output{Known: false})
 		return unknown, nil
 	}
 	if v.IsNull() {

--- a/pf/internal/convert/object.go
+++ b/pf/internal/convert/object.go
@@ -90,8 +90,7 @@ func (enc *objectEncoder) FromPropertyValue(p resource.PropertyValue) (tftypes.V
 
 func (dec *objectDecoder) ToPropertyValue(v tftypes.Value) (resource.PropertyValue, error) {
 	if !v.IsKnown() {
-		zero := resource.NewObjectProperty(make(resource.PropertyMap))
-		return resource.NewComputedProperty(resource.Computed{Element: zero}), nil
+		return resource.NewOutputProperty(resource.Output{Known: false}), nil
 	}
 	if v.IsNull() {
 		return resource.NewPropertyValue(nil), nil

--- a/pf/internal/convert/object.go
+++ b/pf/internal/convert/object.go
@@ -90,7 +90,7 @@ func (enc *objectEncoder) FromPropertyValue(p resource.PropertyValue) (tftypes.V
 
 func (dec *objectDecoder) ToPropertyValue(v tftypes.Value) (resource.PropertyValue, error) {
 	if !v.IsKnown() {
-		return resource.NewOutputProperty(resource.Output{Known: false}), nil
+		return unknownProperty(), nil
 	}
 	if v.IsNull() {
 		return resource.NewPropertyValue(nil), nil

--- a/pf/internal/convert/propertyValue.go
+++ b/pf/internal/convert/propertyValue.go
@@ -18,6 +18,10 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
+func unknownProperty() resource.PropertyValue {
+	return resource.NewOutputProperty(resource.Output{Known: false})
+}
+
 // This is how p.ContainsUnknowns checks if the value itself is unknown before recursing.
 func propertyValueIsUnkonwn(p resource.PropertyValue) bool {
 	return p.IsComputed() || (p.IsOutput() && !p.OutputValue().Known)

--- a/pf/internal/convert/string.go
+++ b/pf/internal/convert/string.go
@@ -49,8 +49,7 @@ func (*stringEncoder) FromPropertyValue(p resource.PropertyValue) (tftypes.Value
 
 func (*stringDecoder) ToPropertyValue(v tftypes.Value) (resource.PropertyValue, error) {
 	if !v.IsKnown() {
-		unknown := resource.NewComputedProperty(
-			resource.Computed{Element: resource.NewStringProperty("")})
+		unknown := resource.NewOutputProperty(resource.Output{Known: false})
 		return unknown, nil
 	}
 	if v.IsNull() {

--- a/pf/internal/convert/string.go
+++ b/pf/internal/convert/string.go
@@ -49,8 +49,7 @@ func (*stringEncoder) FromPropertyValue(p resource.PropertyValue) (tftypes.Value
 
 func (*stringDecoder) ToPropertyValue(v tftypes.Value) (resource.PropertyValue, error) {
 	if !v.IsKnown() {
-		unknown := resource.NewOutputProperty(resource.Output{Known: false})
-		return unknown, nil
+		return unknownProperty(), nil
 	}
 	if v.IsNull() {
 		return resource.NewPropertyValue(nil), nil

--- a/pf/tests/provider_create_test.go
+++ b/pf/tests/provider_create_test.go
@@ -78,3 +78,35 @@ func TestCreateWritesSchemaVersion(t *testing.T) {
 	}
         `)
 }
+
+func TestPreviewCreate(t *testing.T) {
+	server := newProviderServer(t, testprovider.RandomProvider())
+
+	testCase := `
+	{
+	  "method": "/pulumirpc.ResourceProvider/Create",
+	  "request": {
+	    "urn": "urn:pulumi:dev::repro::random:index/randomInteger:RandomInteger::k",
+	    "properties": {
+	      "max": 10,
+	      "min": 0
+	    },
+	    "preview": true
+	  },
+	  "response": {
+	    "properties": {
+	      "id": "04da6b54-80e4-46f7-96ec-b56ff0331ba9",
+	      "max": 10,
+	      "min": 0,
+	      "result": "04da6b54-80e4-46f7-96ec-b56ff0331ba9"
+	    }
+	  },
+	  "metadata": {
+	    "kind": "resource",
+	    "mode": "client",
+	    "name": "random"
+	  }
+	}
+`
+	testutils.Replay(t, server, testCase)
+}

--- a/pf/tests/testdata/genrandom/random-delete-preview.json
+++ b/pf/tests/testdata/genrandom/random-delete-preview.json
@@ -13,7 +13,7 @@
     "method": "/pulumirpc.LanguageRuntime/GetRequiredPlugins",
     "request": {
       "project": "genradom",
-      "pwd": "/Users/t0yv0/code/pulumi-terraform-bridge/pkg/tfpfbridge/tests/testdatagen/genrandom",
+      "pwd": "/Users/t0yv0/code/pulumi-terraform-bridge/pf/tests/testdatagen/genrandom",
       "program": "."
     },
     "response": {
@@ -121,14 +121,14 @@
     "request": {
       "project": "genradom",
       "stack": "generate",
-      "pwd": "/Users/t0yv0/code/pulumi-terraform-bridge/pkg/tfpfbridge/tests/testdatagen/genrandom",
+      "pwd": "/Users/t0yv0/code/pulumi-terraform-bridge/pf/tests/testdatagen/genrandom",
       "program": ".",
       "config": {
         "genradom:min": "0"
       },
       "dryRun": true,
       "parallel": 2147483647,
-      "monitorAddress": "127.0.0.1:57431",
+      "monitorAddress": "127.0.0.1:57354",
       "organization": "t0yv0"
     },
     "response": {},

--- a/pf/tests/testdata/genrandom/random-delete-update.json
+++ b/pf/tests/testdata/genrandom/random-delete-update.json
@@ -13,7 +13,7 @@
     "method": "/pulumirpc.LanguageRuntime/GetRequiredPlugins",
     "request": {
       "project": "genradom",
-      "pwd": "/Users/t0yv0/code/pulumi-terraform-bridge/pkg/tfpfbridge/tests/testdatagen/genrandom",
+      "pwd": "/Users/t0yv0/code/pulumi-terraform-bridge/pf/tests/testdatagen/genrandom",
       "program": "."
     },
     "response": {
@@ -121,13 +121,13 @@
     "request": {
       "project": "genradom",
       "stack": "generate",
-      "pwd": "/Users/t0yv0/code/pulumi-terraform-bridge/pkg/tfpfbridge/tests/testdatagen/genrandom",
+      "pwd": "/Users/t0yv0/code/pulumi-terraform-bridge/pf/tests/testdatagen/genrandom",
       "program": ".",
       "config": {
         "genradom:min": "0"
       },
       "parallel": 2147483647,
-      "monitorAddress": "127.0.0.1:57447",
+      "monitorAddress": "127.0.0.1:57367",
       "organization": "t0yv0"
     },
     "response": {},

--- a/pf/tests/testdata/genrandom/random-empty-preview.json
+++ b/pf/tests/testdata/genrandom/random-empty-preview.json
@@ -13,7 +13,7 @@
     "method": "/pulumirpc.LanguageRuntime/GetRequiredPlugins",
     "request": {
       "project": "genradom",
-      "pwd": "/Users/t0yv0/code/pulumi-terraform-bridge/pkg/tfpfbridge/tests/testdatagen/genrandom",
+      "pwd": "/Users/t0yv0/code/pulumi-terraform-bridge/pf/tests/testdatagen/genrandom",
       "program": "."
     },
     "response": {
@@ -171,7 +171,7 @@
         "min": 1,
         "seed": "pseudo-random-seed"
       },
-      "randomSeed": "GHX81YBaMe4uwWyZFP+SIu93X++x/+JwNS8veSgTDiA="
+      "randomSeed": "08LTuOSvPg3R3V6/QViEvgsQw/6vAQ5nkDGj5R3uHIE="
     },
     "response": {
       "inputs": {
@@ -267,14 +267,14 @@
     "request": {
       "project": "genradom",
       "stack": "generate",
-      "pwd": "/Users/t0yv0/code/pulumi-terraform-bridge/pkg/tfpfbridge/tests/testdatagen/genrandom",
+      "pwd": "/Users/t0yv0/code/pulumi-terraform-bridge/pf/tests/testdatagen/genrandom",
       "program": ".",
       "config": {
         "genradom:min": "1"
       },
       "dryRun": true,
       "parallel": 2147483647,
-      "monitorAddress": "127.0.0.1:57339",
+      "monitorAddress": "127.0.0.1:57281",
       "organization": "t0yv0"
     },
     "response": {},

--- a/pf/tests/testdata/genrandom/random-empty-update.json
+++ b/pf/tests/testdata/genrandom/random-empty-update.json
@@ -13,7 +13,7 @@
     "method": "/pulumirpc.LanguageRuntime/GetRequiredPlugins",
     "request": {
       "project": "genradom",
-      "pwd": "/Users/t0yv0/code/pulumi-terraform-bridge/pkg/tfpfbridge/tests/testdatagen/genrandom",
+      "pwd": "/Users/t0yv0/code/pulumi-terraform-bridge/pf/tests/testdatagen/genrandom",
       "program": "."
     },
     "response": {
@@ -171,7 +171,7 @@
         "min": 1,
         "seed": "pseudo-random-seed"
       },
-      "randomSeed": "czoqll+DW/AZsLo+VDuk8XmxsVk/CpX2AoJTbFgsTBs="
+      "randomSeed": "YqDuSX1TPN+xVAn+E2kvlKAYhTNx74FscxozTWGjiT8="
     },
     "response": {
       "inputs": {
@@ -267,13 +267,13 @@
     "request": {
       "project": "genradom",
       "stack": "generate",
-      "pwd": "/Users/t0yv0/code/pulumi-terraform-bridge/pkg/tfpfbridge/tests/testdatagen/genrandom",
+      "pwd": "/Users/t0yv0/code/pulumi-terraform-bridge/pf/tests/testdatagen/genrandom",
       "program": ".",
       "config": {
         "genradom:min": "1"
       },
       "parallel": 2147483647,
-      "monitorAddress": "127.0.0.1:57360",
+      "monitorAddress": "127.0.0.1:57298",
       "organization": "t0yv0"
     },
     "response": {},

--- a/pf/tests/testdata/genrandom/random-initial-preview.json
+++ b/pf/tests/testdata/genrandom/random-initial-preview.json
@@ -13,7 +13,7 @@
     "method": "/pulumirpc.LanguageRuntime/GetRequiredPlugins",
     "request": {
       "project": "genradom",
-      "pwd": "/Users/t0yv0/code/pulumi-terraform-bridge/pkg/tfpfbridge/tests/testdatagen/genrandom",
+      "pwd": "/Users/t0yv0/code/pulumi-terraform-bridge/pf/tests/testdatagen/genrandom",
       "program": "."
     },
     "response": {
@@ -135,7 +135,7 @@
         "min": 1,
         "seed": "pseudo-random-seed"
       },
-      "randomSeed": "77QAbsqnJ1QgT6oIqTlpQLMoA/da71ieVwsuzfFgKJg="
+      "randomSeed": "LbYDlmKMF2h9TMW2Y4/bv56456PCA2an2ULf4GUadcc="
     },
     "response": {
       "inputs": {
@@ -166,7 +166,7 @@
         "id": "04da6b54-80e4-46f7-96ec-b56ff0331ba9",
         "max": 100,
         "min": 1,
-        "result": "3eeb2bf0-c639-47a8-9e75-3b44932eb421",
+        "result": "04da6b54-80e4-46f7-96ec-b56ff0331ba9",
         "seed": "pseudo-random-seed"
       }
     },
@@ -227,14 +227,14 @@
     "request": {
       "project": "genradom",
       "stack": "generate",
-      "pwd": "/Users/t0yv0/code/pulumi-terraform-bridge/pkg/tfpfbridge/tests/testdatagen/genrandom",
+      "pwd": "/Users/t0yv0/code/pulumi-terraform-bridge/pf/tests/testdatagen/genrandom",
       "program": ".",
       "config": {
         "genradom:min": "1"
       },
       "dryRun": true,
       "parallel": 2147483647,
-      "monitorAddress": "127.0.0.1:57297",
+      "monitorAddress": "127.0.0.1:57248",
       "organization": "t0yv0"
     },
     "response": {},

--- a/pf/tests/testdata/genrandom/random-initial-update.json
+++ b/pf/tests/testdata/genrandom/random-initial-update.json
@@ -13,7 +13,7 @@
     "method": "/pulumirpc.LanguageRuntime/GetRequiredPlugins",
     "request": {
       "project": "genradom",
-      "pwd": "/Users/t0yv0/code/pulumi-terraform-bridge/pkg/tfpfbridge/tests/testdatagen/genrandom",
+      "pwd": "/Users/t0yv0/code/pulumi-terraform-bridge/pf/tests/testdatagen/genrandom",
       "program": "."
     },
     "response": {
@@ -135,7 +135,7 @@
         "min": 1,
         "seed": "pseudo-random-seed"
       },
-      "randomSeed": "waNU/kUfNxCU3WmPOBxHZ0jPMoLx+pOP+KB5gBelMWA="
+      "randomSeed": "UupZ+JB4xIReir1lwoF4eiYhh2NbJ/1iLVYk3lUx3xQ="
     },
     "response": {
       "inputs": {
@@ -230,13 +230,13 @@
     "request": {
       "project": "genradom",
       "stack": "generate",
-      "pwd": "/Users/t0yv0/code/pulumi-terraform-bridge/pkg/tfpfbridge/tests/testdatagen/genrandom",
+      "pwd": "/Users/t0yv0/code/pulumi-terraform-bridge/pf/tests/testdatagen/genrandom",
       "program": ".",
       "config": {
         "genradom:min": "1"
       },
       "parallel": 2147483647,
-      "monitorAddress": "127.0.0.1:57314",
+      "monitorAddress": "127.0.0.1:57262",
       "organization": "t0yv0"
     },
     "response": {},

--- a/pf/tests/testdata/genrandom/random-replace-preview.json
+++ b/pf/tests/testdata/genrandom/random-replace-preview.json
@@ -13,7 +13,7 @@
     "method": "/pulumirpc.LanguageRuntime/GetRequiredPlugins",
     "request": {
       "project": "genradom",
-      "pwd": "/Users/t0yv0/code/pulumi-terraform-bridge/pkg/tfpfbridge/tests/testdatagen/genrandom",
+      "pwd": "/Users/t0yv0/code/pulumi-terraform-bridge/pf/tests/testdatagen/genrandom",
       "program": "."
     },
     "response": {
@@ -171,7 +171,7 @@
         "min": 2,
         "seed": "pseudo-random-seed"
       },
-      "randomSeed": "9RYCnHySpyx8kf9OxnoBQHddW+bNx3NKLw3FWaBXfMM="
+      "randomSeed": "+l8ySBKFQENT21rcHbUFL4e0REZhkVrZvx7Apcf03iY="
     },
     "response": {
       "inputs": {
@@ -229,7 +229,7 @@
         "min": 2,
         "seed": "pseudo-random-seed"
       },
-      "randomSeed": "9RYCnHySpyx8kf9OxnoBQHddW+bNx3NKLw3FWaBXfMM="
+      "randomSeed": "+l8ySBKFQENT21rcHbUFL4e0REZhkVrZvx7Apcf03iY="
     },
     "response": {
       "inputs": {
@@ -260,7 +260,7 @@
         "id": "04da6b54-80e4-46f7-96ec-b56ff0331ba9",
         "max": 100,
         "min": 2,
-        "result": "3eeb2bf0-c639-47a8-9e75-3b44932eb421",
+        "result": "04da6b54-80e4-46f7-96ec-b56ff0331ba9",
         "seed": "pseudo-random-seed"
       }
     },
@@ -321,14 +321,14 @@
     "request": {
       "project": "genradom",
       "stack": "generate",
-      "pwd": "/Users/t0yv0/code/pulumi-terraform-bridge/pkg/tfpfbridge/tests/testdatagen/genrandom",
+      "pwd": "/Users/t0yv0/code/pulumi-terraform-bridge/pf/tests/testdatagen/genrandom",
       "program": ".",
       "config": {
         "genradom:min": "2"
       },
       "dryRun": true,
       "parallel": 2147483647,
-      "monitorAddress": "127.0.0.1:57385",
+      "monitorAddress": "127.0.0.1:57317",
       "organization": "t0yv0"
     },
     "response": {},

--- a/pf/tests/testdata/genrandom/random-replace-update.json
+++ b/pf/tests/testdata/genrandom/random-replace-update.json
@@ -13,7 +13,7 @@
     "method": "/pulumirpc.LanguageRuntime/GetRequiredPlugins",
     "request": {
       "project": "genradom",
-      "pwd": "/Users/t0yv0/code/pulumi-terraform-bridge/pkg/tfpfbridge/tests/testdatagen/genrandom",
+      "pwd": "/Users/t0yv0/code/pulumi-terraform-bridge/pf/tests/testdatagen/genrandom",
       "program": "."
     },
     "response": {
@@ -171,7 +171,7 @@
         "min": 2,
         "seed": "pseudo-random-seed"
       },
-      "randomSeed": "pzRK95WDJ037/tWLJ6zr6aTP6I/Q8UjAqPQS7D2KeOs="
+      "randomSeed": "ZCiVOcvG/CT5jx4XriguWgj2iMpQEb8P3ZLqU/AS2yg="
     },
     "response": {
       "inputs": {
@@ -229,7 +229,7 @@
         "min": 2,
         "seed": "pseudo-random-seed"
       },
-      "randomSeed": "pzRK95WDJ037/tWLJ6zr6aTP6I/Q8UjAqPQS7D2KeOs="
+      "randomSeed": "ZCiVOcvG/CT5jx4XriguWgj2iMpQEb8P3ZLqU/AS2yg="
     },
     "response": {
       "inputs": {
@@ -324,13 +324,13 @@
     "request": {
       "project": "genradom",
       "stack": "generate",
-      "pwd": "/Users/t0yv0/code/pulumi-terraform-bridge/pkg/tfpfbridge/tests/testdatagen/genrandom",
+      "pwd": "/Users/t0yv0/code/pulumi-terraform-bridge/pf/tests/testdatagen/genrandom",
       "program": ".",
       "config": {
         "genradom:min": "2"
       },
       "parallel": 2147483647,
-      "monitorAddress": "127.0.0.1:57406",
+      "monitorAddress": "127.0.0.1:57335",
       "organization": "t0yv0"
     },
     "response": {},


### PR DESCRIPTION
There is a regression in pulumi-random https://github.com/pulumi/pulumi-random/issues/279 motivating this change.

Before the change, Go SDK emits Unknown Number value sentinel that confuses the Node SDK in the user's program.

After the change, only generic Unknown sentinel values are emitted and then the Node program works as expected.