### PR TITLE
Implement GetMapping for Muxed Providers

### DIFF
--- a/pf/tests/provider_get_mapping_test.go
+++ b/pf/tests/provider_get_mapping_test.go
@@ -19,11 +19,15 @@ import (
 	"encoding/json"
 	"testing"
 
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi/pulumi-terraform-bridge/pf/tests/internal/testprovider"
 	"github.com/pulumi/pulumi-terraform-bridge/pf/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/pf/tfgen"
 	tfbridge0 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	tfgen0 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen"
 )
 
 func TestGetMapping(t *testing.T) {
@@ -52,6 +56,57 @@ func TestGetMapping(t *testing.T) {
 
 		assert.Equal(t, "random", info.Name)
 		assert.Contains(t, info.Resources, "random_integer")
-		assert.Equal(t, "random:index/randomInteger:RandomInteger", string(info.Resources["random_integer"].Tok))
+		assert.Equal(t, "random:index/randomInteger:RandomInteger",
+			string(info.Resources["random_integer"].Tok))
+	}
+}
+
+func TestMuxedGetMapping(t *testing.T) {
+	ctx := context.Background()
+
+	servers := testprovider.MuxedRandomProvider()
+
+	_, _, schema, _, err := tfgen.UnstableMuxProviderInfo(ctx,
+		tfgen0.GeneratorOptions{}, "muxedrandom", servers...)
+	require.NoError(t, err)
+
+	schemaBytes, err := json.Marshal(schema)
+	require.NoError(t, err)
+
+	server, err := tfbridge.MakeMuxedServer(ctx, "random",
+		tfbridge.ProviderMetadata{PackageSchema: schemaBytes}, servers...)(nil)
+	require.NoError(t, err)
+
+	req := func(key string) (context.Context, *pulumirpc.GetMappingRequest) {
+		return ctx, &pulumirpc.GetMappingRequest{Key: key}
+	}
+
+	t.Run("unknown-key", func(t *testing.T) {
+		resp, err := server.GetMapping(req("unknown-key"))
+		assert.NoError(t, err)
+		assert.Empty(t, resp.Data)
+		assert.Empty(t, resp.Provider)
+	})
+
+	for _, key := range []string{"tf", "terraform"} {
+		resp, err := server.GetMapping(req(key))
+		assert.NoError(t, err)
+
+		assert.Equal(t, "muxedrandom", resp.Provider)
+
+		var info tfbridge0.MarshallableProviderInfo
+		err = json.Unmarshal(resp.Data, &info)
+		assert.NoError(t, err)
+
+		assert.Equal(t, "muxedrandom", info.Name)
+		assert.Contains(t, info.Resources, "random_integer")
+		assert.Contains(t, info.Resources, "random_human_number")
+
+		// A PF based resource
+		assert.Equal(t, "muxedrandom:index/randomInteger:RandomInteger",
+			string(info.Resources["random_integer"].Tok))
+		// An SDK bases resource
+		assert.Equal(t, "muxedrandom:index/randomHumanNumber:RandomHumanNumber",
+			string(info.Resources["random_human_number"].Tok))
 	}
 }

--- a/x/muxer/muxer.go
+++ b/x/muxer/muxer.go
@@ -451,9 +451,9 @@ func (m *muxer) GetMapping(ctx context.Context, req *rpc.GetMappingRequest) (*rp
 			continue
 		}
 		if response.GetProvider() == "" {
-			errs = multierror.Append(errs,
-				m.Warnf(ctx, "GetMapping", "Missing provider name for subprovider %d", i))
-			// TODO: Do we want to `continue` here, or is this OK with a warning?
+			errs.Errors = append(errs.Errors,
+				fmt.Errorf("Missing provider name for subprovider %d", i))
+			continue
 		} else if providerName == "" {
 			providerName = response.GetProvider()
 		} else if providerName != response.GetProvider() {


### PR DESCRIPTION
Fixes #946

There are three different cases for behavior to consider:
1. No underlying provider implements GetMapping, in which case the muxer provider also doesn't implement GetMapping.
2. Only 1 underlying provider implements GetMapping, in which case the muxer provides unfiltered pass through from the provider.
3. Multiple providers respond to the key, in which case we check for a key merging function. We delegate merging the response to this function. This allows us to avoid a cyclic dependency on the rest of the bridge.