### PR TITLE
Deprecate IDFields

### DIFF
--- a/pf/tfgen/not_supported.go
+++ b/pf/tfgen/not_supported.go
@@ -97,7 +97,6 @@ func (u *notSupportedUtil) datasource(path string, ds *tfbridge.DataSourceInfo) 
 
 func (u *notSupportedUtil) resource(path string, res *tfbridge.ResourceInfo) {
 	u.fields(path, res.Fields)
-	u.assertNotZero(path+".IDFields", res.IDFields)
 	u.assertNotZero(path+".UniqueNameFields", res.UniqueNameFields)
 	u.assertNotZero(path+".Docs", res.Docs)
 	u.assertNotZero(path+".DeleteBeforeReplace", res.DeleteBeforeReplace)

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -179,9 +179,13 @@ type ResourceOrDataSourceInfo interface {
 // also give custom metadata for fields, using the SchemaInfo structure below.  Finally, a set of composite keys can be
 // given; this is used when Terraform needs more than just the ID to uniquely identify and query for a resource.
 type ResourceInfo struct {
-	Tok      tokens.Type            // a type token to override the default; "" uses the default.
-	Fields   map[string]*SchemaInfo // a map of custom field names; if a type is missing, uses the default.
-	IDFields []string               // an optional list of ID alias fields.
+	Tok    tokens.Type            // a type token to override the default; "" uses the default.
+	Fields map[string]*SchemaInfo // a map of custom field names; if a type is missing, uses the default.
+
+	// Deprecated: IDFields is not currently used and will be removed in the next major version of
+	// pulumi-terraform-bridge.
+	IDFields []string
+
 	// list of parameters that we can trust that any change will allow a createBeforeDelete
 	UniqueNameFields    []string
 	Docs                *DocInfo    // overrides for finding and mapping TF docs.
@@ -705,9 +709,12 @@ func (m *MarshallableDefaultInfo) Unmarshal() *DefaultInfo {
 
 // MarshallableResourceInfo is the JSON-marshallable form of a Pulumi ResourceInfo value.
 type MarshallableResourceInfo struct {
-	Tok      tokens.Type                        `json:"tok"`
-	Fields   map[string]*MarshallableSchemaInfo `json:"fields"`
-	IDFields []string                           `json:"idFields"`
+	Tok    tokens.Type                        `json:"tok"`
+	Fields map[string]*MarshallableSchemaInfo `json:"fields"`
+
+	// Deprecated: IDFields is not currently used and will be deprecated in the next major version of
+	// pulumi-terraform-bridge.
+	IDFields []string `json:"idFields"`
 }
 
 // MarshalResourceInfo converts a Pulumi ResourceInfo value into a MarshallableResourceInfo value.


### PR DESCRIPTION
A search across Pulumi org repos finds no usage of this field, introduced in 2017.