### PR TITLE
remove double-slashes to fix examples docs generation

### DIFF
--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -1090,7 +1090,7 @@ func (g *Generator) convertExamples(docs, name string, stripSubsectionsWithError
 		strings.Contains(docs, "```csharp") {
 		// we have explicitly rewritten these examples and need to just return them directly rather than trying
 		// to reconvert them. But we need to surround them in the examples shortcode for rendering on the registry
-		return fmt.Sprintf("{{%% examples %%}}\n%s\n{{%% //examples %%}}", docs)
+		return fmt.Sprintf("{{%% examples %%}}\n%s\n{{%% /examples %%}}", docs)
 	}
 
 	output := &bytes.Buffer{}

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -1090,7 +1090,7 @@ func (g *Generator) convertExamples(docs, name string, stripSubsectionsWithError
 		strings.Contains(docs, "```csharp") {
 		// we have explicitly rewritten these examples and need to just return them directly rather than trying
 		// to reconvert them. But we need to surround them in the examples shortcode for rendering on the registry
-		return fmt.Sprintf("{{%% examples %%}}\n%s\n{{%% /examples %%}}", docs)
+		return docs
 	}
 
 	output := &bytes.Buffer{}

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -1087,10 +1087,10 @@ func (g *Generator) convertExamples(docs, name string, stripSubsectionsWithError
 
 	if strings.Contains(docs, "```typescript") || strings.Contains(docs, "```python") ||
 		strings.Contains(docs, "```go") || strings.Contains(docs, "```yaml") ||
-		strings.Contains(docs, "```csharp") {
+		strings.Contains(docs, "```csharp") || strings.Contains(docs, "```java") {
 		// we have explicitly rewritten these examples and need to just return them directly rather than trying
 		// to reconvert them. But we need to surround them in the examples shortcode for rendering on the registry
-		return docs
+		return fmt.Sprintf("{{%% examples %%}}\n%s\n{{%% /examples %%}}", docs)
 	}
 
 	output := &bytes.Buffer{}


### PR DESCRIPTION
for https://github.com/pulumi/docs/issues/8672

pulumi-docker reached an edge case in docsgen that uses a template with invalid syntax (double-slashes, changed to single-slash should be the way to go according to docs team)