### PR TITLE
Implement Read variant via ImportResourceState

### DIFF
--- a/pf/internal/schemashim/attr_schema.go
+++ b/pf/internal/schemashim/attr_schema.go
@@ -75,7 +75,9 @@ func (s *attrSchema) ForceNew() bool {
 }
 
 func (*attrSchema) StateFunc() shim.SchemaStateFunc {
-	panic("StateFunc() should not be caleld during schema generation")
+	// StateFunc() should not be called by tfgen, but it currently may be called by ExtractInputsFromOutputs, so
+	// returning nil is better than a panic.
+	return nil
 }
 
 // Needs to return a shim.Schema, a shim.Resource, or nil.

--- a/pf/internal/schemashim/attr_schema.go
+++ b/pf/internal/schemashim/attr_schema.go
@@ -55,7 +55,9 @@ func (*attrSchema) DefaultFunc() shim.SchemaDefaultFunc {
 	panic("DefaultFunc() should not be called during schema generation")
 }
 func (*attrSchema) DefaultValue() (interface{}, error) {
-	panic("DefaultValue() should not be called during schema generation")
+	// DefaultValue() should not be called by tfgen, but it currently may be called by ExtractInputsFromOutputs, so
+	// returning nil is better than a panic.
+	return nil, nil
 }
 
 func (s *attrSchema) Description() string {

--- a/pf/internal/schemashim/schema_map.go
+++ b/pf/internal/schemashim/schema_map.go
@@ -15,7 +15,6 @@
 package schemashim
 
 import (
-	"fmt"
 	"sort"
 
 	"github.com/pulumi/pulumi-terraform-bridge/pf/internal/pfutils"
@@ -52,7 +51,7 @@ func (m *schemaMap) Len() int {
 func (m *schemaMap) Get(key string) shim.Schema {
 	s, ok := m.GetOk(key)
 	if !ok {
-		panic(fmt.Sprintf("Missing key: %v", key))
+		return nil
 	}
 	return s
 }

--- a/pf/internal/schemashim/schema_map.go
+++ b/pf/internal/schemashim/schema_map.go
@@ -27,6 +27,10 @@ type schemaMap struct {
 	blocks map[string]pfutils.Block
 }
 
+func NewSchemaMap(pf pfutils.Schema) shim.SchemaMap {
+	return newSchemaMap(pf)
+}
+
 func newSchemaMap(tf pfutils.Schema) *schemaMap {
 	return &schemaMap{
 		attrs:  tf.Attrs(),

--- a/pf/internal/schemashim/type_schema.go
+++ b/pf/internal/schemashim/type_schema.go
@@ -96,7 +96,8 @@ func (*typeSchema) Description() string {
 }
 
 func (*typeSchema) StateFunc() shim.SchemaStateFunc {
-	panic("StateFunc() should not be called during schema generation")
+	// StateFunc() should not be called during schema generation, but may be called by ExtractInputsFromOutputs.
+	return nil
 }
 
 func (*typeSchema) ConflictsWith() []string {

--- a/pf/internal/server/server.go
+++ b/pf/internal/server/server.go
@@ -1,0 +1,92 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+)
+
+func NewProviderServer(provider plugin.Provider) pulumirpc.ResourceProviderServer {
+	return &providerServer{
+		ResourceProviderServer: plugin.NewProviderServer(provider),
+		provider:               provider,
+	}
+}
+
+type providerServer struct {
+	pulumirpc.ResourceProviderServer
+	provider plugin.Provider
+}
+
+var _ pulumirpc.ResourceProviderServer = &providerServer{}
+
+// Override Read from pulumirpc.ResourceProviderServer to actually propagate ID returned from inner provider.Read.
+func (p *providerServer) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*pulumirpc.ReadResponse, error) {
+
+	urn, id := resource.URN(req.GetUrn()), resource.ID(req.GetId())
+
+	state, err := plugin.UnmarshalProperties(req.GetProperties(), p.unmarshalOptions("state"))
+	if err != nil {
+		return nil, err
+	}
+
+	inputs, err := plugin.UnmarshalProperties(req.GetInputs(), p.unmarshalOptions("inputs"))
+	if err != nil {
+		return nil, err
+	}
+
+	result, _, err := p.provider.Read(urn, id, inputs, state)
+	if err != nil {
+		return nil, err
+	}
+
+	rpcState, err := plugin.MarshalProperties(result.Outputs, p.marshalOptions("newState"))
+	if err != nil {
+		return nil, err
+	}
+
+	rpcInputs, err := plugin.MarshalProperties(result.Inputs, p.marshalOptions("newInputs"))
+	if err != nil {
+		return nil, err
+	}
+
+	return &pulumirpc.ReadResponse{
+		Id:         string(result.ID),
+		Properties: rpcState,
+		Inputs:     rpcInputs,
+	}, nil
+}
+
+func (p *providerServer) unmarshalOptions(label string) plugin.MarshalOptions {
+	return plugin.MarshalOptions{
+		Label:         label,
+		KeepUnknowns:  true,
+		KeepSecrets:   true,
+		KeepResources: true,
+	}
+}
+
+func (p *providerServer) marshalOptions(label string) plugin.MarshalOptions {
+	return plugin.MarshalOptions{
+		Label:         label,
+		KeepUnknowns:  true,
+		KeepSecrets:   true,
+		KeepResources: true,
+	}
+}

--- a/pf/tests/provider_read_test.go
+++ b/pf/tests/provider_read_test.go
@@ -122,32 +122,20 @@ func TestReadFromRefresh(t *testing.T) {
 	      "special": true,
 	      "upper": true
 	    },
-            "inputs": {}
+	    "inputs": {
+	      "length": 8,
+	      "lower": true,
+	      "minLower": 0,
+	      "minNumeric": 0,
+	      "minSpecial": 0,
+	      "minUpper": 0,
+	      "number": true,
+	      "overrideSpecial": "_%@:",
+	      "special": true,
+	      "upper": true
+	    }
 	  }
 	}]`
-
-	// TODO populate inputs
-	// "inputs": {
-	//   "__defaults": [
-	// 	"lower",
-	// 	"minLower",
-	// 	"minNumeric",
-	// 	"minSpecial",
-	// 	"minUpper",
-	// 	"number",
-	// 	"upper"
-	//   ],
-	//   "length": 8,
-	//   "lower": true,
-	//   "minLower": 0,
-	//   "minNumeric": 0,
-	//   "minSpecial": 0,
-	//   "minUpper": 0,
-	//   "number": true,
-	//   "overrideSpecial": "_%@:",
-	//   "special": true,
-	//   "upper": true
-	// }
 
 	testutils.ReplaySequence(t, server, testCase)
 }

--- a/pf/tests/provider_read_test.go
+++ b/pf/tests/provider_read_test.go
@@ -180,7 +180,14 @@ func TestImportRandomPassword(t *testing.T) {
 	      "special": true,
 	      "upper": true
 	    },
-	    "inputs": {}
+	    "inputs": {
+              "length": 11,
+              "lower": true,
+              "number": true,
+              "numeric": true,
+              "special": true,
+              "upper": true
+            }
 	  }
 	}`
 	testutils.Replay(t, server, testCase)

--- a/pf/tests/provider_read_test.go
+++ b/pf/tests/provider_read_test.go
@@ -151,3 +151,37 @@ func TestReadFromRefresh(t *testing.T) {
 
 	testutils.ReplaySequence(t, server, testCase)
 }
+
+func TestImportRandomPassword(t *testing.T) {
+	server := newProviderServer(t, testprovider.RandomProvider())
+	testCase := `
+	{
+	  "method": "/pulumirpc.ResourceProvider/Read",
+	  "request": {
+	    "id": "supersecret",
+	    "urn": "urn:pulumi:v2::re::random:index/randomPassword:RandomPassword::newPassword",
+	    "properties": {}
+	  },
+	  "response": {
+	    "id": "none",
+	    "properties": {
+	      "__meta": "{\"schema_version\":\"3\"}",
+	      "bcryptHash": "*",
+	      "id": "none",
+	      "length": 11,
+	      "lower": true,
+	      "minLower": 0,
+	      "minNumeric": 0,
+	      "minSpecial": 0,
+	      "minUpper": 0,
+	      "number": true,
+	      "numeric": true,
+	      "result": "*",
+	      "special": true,
+	      "upper": true
+	    },
+	    "inputs": {}
+	  }
+	}`
+	testutils.Replay(t, server, testCase)
+}

--- a/pf/tests/testdata/updateprogram.json
+++ b/pf/tests/testdata/updateprogram.json
@@ -13,7 +13,7 @@
     "method": "/pulumirpc.LanguageRuntime/GetRequiredPlugins",
     "request": {
       "project": "updateprogram",
-      "pwd": "/private/var/folders/gk/cchgxh512m72f_dmkcc3d09h0000gp/T/p-it-antons-mac-updateprog-eda2f96d-1774672388",
+      "pwd": "/private/var/folders/gk/cchgxh512m72f_dmkcc3d09h0000gp/T/p-it-antons-mac-updateprog-459bc9d7-3471742073",
       "program": "."
     },
     "response": {
@@ -55,17 +55,29 @@
     }
   },
   {
+    "method": "/pulumirpc.ResourceMonitor/SupportsFeature",
+    "request": {
+      "id": "deletedWith"
+    },
+    "response": {
+      "hasSupport": true
+    },
+    "metadata": {
+      "mode": "server"
+    }
+  },
+  {
     "method": "/pulumirpc.ResourceMonitor/RegisterResource",
     "request": {
       "type": "pulumi:pulumi:Stack",
-      "name": "updateprogram-p-it-antons-mac-updateprog-eda2f96d",
+      "name": "updateprogram-p-it-antons-mac-updateprog-459bc9d7",
       "object": {},
       "acceptSecrets": true,
       "customTimeouts": {},
       "acceptResources": true
     },
     "response": {
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::pulumi:pulumi:Stack::updateprogram-p-it-antons-mac-updateprog-eda2f96d",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::pulumi:pulumi:Stack::updateprogram-p-it-antons-mac-updateprog-459bc9d7",
       "object": {}
     },
     "metadata": {
@@ -87,7 +99,7 @@
   {
     "method": "/pulumirpc.ResourceProvider/CheckConfig",
     "request": {
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::pulumi:providers:testbridge::default",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::pulumi:providers:testbridge::default",
       "olds": {},
       "news": {}
     },
@@ -121,14 +133,14 @@
   {
     "method": "/pulumirpc.ResourceProvider/Check",
     "request": {
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::testbridge:index/testres:Testres::r",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::testbridge:index/testres:Testres::r",
       "olds": {},
       "news": {
         "optionalInputString": "input2",
         "requiredInputString": "input1",
         "statedir": "state"
       },
-      "randomSeed": "Sqav4keFU/KVUnh7nrHvWetsASJ0IsbBWJrXRB/bkk0="
+      "randomSeed": "wqZZaHWVfsS1ozo3bdauTfZmjslvWcZpUjn7BzpS79c="
     },
     "response": {
       "inputs": {
@@ -146,7 +158,7 @@
   {
     "method": "/pulumirpc.ResourceProvider/Create",
     "request": {
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::testbridge:index/testres:Testres::r",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::testbridge:index/testres:Testres::r",
       "properties": {
         "optionalInputString": "input2",
         "requiredInputString": "input1",
@@ -175,19 +187,24 @@
     "request": {
       "type": "testbridge:index/testres:Testres",
       "name": "r",
-      "parent": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::pulumi:pulumi:Stack::updateprogram-p-it-antons-mac-updateprog-eda2f96d",
+      "parent": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::pulumi:pulumi:Stack::updateprogram-p-it-antons-mac-updateprog-459bc9d7",
       "custom": true,
       "object": {
         "optionalInputString": "input2",
         "requiredInputString": "input1",
         "statedir": "state"
       },
+      "propertyDependencies": {
+        "optionalInputString": {},
+        "requiredInputString": {},
+        "statedir": {}
+      },
       "acceptSecrets": true,
       "customTimeouts": {},
       "acceptResources": true
     },
     "response": {
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::testbridge:index/testres:Testres::r",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::testbridge:index/testres:Testres::r",
       "object": {
         "optionalInputString": "input2",
         "requiredInputString": "input1",
@@ -201,7 +218,7 @@
   {
     "method": "/pulumirpc.ResourceMonitor/RegisterResourceOutputs",
     "request": {
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::pulumi:pulumi:Stack::updateprogram-p-it-antons-mac-updateprog-eda2f96d",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::pulumi:pulumi:Stack::updateprogram-p-it-antons-mac-updateprog-459bc9d7",
       "outputs": {
         "testOptionalString__actual": "04da6b54-80e4-46f7-96ec-b56ff0331ba9",
         "testOptionalString__expect": "input2",
@@ -218,12 +235,12 @@
     "method": "/pulumirpc.LanguageRuntime/Run",
     "request": {
       "project": "updateprogram",
-      "stack": "p-it-antons-mac-updateprog-eda2f96d",
-      "pwd": "/private/var/folders/gk/cchgxh512m72f_dmkcc3d09h0000gp/T/p-it-antons-mac-updateprog-eda2f96d-1774672388",
+      "stack": "p-it-antons-mac-updateprog-459bc9d7",
+      "pwd": "/private/var/folders/gk/cchgxh512m72f_dmkcc3d09h0000gp/T/p-it-antons-mac-updateprog-459bc9d7-3471742073",
       "program": ".",
       "dryRun": true,
       "parallel": 2147483647,
-      "monitorAddress": "127.0.0.1:65059"
+      "monitorAddress": "127.0.0.1:62229"
     },
     "response": {},
     "metadata": {
@@ -246,7 +263,7 @@
     "method": "/pulumirpc.LanguageRuntime/GetRequiredPlugins",
     "request": {
       "project": "updateprogram",
-      "pwd": "/private/var/folders/gk/cchgxh512m72f_dmkcc3d09h0000gp/T/p-it-antons-mac-updateprog-eda2f96d-1774672388",
+      "pwd": "/private/var/folders/gk/cchgxh512m72f_dmkcc3d09h0000gp/T/p-it-antons-mac-updateprog-459bc9d7-3471742073",
       "program": "."
     },
     "response": {
@@ -288,17 +305,29 @@
     }
   },
   {
+    "method": "/pulumirpc.ResourceMonitor/SupportsFeature",
+    "request": {
+      "id": "deletedWith"
+    },
+    "response": {
+      "hasSupport": true
+    },
+    "metadata": {
+      "mode": "server"
+    }
+  },
+  {
     "method": "/pulumirpc.ResourceMonitor/RegisterResource",
     "request": {
       "type": "pulumi:pulumi:Stack",
-      "name": "updateprogram-p-it-antons-mac-updateprog-eda2f96d",
+      "name": "updateprogram-p-it-antons-mac-updateprog-459bc9d7",
       "object": {},
       "acceptSecrets": true,
       "customTimeouts": {},
       "acceptResources": true
     },
     "response": {
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::pulumi:pulumi:Stack::updateprogram-p-it-antons-mac-updateprog-eda2f96d",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::pulumi:pulumi:Stack::updateprogram-p-it-antons-mac-updateprog-459bc9d7",
       "object": {}
     },
     "metadata": {
@@ -320,7 +349,7 @@
   {
     "method": "/pulumirpc.ResourceProvider/CheckConfig",
     "request": {
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::pulumi:providers:testbridge::default",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::pulumi:providers:testbridge::default",
       "olds": {},
       "news": {}
     },
@@ -354,14 +383,14 @@
   {
     "method": "/pulumirpc.ResourceProvider/Check",
     "request": {
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::testbridge:index/testres:Testres::r",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::testbridge:index/testres:Testres::r",
       "olds": {},
       "news": {
         "optionalInputString": "input2",
         "requiredInputString": "input1",
         "statedir": "state"
       },
-      "randomSeed": "TPqy5OFGXBx+D6kcx7L9kvLUGHmgLHcSYuLBUfVimgM="
+      "randomSeed": "mXxjZs8RWIdR4ZkDvZGY436ECmglOiT4Vl51+CTTVfs="
     },
     "response": {
       "inputs": {
@@ -379,7 +408,7 @@
   {
     "method": "/pulumirpc.ResourceProvider/Create",
     "request": {
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::testbridge:index/testres:Testres::r",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::testbridge:index/testres:Testres::r",
       "properties": {
         "optionalInputString": "input2",
         "requiredInputString": "input1",
@@ -408,19 +437,24 @@
     "request": {
       "type": "testbridge:index/testres:Testres",
       "name": "r",
-      "parent": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::pulumi:pulumi:Stack::updateprogram-p-it-antons-mac-updateprog-eda2f96d",
+      "parent": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::pulumi:pulumi:Stack::updateprogram-p-it-antons-mac-updateprog-459bc9d7",
       "custom": true,
       "object": {
         "optionalInputString": "input2",
         "requiredInputString": "input1",
         "statedir": "state"
       },
+      "propertyDependencies": {
+        "optionalInputString": {},
+        "requiredInputString": {},
+        "statedir": {}
+      },
       "acceptSecrets": true,
       "customTimeouts": {},
       "acceptResources": true
     },
     "response": {
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::testbridge:index/testres:Testres::r",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::testbridge:index/testres:Testres::r",
       "id": "0",
       "object": {
         "id": "0",
@@ -438,7 +472,7 @@
   {
     "method": "/pulumirpc.ResourceMonitor/RegisterResourceOutputs",
     "request": {
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::pulumi:pulumi:Stack::updateprogram-p-it-antons-mac-updateprog-eda2f96d",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::pulumi:pulumi:Stack::updateprogram-p-it-antons-mac-updateprog-459bc9d7",
       "outputs": {
         "testOptionalString__actual": "input2",
         "testOptionalString__expect": "input2",
@@ -455,11 +489,11 @@
     "method": "/pulumirpc.LanguageRuntime/Run",
     "request": {
       "project": "updateprogram",
-      "stack": "p-it-antons-mac-updateprog-eda2f96d",
-      "pwd": "/private/var/folders/gk/cchgxh512m72f_dmkcc3d09h0000gp/T/p-it-antons-mac-updateprog-eda2f96d-1774672388",
+      "stack": "p-it-antons-mac-updateprog-459bc9d7",
+      "pwd": "/private/var/folders/gk/cchgxh512m72f_dmkcc3d09h0000gp/T/p-it-antons-mac-updateprog-459bc9d7-3471742073",
       "program": ".",
       "parallel": 2147483647,
-      "monitorAddress": "127.0.0.1:65079"
+      "monitorAddress": "127.0.0.1:62246"
     },
     "response": {},
     "metadata": {
@@ -482,7 +516,7 @@
     "method": "/pulumirpc.LanguageRuntime/GetRequiredPlugins",
     "request": {
       "project": "updateprogram",
-      "pwd": "/private/var/folders/gk/cchgxh512m72f_dmkcc3d09h0000gp/T/p-it-antons-mac-updateprog-eda2f96d-1774672388",
+      "pwd": "/private/var/folders/gk/cchgxh512m72f_dmkcc3d09h0000gp/T/p-it-antons-mac-updateprog-459bc9d7-3471742073",
       "program": "."
     },
     "response": {
@@ -554,17 +588,29 @@
     }
   },
   {
+    "method": "/pulumirpc.ResourceMonitor/SupportsFeature",
+    "request": {
+      "id": "deletedWith"
+    },
+    "response": {
+      "hasSupport": true
+    },
+    "metadata": {
+      "mode": "server"
+    }
+  },
+  {
     "method": "/pulumirpc.ResourceMonitor/RegisterResource",
     "request": {
       "type": "pulumi:pulumi:Stack",
-      "name": "updateprogram-p-it-antons-mac-updateprog-eda2f96d",
+      "name": "updateprogram-p-it-antons-mac-updateprog-459bc9d7",
       "object": {},
       "acceptSecrets": true,
       "customTimeouts": {},
       "acceptResources": true
     },
     "response": {
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::pulumi:pulumi:Stack::updateprogram-p-it-antons-mac-updateprog-eda2f96d",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::pulumi:pulumi:Stack::updateprogram-p-it-antons-mac-updateprog-459bc9d7",
       "object": {}
     },
     "metadata": {
@@ -586,7 +632,7 @@
   {
     "method": "/pulumirpc.ResourceProvider/CheckConfig",
     "request": {
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::pulumi:providers:testbridge::default",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::pulumi:providers:testbridge::default",
       "olds": {},
       "news": {}
     },
@@ -602,7 +648,7 @@
   {
     "method": "/pulumirpc.ResourceProvider/DiffConfig",
     "request": {
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::pulumi:providers:testbridge::default",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::pulumi:providers:testbridge::default",
       "olds": {},
       "news": {}
     },
@@ -616,7 +662,7 @@
   {
     "method": "/pulumirpc.ResourceProvider/Check",
     "request": {
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::testbridge:index/testres:Testres::r",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::testbridge:index/testres:Testres::r",
       "olds": {
         "optionalInputString": "input2",
         "requiredInputString": "input1",
@@ -627,7 +673,7 @@
         "requiredInputString": "input1",
         "statedir": "state"
       },
-      "randomSeed": "joCgzdLbHgSWPr4BpmN2tXpqD5fKjs2ajRGOPzC27WA="
+      "randomSeed": "PBGGd3cPiHkDPOLcY6t7sbeE8lyU+RtsjYm1qcLwwqI="
     },
     "response": {
       "inputs": {
@@ -646,7 +692,7 @@
     "method": "/pulumirpc.ResourceProvider/Diff",
     "request": {
       "id": "0",
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::testbridge:index/testres:Testres::r",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::testbridge:index/testres:Testres::r",
       "olds": {
         "id": "0",
         "optionalInputString": "input2",
@@ -675,19 +721,24 @@
     "request": {
       "type": "testbridge:index/testres:Testres",
       "name": "r",
-      "parent": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::pulumi:pulumi:Stack::updateprogram-p-it-antons-mac-updateprog-eda2f96d",
+      "parent": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::pulumi:pulumi:Stack::updateprogram-p-it-antons-mac-updateprog-459bc9d7",
       "custom": true,
       "object": {
         "optionalInputString": "input2",
         "requiredInputString": "input1",
         "statedir": "state"
       },
+      "propertyDependencies": {
+        "optionalInputString": {},
+        "requiredInputString": {},
+        "statedir": {}
+      },
       "acceptSecrets": true,
       "customTimeouts": {},
       "acceptResources": true
     },
     "response": {
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::testbridge:index/testres:Testres::r",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::testbridge:index/testres:Testres::r",
       "id": "0",
       "object": {
         "id": "0",
@@ -705,7 +756,7 @@
   {
     "method": "/pulumirpc.ResourceMonitor/RegisterResourceOutputs",
     "request": {
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::pulumi:pulumi:Stack::updateprogram-p-it-antons-mac-updateprog-eda2f96d",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::pulumi:pulumi:Stack::updateprogram-p-it-antons-mac-updateprog-459bc9d7",
       "outputs": {
         "testOptionalString__actual": "input2",
         "testOptionalString__expect": "input2",
@@ -722,12 +773,12 @@
     "method": "/pulumirpc.LanguageRuntime/Run",
     "request": {
       "project": "updateprogram",
-      "stack": "p-it-antons-mac-updateprog-eda2f96d",
-      "pwd": "/private/var/folders/gk/cchgxh512m72f_dmkcc3d09h0000gp/T/p-it-antons-mac-updateprog-eda2f96d-1774672388",
+      "stack": "p-it-antons-mac-updateprog-459bc9d7",
+      "pwd": "/private/var/folders/gk/cchgxh512m72f_dmkcc3d09h0000gp/T/p-it-antons-mac-updateprog-459bc9d7-3471742073",
       "program": ".",
       "dryRun": true,
       "parallel": 2147483647,
-      "monitorAddress": "127.0.0.1:65106"
+      "monitorAddress": "127.0.0.1:62267"
     },
     "response": {},
     "metadata": {
@@ -750,7 +801,7 @@
     "method": "/pulumirpc.LanguageRuntime/GetRequiredPlugins",
     "request": {
       "project": "updateprogram",
-      "pwd": "/private/var/folders/gk/cchgxh512m72f_dmkcc3d09h0000gp/T/p-it-antons-mac-updateprog-eda2f96d-1774672388",
+      "pwd": "/private/var/folders/gk/cchgxh512m72f_dmkcc3d09h0000gp/T/p-it-antons-mac-updateprog-459bc9d7-3471742073",
       "program": "."
     },
     "response": {
@@ -822,17 +873,29 @@
     }
   },
   {
+    "method": "/pulumirpc.ResourceMonitor/SupportsFeature",
+    "request": {
+      "id": "deletedWith"
+    },
+    "response": {
+      "hasSupport": true
+    },
+    "metadata": {
+      "mode": "server"
+    }
+  },
+  {
     "method": "/pulumirpc.ResourceMonitor/RegisterResource",
     "request": {
       "type": "pulumi:pulumi:Stack",
-      "name": "updateprogram-p-it-antons-mac-updateprog-eda2f96d",
+      "name": "updateprogram-p-it-antons-mac-updateprog-459bc9d7",
       "object": {},
       "acceptSecrets": true,
       "customTimeouts": {},
       "acceptResources": true
     },
     "response": {
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::pulumi:pulumi:Stack::updateprogram-p-it-antons-mac-updateprog-eda2f96d",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::pulumi:pulumi:Stack::updateprogram-p-it-antons-mac-updateprog-459bc9d7",
       "object": {}
     },
     "metadata": {
@@ -854,7 +917,7 @@
   {
     "method": "/pulumirpc.ResourceProvider/CheckConfig",
     "request": {
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::pulumi:providers:testbridge::default",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::pulumi:providers:testbridge::default",
       "olds": {},
       "news": {}
     },
@@ -870,7 +933,7 @@
   {
     "method": "/pulumirpc.ResourceProvider/DiffConfig",
     "request": {
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::pulumi:providers:testbridge::default",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::pulumi:providers:testbridge::default",
       "olds": {},
       "news": {}
     },
@@ -884,7 +947,7 @@
   {
     "method": "/pulumirpc.ResourceProvider/Check",
     "request": {
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::testbridge:index/testres:Testres::r",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::testbridge:index/testres:Testres::r",
       "olds": {
         "optionalInputString": "input2",
         "requiredInputString": "input1",
@@ -895,7 +958,7 @@
         "requiredInputString": "input1",
         "statedir": "state"
       },
-      "randomSeed": "0IJO7oOdpCForD8heaesgTsNhB1wz1r4vIFf1ZkJiqk="
+      "randomSeed": "PSQjjsavj+BDo7myDo7Vd3Inz0QVgJ6VetG5XUQV9LE="
     },
     "response": {
       "inputs": {
@@ -914,7 +977,7 @@
     "method": "/pulumirpc.ResourceProvider/Diff",
     "request": {
       "id": "0",
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::testbridge:index/testres:Testres::r",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::testbridge:index/testres:Testres::r",
       "olds": {
         "id": "0",
         "optionalInputString": "input2",
@@ -943,19 +1006,24 @@
     "request": {
       "type": "testbridge:index/testres:Testres",
       "name": "r",
-      "parent": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::pulumi:pulumi:Stack::updateprogram-p-it-antons-mac-updateprog-eda2f96d",
+      "parent": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::pulumi:pulumi:Stack::updateprogram-p-it-antons-mac-updateprog-459bc9d7",
       "custom": true,
       "object": {
         "optionalInputString": "input2",
         "requiredInputString": "input1",
         "statedir": "state"
       },
+      "propertyDependencies": {
+        "optionalInputString": {},
+        "requiredInputString": {},
+        "statedir": {}
+      },
       "acceptSecrets": true,
       "customTimeouts": {},
       "acceptResources": true
     },
     "response": {
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::testbridge:index/testres:Testres::r",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::testbridge:index/testres:Testres::r",
       "id": "0",
       "object": {
         "id": "0",
@@ -973,7 +1041,7 @@
   {
     "method": "/pulumirpc.ResourceMonitor/RegisterResourceOutputs",
     "request": {
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::pulumi:pulumi:Stack::updateprogram-p-it-antons-mac-updateprog-eda2f96d",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::pulumi:pulumi:Stack::updateprogram-p-it-antons-mac-updateprog-459bc9d7",
       "outputs": {
         "testOptionalString__actual": "input2",
         "testOptionalString__expect": "input2",
@@ -990,11 +1058,11 @@
     "method": "/pulumirpc.LanguageRuntime/Run",
     "request": {
       "project": "updateprogram",
-      "stack": "p-it-antons-mac-updateprog-eda2f96d",
-      "pwd": "/private/var/folders/gk/cchgxh512m72f_dmkcc3d09h0000gp/T/p-it-antons-mac-updateprog-eda2f96d-1774672388",
+      "stack": "p-it-antons-mac-updateprog-459bc9d7",
+      "pwd": "/private/var/folders/gk/cchgxh512m72f_dmkcc3d09h0000gp/T/p-it-antons-mac-updateprog-459bc9d7-3471742073",
       "program": ".",
       "parallel": 2147483647,
-      "monitorAddress": "127.0.0.1:65131"
+      "monitorAddress": "127.0.0.1:62288"
     },
     "response": {},
     "metadata": {
@@ -1037,7 +1105,7 @@
     "method": "/pulumirpc.ResourceProvider/Read",
     "request": {
       "id": "0",
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::testbridge:index/testres:Testres::r",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::testbridge:index/testres:Testres::r",
       "properties": {
         "id": "0",
         "optionalInputString": "input2",
@@ -1062,7 +1130,11 @@
         "requiredInputStringCopy": "input1",
         "statedir": "state"
       },
-      "inputs": {}
+      "inputs": {
+        "optionalInputString": "input2",
+        "requiredInputString": "input1",
+        "statedir": "state"
+      }
     },
     "metadata": {
       "kind": "resource",
@@ -1084,7 +1156,7 @@
     "method": "/pulumirpc.LanguageRuntime/GetRequiredPlugins",
     "request": {
       "project": "updateprogram",
-      "pwd": "/private/var/folders/gk/cchgxh512m72f_dmkcc3d09h0000gp/T/p-it-antons-mac-updateprog-eda2f96d-1774672388",
+      "pwd": "/private/var/folders/gk/cchgxh512m72f_dmkcc3d09h0000gp/T/p-it-antons-mac-updateprog-459bc9d7-3471742073",
       "program": "."
     },
     "response": {
@@ -1156,17 +1228,29 @@
     }
   },
   {
+    "method": "/pulumirpc.ResourceMonitor/SupportsFeature",
+    "request": {
+      "id": "deletedWith"
+    },
+    "response": {
+      "hasSupport": true
+    },
+    "metadata": {
+      "mode": "server"
+    }
+  },
+  {
     "method": "/pulumirpc.ResourceMonitor/RegisterResource",
     "request": {
       "type": "pulumi:pulumi:Stack",
-      "name": "updateprogram-p-it-antons-mac-updateprog-eda2f96d",
+      "name": "updateprogram-p-it-antons-mac-updateprog-459bc9d7",
       "object": {},
       "acceptSecrets": true,
       "customTimeouts": {},
       "acceptResources": true
     },
     "response": {
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::pulumi:pulumi:Stack::updateprogram-p-it-antons-mac-updateprog-eda2f96d",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::pulumi:pulumi:Stack::updateprogram-p-it-antons-mac-updateprog-459bc9d7",
       "object": {}
     },
     "metadata": {
@@ -1188,7 +1272,7 @@
   {
     "method": "/pulumirpc.ResourceProvider/CheckConfig",
     "request": {
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::pulumi:providers:testbridge::default",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::pulumi:providers:testbridge::default",
       "olds": {},
       "news": {}
     },
@@ -1204,7 +1288,7 @@
   {
     "method": "/pulumirpc.ResourceProvider/DiffConfig",
     "request": {
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::pulumi:providers:testbridge::default",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::pulumi:providers:testbridge::default",
       "olds": {},
       "news": {}
     },
@@ -1218,14 +1302,18 @@
   {
     "method": "/pulumirpc.ResourceProvider/Check",
     "request": {
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::testbridge:index/testres:Testres::r",
-      "olds": {},
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::testbridge:index/testres:Testres::r",
+      "olds": {
+        "optionalInputString": "input2",
+        "requiredInputString": "input1",
+        "statedir": "state"
+      },
       "news": {
         "optionalInputString": "input2-updated",
         "requiredInputString": "input1-updated",
         "statedir": "state"
       },
-      "randomSeed": "MQIuy8SpmPGzxPes07ANWtgyfxw8yEaVQ21NRLzPSJ8="
+      "randomSeed": "8Y14Kr2WGr7ZQCdtUM/YVlzKQMmmI+JWfDimFhI4x3o="
     },
     "response": {
       "inputs": {
@@ -1244,7 +1332,7 @@
     "method": "/pulumirpc.ResourceProvider/Diff",
     "request": {
       "id": "0",
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::testbridge:index/testres:Testres::r",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::testbridge:index/testres:Testres::r",
       "olds": {
         "id": "0",
         "optionalInputString": "input2",
@@ -1276,7 +1364,7 @@
     "method": "/pulumirpc.ResourceProvider/Update",
     "request": {
       "id": "0",
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::testbridge:index/testres:Testres::r",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::testbridge:index/testres:Testres::r",
       "olds": {
         "id": "0",
         "optionalInputString": "input2",
@@ -1313,19 +1401,24 @@
     "request": {
       "type": "testbridge:index/testres:Testres",
       "name": "r",
-      "parent": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::pulumi:pulumi:Stack::updateprogram-p-it-antons-mac-updateprog-eda2f96d",
+      "parent": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::pulumi:pulumi:Stack::updateprogram-p-it-antons-mac-updateprog-459bc9d7",
       "custom": true,
       "object": {
         "optionalInputString": "input2-updated",
         "requiredInputString": "input1-updated",
         "statedir": "state"
       },
+      "propertyDependencies": {
+        "optionalInputString": {},
+        "requiredInputString": {},
+        "statedir": {}
+      },
       "acceptSecrets": true,
       "customTimeouts": {},
       "acceptResources": true
     },
     "response": {
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::testbridge:index/testres:Testres::r",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::testbridge:index/testres:Testres::r",
       "id": "0",
       "object": {
         "id": "0",
@@ -1343,7 +1436,7 @@
   {
     "method": "/pulumirpc.ResourceMonitor/RegisterResourceOutputs",
     "request": {
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::pulumi:pulumi:Stack::updateprogram-p-it-antons-mac-updateprog-eda2f96d",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::pulumi:pulumi:Stack::updateprogram-p-it-antons-mac-updateprog-459bc9d7",
       "outputs": {
         "testOptionalStringAfterUpdate__actual": "input2",
         "testOptionalStringAfterUpdate__expect": "input2-updated",
@@ -1360,12 +1453,12 @@
     "method": "/pulumirpc.LanguageRuntime/Run",
     "request": {
       "project": "updateprogram",
-      "stack": "p-it-antons-mac-updateprog-eda2f96d",
-      "pwd": "/private/var/folders/gk/cchgxh512m72f_dmkcc3d09h0000gp/T/p-it-antons-mac-updateprog-eda2f96d-1774672388",
+      "stack": "p-it-antons-mac-updateprog-459bc9d7",
+      "pwd": "/private/var/folders/gk/cchgxh512m72f_dmkcc3d09h0000gp/T/p-it-antons-mac-updateprog-459bc9d7-3471742073",
       "program": ".",
       "dryRun": true,
       "parallel": 2147483647,
-      "monitorAddress": "127.0.0.1:65164"
+      "monitorAddress": "127.0.0.1:62314"
     },
     "response": {},
     "metadata": {
@@ -1388,7 +1481,7 @@
     "method": "/pulumirpc.LanguageRuntime/GetRequiredPlugins",
     "request": {
       "project": "updateprogram",
-      "pwd": "/private/var/folders/gk/cchgxh512m72f_dmkcc3d09h0000gp/T/p-it-antons-mac-updateprog-eda2f96d-1774672388",
+      "pwd": "/private/var/folders/gk/cchgxh512m72f_dmkcc3d09h0000gp/T/p-it-antons-mac-updateprog-459bc9d7-3471742073",
       "program": "."
     },
     "response": {
@@ -1460,17 +1553,29 @@
     }
   },
   {
+    "method": "/pulumirpc.ResourceMonitor/SupportsFeature",
+    "request": {
+      "id": "deletedWith"
+    },
+    "response": {
+      "hasSupport": true
+    },
+    "metadata": {
+      "mode": "server"
+    }
+  },
+  {
     "method": "/pulumirpc.ResourceMonitor/RegisterResource",
     "request": {
       "type": "pulumi:pulumi:Stack",
-      "name": "updateprogram-p-it-antons-mac-updateprog-eda2f96d",
+      "name": "updateprogram-p-it-antons-mac-updateprog-459bc9d7",
       "object": {},
       "acceptSecrets": true,
       "customTimeouts": {},
       "acceptResources": true
     },
     "response": {
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::pulumi:pulumi:Stack::updateprogram-p-it-antons-mac-updateprog-eda2f96d",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::pulumi:pulumi:Stack::updateprogram-p-it-antons-mac-updateprog-459bc9d7",
       "object": {}
     },
     "metadata": {
@@ -1492,7 +1597,7 @@
   {
     "method": "/pulumirpc.ResourceProvider/CheckConfig",
     "request": {
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::pulumi:providers:testbridge::default",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::pulumi:providers:testbridge::default",
       "olds": {},
       "news": {}
     },
@@ -1508,7 +1613,7 @@
   {
     "method": "/pulumirpc.ResourceProvider/DiffConfig",
     "request": {
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::pulumi:providers:testbridge::default",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::pulumi:providers:testbridge::default",
       "olds": {},
       "news": {}
     },
@@ -1522,14 +1627,18 @@
   {
     "method": "/pulumirpc.ResourceProvider/Check",
     "request": {
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::testbridge:index/testres:Testres::r",
-      "olds": {},
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::testbridge:index/testres:Testres::r",
+      "olds": {
+        "optionalInputString": "input2",
+        "requiredInputString": "input1",
+        "statedir": "state"
+      },
       "news": {
         "optionalInputString": "input2-updated",
         "requiredInputString": "input1-updated",
         "statedir": "state"
       },
-      "randomSeed": "lJaW1czReZ1fe8rBgBIwWyWUq5U+PExTtlhCmGag+XA="
+      "randomSeed": "+Z91SD4Kl0Ka/Ds9LlYogGCFTO6OLfYv+P6aTDv21sA="
     },
     "response": {
       "inputs": {
@@ -1548,7 +1657,7 @@
     "method": "/pulumirpc.ResourceProvider/Diff",
     "request": {
       "id": "0",
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::testbridge:index/testres:Testres::r",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::testbridge:index/testres:Testres::r",
       "olds": {
         "id": "0",
         "optionalInputString": "input2",
@@ -1580,7 +1689,7 @@
     "method": "/pulumirpc.ResourceProvider/Update",
     "request": {
       "id": "0",
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::testbridge:index/testres:Testres::r",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::testbridge:index/testres:Testres::r",
       "olds": {
         "id": "0",
         "optionalInputString": "input2",
@@ -1616,19 +1725,24 @@
     "request": {
       "type": "testbridge:index/testres:Testres",
       "name": "r",
-      "parent": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::pulumi:pulumi:Stack::updateprogram-p-it-antons-mac-updateprog-eda2f96d",
+      "parent": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::pulumi:pulumi:Stack::updateprogram-p-it-antons-mac-updateprog-459bc9d7",
       "custom": true,
       "object": {
         "optionalInputString": "input2-updated",
         "requiredInputString": "input1-updated",
         "statedir": "state"
       },
+      "propertyDependencies": {
+        "optionalInputString": {},
+        "requiredInputString": {},
+        "statedir": {}
+      },
       "acceptSecrets": true,
       "customTimeouts": {},
       "acceptResources": true
     },
     "response": {
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::testbridge:index/testres:Testres::r",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::testbridge:index/testres:Testres::r",
       "id": "0",
       "object": {
         "id": "0",
@@ -1646,7 +1760,7 @@
   {
     "method": "/pulumirpc.ResourceMonitor/RegisterResourceOutputs",
     "request": {
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::pulumi:pulumi:Stack::updateprogram-p-it-antons-mac-updateprog-eda2f96d",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::pulumi:pulumi:Stack::updateprogram-p-it-antons-mac-updateprog-459bc9d7",
       "outputs": {
         "testOptionalStringAfterUpdate__actual": "input2-updated",
         "testOptionalStringAfterUpdate__expect": "input2-updated",
@@ -1663,11 +1777,11 @@
     "method": "/pulumirpc.LanguageRuntime/Run",
     "request": {
       "project": "updateprogram",
-      "stack": "p-it-antons-mac-updateprog-eda2f96d",
-      "pwd": "/private/var/folders/gk/cchgxh512m72f_dmkcc3d09h0000gp/T/p-it-antons-mac-updateprog-eda2f96d-1774672388",
+      "stack": "p-it-antons-mac-updateprog-459bc9d7",
+      "pwd": "/private/var/folders/gk/cchgxh512m72f_dmkcc3d09h0000gp/T/p-it-antons-mac-updateprog-459bc9d7-3471742073",
       "program": ".",
       "parallel": 2147483647,
-      "monitorAddress": "127.0.0.1:65189"
+      "monitorAddress": "127.0.0.1:62335"
     },
     "response": {},
     "metadata": {
@@ -1710,7 +1824,7 @@
     "method": "/pulumirpc.ResourceProvider/Delete",
     "request": {
       "id": "0",
-      "urn": "urn:pulumi:p-it-antons-mac-updateprog-eda2f96d::updateprogram::testbridge:index/testres:Testres::r",
+      "urn": "urn:pulumi:p-it-antons-mac-updateprog-459bc9d7::updateprogram::testbridge:index/testres:Testres::r",
       "properties": {
         "id": "0",
         "optionalInputString": "input2-updated",

--- a/pf/tests/util.go
+++ b/pf/tests/util.go
@@ -20,9 +20,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 
+	serverutil "github.com/pulumi/pulumi-terraform-bridge/pf/internal/server"
 	"github.com/pulumi/pulumi-terraform-bridge/pf/tfbridge"
 )
 
@@ -31,5 +31,5 @@ func newProviderServer(t *testing.T, info tfbridge.ProviderInfo) pulumirpc.Resou
 	meta := genMetadata(t, info)
 	p, err := tfbridge.NewProvider(ctx, info, meta)
 	require.NoError(t, err)
-	return plugin.NewProviderServer(p)
+	return serverutil.NewProviderServer(p)
 }

--- a/pf/tfbridge/provider.go
+++ b/pf/tfbridge/provider.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/pulumi/pulumi-terraform-bridge/pf/internal/convert"
 	"github.com/pulumi/pulumi-terraform-bridge/pf/internal/pfutils"
+	serverutil "github.com/pulumi/pulumi-terraform-bridge/pf/internal/server"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen"
 )
 
@@ -133,7 +134,7 @@ func newProviderServer(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	return plugin.NewProviderServer(p), nil
+	return serverutil.NewProviderServer(p), nil
 }
 
 // Closer closes any underlying OS resources associated with this provider (like processes, RPC channels, etc).

--- a/pf/tfbridge/provider_read.go
+++ b/pf/tfbridge/provider_read.go
@@ -16,6 +16,7 @@ package tfbridge
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 
@@ -32,8 +33,8 @@ func (p *provider) Read(
 	inputs,
 	currentStateMap resource.PropertyMap,
 ) (plugin.ReadResult, resource.Status, error) {
-	// TODO[pulumi/pulumi-terraform-bridge#793] Add a test for Read handling a not-found resource
 
+	// TODO[pulumi/pulumi-terraform-bridge#793] Add a test for Read handling a not-found resource
 	ctx := context.TODO()
 
 	rh, err := p.resourceHandle(ctx, urn)
@@ -41,12 +42,33 @@ func (p *provider) Read(
 		return plugin.ReadResult{}, 0, err
 	}
 
-	currentStateRaw, err := parseResourceState(&rh, currentStateMap)
+	// Both "get" and "refresh" scenarios call Read. Detect and dispatch.
+	isRefresh := len(currentStateMap) != 0
+
+	if isRefresh {
+		return p.readViaReadResource(ctx, &rh, id, inputs, currentStateMap)
+	}
+
+	return p.readViaImportResourceState(ctx, &rh, id)
+
+	// panic(fmt.Sprintf("READ urn=%v id=%v inputs=%v currentStateMap=%v", urn, id, len(inputs), len(currentStateMap)))
+	// panic: READ urn=urn:pulumi:dev::re::random:index/randomPassword:RandomPassword::newPassword id=supersecret inputs=0 currentStateMap=0
+}
+
+func (p *provider) readViaReadResource(
+	ctx context.Context,
+	rh *resourceHandle,
+	id resource.ID,
+	unusedInputs,
+	currentStateMap resource.PropertyMap,
+) (plugin.ReadResult, resource.Status, error) {
+
+	currentStateRaw, err := parseResourceState(rh, currentStateMap)
 	if err != nil {
 		return plugin.ReadResult{}, 0, err
 	}
 
-	currentState, err := p.UpgradeResourceState(ctx, &rh, currentStateRaw)
+	currentState, err := p.UpgradeResourceState(ctx, rh, currentStateRaw)
 	if err != nil {
 		return plugin.ReadResult{}, 0, err
 	}
@@ -75,26 +97,85 @@ func (p *provider) Read(
 
 	// TODO[pulumi/pulumi-terraform-bridge#747] handle resp.Private
 	if resp.NewState == nil {
-		return plugin.ReadResult{}, resource.StatusUnknown, nil
+		return plugin.ReadResult{}, resource.StatusOK, nil
 	}
 
-	readState, err := parseResourceStateFromTF(ctx, &rh, resp.NewState)
+	readState, err := parseResourceStateFromTF(ctx, rh, resp.NewState)
 	if err != nil {
 		return plugin.ReadResult{}, 0, err
 	}
 
-	readID, err := readState.ExtractID(&rh)
+	readID, err := readState.ExtractID(rh)
 	if err != nil {
-		return plugin.ReadResult{}, 0, err
+		readID = ""
 	}
 
-	readStateMap, err := readState.ToPropertyMap(&rh)
+	readStateMap, err := readState.ToPropertyMap(rh)
 	if err != nil {
 		return plugin.ReadResult{}, 0, err
 	}
 
 	return plugin.ReadResult{
 		ID: readID,
+		// TODO[pulumi/pulumi-terraform-bridge#795] populate Inputs
+		Inputs:  nil,
+		Outputs: readStateMap,
+	}, resource.StatusOK, nil
+}
+
+func (p *provider) readViaImportResourceState(
+	ctx context.Context,
+	rh *resourceHandle,
+	id resource.ID,
+) (plugin.ReadResult, resource.Status, error) {
+	// TODO[pulumi/pulumi-terraform-bridge#794] set ProviderMeta
+	// TODO[pulumi/pulumi-terraform-bridge#747] set Private
+	req := tfprotov6.ImportResourceStateRequest{
+		TypeName: rh.terraformResourceName,
+		ID:       string(id),
+	}
+
+	resp, err := p.tfServer.ImportResourceState(ctx, &req)
+	if err != nil {
+		return plugin.ReadResult{}, 0, err
+	}
+
+	// TODO[pulumi/pulumi-terraform-bridge#747] handle resp.Private
+
+	if err := p.processDiagnostics(resp.Diagnostics); err != nil {
+		return plugin.ReadResult{}, 0, err
+	}
+
+	if len(resp.ImportedResources) > 1 {
+		return plugin.ReadResult{}, 0,
+			fmt.Errorf("ImportResourceState returned more than one result, " +
+				"but reading only one is supported by Pulumi")
+	}
+
+	if len(resp.ImportedResources) == 0 {
+		return plugin.ReadResult{}, 0,
+			fmt.Errorf("ImportResourceState failed to return a result")
+	}
+
+	r := resp.ImportedResources[0]
+
+	readState, err := parseResourceStateFromTF(ctx, rh, r.State)
+	if err != nil {
+		return plugin.ReadResult{}, 0, err
+	}
+
+	finalID, err := readState.ExtractID(rh)
+	if err != nil {
+		return plugin.ReadResult{}, 0, err
+	}
+
+	readStateMap, err := readState.ToPropertyMap(rh)
+	if err != nil {
+		return plugin.ReadResult{}, 0, err
+	}
+
+	return plugin.ReadResult{
+		ID: finalID,
 		// TODO[pulumi/pulumi-terraform-bridge#795] populate Inputs
 		Inputs:  nil,
 		Outputs: readStateMap,

--- a/pf/tfbridge/provider_read.go
+++ b/pf/tfbridge/provider_read.go
@@ -73,6 +73,11 @@ func (p *provider) Read(
 		if err != nil {
 			return result, ignoredStatus, err
 		}
+
+		// __defaults is not needed for Plugin Framework bridged providers
+		if _, ok := result.Inputs["__defaults"]; ok {
+			delete(result.Inputs, "__defaults")
+		}
 	}
 
 	return result, ignoredStatus, err

--- a/pf/tfbridge/provider_read.go
+++ b/pf/tfbridge/provider_read.go
@@ -75,9 +75,7 @@ func (p *provider) Read(
 		}
 
 		// __defaults is not needed for Plugin Framework bridged providers
-		if _, ok := result.Inputs["__defaults"]; ok {
-			delete(result.Inputs, "__defaults")
-		}
+		delete(result.Inputs, "__defaults")
 	}
 
 	return result, ignoredStatus, err

--- a/pf/tfgen/gen.go
+++ b/pf/tfgen/gen.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 
-	"github.com/pulumi/pulumi-terraform-bridge/pf/internal/schemashim"
 	"github.com/pulumi/pulumi-terraform-bridge/pf/tfbridge"
 	realtfgen "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen"
 )
@@ -52,7 +51,7 @@ func GenerateSchema(ctx context.Context, opts GenerateSchemaOptions) (*GenerateS
 			Color: colors.Never,
 		})
 	}
-	shimInfo := schemashim.ShimSchemaOnlyProviderInfo(ctx, opts.ProviderInfo)
+	shimInfo := shimSchemaOnlyProviderInfo(ctx, opts.ProviderInfo)
 
 	generated, err := realtfgen.GenerateSchemaWithOptions(realtfgen.GenerateSchemaOptions{
 		ProviderInfo:    shimInfo,

--- a/pf/tfgen/main.go
+++ b/pf/tfgen/main.go
@@ -18,8 +18,6 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/pulumi/pulumi-terraform-bridge/pf/internal/schemashim"
-
 	"github.com/pulumi/pulumi-terraform-bridge/pf/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen"
 )
@@ -35,7 +33,7 @@ import (
 func Main(provider string, info tfbridge.ProviderInfo) {
 	version := info.Version
 	ctx := context.Background()
-	shimInfo := schemashim.ShimSchemaOnlyProviderInfo(ctx, info)
+	shimInfo := shimSchemaOnlyProviderInfo(ctx, info)
 
 	tfgen.MainWithCustomGenerate(provider, version, shimInfo, func(opts tfgen.GeneratorOptions) error {
 

--- a/pf/tfgen/schemashim.go
+++ b/pf/tfgen/schemashim.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2022, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,18 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package schemashim
+package tfgen
 
 import (
 	"context"
 
-	pfprovider "github.com/hashicorp/terraform-plugin-framework/provider"
-	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	"github.com/pulumi/pulumi-terraform-bridge/pf/internal/schemashim"
+	pf "github.com/pulumi/pulumi-terraform-bridge/pf/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 )
 
-func ShimSchemaOnlyProvider(ctx context.Context, provider pfprovider.Provider) shim.Provider {
-	return &schemaOnlyProvider{
-		ctx: ctx,
-		tf:  provider,
-	}
+func shimSchemaOnlyProviderInfo(ctx context.Context, provider pf.ProviderInfo) tfbridge.ProviderInfo {
+	shimProvider := schemashim.ShimSchemaOnlyProvider(ctx, provider.NewProvider())
+	var copy tfbridge.ProviderInfo = provider.ProviderInfo
+	copy.P = shimProvider
+	return copy
 }

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -998,7 +998,7 @@ func (p *Provider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*pulum
 			return nil, err
 		}
 
-		inputs, err := extractInputsFromOutputs(oldInputs, props, res.TF.Schema(), res.Schema.Fields, isRefresh)
+		inputs, err := ExtractInputsFromOutputs(oldInputs, props, res.TF.Schema(), res.Schema.Fields, isRefresh)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -1437,7 +1437,7 @@ func extractSchemaInputs(state resource.PropertyValue, tfs shim.Schema, ps *Sche
 	}
 }
 
-func extractInputsFromOutputs(oldInputs, outs resource.PropertyMap,
+func ExtractInputsFromOutputs(oldInputs, outs resource.PropertyMap,
 	tfs shim.SchemaMap, ps map[string]*SchemaInfo, isRefresh bool) (resource.PropertyMap, error) {
 
 	sch := (&schema.Schema{


### PR DESCRIPTION
Fixes #795 

The motivation is to support Random resource import scenario:

```
pulumi import random:index/randomPassword:RandomPassword newPassword supersecret
```

With these changes I am able to do the above and get a program back. The program does successfully import the secret password:

```
new_password = random.RandomPassword("newPassword",
    length=11,
    lower=True,
    number=True,
    numeric=True,
    special=True,
    upper=True,
    opts=pulumi.ResourceOptions(protect=True))
```

But has a few extra parameters like lower, number, numeric, special, etc that are unnecessary, and only appear because of the difficulties we have with detecting default values, see #732.

The PR has to fix #795 because otherwise the generated program is this, which doesn't work:

```
new_password = random.RandomPassword("newPassword", length=0)
```
