### PR TITLE
Assert Generated renames match existing renames

### DIFF
--- a/pf/tfgen/main.go
+++ b/pf/tfgen/main.go
@@ -229,10 +229,11 @@ func MainWithMuxer(provider string, infos ...tfbridge.Muxed) {
 
 		// In the muxing case precompute renames by merging them and set them to MetadataInfo, this will avoid
 		// recomputing the renames in GenerateFromSchema, it will write out the mergedRenames as-is.
-		mergedRenames := mergeRenames(renames)
+		mergedRenames := tfgen.MergeRenames(renames)
 		if err := metadata.Set(muxedInfo.GetMetadata(), "renames", mergedRenames); err != nil {
 			return fmt.Errorf("[pf/tfgen]: Failed to set renames data in MetadataInfo: %w", err)
 		}
+		opts.ExpectExistingRenames = true
 
 		// Having computed the schema, we now want to complete the tfgen process,
 		// reusing as much of the standard process as possible.
@@ -246,42 +247,4 @@ func MainWithMuxer(provider string, infos ...tfbridge.Muxed) {
 	}
 
 	tfgen.MainWithCustomGenerate(provider, infos[0].GetInfo().Version, infos[0].GetInfo(), gen)
-}
-
-func mergeRenames(renames []tfgen.Renames) tfgen.Renames {
-	main := renames[0]
-	for _, rename := range renames[1:] {
-		for k, v := range rename.Resources {
-			_, exists := main.Resources[k]
-			if !exists {
-				main.Resources[k] = v
-			}
-		}
-
-		for k, v := range rename.Functions {
-			_, exists := main.Functions[k]
-			if !exists {
-				main.Functions[k] = v
-			}
-		}
-		for k, v := range rename.RenamedProperties {
-			_, exists := main.RenamedProperties[k]
-			if !exists {
-				main.RenamedProperties[k] = v
-			}
-		}
-		for k, v := range rename.RenamedConfigProperties {
-			_, exists := main.RenamedConfigProperties[k]
-			if !exists {
-				main.RenamedConfigProperties[k] = v
-			}
-		}
-		for k, v := range rename.Resources {
-			_, exists := main.Resources[k]
-			if !exists {
-				main.Resources[k] = v
-			}
-		}
-	}
-	return main
 }

--- a/pf/tfgen/main.go
+++ b/pf/tfgen/main.go
@@ -16,7 +16,6 @@ package tfgen
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/hashicorp/go-multierror"
@@ -25,11 +24,10 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 
+	"github.com/pulumi/pulumi-terraform-bridge/pf/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/metadata"
 	"github.com/pulumi/pulumi-terraform-bridge/x/muxer"
-
-	"github.com/pulumi/pulumi-terraform-bridge/pf/tfbridge"
 )
 
 // Implements main() logic for a provider build-time helper utility. By convention these utilities are named
@@ -62,16 +60,6 @@ func Main(provider string, info tfbridge.ProviderInfo) {
 
 		if err := g.Generate(); err != nil {
 			return err
-		}
-
-		if opts.Language == tfgen.Schema {
-			renames, err := g.Renames()
-			if err != nil {
-				return err
-			}
-			if err := writeRenames(renames, opts); err != nil {
-				return err
-			}
 		}
 
 		return nil
@@ -110,7 +98,7 @@ func MainWithMuxer(provider string, infos ...tfbridge.Muxed) {
 		schemas := []schema.PackageSpec{}
 		var errs multierror.Error
 
-		var pfRenames []tfgen.Renames
+		var renames []tfgen.Renames
 
 		for i, union := range infos {
 			// Concurrency safety
@@ -207,14 +195,12 @@ func MainWithMuxer(provider string, infos ...tfbridge.Muxed) {
 				}
 			}
 
-			s, renames, err := tfgen.GenerateSchemaAndRenames(*info, opts.Sink)
+			s, renamesPart, err := tfgen.GenerateSchemaAndRenames(*info, opts.Sink)
 			if anErr(err) {
 				continue
 			}
 
-			if union.PF != nil {
-				pfRenames = append(pfRenames, renames)
-			}
+			renames = append(renames, renamesPart)
 
 			schemas = append(schemas, s)
 		}
@@ -235,19 +221,21 @@ func MainWithMuxer(provider string, infos ...tfbridge.Muxed) {
 			"Must provide a metadata store when muxing providers. See ProviderInfo.MetadataInfo")
 		err = metadata.Set(muxedInfo.GetMetadata(), "mux", mapping)
 		if err != nil {
-			return fmt.Errorf("Failed to save metadata: %w", err)
+			return fmt.Errorf("[pf/tfgen] Failed to set mux data in MetadataInfo: %w", err)
+		}
+
+		// In the muxing case precompute renames by merging them and set them to MetadataInfo, this will avoid
+		// recomputing the renames in GenerateFromSchema, it will write out the mergedRenames as-is.
+		mergedRenames := mergeRenames(renames)
+		if err := metadata.Set(muxedInfo.GetMetadata(), "renames", mergedRenames); err != nil {
+			return fmt.Errorf("[pf/tfgen]: Failed to set renames data in MetadataInfo: %w", err)
 		}
 
 		// Having computed the schema, we now want to complete the tfgen process,
 		// reusing as much of the standard process as possible.
-
 		opts.ProviderInfo = muxedInfo
 		g, err := tfgen.NewGenerator(opts)
 		if err != nil {
-			return err
-		}
-
-		if err := writeRenames(mergeRenames(pfRenames), opts); err != nil {
 			return err
 		}
 
@@ -293,26 +281,4 @@ func mergeRenames(renames []tfgen.Renames) tfgen.Renames {
 		}
 	}
 	return main
-}
-
-func writeRenames(renames tfgen.Renames, opts tfgen.GeneratorOptions) error {
-	renamesFile, err := opts.Root.Create("bridge-metadata.json")
-	if err != nil {
-		return err
-	}
-
-	renamesBytes, err := json.MarshalIndent(renames, "", "  ")
-	if err != nil {
-		return err
-	}
-
-	if _, err := renamesFile.Write(renamesBytes); err != nil {
-		return err
-	}
-
-	if err := renamesFile.Close(); err != nil {
-		return err
-	}
-
-	return nil
 }

--- a/pf/tfgen/main.go
+++ b/pf/tfgen/main.go
@@ -195,14 +195,17 @@ func MainWithMuxer(provider string, infos ...tfbridge.Muxed) {
 				}
 			}
 
-			s, renamesPart, err := tfgen.GenerateSchemaAndRenames(*info, opts.Sink)
+			genResult, err := tfgen.GenerateSchemaWithOptions(tfgen.GenerateSchemaOptions{
+				ProviderInfo:    *info,
+				DiagnosticsSink: opts.Sink,
+			})
+
 			if anErr(err) {
 				continue
 			}
 
-			renames = append(renames, renamesPart)
-
-			schemas = append(schemas, s)
+			renames = append(renames, genResult.Renames)
+			schemas = append(schemas, genResult.PackageSpec)
 		}
 
 		if err := errs.ErrorOrNil(); err != nil {

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -662,20 +662,15 @@ func (of *overlayFile) Name() string { return of.name }
 func (of *overlayFile) Doc() string  { return "" }
 func (of *overlayFile) Copy() bool   { return of.src != "" }
 
-func GenerateSchemaAndRenames(info tfbridge.ProviderInfo, sink diag.Sink) (pschema.PackageSpec, Renames, error) {
+func GenerateSchema(info tfbridge.ProviderInfo, sink diag.Sink) (pschema.PackageSpec, error) {
 	res, err := GenerateSchemaWithOptions(GenerateSchemaOptions{
 		ProviderInfo:    info,
 		DiagnosticsSink: sink,
 	})
 	if err != nil {
-		return pschema.PackageSpec{}, res.Renames, err
+		return pschema.PackageSpec{}, err
 	}
-	return res.PackageSpec, res.Renames, nil
-}
-
-func GenerateSchema(info tfbridge.ProviderInfo, sink diag.Sink) (pschema.PackageSpec, error) {
-	p, _, err := GenerateSchemaAndRenames(info, sink)
-	return p, err
+	return res.PackageSpec, nil
 }
 
 type GenerateSchemaOptions struct {

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -1814,7 +1814,20 @@ func addRenamesToMetadataInfo(g *Generator) error {
 		return nil
 	}
 
-	renames, err := g.Renames()
+	var renames Renames
+
+	_, renamesAlreadySet, err := metadata.Get[Renames](g.info.MetadataInfo.Data, "renames")
+	if err != nil {
+		return fmt.Errorf("[pkg/tfgen] failed to retrieve renames from MetadataInfo: %w", err)
+	}
+
+	// Skip setting renames, for scenarios such as muxed providers that have them precomputed.
+	if renamesAlreadySet {
+		return nil
+	}
+
+	// Otherwise propagate renames computed in the generator to the metadata.
+	renames, err = g.Renames()
 	if err != nil {
 		return err
 	}

--- a/pkg/tfgen/renames.go
+++ b/pkg/tfgen/renames.go
@@ -49,6 +49,38 @@ func newRenames() Renames {
 	}
 }
 
+func MergeRenames(renames []Renames) Renames {
+	result := newRenames()
+	for _, rename := range renames {
+		for k, v := range rename.Resources {
+			_, exists := result.Resources[k]
+			if !exists {
+				result.Resources[k] = v
+			}
+		}
+
+		for k, v := range rename.Functions {
+			_, exists := result.Functions[k]
+			if !exists {
+				result.Functions[k] = v
+			}
+		}
+		for k, v := range rename.RenamedProperties {
+			_, exists := result.RenamedProperties[k]
+			if !exists {
+				result.RenamedProperties[k] = v
+			}
+		}
+		for k, v := range rename.RenamedConfigProperties {
+			_, exists := result.RenamedConfigProperties[k]
+			if !exists {
+				result.RenamedConfigProperties[k] = v
+			}
+		}
+	}
+	return result
+}
+
 func (r Renames) renamedProps(tok tokens.Token) map[tokens.Name]string {
 	props, ok := r.RenamedProperties[tok]
 	if ok {


### PR DESCRIPTION
It's surprisingly difficult to create/use an existing rename. This strategy allows us to recompute a rename set safely. Instead of saving it, we just check if the computed renames match existing renames, erroring out if that isn't the case.