### PR TITLE
Make eject error message more correct

### DIFF
--- a/pkg/tf2pulumi/convert/eject.go
+++ b/pkg/tf2pulumi/convert/eject.go
@@ -116,10 +116,10 @@ func ejectWithOpts(dir string, loader schema.ReferenceLoader, mapper convert.Map
 		}
 	}
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to load Terraform configuration, %v", err)
+		return nil, nil, fmt.Errorf("failed to convert Terraform configuration, %v", err)
 	}
 	if diags.HasErrors() {
-		return nil, nil, fmt.Errorf("failed to load Terraform configuration, %v", diags)
+		return nil, nil, fmt.Errorf("failed to convert Terraform configuration, %v", diags)
 	}
 
 	project := &workspace.Project{


### PR DESCRIPTION
It's not that it couldn't load the terraform, it's that it couldn't convert the terraform. The error could just have likely come from PCL binding as TF loading.