### PR TITLE
Handle complex types for config variables

### DIFF
--- a/pkg/tf2pulumi/convert/testdata/simple_config/experimental_pcl/main.pp
+++ b/pkg/tf2pulumi/convert/testdata/simple_config/experimental_pcl/main.pp
@@ -1,0 +1,12 @@
+config "numberIn" "number" {
+}
+config "stringIn" "string" {
+}
+config "boolIn" "bool" {
+}
+config "stringListIn" "list(string)" {
+}
+config "stringMapIn" "map(string)" {
+}
+config "objectIn" "object({first=number, second=string})" {
+}

--- a/pkg/tf2pulumi/convert/testdata/simple_config/main.tf
+++ b/pkg/tf2pulumi/convert/testdata/simple_config/main.tf
@@ -1,0 +1,26 @@
+variable "number_in" {
+    type = number
+}
+
+variable "string_in" {
+    type = string
+}
+
+variable "bool_in" {
+    type = bool
+}
+
+variable "string_list_in" {
+    type = list(string)
+}
+
+variable "string_map_in" {
+    type = map(string)
+}
+
+variable "object_in" {
+    type = object({
+       first = number,
+       second = string
+    })
+}

--- a/pkg/tf2pulumi/convert/testdata/simple_config/pcl/main.pp
+++ b/pkg/tf2pulumi/convert/testdata/simple_config/pcl/main.pp
@@ -1,0 +1,12 @@
+config numberIn number {
+}
+config stringIn string {
+}
+config boolIn bool {
+}
+config stringListIn "list(string)" {
+}
+config stringMapIn "map(string)" {
+}
+config objectIn "object({first = number, second = string})" {
+}

--- a/pkg/tf2pulumi/convert/tf.go
+++ b/pkg/tf2pulumi/convert/tf.go
@@ -39,6 +39,37 @@ func convertCtyType(typ cty.Type) string {
 	if typ.Equals(cty.String) {
 		return "string"
 	}
+	if typ.IsListType() {
+		elementType := convertCtyType(typ.ElementType())
+		return fmt.Sprintf("list(%s)", elementType)
+	}
+	if typ.IsMapType() {
+		elementType := convertCtyType(typ.ElementType())
+		return fmt.Sprintf("map(%s)", elementType)
+	}
+	if typ.IsSetType() {
+		// handle sets like lists
+		elementType := convertCtyType(typ.ElementType())
+		return fmt.Sprintf("list(%s)", elementType)
+	}
+	if typ.IsObjectType() {
+		attributes := []string{}
+		for attributeKey, attributeType := range typ.AttributeTypes() {
+			attributes = append(attributes, fmt.Sprintf("%s=%s", attributeKey, convertCtyType(attributeType)))
+		}
+
+		attributePairs := ""
+		length := len(attributes)
+		for i, attribute := range attributes {
+			attributePairs = attributePairs + attribute
+			if i < length-1 {
+				// add a comma to all pairs but the last one
+				attributePairs = attributePairs + ", "
+			}
+		}
+
+		return fmt.Sprintf("object({%s})", attributePairs)
+	}
 
 	// If we got here it's probably the "dynamic type" and we just report back "any"
 	return ""


### PR DESCRIPTION
Handle mappings for `list(T)`, `map(T)`, `object({...})` and `set(T)` though sets are mapped to lists for convenience
