### PR TITLE
Hook ProviderMetadata into ProviderInfo

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -98,9 +98,7 @@ type ProviderInfo struct {
 
 	// Information for the embedded metadata file.
 	//
-	// If provided, the user should call NewMetadataInfo(path, bytes) where path is
-	// the path (relative to schema.json) of the embedded file, and bytes is the
-	// compile time embedded file.
+	// See NewProviderMetadata for in-place construction of a *MetadataInfo.
 	MetadataInfo *MetadataInfo
 
 	UpstreamRepoPath string // An optional path that overrides upstream location during docs lookup

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -98,8 +98,9 @@ type ProviderInfo struct {
 
 	// Information for the embedded metadata file.
 	//
-	// If provided, the user should embed the file at `MetadataInfo.Path`, and store
-	// the resulting embedded bytes in `MetadataInfo.Bytes`.
+	// If provided, the user should call NewMetadataInfo(path, bytes) where path is
+	// the path (relative to schema.json) of the embedded file, and bytes is the
+	// compile time embedded file.
 	MetadataInfo *MetadataInfo
 
 	UpstreamRepoPath string // An optional path that overrides upstream location during docs lookup
@@ -121,7 +122,7 @@ func (info ProviderInfo) GetResourcePrefix() string {
 
 func (info ProviderInfo) GetMetadata() ProviderMetadata {
 	info.MetadataInfo.assertValid()
-	return info.MetadataInfo.data
+	return info.MetadataInfo.Data
 }
 
 func (info ProviderInfo) GetGitHubOrg() string {

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -96,6 +96,12 @@ type ProviderInfo struct {
 	PreConfigureCallback           PreConfigureCallback // a provider-specific callback to invoke prior to TF Configure
 	PreConfigureCallbackWithLogger PreConfigureCallbackWithLogger
 
+	// Information for the embedded metadata file.
+	//
+	// If provided, the user should embed the file at `MetadataInfo.Path`, and store
+	// the resulting embedded bytes in `MetadataInfo.Bytes`.
+	MetadataInfo *MetadataInfo
+
 	UpstreamRepoPath string // An optional path that overrides upstream location during docs lookup
 }
 
@@ -111,6 +117,11 @@ func (info ProviderInfo) GetResourcePrefix() string {
 	}
 
 	return info.ResourcePrefix
+}
+
+func (info ProviderInfo) GetMetadata() ProviderMetadata {
+	info.MetadataInfo.assertValid()
+	return info.MetadataInfo.data
 }
 
 func (info ProviderInfo) GetGitHubOrg() string {

--- a/pkg/tfbridge/metadata.go
+++ b/pkg/tfbridge/metadata.go
@@ -1,0 +1,35 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfbridge
+
+import (
+	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/metadata"
+)
+
+// A store persisted between `tfgen` and a running provider.
+type ProviderMetadata *metadata.Data
+
+// Create a new ProviderMetadata from a persisted byte slice.
+func NewProviderMetadata(data []byte) (ProviderMetadata, error) {
+	parsed, err := metadata.New(data)
+	if err != nil {
+		return nil, err
+	}
+	return ProviderMetadata(parsed), nil
+}
+
+func MarshalProviderMetadata(p ProviderMetadata) []byte {
+	return (*metadata.Data)(p).Marshal()
+}

--- a/pkg/tfbridge/metadata.go
+++ b/pkg/tfbridge/metadata.go
@@ -32,7 +32,7 @@ type MetadataInfo struct {
 // `path` is the path (relative to schema.json) where the metadata file is stored.
 // `bytes` is the embedded metadata file.
 func NewProviderMetadata(path string, bytes []byte) *MetadataInfo {
-	data, err := newProviderMetadata(bytes)
+	parsed, err := metadata.New(bytes)
 	// We assert instead of returning an (MetadataInfo, error) because we are
 	// validating compile time embedded data.
 	//
@@ -40,22 +40,9 @@ func NewProviderMetadata(path string, bytes []byte) *MetadataInfo {
 	// `go:embed`ed.
 	contract.AssertNoErrorf(err, "This always signals an error at compile time.")
 
-	info := &MetadataInfo{path, data}
+	info := &MetadataInfo{path, ProviderMetadata(parsed)}
 	info.assertValid()
 	return info
-}
-
-// Create a new ProviderMetadata from a persisted byte slice.
-func newProviderMetadata(data []byte) (ProviderMetadata, error) {
-	parsed, err := metadata.New(data)
-	if err != nil {
-		return nil, err
-	}
-	return ProviderMetadata(parsed), nil
-}
-
-func marshalProviderMetadata(p ProviderMetadata) []byte {
-	return (*metadata.Data)(p).Marshal()
 }
 
 func (info *MetadataInfo) assertValid() {

--- a/pkg/tfbridge/metadata.go
+++ b/pkg/tfbridge/metadata.go
@@ -23,23 +23,15 @@ import (
 type ProviderMetadata *metadata.Data
 
 type MetadataInfo struct {
-	bytes []byte
-
-	// Field names are depended upon via reflect by tfgen/generate.go.
-	// It needs to be adjusted in tandem.
-	//
-	// This doesn't introduce version compatibility problems because tfgen is in the
-	// same module as tfbride (this module), just a different package. They are
-	// versioned together.
-	path string
-	data ProviderMetadata
+	Path string
+	Data ProviderMetadata
 }
 
 // Describe a metadata file to ProviderInfo.
 //
 // `path` is the path (relative to schema.json) where the metadata file is stored.
 // `bytes` is the embedded metadata file.
-func NewProviderMetadata(path string, bytes []byte) MetadataInfo {
+func NewProviderMetadata(path string, bytes []byte) *MetadataInfo {
 	data, err := newProviderMetadata(bytes)
 	// We assert instead of returning an (MetadataInfo, error) because we are
 	// validating compile time embedded data.
@@ -47,12 +39,10 @@ func NewProviderMetadata(path string, bytes []byte) MetadataInfo {
 	// The error could never be handled, because it signals that invalid data was
 	// `go:embed`ed.
 	contract.AssertNoErrorf(err, "This always signals an error at compile time.")
-	// We assert instead of returning an (MetadataInfo, error) because path should be
-	// a string constant, the tfgen time location from which bytes was extracted. This
-	// error is irrecoverable and needs to be fixed at compile time.
-	contract.Assertf(path != "", "Path must be non-empty")
 
-	return MetadataInfo{bytes, path, data}
+	info := &MetadataInfo{path, data}
+	info.assertValid()
+	return info
 }
 
 // Create a new ProviderMetadata from a persisted byte slice.
@@ -71,4 +61,10 @@ func marshalProviderMetadata(p ProviderMetadata) []byte {
 func (info *MetadataInfo) assertValid() {
 	contract.Assertf(info != nil,
 		"Attempting to use provider metadata without setting ProviderInfo.MetadataInfo")
+
+	// We assert instead of returning an (MetadataInfo, error) because path should be
+	// a string constant, the tfgen time location from which bytes was extracted. This
+	// error is irrecoverable and needs to be fixed at compile time.
+	contract.Assertf(info.Path != "", "Path must be non-empty")
+
 }

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 
@@ -54,6 +55,10 @@ const (
 	defaultOutDir = "sdk/"
 	maxWidth      = 120 // the ideal maximum width of the generated file.
 )
+
+// Additional files to put next schema.json when it is generated.
+var additionalSchemaFilesHook = map[string][]byte{}
+var hookMutex = new(sync.Mutex)
 
 type Generator struct {
 	pkg              tokens.Package        // the Pulum package name (e.g. `gcp`)
@@ -889,6 +894,12 @@ func (g *Generator) Generate() error {
 
 		if err := nameCheck(g.info, pulumiPackageSpec, g.renamesBuilder, g.sink); err != nil {
 			return err
+		}
+
+		hookMutex.Lock()
+		defer hookMutex.Unlock()
+		for path, bytes := range additionalSchemaFilesHook {
+			files[path] = bytes
 		}
 	case PCL:
 		if g.skipExamples {
@@ -1785,4 +1796,19 @@ func ignoreMappingError(s []string, str string) bool {
 		}
 	}
 	return false
+}
+
+// Add a file to be emitted next to the schema.json only when the schema is itself
+// emitted.
+//
+// `panic`s if called with a `path` that conflicts with an existing file, including
+// `schema.json`.
+func AdditionalSchemaFile(path string, bytes []byte) {
+	hookMutex.Lock()
+	defer hookMutex.Unlock()
+	contract.Assertf(path != "", "Cannot add additional schema file with empty path")
+	contract.Assertf(path != "schema.json", "Cannot override '%s'", path)
+	_, has := additionalSchemaFilesHook[path]
+	contract.Assertf(!has, "Cannot overwrite an additional file that has already been added: '%s'", path)
+	additionalSchemaFilesHook[path] = bytes
 }

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"reflect"
 	"sort"
 	"strings"
 	"unicode"
@@ -894,11 +893,7 @@ func (g *Generator) Generate() error {
 		}
 
 		if meta := g.info.MetadataInfo; meta != nil {
-			// Use reflect to read private fields.
-			s := reflect.ValueOf(meta).Elem()
-			data := s.FieldByName("data").Interface().(*metadata.Data)
-			path := s.FieldByName("path").String()
-			files[path] = (*metadata.Data)(data).Marshal()
+			files[meta.Path] = (*metadata.Data)(meta.Data).Marshal()
 		}
 	case PCL:
 		if g.skipExamples {

--- a/unstable/doc.go
+++ b/unstable/doc.go
@@ -1,0 +1,21 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A package that exposes an unstable interface across go module boundaries. This is
+// necessary to get around granularity limitations of the `internal` path that go modules
+// provides.
+//
+// It is not recommended to rely on exports from this package. We do not provide stability
+// guarantees for this package.
+package unstable

--- a/unstable/doc.go
+++ b/unstable/doc.go
@@ -14,8 +14,10 @@
 
 // A package that exposes an unstable interface across go module boundaries. This is
 // necessary to get around granularity limitations of the `internal` path that go modules
-// provides.
+// provides. Conceptually, the content of `unstable` is an implementation detail of this
+// repository.
 //
 // It is not recommended to rely on exports from this package. We do not provide stability
-// guarantees for this package.
+// guarantees for this package. Unlike experimental `x` packages, APIs in `unstable` are
+// not intended to be stabilized.
 package unstable

--- a/unstable/metadata/metadata.go
+++ b/unstable/metadata/metadata.go
@@ -27,7 +27,7 @@ type Data struct {
 
 func New(data []byte) (*Data, error) {
 	m := map[string]json.RawMessage{}
-	if data != nil {
+	if len(data) > 0 {
 		err := json.Unmarshal(data, &m)
 		if err != nil {
 			return nil, err

--- a/unstable/metadata/metadata.go
+++ b/unstable/metadata/metadata.go
@@ -1,0 +1,97 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"encoding/json"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+// The underlying value of a metadata blob.
+type Data struct {
+	m map[string]json.RawMessage
+}
+
+func New(data []byte) (*Data, error) {
+	m := map[string]json.RawMessage{}
+	if data != nil {
+		err := json.Unmarshal(data, &m)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &Data{m}, nil
+}
+
+func (d *Data) Marshal() []byte {
+	if d == nil {
+		d = &Data{m: make(map[string]json.RawMessage)}
+	}
+	bytes, err := json.MarshalIndent(d.m, "", "    ")
+	// `d.m` is a `map[string]json.RawMessage`. `json.MarshalIndent` errors only when
+	// it is asked to serialize an unmarshalable type (complex, function or channel)
+	// or a cyclic data structure. Because `string` and `json.RawMessage` are
+	// trivially marshallable and cannot contain cycles, all values of `d.m` can be
+	// marshaled without error.
+	//
+	// See https://pkg.go.dev/encoding/json#Marshal for details.
+	contract.AssertNoErrorf(err, "internal: failed to marshal metadata")
+	return bytes
+}
+
+// Set a piece of metadata to a value.
+//
+// Set errors only if value fails to serialize.
+func Set(d *Data, key string, value any) error {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	d.m[key] = data
+	return nil
+}
+
+func Get[T any](d *Data, key string) (T, bool, error) {
+	data, ok := d.m[key]
+	var t T
+	if !ok {
+		return t, false, nil
+	}
+	err := json.Unmarshal(data, &t)
+	return t, true, err
+}
+
+func Clone(data *Data) *Data {
+	if data == nil {
+		return nil
+	}
+	m := make(map[string]json.RawMessage, len(data.m))
+	for k, v := range data.m {
+		dst := make(json.RawMessage, len(v))
+		n := copy(dst, v)
+		// According to the documentation for `copy`:
+		//
+		//   Copy returns the number of elements copied, which will be the minimum
+		//   of len(src) and len(dst).
+		//
+		// Since `len(src)` is `len(dst)`, and `copy` cannot copy more bytes the
+		// its source, we know that `n == len(v)`.
+		contract.Assertf(n == len(v), "failed to perform full copy")
+		m[k] = dst
+	}
+	return &Data{m}
+
+}


### PR DESCRIPTION
Adds a untyped KV store managed by the `tfbridge.ProviderInfo` life cycle.

The store is read-write when the schema is being generated, and is persisted to disk with `schema.json`. During normal provider operation (`pulumi-resource-${PKG}`), the store if not persisted (making it effectively read-only).

Because the user must opt-in to using `ProviderMetadata` (by embedding the file using `go:embed`), the store is only available when `ProviderInfo.MetadataInfo` is non-nil.