### PR TITLE
Do not warn on ExtraConfig, ExtraTypes, ExtraFunctions, ExtraResources

### DIFF
--- a/pf/tfgen/not_supported.go
+++ b/pf/tfgen/not_supported.go
@@ -57,10 +57,6 @@ func notSupported(sink diag.Sink, prov tfbridge.ProviderInfo) error {
 		}
 	}
 
-	u.assertNotZero("ExtraConfig", prov.ExtraConfig)
-	u.assertNotZero("ExtraTypes", prov.ExtraTypes)
-	u.assertNotZero("ExtraResources", prov.ExtraResources)
-	u.assertNotZero("ExtraFunctions", prov.ExtraFunctions)
 	u.assertNotZero("PreConfigureCallback", prov.PreConfigureCallback)
 	u.assertNotZero("PreConfigureCallbackWithLogger", prov.PreConfigureCallbackWithLogger)
 


### PR DESCRIPTION
Part of #828 

It appears that these are tfgen-only features so should work in Plugin Framework case. The ExtraConfig is special as the bridge does consult it at runtime to filter out extraneous properties when configuring the provider. PF does not need to do this since the serializer is schema-driven and ignores properties it does not understand. So we do not need to warn on these things. 