### PR TITLE
Migrate off setup-pulumi

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Install pulumi
-        uses: pulumi/setup-pulumi@v2
+        uses: pulumi/actions@v4
         with:
           pulumi-version: ^3.0.0
       - name: Check out source code

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -28,7 +28,7 @@ jobs:
           cache-dependency-path: |
             **/go.sum
       - name: Install pulumi
-        uses: pulumi/setup-pulumi@v2
+        uses: pulumi/actions@v4
         with:
           pulumi-version: ^3.0.0
       - name: Build


### PR DESCRIPTION
This PR moves CI from `setup-pulumi` to the default action. `setup-pulumi` is deprecated since the pulumi action has subsumed its behavior.