### PR TITLE
Don't Base64 Encode Metadata

### DIFF
--- a/unstable/metadata/metadata_test.go
+++ b/unstable/metadata/metadata_test.go
@@ -1,0 +1,37 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarshal(t *testing.T) {
+	data, err := New(nil)
+	require.NoError(t, err)
+
+	err = Set(data, "hi", []string{"hello", "world"})
+	assert.NoError(t, err)
+
+	assert.Equal(t, `{
+    "hi": [
+        "hello",
+        "world"
+    ]
+}`, string(data.Marshal()))
+}


### PR DESCRIPTION
This provides a much more debuggable and diff friendly result.