### PR TITLE
Fix broken workflow

### DIFF
--- a/.github/workflows/update-providers-ci-mgmt.yml
+++ b/.github/workflows/update-providers-ci-mgmt.yml
@@ -1,4 +1,11 @@
 name: Update Providers with new bridge version via ci-mgmt
 on:
   workflow_dispatch:
-    
+jobs:
+  update-providers:
+    name: update-providers
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@master
+    # TBD


### PR DESCRIPTION
This workflow has been sending alerts because it has no jobs defined, which is invalid.