### PR TITLE
Fix Elem marshalling to support empty resource turnaround

### DIFF
--- a/pkg/tfbridge/info_test.go
+++ b/pkg/tfbridge/info_test.go
@@ -1,8 +1,11 @@
 package tfbridge
 
 import (
+	"encoding/json"
 	"testing"
 
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	shimschema "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
 )
@@ -121,4 +124,68 @@ func TestConfigArrayValue(t *testing.T) {
 	assert.Equal(t, []string{"tangerine", "quince", "peach"}, ConfigArrayValue(testConf, "FRUIT_SALAD", testEnvs))
 	assert.Equal(t, []string(nil), ConfigArrayValue(testConf, "FRUIT_SALAD", emptyEnvs))
 	assert.Equal(t, []string(nil), ConfigArrayValue(testConf, "idontlikefruitsalad", emptyEnvs))
+}
+
+func TestMarshalElem(t *testing.T) {
+	turnaround := func(elem interface{}) interface{} {
+		me := MarshallableSchema{Elem: MarshalElem(elem)}
+		bytes, err := json.Marshal(me)
+		if err != nil {
+			panic(err)
+		}
+		t.Logf("me: %#v", me.Elem)
+		t.Logf("bytes: %s", string(bytes))
+		var meBack MarshallableSchema
+		err = json.Unmarshal(bytes, &meBack)
+		t.Logf("meBack: %#v", meBack.Elem)
+		if err != nil {
+			panic(err)
+		}
+		return meBack.Elem.Unmarshal()
+	}
+
+	t.Run("nil", func(t *testing.T) {
+		assert.Nil(t, turnaround(nil))
+	})
+
+	t.Run("emptySchema", func(t *testing.T) {
+		var emptySchema shim.Schema = (&shimschema.Schema{}).Shim()
+		actual := turnaround(emptySchema)
+		s, ok := actual.(shim.Schema)
+		assert.True(t, ok)
+		assert.Equal(t, emptySchema, s)
+	})
+
+	t.Run("simpleSchema", func(t *testing.T) {
+		var simpleSchema shim.Schema = (&shimschema.Schema{
+			Type: shim.TypeInt,
+		}).Shim()
+		actual := turnaround(simpleSchema)
+		s, ok := actual.(shim.Schema)
+		assert.True(t, ok)
+		assert.Equal(t, simpleSchema, s)
+	})
+
+	t.Run("emptyResource", func(t *testing.T) {
+		var emptyResource shim.Resource = (&shimschema.Resource{}).Shim()
+		actual := turnaround(emptyResource)
+		r, ok := actual.(shim.Resource)
+		assert.True(t, ok)
+		assert.Equal(t, 0, r.Schema().Len())
+	})
+
+	t.Run("simpleResource", func(t *testing.T) {
+		var simpleResource shim.Resource = (&shimschema.Resource{
+			SchemaVersion: 1,
+			Schema: (&shimschema.SchemaMap{
+				"k": (&shimschema.Schema{
+					Type: shim.TypeInt,
+				}).Shim(),
+			}),
+		}).Shim()
+		actual := turnaround(simpleResource)
+		r, ok := actual.(shim.Resource)
+		assert.True(t, ok)
+		assert.Equal(t, shim.TypeInt, r.Schema().Get("k").Type())
+	})
 }


### PR DESCRIPTION
@Frassle discovered a bug where MarshalElem does not turnaround through JSON on empty resources. A resource came up in:

```
                            "connector_profile_properties": {
                                "type": 5,
                                "required": true,
                                "element": {
                                    "resource": {
                                        "amplitude": {
                                            "type": 5,
                                            "optional": true,
                                            "element": {},
                                            "maxItems": 1
                                        },
``` 

> That maps to an empty object in the codegen (see ConnectorProfileConnectorProfileConfigConnectorProfilePropertiesAmplitude type in the aws typescript sdk for example)

The problem is with this type:

```
type MarshallableElem struct {
	Schema   *MarshallableSchema  `json:"schema,omitempty"`
	Resource MarshallableResource `json:"resource,omitempty"`
}
```

Logically it has to represent three distinct cases. 1. `nil`; 2. `Schema`; 3. `Resource` - see the semantic distinction documented on `Elem()`.

However due to `omitempty` on Resource empty resources get the nil and Resource cases confused.

We expect the marshal facility to turn around all the semantic cases. 

The PR exploits the distinction between case 1 being serialized as `null` in JSON and case 3 on empty resource being serialized as `{}`. To make the distinction matter a custom UnmarshalJSON serializer is added. Test cases are added to check marshal turnaround for Resource, Schema and nil. 