### PR TITLE
Update golangci-lint-action to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Build
         run: make build
       - name: Install golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
             version: v1.51.2
       - name: Lint

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build
         run: make build
       - name: Install golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
             version: v1.51.2
       - name: Lint

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -29,7 +29,7 @@ jobs:
         GOPROXY: "https://proxy.golang.org"
       run: go mod download
     - name: Install golangci-lint
-      uses: golangci/golangci-lint-action@v3
+      uses: golangci/golangci-lint-action@v4
       with:
           version: v1.51.2
     - name: Update Pulumi/Pulumi


### PR DESCRIPTION
v3 doesn't seem to be quite working anymore (see https://github.com/pulumi/pulumi-terraform-bridge/actions/runs/4480726203/jobs/7876429264?pr=677)