### PR TITLE
Fixes an failure to derive Config encoder encountered in pulumi-aws

### DIFF
--- a/pf/internal/convert/convert.go
+++ b/pf/internal/convert/convert.go
@@ -25,7 +25,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
 	"github.com/pulumi/pulumi-terraform-bridge/pf/internal/propertyvalue"
-	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 )
@@ -40,14 +39,6 @@ type Encoding interface {
 	NewResourceEncoder(tokens.Type, tftypes.Object) (Encoder, error)
 	NewDataSourceDecoder(tokens.ModuleMember, tftypes.Object) (Decoder, error)
 	NewDataSourceEncoder(tokens.ModuleMember, tftypes.Object) (Encoder, error)
-}
-
-// Subset of pschema.PackageSpec required for conversion.
-type PackageSpec interface {
-	Config() *pschema.ConfigSpec
-	Function(tok tokens.ModuleMember) *pschema.FunctionSpec
-	Resource(tok tokens.Type) *pschema.ResourceSpec
-	Type(tok tokens.Type) *pschema.ComplexTypeSpec
 }
 
 type PropertyNames interface {

--- a/pf/internal/convert/dangling_ref_test.go
+++ b/pf/internal/convert/dangling_ref_test.go
@@ -1,0 +1,91 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package convert
+
+import (
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+// AWS has a dangling enum ref, tracked in pulumi/pulumi-aws#2463 - this code needs to be able to handle this.
+func TestRegressEncodingConfigWithDanglingEnumRefs(t *testing.T) {
+	spec := PrecomputedPackageSpec(&schema.PackageSpec{
+		Config: schema.ConfigSpec{
+			Variables: map[string]schema.PropertySpec{
+				"region": {
+					TypeSpec: schema.TypeSpec{
+						Type: "string",
+						Ref:  "#/types/aws:index/region:Region",
+					},
+					DefaultInfo: &schema.DefaultSpec{
+						Environment: []string{
+							"AWS_REGION",
+							"AWS_DEFAULT_REGION",
+						},
+					},
+				},
+			},
+		},
+		Types: map[string]schema.ComplexTypeSpec{
+			"#/types/aws:index/Region:Region": {
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Type: "string",
+				},
+				Enum: []schema.EnumValueSpec{
+					{Name: "AFSouth1", Value: "af-south-1"},
+				},
+			},
+		},
+	})
+
+	enc := NewEncoding(spec, &trivialPropertyNames{})
+
+	ty := tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{
+			"region": tftypes.String,
+		},
+	}
+
+	encoder, err := enc.NewConfigEncoder(ty)
+	require.NoError(t, err)
+
+	actual, err := encoder.fromPropertyValue(resource.NewObjectProperty(resource.PropertyMap{
+		"region": resource.NewStringProperty("us-west-1"),
+	}))
+	require.NoError(t, err)
+
+	expect := tftypes.NewValue(ty, map[string]tftypes.Value{
+		"region": tftypes.NewValue(tftypes.String, "us-west-1"),
+	})
+
+	require.True(t, expect.Equal(actual))
+}
+
+type trivialPropertyNames struct{}
+
+var _ PropertyNames = (*trivialPropertyNames)(nil)
+
+func (*trivialPropertyNames) PropertyKey(typeToken tokens.Token, property TerraformPropertyName,
+	t tftypes.Type) resource.PropertyKey {
+	return resource.PropertyKey(string(typeToken))
+}
+
+func (*trivialPropertyNames) ConfigPropertyKey(property TerraformPropertyName, t tftypes.Type) resource.PropertyKey {
+	return resource.PropertyKey(property)
+}

--- a/pf/internal/convert/encoding.go
+++ b/pf/internal/convert/encoding.go
@@ -253,7 +253,17 @@ func (e *encoding) deriveEncoder(typeSpec *pschema.TypeSpec, t tftypes.Type) (En
 		case tftypes.Tuple:
 			return e.deriveTupleEncoder(typeSpec.Ref, t)
 		default:
-			return nil, fmt.Errorf("expected Object or Tuple type but got %s", t.String())
+			// Workaround dangling local references.
+			dangling := false
+			if strings.HasPrefix(typeSpec.Ref, "#/types/") {
+				token := strings.TrimPrefix(typeSpec.Ref, "#/types/")
+				if e.spec.Type(tokens.Type(token)) == nil {
+					dangling = true
+				}
+			}
+			if !dangling {
+				return nil, fmt.Errorf("expected Object or Tuple type but got %s", t.String())
+			}
 		}
 	}
 

--- a/pf/internal/convert/encoding.go
+++ b/pf/internal/convert/encoding.go
@@ -187,42 +187,49 @@ func (e *encoding) newPropertyDecoder(name string, propSpec pschema.PropertySpec
 }
 
 func (e *encoding) resolveRef(ref string) (tokens.Token, *pschema.ComplexTypeSpec, error) {
-	tok := tokens.Type(strings.TrimPrefix(ref, "#/types/"))
+	if ref == "" {
+		return "", nil, fmt.Errorf(
+			"expecting a non-empty Ref in a Package Schema type")
+	}
+	const typesPrefix = "#/types/"
+	if !strings.HasPrefix(ref, typesPrefix) {
+		return "", nil, fmt.Errorf(
+			"expecting a Ref starting with %q in a Package Schema type, got %s. "+
+				"Cross-provider references are not yet supported.",
+			typesPrefix, ref)
+	}
+	tok := tokens.Type(strings.TrimPrefix(ref, typesPrefix))
 	refSpec := e.spec.Type(tok)
 	if refSpec == nil {
-		return "", nil, fmt.Errorf("dangling schema ref: %q", ref)
+		return "", nil, fmt.Errorf(
+			"unexpected TokenType with Ref=%q but no matching definition in the types section.",
+			ref)
 	}
 	return tokens.Token(tok), refSpec, nil
 }
 
-func (e *encoding) deriveEncoderForNamedObjectType(ref string, t tftypes.Object) (Encoder, error) {
-	tok, refSpec, err := e.resolveRef(ref)
-	if err != nil {
-		return nil, err
-	}
+func (e *encoding) deriveEncoderForNamedObjectType(tok tokens.Token, refSpec *pschema.ComplexTypeSpec,
+	t tftypes.Object) (Encoder, error) {
 	if refSpec.Enum != nil {
-		return nil, fmt.Errorf("enums are not supported: %q", ref)
+		return nil, fmt.Errorf("enums are not supported: %q", tok)
 	}
 	propNames := NewTypeLocalPropertyNames(e.propertyNames, tok)
 	propertyEncoders, err := e.buildPropertyEncoders(propNames, specFinder(refSpec.Properties), t)
 	if err != nil {
-		return nil, fmt.Errorf("issue deriving an encoder for %q: %w", ref, err)
+		return nil, fmt.Errorf("issue deriving an encoder for %q: %w", tok, err)
 	}
 	return newObjectEncoder(t, propertyEncoders, propNames)
 }
 
-func (e *encoding) deriveDecoderForNamedObjectType(ref string, t tftypes.Object) (Decoder, error) {
-	tok, refSpec, err := e.resolveRef(ref)
-	if err != nil {
-		return nil, err
-	}
+func (e *encoding) deriveDecoderForNamedObjectType(tok tokens.Token, refSpec *pschema.ComplexTypeSpec,
+	t tftypes.Object) (Decoder, error) {
 	if refSpec.Enum != nil {
-		return nil, fmt.Errorf("enums are not supported: %q", ref)
+		return nil, fmt.Errorf("enums are not supported: %q", tok)
 	}
 	propNames := NewTypeLocalPropertyNames(e.propertyNames, tok)
 	propertyDecoders, err := e.buildPropertyDecoders(propNames, specFinder(refSpec.Properties), t)
 	if err != nil {
-		return nil, fmt.Errorf("issue deriving an decoder for %q: %w", ref, err)
+		return nil, fmt.Errorf("issue deriving an decoder for %q: %w", tok, err)
 	}
 	return newObjectDecoder(t, propertyDecoders, propNames)
 }
@@ -246,25 +253,19 @@ func (e *encoding) deriveEncoder(typeSpec *pschema.TypeSpec, t tftypes.Type) (En
 		}, nil
 	}
 
-	if typeSpec.Ref != "" {
-		switch t := t.(type) {
-		case tftypes.Object:
-			return e.deriveEncoderForNamedObjectType(typeSpec.Ref, t)
-		case tftypes.Tuple:
-			return e.deriveTupleEncoder(typeSpec.Ref, t)
-		default:
-			// Workaround dangling local references.
-			dangling := false
-			if strings.HasPrefix(typeSpec.Ref, "#/types/") {
-				token := strings.TrimPrefix(typeSpec.Ref, "#/types/")
-				if e.spec.Type(tokens.Type(token)) == nil {
-					dangling = true
-				}
-			}
-			if !dangling {
-				return nil, fmt.Errorf("expected Object or Tuple type but got %s", t.String())
-			}
+	switch t := t.(type) {
+	case tftypes.Object:
+		tok, referredType, err := e.resolveRef(typeSpec.Ref)
+		if err != nil {
+			return nil, fmt.Errorf("expected an Object type: %w", err)
 		}
+		return e.deriveEncoderForNamedObjectType(tok, referredType, t)
+	case tftypes.Tuple:
+		tok, referredType, err := e.resolveRef(typeSpec.Ref)
+		if err != nil {
+			return nil, fmt.Errorf("expected a Tuple type: %w", err)
+		}
+		return e.deriveTupleEncoder(tokens.Type(tok), referredType, t)
 	}
 
 	switch typeSpec.Type {
@@ -330,16 +331,21 @@ func (e *encoding) deriveDecoder(typeSpec *pschema.TypeSpec, t tftypes.Type) (De
 		}, nil
 	}
 
-	if typeSpec.Ref != "" {
-		switch t := t.(type) {
-		case tftypes.Object:
-			return e.deriveDecoderForNamedObjectType(typeSpec.Ref, t)
-		case tftypes.Tuple:
-			return e.deriveTupleDecoder(typeSpec.Ref, t)
-		default:
-			return nil, fmt.Errorf("expected Object or Tuple type but got %s", t.String())
+	switch t := t.(type) {
+	case tftypes.Object:
+		ref, referredType, err := e.resolveRef(typeSpec.Ref)
+		if err != nil {
+			return nil, fmt.Errorf("expected an Object type: %w", err)
 		}
+		return e.deriveDecoderForNamedObjectType(ref, referredType, t)
+	case tftypes.Tuple:
+		ref, referredType, err := e.resolveRef(typeSpec.Ref)
+		if err != nil {
+			return nil, fmt.Errorf("expected a Tuple type: %w", err)
+		}
+		return e.deriveTupleDecoder(tokens.Type(ref), referredType, t)
 	}
+
 	switch typeSpec.Type {
 	case "boolean":
 		return newBoolDecoder(), nil
@@ -389,24 +395,18 @@ func (e *encoding) deriveDecoder(typeSpec *pschema.TypeSpec, t tftypes.Type) (De
 //
 // It handles reference validation and property discovery.
 func deriveTupleBase[T any](
-	e *encoding, f func(*pschema.TypeSpec, tftypes.Type) (T, error), ref string, t tftypes.Tuple,
+	f func(*pschema.TypeSpec, tftypes.Type) (T, error),
+	tok tokens.Type,
+	typ *pschema.ComplexTypeSpec,
+	t tftypes.Tuple,
 ) ([]T, error) {
-	const typPrefix = "#/types/"
-	if !strings.HasPrefix(ref, typPrefix) {
-		return nil, fmt.Errorf("expected '%s' prefix, found '%s'", typPrefix, ref)
-	}
-	ref = strings.TrimPrefix(ref, typPrefix)
-	typ := e.spec.Type(tokens.Type(ref))
-	if typ == nil {
-		return nil, fmt.Errorf("dangling ref: '%s'", ref)
-	}
 	elements := make([]T, len(t.ElementTypes))
 	for i := range t.ElementTypes {
 		propName := tuplePropertyName(i)
 		prop, ok := typ.Properties[propName]
 		if !ok {
-			return nil, fmt.Errorf("could not find expected property '%s' on typ '%s'",
-				propName, ref)
+			return nil, fmt.Errorf("could not find expected property '%s' on type '%s'",
+				propName, tok)
 		}
 		var err error
 		elements[i], err = f(&prop.TypeSpec, t.ElementTypes[i])
@@ -417,16 +417,18 @@ func deriveTupleBase[T any](
 	return elements, nil
 }
 
-func (e *encoding) deriveTupleEncoder(ref string, t tftypes.Tuple) (*tupleEncoder, error) {
-	encoders, err := deriveTupleBase(e, e.deriveEncoder, ref, t)
+func (e *encoding) deriveTupleEncoder(tok tokens.Type, typeSpec *pschema.ComplexTypeSpec,
+	t tftypes.Tuple) (*tupleEncoder, error) {
+	encoders, err := deriveTupleBase(e.deriveEncoder, tok, typeSpec, t)
 	if err != nil {
 		return nil, fmt.Errorf("could not build tuple encoder: %w", err)
 	}
 	return &tupleEncoder{t.ElementTypes, encoders}, nil
 }
 
-func (e *encoding) deriveTupleDecoder(ref string, t tftypes.Tuple) (*tupleDecoder, error) {
-	decoders, err := deriveTupleBase(e, e.deriveDecoder, ref, t)
+func (e *encoding) deriveTupleDecoder(tok tokens.Type, typeSpec *pschema.ComplexTypeSpec,
+	t tftypes.Tuple) (*tupleDecoder, error) {
+	decoders, err := deriveTupleBase(e.deriveDecoder, tok, typeSpec, t)
 	if err != nil {
 		return nil, fmt.Errorf("could not build tuple decoder: %w", err)
 	}

--- a/pf/internal/convert/encoding.go
+++ b/pf/internal/convert/encoding.go
@@ -202,7 +202,7 @@ func (e *encoding) resolveRef(ref string) (tokens.Token, *pschema.ComplexTypeSpe
 	refSpec := e.spec.Type(tok)
 	if refSpec == nil {
 		return "", nil, fmt.Errorf(
-			"unexpected TokenType with Ref=%q but no matching definition in the types section.",
+			"unexpected TokenType with Ref=%q but no matching definition in the types section",
 			ref)
 	}
 	return tokens.Token(tok), refSpec, nil

--- a/pf/internal/convert/packagespec.go
+++ b/pf/internal/convert/packagespec.go
@@ -1,0 +1,66 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package convert
+
+import (
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+)
+
+// Subset of pschema.PackageSpec required for conversion.
+type PackageSpec interface {
+	Config() *schema.ConfigSpec
+	Function(tok tokens.ModuleMember) *schema.FunctionSpec
+	Resource(tok tokens.Type) *schema.ResourceSpec
+	Type(tok tokens.Type) *schema.ComplexTypeSpec
+}
+
+func PrecomputedPackageSpec(s *schema.PackageSpec) PackageSpec {
+	return &packageSpec{s}
+}
+
+type packageSpec struct {
+	spec *schema.PackageSpec
+}
+
+var _ PackageSpec = (*packageSpec)(nil)
+
+func (p packageSpec) Config() *schema.ConfigSpec {
+	return &p.spec.Config
+}
+
+func (p packageSpec) Resource(tok tokens.Type) *schema.ResourceSpec {
+	res, ok := p.spec.Resources[string(tok)]
+	if ok {
+		return &res
+	}
+	return nil
+}
+
+func (p packageSpec) Type(tok tokens.Type) *schema.ComplexTypeSpec {
+	typ, ok := p.spec.Types[string(tok)]
+	if ok {
+		return &typ
+	}
+	return nil
+}
+
+func (p packageSpec) Function(tok tokens.ModuleMember) *schema.FunctionSpec {
+	res, ok := p.spec.Functions[string(tok)]
+	if ok {
+		return &res
+	}
+	return nil
+}

--- a/pf/tfbridge/provider.go
+++ b/pf/tfbridge/provider.go
@@ -110,7 +110,7 @@ func newProviderWithContext(ctx context.Context, info ProviderInfo,
 	}
 
 	propertyNames := newPrecisePropertyNames(renames)
-	enc := convert.NewEncoding(packageSpec{&thePackageSpec}, propertyNames)
+	enc := convert.NewEncoding(convert.PrecomputedPackageSpec(&thePackageSpec), propertyNames)
 
 	schemaResponse := &pfprovider.SchemaResponse{}
 	p.Schema(ctx, pfprovider.SchemaRequest{}, schemaResponse)
@@ -242,38 +242,4 @@ func newProviderServer6(ctx context.Context, p pfprovider.Provider) (tfprotov6.P
 	}
 
 	return server6, nil
-}
-
-type packageSpec struct {
-	spec *pschema.PackageSpec
-}
-
-var _ convert.PackageSpec = (*packageSpec)(nil)
-
-func (p packageSpec) Config() *pschema.ConfigSpec {
-	return &p.spec.Config
-}
-
-func (p packageSpec) Resource(tok tokens.Type) *pschema.ResourceSpec {
-	res, ok := p.spec.Resources[string(tok)]
-	if ok {
-		return &res
-	}
-	return nil
-}
-
-func (p packageSpec) Type(tok tokens.Type) *pschema.ComplexTypeSpec {
-	typ, ok := p.spec.Types[string(tok)]
-	if ok {
-		return &typ
-	}
-	return nil
-}
-
-func (p packageSpec) Function(tok tokens.ModuleMember) *pschema.FunctionSpec {
-	res, ok := p.spec.Functions[string(tok)]
-	if ok {
-		return &res
-	}
-	return nil
 }


### PR DESCRIPTION
Currently pulumi-aws has a dangling reference in the schema, confusing the code in encoder derivation. The change works around this until the underlying issue is fixed.