### PR TITLE
camelCase the attributes of the default value of object-typed config variables

### DIFF
--- a/pkg/tf2pulumi/convert/testdata/object_config_rename/experimental_pcl/main.pp
+++ b/pkg/tf2pulumi/convert/testdata/object_config_rename/experimental_pcl/main.pp
@@ -1,0 +1,51 @@
+config "simpleObjectConfig" "object({firstMember=number, secondMember=string})" {
+  default = {
+    firstMember  = 10
+    secondMember = "hello"
+  }
+}
+config "objectListConfig" "list(object({firstMember=number, secondMember=string}))" {
+  default = [{
+    firstMember  = 10
+    secondMember = "hello"
+  }]
+}
+config "objectMapConfig" "map(object({firstMember=number, secondMember=string}))" {
+  default = {
+    hello = {
+      firstMember  = 10
+      secondMember = "hello"
+    }
+  }
+}
+resource "usingSimpleObjectConfig" "simple:index:resource" {
+  inputOne = simpleObjectConfig.firstMember
+}
+resource "usingListObjectConfig" "simple:index:resource" {
+  inputOne = objectListConfig[0].firstMember
+}
+resource "usingListObjectConfigForEach" "simple:index:resource" {
+  options {
+    range = objectListConfig
+  }
+  inputOne = range.value.firstMember
+}
+resource "usingMapObjectConfig" "simple:index:resource" {
+  inputOne = objectMapConfig["hello"].firstMember
+}
+resource "usingMapObjectConfigForEach" "simple:index:resource" {
+  options {
+    range = objectMapConfig
+  }
+  inputOne = range.value.firstMember
+}
+resource "usingDynamic" "blocks:index/index:resource" {
+  aListOfResources = [for entry in entries(objectMapConfig) : {
+    innerString = entry.value.firstMember
+  }]
+}
+resource "usingDynamicIterator" "blocks:index/index:resource" {
+  aListOfResources = [for entry in entries(objectMapConfig) : {
+    innerString = entry.value.firstMember
+  }]
+}

--- a/pkg/tf2pulumi/convert/testdata/object_config_rename/main.tf
+++ b/pkg/tf2pulumi/convert/testdata/object_config_rename/main.tf
@@ -1,0 +1,82 @@
+#if EXPERIMENTAL
+
+variable "simple_object_config" {
+    type = object({
+        first_member = number,
+        second_member = string
+    })
+
+    default = {
+        first_member = 10
+        second_member = "hello"
+    }
+}
+
+variable "object_list_config" {
+    type = list(object({
+        first_member = number,
+        second_member = string
+    }))
+
+    default = [{
+        first_member = 10
+        second_member = "hello"
+    }]
+}
+
+variable "object_map_config" {
+    type = map(object({
+        first_member = number,
+        second_member = string
+    }))
+
+    default = {
+        "hello" = {
+             first_member = 10
+             second_member = "hello"
+        }
+    }
+}
+
+resource "simple_resource" "using_simple_object_config" {
+    input_one = var.simple_object_config.first_member
+}
+
+resource "simple_resource" "using_list_object_config" {
+    input_one = var.object_list_config[0].first_member
+}
+
+resource "simple_resource" "using_list_object_config_for_each" {
+    for_each = var.object_list_config
+    input_one = each.value.first_member
+}
+
+resource "simple_resource" "using_map_object_config" {
+    input_one = var.object_map_config["hello"].first_member
+}
+
+resource "simple_resource" "using_map_object_config_for_each" {
+    for_each = var.object_map_config
+    input_one = each.value.first_member
+}
+
+resource "blocks_resource" "using_dynamic" {
+    dynamic "a_list_of_resources" {
+        for_each = var.object_map_config
+        content {
+            inner_string = a_list_of_resources.value.first_member
+        }
+    }
+}
+
+resource "blocks_resource" "using_dynamic_iterator" {
+    dynamic "a_list_of_resources" {
+        for_each = var.object_map_config
+        iterator = "each"
+        content {
+            inner_string = each.value.first_member
+        }
+    }
+}
+
+#endif

--- a/pkg/tf2pulumi/convert/tf.go
+++ b/pkg/tf2pulumi/convert/tf.go
@@ -2045,9 +2045,9 @@ func (items terraformItems) Less(i, j int) bool {
 
 func translateRemoteModule(
 	modules map[addrs.ModuleSource]string, // A map of module source addresses to paths in destination.
-	packageAddr string,                    // The address of the remote terraform module to translate.
+	packageAddr string, // The address of the remote terraform module to translate.
 	packageSubdir string,
-	destinationRoot afero.Fs,    // The root of the destination filesystem to write PCL to.
+	destinationRoot afero.Fs, // The root of the destination filesystem to write PCL to.
 	destinationDirectory string, // A path in destination to write the translated code to.
 	info il.ProviderInfoSource) hcl.Diagnostics {
 
@@ -2098,10 +2098,10 @@ func translateRemoteModule(
 
 func translateModuleSourceCode(
 	modules map[addrs.ModuleSource]string, // A map of module source addresses to paths in destination.
-	sourceRoot afero.Fs,                   // The root of the source terraform package.
-	sourceDirectory string,                // The path in sourceRoot to the source terraform module.
-	destinationRoot afero.Fs,              // The root of the destination filesystem to write PCL to.
-	destinationDirectory string,           // A path in destination to write the translated code to.
+	sourceRoot afero.Fs, // The root of the source terraform package.
+	sourceDirectory string, // The path in sourceRoot to the source terraform module.
+	destinationRoot afero.Fs, // The root of the destination filesystem to write PCL to.
+	destinationDirectory string, // A path in destination to write the translated code to.
 	info il.ProviderInfoSource) hcl.Diagnostics {
 
 	sources, module, moduleDiagnostics := loadConfigDir(sourceRoot, sourceDirectory)


### PR DESCRIPTION
Also adding examples of resources of which the inputs are using members of object-typed config variables that are rewritten  as camelCase as well. 