### PR TITLE
Improves Plugin Framework bridge interop with tf2pulumi.

### DIFF
--- a/pf/tests/provider_get_mapping_test.go
+++ b/pf/tests/provider_get_mapping_test.go
@@ -1,0 +1,57 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfbridgetests
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi-terraform-bridge/pf/tests/internal/testprovider"
+	"github.com/pulumi/pulumi-terraform-bridge/pf/tfbridge"
+	tfbridge0 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+)
+
+func TestGetMapping(t *testing.T) {
+	ctx := context.Background()
+	info := testprovider.RandomProvider()
+
+	p, err := tfbridge.NewProvider(ctx, info, genMetadata(t, info))
+	assert.NoError(t, err)
+
+	{
+		m, p, err := p.GetMappingWithContext(ctx, "unknown-key")
+		assert.NoError(t, err)
+		assert.Empty(t, m)
+		assert.Empty(t, p)
+	}
+
+	for _, key := range []string{"tf", "terraform"} {
+		m, p, err := p.GetMappingWithContext(ctx, key)
+		assert.NoError(t, err)
+
+		assert.Equal(t, "random", p)
+
+		var info tfbridge0.MarshallableProviderInfo
+		err = json.Unmarshal(m, &info)
+		assert.NoError(t, err)
+
+		assert.Equal(t, "random", info.Name)
+		assert.Contains(t, info.Resources, "random_integer")
+		assert.Equal(t, "random:index/randomInteger:RandomInteger", string(info.Resources["random_integer"].Tok))
+	}
+}

--- a/pf/tfbridge/main.go
+++ b/pf/tfbridge/main.go
@@ -56,12 +56,12 @@ func Main(ctx context.Context, pkg string, prov ProviderInfo, meta ProviderMetad
 	}
 
 	if *dumpInfo {
-		// TODO[pulumi/pulumi-terraform-bridge#819] port MarshalProviderInfo
-		//
-		// if err := json.NewEncoder(os.Stdout).Encode(MarshalProviderInfo(&prov)); err != nil {
-		// 	cmdutil.ExitError(err.Error())
-		// }
-		if err := json.NewEncoder(os.Stdout).Encode([]int{}); err != nil {
+		pp, err := NewProvider(ctx, prov, meta)
+		if err != nil {
+			cmdutil.ExitError(err.Error())
+		}
+		info := pp.(*provider).marshalProviderInfo(ctx)
+		if err := json.NewEncoder(os.Stdout).Encode(info); err != nil {
 			cmdutil.ExitError(err.Error())
 		}
 		os.Exit(0)

--- a/pf/tfbridge/provider.go
+++ b/pf/tfbridge/provider.go
@@ -227,10 +227,6 @@ func newProviderServer6(ctx context.Context, p pfprovider.Provider) (tfprotov6.P
 	return server6, nil
 }
 
-func (p *provider) GetMappingWithContext(_ context.Context, key string) ([]byte, string, error) {
-	return []byte{}, "", nil
-}
-
 type packageSpec struct {
 	spec *pschema.PackageSpec
 }

--- a/pf/tfbridge/provider_get_mapping.go
+++ b/pf/tfbridge/provider_get_mapping.go
@@ -1,0 +1,47 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfbridge
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/pulumi/pulumi-terraform-bridge/pf/internal/schemashim"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+)
+
+func (p *provider) GetMappingWithContext(ctx context.Context, key string) ([]byte, string, error) {
+	// Code and comments follow Provider.GetMapping in pkg/tfbridge/provider.go
+
+	// The prototype converter uses the key "tf", but the new plugin converter uses "terraform". For now support
+	// both, eventually we can remove the "tf" key.
+	if key == "tf" || key == "terraform" {
+		info := p.marshalProviderInfo(ctx)
+		mapping, err := json.Marshal(info)
+		if err != nil {
+			return nil, "", err
+		}
+		return mapping, p.info.Name, nil
+	}
+
+	// An empty response is valid for GetMapping, it means we don't have a mapping for the given key
+	return []byte{}, "", nil
+}
+
+func (p *provider) marshalProviderInfo(ctx context.Context) *tfbridge.MarshallableProviderInfo {
+	var providerInfoCopy tfbridge.ProviderInfo = p.info.ProviderInfo
+	providerInfoCopy.P = schemashim.ShimSchemaOnlyProvider(ctx, p.tfProvider)
+	return tfbridge.MarshalProviderInfo(&providerInfoCopy)
+}


### PR DESCRIPTION
Implements GetMapping call for Plugin Framework bridged providers to correctly respond to "tf" and "terraform" key requests. Also enables these providers to dump MarshallableProviderInfo when requested to do so with the "get-provider-info" command-line flag.

Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/819