### PR TITLE
Don't pass open/close quotes to PyName

### DIFF
--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -1690,7 +1690,7 @@ func fixupPropertyReferences(language Language, pkg tokens.Package, info tfbridg
 				return open + modname + getname.String() + close
 			case Python:
 				// Use `ec2.get_ami` format
-				return python.PyName(open + modname + getname.String() + close)
+				return open + python.PyName(modname+getname.String()) + close
 			default:
 				// Use `aws.ec2.getAmi` format
 				return open + pkg.String() + "." + modname + getname.String() + close


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/896

https://github.com/pulumi/pulumi-terraform-bridge/pull/734 removed `PyName` from tfbridge and replaced uses of it with a call to `PyName` in "github.com/pulumi/pulumi/pkg/v3/codegen/python".
Unfortunately the behavior of the two functions was slightly different for characters that were not valid identifier characters. That coupled with the fact that `open` and `close` characters were being passed into PyName in `fixupPropertyReferences` meant that when this changed we started outputing docs with text like `"This data source is different from the _directconnect_get_locations_ data source"` rather than ``"This data source is different from the `directconnect_get_locations` data source"``.