### PR TITLE
Fix pulumi dependency update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,8 +35,6 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/pulumi/pulumi-java/pkg v0.8.0
 	github.com/pulumi/pulumi-yaml v1.0.4
-	github.com/pulumi/pulumi/pkg/v3 v3.56.0
-	github.com/pulumi/pulumi/sdk/v3 v3.56.0
 	github.com/pulumi/schema-tools v0.1.2
 	github.com/pulumi/terraform-diff-reader v0.0.0-20201211191010-ad4715e9285e
 	github.com/russross/blackfriday/v2 v2.1.0
@@ -187,6 +185,8 @@ require (
 	github.com/pkg/term v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/posener/complete v1.2.3 // indirect
+	github.com/pulumi/pulumi/pkg/v3 v3.58.0
+	github.com/pulumi/pulumi/sdk/v3 v3.58.0
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1652,10 +1652,10 @@ github.com/pulumi/pulumi-java/pkg v0.8.0 h1:b81/D/dk5/9OEH1k5BJxhqYiQc7Y4TPDbHVG
 github.com/pulumi/pulumi-java/pkg v0.8.0/go.mod h1:x7/J1GCJ+hHFBEgnMr4QpsTfjXUNHccAHJ9gvFfmAFU=
 github.com/pulumi/pulumi-yaml v1.0.4 h1:p+989rW3AqkkxbzxtxccHKAN4xCJi3K2cRpvA2K84tw=
 github.com/pulumi/pulumi-yaml v1.0.4/go.mod h1:Szj8ud4Vqyq3oO1n3kzIUfaP3AiCjYZM4FYjOVWwJn8=
-github.com/pulumi/pulumi/pkg/v3 v3.56.0 h1:GAqRHERowIXCTUM2PX2t0G/UKze06WVhv52S8eO2lE8=
-github.com/pulumi/pulumi/pkg/v3 v3.56.0/go.mod h1:l91pIemOEbGBX2tIoVb3r4YlIv3BoTBvyVpECFsVZ3c=
-github.com/pulumi/pulumi/sdk/v3 v3.56.0 h1:OQHb17GwDaLdzffvdr6+1KKRA9PNR8XVWmKkQOEm6Yk=
-github.com/pulumi/pulumi/sdk/v3 v3.56.0/go.mod h1:Pb5H3OaRZg0n4TRIfY0pagR/NBIEvjp3lZe2Spr6Umc=
+github.com/pulumi/pulumi/pkg/v3 v3.58.0 h1:VesuQHe6Rgmp37/tF4FVqIUohvwp+DItzhSdgUFoqbA=
+github.com/pulumi/pulumi/pkg/v3 v3.58.0/go.mod h1:+VE6TqhNUlbwaZ3I3JF9iKOwqoHSvtk7lmCEvXSvJpM=
+github.com/pulumi/pulumi/sdk/v3 v3.58.0 h1:j02FvYlVCAWHGbJ83TXGLwYTPzF2bR4/q1fo038WsFo=
+github.com/pulumi/pulumi/sdk/v3 v3.58.0/go.mod h1:Pb5H3OaRZg0n4TRIfY0pagR/NBIEvjp3lZe2Spr6Umc=
 github.com/pulumi/schema-tools v0.1.2 h1:Fd9xvUjgck4NA+7/jSk7InqCUT4Kj940+EcnbQKpfZo=
 github.com/pulumi/schema-tools v0.1.2/go.mod h1:62lgj52Tzq11eqWTIaKd+EVyYAu5dEcDJxMhTjvMO/k=
 github.com/pulumi/terraform-diff-reader v0.0.0-20201211191010-ad4715e9285e h1:Dik4Qe/+xguB8JagPyXNlbOnRiXGmq/PSPQTGunYnTk=

--- a/pkg/tf2pulumi/convert/eject.go
+++ b/pkg/tf2pulumi/convert/eject.go
@@ -146,7 +146,7 @@ func internalEject(opts EjectOptions) ([]*syntax.File, *pcl.Program, hcl.Diagnos
 		parser := syntax.NewParser()
 		for filename, contents := range generatedFiles {
 			err := parser.ParseFile(bytes.NewReader(contents), filename)
-			contract.Assert(err == nil)
+			contract.Assertf(err == nil, "err != nil")
 		}
 		tf12Files, diagnostics = parser.Files, append(diagnostics, parser.Diagnostics...)
 		if diagnostics.HasErrors() {

--- a/pkg/tf2pulumi/convert/tf12.go
+++ b/pkg/tf2pulumi/convert/tf12.go
@@ -166,14 +166,14 @@ func convertTF12(files []*syntax.File, opts EjectOptions) ([]*syntax.File, *pcl.
 		contents := file.output.String()
 
 		err := pulumiParser.ParseFile(file.output, changeExtension(file.syntax.Name, ".pp"))
-		contract.AssertNoError(err)
+		contract.AssertNoErrorf(err, "err != nil")
 		file.output.Reset()
 
 		if pulumiParser.Diagnostics.HasErrors() {
 			opts.logf("%v", contents)
 			opts.logf("%v", diagnostics)
 			opts.logf("%v", pulumiParser.Diagnostics)
-			contract.Fail()
+			contract.Failf("pulumiParser.Diagnostics.HasErrors()")
 		}
 	}
 
@@ -514,7 +514,7 @@ func (b *tf12binder) bindNode(node tf12Node) hcl.Diagnostics {
 		}
 		return nil
 	})
-	contract.Assert(len(diagnostics) == 0)
+	contract.Assertf(len(diagnostics) == 0, "len(diagnostics) == 0")
 
 	sort.Slice(deps, func(i, j int) bool {
 		return model.SourceOrderLess(deps[i].SyntaxNode().Range(), deps[j].SyntaxNode().Range())
@@ -684,11 +684,11 @@ func (b *tf12binder) annotateExpressionsWithSchemas(item model.BodyItem) {
 						}
 						return x, nil
 					})
-				contract.Assert(len(diags) == 0)
+				contract.Assertf(len(diags) == 0, "len(diags) == 0")
 			}
 			return item, nil
 		})
-	contract.Assert(len(diags) == 0)
+	contract.Assertf(len(diags) == 0, "len(diags) == 0")
 }
 
 func (b *tf12binder) bindBodyItem(item *bodyItem) hcl.Diagnostics {
@@ -1059,7 +1059,7 @@ func (rr *resourceRewriter) push(name string, block bool) *blockInfo {
 }
 
 func (rr *resourceRewriter) pushElem() *blockInfo {
-	contract.Assert(len(rr.stack) > 0)
+	contract.Assertf(len(rr.stack) > 0, "len(rr.stack) > 0")
 	schemas := rr.schemas().ElemSchemas()
 	info := &blockInfo{
 		name:           rr.stack[len(rr.stack)-1].name,
@@ -1194,7 +1194,7 @@ func (rr *resourceRewriter) rewriteBlockAsObjectCons(block *model.Block) *model.
 	objectCons := &model.ObjectConsExpression{Tokens: tokens}
 	for i, item := range block.Body.Items {
 		attr, ok := item.(*model.Attribute)
-		contract.Assert(ok)
+		contract.Assertf(ok, "ok")
 
 		objectCons.Items = append(objectCons.Items, model.ObjectConsItem{
 			Key: &model.LiteralValueExpression{
@@ -1506,7 +1506,7 @@ func (b *tf12binder) rewriteScopeTraversal(n *model.ScopeTraversalExpression,
 	if n.Tokens == nil {
 		n.Tokens = syntax.NewScopeTraversalTokens(n.Traversal)
 	} else {
-		contract.Assert(len(n.Tokens.Traversal) == len(n.Traversal)-1)
+		contract.Assertf(len(n.Tokens.Traversal) == len(n.Traversal)-1, "len(n.Tokens.Traversal) == len(n.Traversal)-1")
 	}
 
 	var newTraverserTokens []syntax.TraverserTokens
@@ -1623,7 +1623,7 @@ func (b *tf12binder) genResource(w io.Writer, r *resource) hcl.Diagnostics {
 		bodyItems := make([]model.BodyItem, 0, len(r.block.Body.Items))
 		for _, item := range r.block.Body.Items {
 			if block, ok := item.(*model.Block); ok {
-				contract.Assert(block.Type == "options")
+				contract.Assertf(block.Type == "options", `block.Type == "options"`)
 				options = block
 				continue
 			}

--- a/pkg/tf2pulumi/convert/tf12_eval.go
+++ b/pkg/tf2pulumi/convert/tf12_eval.go
@@ -23,7 +23,7 @@ func newConditionalAnalyzer() *conditionalAnalyzer {
 
 func (analyzer *conditionalAnalyzer) isConditionalValue(n model.Expression) bool {
 	_, diags := model.VisitExpression(n, model.IdentityVisitor, analyzer.postVisit)
-	contract.Assert(len(diags) == 0)
+	contract.Assertf(len(diags) == 0, "len(diags) == 0")
 	return analyzer.booleanValues.Has(n)
 }
 

--- a/pkg/tf2pulumi/convert/tf12_names.go
+++ b/pkg/tf2pulumi/convert/tf12_names.go
@@ -97,7 +97,7 @@ func (nt *nameTable) disambiguate(name string) string {
 // assignOutput assigns an unambiguous name to an output node.
 func (nt *nameTable) assignOutput(n *output) {
 	name := nt.pulumiName(n.name)
-	contract.Assert(!nt.assigned[name])
+	contract.Assertf(!nt.assigned[name], "!nt.assigned[name]")
 
 	n.pulumiName, nt.assigned[name] = name, true
 }

--- a/pkg/tf2pulumi/gen/util.go
+++ b/pkg/tf2pulumi/gen/util.go
@@ -25,8 +25,8 @@ import (
 func SortedKeys(m interface{}) []string {
 	mv := reflect.ValueOf(m)
 
-	contract.Require(mv.Type().Kind() == reflect.Map, "m")
-	contract.Require(mv.Type().Key().Kind() == reflect.String, "m")
+	contract.Requiref(mv.Type().Kind() == reflect.Map, "m", "mv.Type().Kind() == reflect.Map")
+	contract.Requiref(mv.Type().Key().Kind() == reflect.String, "m", "mv.Type().Key().Kind() == reflect.String")
 
 	keys := make([]string, mv.Len())
 	for i, k := range mv.MapKeys() {

--- a/pkg/tf2pulumi/il/binder_properties.go
+++ b/pkg/tf2pulumi/il/binder_properties.go
@@ -40,7 +40,7 @@ type propertyBinder struct {
 // rather than the list itself. Note that this implies that the result of this function is not necessarily of
 // type TypeList.
 func (b *propertyBinder) bindListProperty(path string, s reflect.Value, sch Schemas) (BoundNode, error) {
-	contract.Require(s.Kind() == reflect.Slice, "s")
+	contract.Requiref(s.Kind() == reflect.Slice, "s", "s.Kind() == reflect.Slice")
 
 	// Grab the element schemas.
 	elemSchemas := sch.ElemSchemas()
@@ -92,7 +92,7 @@ func (b *propertyBinder) bindListProperty(path string, s reflect.Value, sch Sche
 
 // bindMapProperty binds a map property according to the given schema.
 func (b *propertyBinder) bindMapProperty(path string, m reflect.Value, sch Schemas) (*BoundMapProperty, error) {
-	contract.Require(m.Kind() == reflect.Map, "m")
+	contract.Requiref(m.Kind() == reflect.Map, "m", "m.Kind() == reflect.Map")
 
 	// Grab the key type and ensure it is of type string.
 	if m.Type().Key().Kind() != reflect.String {
@@ -135,7 +135,7 @@ func (b *propertyBinder) bindProperty(path string, p reflect.Value, sch Schemas)
 		if err != nil {
 			return nil, errors.Errorf("%v: could not parse HIL (%v)", path, err)
 		}
-		contract.Assert(rootNode != nil)
+		contract.Assertf(rootNode != nil, "rootNode != nil")
 		n, err := b.bindExpr(rootNode)
 		if err != nil {
 			return nil, errors.Errorf("%v: %v", path, err)

--- a/pkg/tf2pulumi/il/graph.go
+++ b/pkg/tf2pulumi/il/graph.go
@@ -541,7 +541,7 @@ func (b *builder) bindProperty(
 		}
 		return n, nil
 	})
-	contract.Assert(err == nil)
+	contract.Assertf(err == nil, "err == nil")
 
 	return prop, deps, nil
 }
@@ -619,7 +619,7 @@ func (b *builder) buildModule(m *ModuleNode) error {
 		providers = append(providers, p)
 	}
 	allDeps, _, err := b.buildDeps(deps, nil, providers)
-	contract.Assert(err == nil)
+	contract.Assertf(err == nil, "err == nil")
 
 	m.Properties, m.Deps = props, allDeps
 	return nil
@@ -643,7 +643,7 @@ func (b *builder) buildProvider(p *ProviderNode) error {
 		return err
 	}
 	allDeps, _, err := b.buildDeps(deps, nil, nil)
-	contract.Assert(err == nil)
+	contract.Assertf(err == nil, "err == nil")
 
 	p.Properties, p.Deps = props, allDeps
 	return nil
@@ -860,7 +860,7 @@ func (b *builder) buildLocal(l *LocalNode) error {
 		return err
 	}
 	allDeps, _, err := b.buildDeps(deps, nil, nil)
-	contract.Assert(err == nil)
+	contract.Assertf(err == nil, "err == nil")
 
 	// In general, a local should have a single property named "value". If this is the case, promote it to the
 	// local's value.

--- a/pkg/tf2pulumi/il/graph_comments.go
+++ b/pkg/tf2pulumi/il/graph_comments.go
@@ -392,15 +392,15 @@ func processBlockComment(text string) []string {
 		switch i {
 		case 0:
 			start := blockStartPat.FindString(l)
-			contract.Assert(start != "")
+			contract.Assertf(start != "", "start != \"\"")
 			l = l[len(start):]
 
 			// If this is a single-line block comment, trim the end pattern as well.
 			if len(lines) == 1 {
-				contract.Assert(prefix == "")
+				contract.Assertf(prefix == "", "prefix == \"\"")
 
 				end := blockEndPat.FindString(l)
-				contract.Assert(end != "")
+				contract.Assertf(end != "", "end != \"\"")
 				l = l[:len(l)-len(end)]
 			}
 		case len(lines) - 1:
@@ -411,7 +411,7 @@ func processBlockComment(text string) []string {
 			} else {
 				l = l[len(prefix):]
 				end := blockEndPat.FindString(l)
-				contract.Assert(end != "")
+				contract.Assertf(end != "", "end != \"\"")
 				l = l[:len(l)-len(end)]
 			}
 		default:

--- a/pkg/tf2pulumi/il/intrinsics.go
+++ b/pkg/tf2pulumi/il/intrinsics.go
@@ -50,7 +50,7 @@ func NewApplyCall(args []*BoundVariableAccess, then BoundExpr) *BoundCall {
 
 // ParseApplyCall extracts the apply arguments and the continuation from a call to the apply intrinsic.
 func ParseApplyCall(c *BoundCall) (applyArgs []*BoundVariableAccess, then BoundExpr) {
-	contract.Assert(c.Func == IntrinsicApply)
+	contract.Assertf(c.Func == IntrinsicApply, "c.Func == IntrinsicApply")
 
 	args := make([]*BoundVariableAccess, len(c.Args)-1)
 	for i, a := range c.Args[:len(args)] {
@@ -62,7 +62,7 @@ func ParseApplyCall(c *BoundCall) (applyArgs []*BoundVariableAccess, then BoundE
 
 // NewApplyArgCall returns a new IL tree that represents a call to IntrinsicApplyArg.
 func NewApplyArgCall(argIndex int, argType Type) *BoundCall {
-	contract.Assert(!argType.IsOutput())
+	contract.Assertf(!argType.IsOutput(), "!argType.IsOutput()")
 	return &BoundCall{
 		Func:     IntrinsicApplyArg,
 		ExprType: argType,
@@ -72,7 +72,7 @@ func NewApplyArgCall(argIndex int, argType Type) *BoundCall {
 
 // ParseapplyArgCall extracts the argument index from a call to the apply arg intrinsic.
 func ParseApplyArgCall(c *BoundCall) int {
-	contract.Assert(c.Func == IntrinsicApplyArg)
+	contract.Assertf(c.Func == IntrinsicApplyArg, "c.Func == IntrinsicApplyArg")
 	return c.Args[0].(*BoundLiteral).Value.(int)
 }
 
@@ -87,7 +87,7 @@ func NewArchiveCall(arg BoundExpr) *BoundCall {
 
 // ParseArchiveCall extracts the single argument expression from a call to the archive intrinsic.
 func ParseArchiveCall(c *BoundCall) (arg BoundExpr) {
-	contract.Assert(c.Func == IntrinsicArchive)
+	contract.Assertf(c.Func == IntrinsicArchive, "c.Func == IntrinsicArchive")
 	return c.Args[0]
 }
 
@@ -102,7 +102,7 @@ func NewAssetCall(arg BoundExpr) *BoundCall {
 
 // ParseAssetCall extracts the single argument expression from a call to the asset intrinsic.
 func ParseAssetCall(c *BoundCall) (arg BoundExpr) {
-	contract.Assert(c.Func == IntrinsicAsset)
+	contract.Assertf(c.Func == IntrinsicAsset, "c.Func == IntrinsicAsset")
 	return c.Args[0]
 }
 
@@ -119,7 +119,7 @@ func NewCoerceCall(value BoundExpr, toType Type) *BoundCall {
 // ParseCoerceCall extracts the value being coerced and the type to which it is being coerced from a call to the coerce
 // intrinsic.
 func ParseCoerceCall(c *BoundCall) (value BoundExpr, toType Type) {
-	contract.Assert(c.Func == IntrinsicCoerce)
+	contract.Assertf(c.Func == IntrinsicCoerce, "c.Func == IntrinsicCoerce")
 	return c.Args[0], c.ExprType
 }
 

--- a/pkg/tf2pulumi/il/rewriters.go
+++ b/pkg/tf2pulumi/il/rewriters.go
@@ -49,7 +49,7 @@ func (r *applyRewriter) rewriteBoundVariableAccess(n *BoundVariableAccess) (Boun
 
 // rewriteRoot replaces the root node in a bound expression with a call to the __apply intrinsic if necessary.
 func (r *applyRewriter) rewriteRoot(n BoundExpr) (BoundNode, error) {
-	contract.Require(n == r.root, "n")
+	contract.Requiref(n == r.root, "n", "n == r.root")
 
 	// Clear the root context so that future calls to enterNode recognize new expression roots.
 	r.root = nil
@@ -254,7 +254,7 @@ func MarkPromptDataSources(g *Graph) map[*ResourceNode]bool {
 					containsOutputs = containsOutputs || n.Type().IsOutput()
 					return n, nil
 				})
-				contract.Assert(err == nil)
+				contract.Assertf(err == nil, `err == nil`)
 
 				if !containsOutputs && !promptDataSources[r] {
 					promptDataSources[r] = true
@@ -279,7 +279,7 @@ func MarkPromptDataSources(g *Graph) map[*ResourceNode]bool {
 			}
 			return n, nil
 		})
-		contract.Assert(err == nil)
+		contract.Assertf(err == nil, `err == nil`)
 	}
 
 }

--- a/pkg/tfbridge/assets.go
+++ b/pkg/tfbridge/assets.go
@@ -124,7 +124,7 @@ func (a *AssetTranslation) IsArchive() bool {
 
 // TranslateAsset translates the given asset using the directives provided by the translation info.
 func (a *AssetTranslation) TranslateAsset(asset *resource.Asset) (interface{}, error) {
-	contract.Assert(a.IsAsset())
+	contract.Assertf(a.IsAsset(), "a.IsAsset()")
 
 	// TODO[pulumi/pulumi#153]: support HashField.
 

--- a/pkg/tfbridge/log.go
+++ b/pkg/tfbridge/log.go
@@ -100,7 +100,7 @@ func (lr *LogRedirector) Write(p []byte) (n int, err error) {
 		if !has || !lr.enabled {
 			// If there was no writer for this label, or logging is disabled, use the debug label.
 			w = lr.writers[tfDebugPrefix]
-			contract.Assert(w != nil)
+			contract.Assertf(w != nil, "w != nil")
 		}
 		if err := w(s); err != nil {
 			return written, err

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -78,7 +78,7 @@ type Resource struct {
 // with no error should be interpreted by the caller as meaning the resource does not exist,
 // but there were no errors in determining this.
 func (res *Resource) runTerraformImporter(id string, provider *Provider) (shim.InstanceState, error) {
-	contract.Assert(res.TF.Importer() != nil)
+	contract.Assertf(res.TF.Importer() != nil, "res.TF.Importer() != nil")
 
 	// Run the importer defined in the Terraform resource schema
 	states, err := res.TF.Importer()(res.TFName, id, provider.tf.Meta())

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -460,7 +460,7 @@ func (ctx *conversionContext) MakeTerraformInputs(olds, news resource.PropertyMa
 
 		// First translate the Pulumi property name to a Terraform name.
 		name, tfi, psi := getInfoFromPulumiName(key, tfs, ps, rawNames)
-		contract.Assert(name != "")
+		contract.Assertf(name != "", `name != ""`)
 		if _, duplicate := result[name]; duplicate {
 			// If multiple Pulumi `key`s map to the same Terraform attribute `name`, then
 			// this function's output is dependent on the iteration order of `news`, and
@@ -850,7 +850,7 @@ func MakeTerraformResult(p shim.Provider, state shim.InstanceState,
 	// If there is any Terraform metadata associated with this state, record it.
 	if state != nil && len(state.Meta()) != 0 {
 		metaJSON, err := json.Marshal(state.Meta())
-		contract.Assert(err == nil)
+		contract.Assertf(err == nil, "err == nil")
 		outMap[metaKey] = resource.NewStringProperty(string(metaJSON))
 	}
 
@@ -867,7 +867,7 @@ func MakeTerraformOutputs(p shim.Provider, outs map[string]interface{},
 	for key, value := range outs {
 		// First do a lookup of the name/info.
 		name, tfi, psi := getInfoFromTerraformName(key, tfs, ps, rawNames)
-		contract.Assert(name != "")
+		contract.Assertf(name != "", `name != ""`)
 
 		// Next perform a translation of the value accordingly.
 		out := MakeTerraformOutput(p, value, tfi, psi, assets, rawNames, supportsSecrets)
@@ -894,7 +894,7 @@ func MakeTerraformOutput(p shim.Provider, v interface{},
 		if assets != nil && ps != nil && ps.Asset != nil {
 			if asset, has := assets[ps]; has {
 				// if we have the value, it better actually be an asset or an archive.
-				contract.Assert(asset.IsAsset() || asset.IsArchive())
+				contract.Assertf(asset.IsAsset() || asset.IsArchive(), "asset.IsAsset() || asset.IsArchive()")
 				return asset
 			}
 
@@ -976,7 +976,7 @@ func MakeTerraformOutput(p shim.Provider, v interface{},
 		case reflect.Map:
 			outs := map[string]interface{}{}
 			for _, key := range val.MapKeys() {
-				contract.Assert(key.Kind() == reflect.String)
+				contract.Assertf(key.Kind() == reflect.String, "key.Kind() == reflect.String")
 				outs[key.String()] = val.MapIndex(key).Interface()
 			}
 			var tfflds shim.SchemaMap

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -1308,9 +1308,9 @@ func (g *Generator) convertHCLToString(hcl, path, languageName string) (string, 
 	input := afero.NewMemMapFs()
 	fileName := fmt.Sprintf("/%s.tf", strings.ReplaceAll(path, "/", "-"))
 	f, err := input.Create(fileName)
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "err != nil")
 	_, err = f.Write([]byte(hcl))
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "err != nil")
 	contract.IgnoreClose(f)
 
 	files, diags, err := g.convert(input, languageName)
@@ -1338,7 +1338,7 @@ func (g *Generator) convertHCLToString(hcl, path, languageName string) (string, 
 		return "", fmt.Errorf(errMsg)
 	}
 
-	contract.Assert(len(files) == 1)
+	contract.Assertf(len(files) == 1, `len(files) == 1`)
 
 	convertedHcl := ""
 	for _, output := range files {

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -1601,7 +1601,7 @@ func resourceName(provider string, rawname string,
 
 // withoutPackageName strips off the package prefix from a raw name.
 func withoutPackageName(pkg string, rawname string) string {
-	contract.Assert(strings.HasPrefix(rawname, pkg+"_"))
+	contract.Assertf(strings.HasPrefix(rawname, pkg+"_"), `strings.HasPrefix(rawname, pkg+"_")`)
 	name := rawname[len(pkg)+1:] // strip off the pkg prefix.
 	return name
 }

--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -93,7 +93,7 @@ func (nt *schemaNestedTypes) gatherFromMember(member moduleMember) {
 		nt.gatherFromProperties(p.Args(), member, member.name, member.args, true)
 		nt.gatherFromProperties(p.Results(), member, member.name, member.rets, false)
 	case *variable:
-		contract.Assert(member.config)
+		contract.Assertf(member.config, `member.config`)
 		p := paths.NewProperyPath(paths.NewConfigPath(), member.propertyName)
 		nt.gatherFromPropertyType(p, member, member.name, "", member.typ, false)
 	}
@@ -193,7 +193,7 @@ func (nt *schemaNestedTypes) gatherFromPropertyType(typePath paths.TypePath, dec
 
 func rawMessage(v interface{}) pschema.RawMessage {
 	bytes, err := json.Marshal(v)
-	contract.Assert(err == nil)
+	contract.Assertf(err == nil, `err == nil`)
 	return pschema.RawMessage(bytes)
 }
 
@@ -256,7 +256,7 @@ func (g *schemaGenerator) genPackageSpec(pack *pkg) (pschema.PackageSpec, error)
 			case *resourceFunc:
 				spec.Functions[string(t.info.Tok)] = g.genDatasourceFunc(mod.name, t)
 			case *variable:
-				contract.Assert(mod.config())
+				contract.Assertf(mod.config(), `mod.config()`)
 				config = append(config, t)
 			}
 		}
@@ -638,7 +638,7 @@ func setEquals(a, b codegen.StringSet) bool {
 
 func (g *schemaGenerator) genObjectTypeToken(typInfo *schemaNestedType) string {
 	typ := typInfo.typ
-	contract.Assert(typ.kind == kindObject)
+	contract.Assertf(typ.kind == kindObject, `typ.kind == kindObject`)
 
 	name := typ.name
 	if typ.nestedType != "" {
@@ -655,7 +655,7 @@ func (g *schemaGenerator) genObjectTypeToken(typInfo *schemaNestedType) string {
 
 func (g *schemaGenerator) genObjectType(typInfo *schemaNestedType, isTopLevel bool) pschema.ObjectTypeSpec {
 	typ := typInfo.typ
-	contract.Assert(typ.kind == kindObject)
+	contract.Assertf(typ.kind == kindObject, `typ.kind == kindObject`)
 
 	spec := pschema.ObjectTypeSpec{
 		Type: "object",
@@ -783,7 +783,7 @@ func (g *schemaGenerator) schemaType(path paths.TypePath, typ *propertyType, out
 	switch typ.kind {
 	case kindBool, kindInt, kindFloat, kindString:
 		t := g.schemaPrimitiveType(typ.kind)
-		contract.Assert(t != "")
+		contract.Assertf(t != "", `t != ""`)
 		return pschema.TypeSpec{Type: t}
 	case kindSet, kindList:
 		items := g.schemaType(paths.NewElementPath(path), typ.element, out)

--- a/pkg/tfgen/main.go
+++ b/pkg/tfgen/main.go
@@ -198,7 +198,7 @@ func newTFGenCmd(pkg string, version string, prov tfbridge.ProviderInfo,
 		&overlaysDir, "overlays", "",
 		"Use the target directory for overlays rather than the default of overlays/ (unsupported)")
 	err := cmd.PersistentFlags().MarkHidden("overlays")
-	contract.AssertNoError(err)
+	contract.AssertNoErrorf(err, "err != nil")
 
 	return cmd
 }

--- a/pkg/tfshim/tfplugin5/cty.go
+++ b/pkg/tfshim/tfplugin5/cty.go
@@ -54,8 +54,8 @@ func ctyToGo(val cty.Value) (interface{}, error) {
 		for iter.Next() {
 			k, v := iter.Element()
 
-			contract.Assert(k.Type() == cty.String)
-			contract.Assert(!k.IsNull())
+			contract.Assertf(k.Type() == cty.String, "k.Type() == cty.String")
+			contract.Assertf(!k.IsNull(), "!k.IsNull()")
 			if !k.IsKnown() {
 				return UnknownVariableValue, nil
 			}

--- a/pkg/tfshim/tfplugin5/instance_diff.go
+++ b/pkg/tfshim/tfplugin5/instance_diff.go
@@ -192,7 +192,7 @@ func pathString(path *proto.AttributePath) string {
 }
 
 func primitiveString(value cty.Value) string {
-	contract.Assert(value.Type().IsPrimitiveType())
+	contract.Assertf(value.Type().IsPrimitiveType(), "value.Type().IsPrimitiveType()")
 
 	switch {
 	case value.IsNull():
@@ -312,8 +312,8 @@ func (d *differ) addValue(path string, value cty.Value, requiresNew bool) {
 
 		d.addValue(d.extendPath(path, "%"), value.Length(), requiresNew)
 		rangeValue(value, func(key, value cty.Value) {
-			contract.Assert(key.Type() == cty.String)
-			contract.Assert(key.IsKnown())
+			contract.Assertf(key.Type() == cty.String, "key.Type() == cty.String")
+			contract.Assertf(key.IsKnown(), "key.IsKnown()")
 			d.addValue(d.extendPath(path, key.AsString()), value, requiresNew)
 		})
 	case value.Type().IsObjectType():
@@ -363,8 +363,8 @@ func (d *differ) removeValue(path string, value cty.Value, requiresNew bool) {
 	case value.Type().IsMapType():
 		d.removeValue(d.extendPath(path, "%"), value.Length(), requiresNew)
 		rangeValue(value, func(key, value cty.Value) {
-			contract.Assert(key.Type() == cty.String)
-			contract.Assert(key.IsKnown())
+			contract.Assertf(key.Type() == cty.String, "key.Type() == cty.String")
+			contract.Assertf(key.IsKnown(), "key.IsKnown()")
 			d.removeValue(d.extendPath(path, key.AsString()), value, requiresNew)
 		})
 	case value.Type().IsObjectType():

--- a/pkg/tfshim/tfplugin5/marshal.go
+++ b/pkg/tfshim/tfplugin5/marshal.go
@@ -82,7 +82,7 @@ func unmarshalCompositeType(ty cty.Type) (shim.ValueType, interface{}, error) {
 				properties[name] = s
 			} else {
 				r, isResource := property.(*resource)
-				contract.Assert(isResource)
+				contract.Assertf(isResource, "isResource")
 				properties[name] = &attributeSchema{
 					ctyType:   r.ctyType,
 					valueType: shim.TypeMap,

--- a/scripts/build.go
+++ b/scripts/build.go
@@ -98,7 +98,7 @@ func execCommandOrLogFatal(cwd, name string, arg ...string) {
 // Finds directories containing go.mod files in the repository.
 func findGoModuleRoots() (result []string) {
 	var buf bytes.Buffer
-	cmd := exec.Command("git", "ls-files", "-z", "**/go.mod")
+	cmd := exec.Command("git", "ls-files", "-z", "**go.mod")
 	cmd.Dir = "."
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = &buf


### PR DESCRIPTION
Due to an issue with an auto-upgrade script, dependencies in top-level go.mod did not yet get updated. And once they did, there was a lot more lint work to do to make the linter pass. 