### PR TITLE
Add a  test for example generation

### DIFF
--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -866,7 +866,7 @@ throw new Exception("!");
 ~~~
 `)
 
-	markdown = bytes.ReplaceAll([]byte(markdown), []byte("~~~"), []byte("```"))
+	markdown = bytes.ReplaceAll(markdown, []byte("~~~"), []byte("```"))
 
 	info.Resources["random_integer"].Docs = &tfbridge.DocInfo{
 		Markdown: markdown,


### PR DESCRIPTION
For #877 

Example rendering seems pretty coupled with the rest of tfgen. It doesn't have a testable exported API. Perhaps it should. In the meanwhile there's a way to test example rendering through an entire schema generation test. 