### PR TITLE
Re-enable CheckConfig for bridged providers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/pulumi/pulumi-terraform-bridge/v3
 
 go 1.18
 
-replace github.com/pulumi/pulumi-terraform-bridge/x/muxer => ./x/muxer
+replace (
+	github.com/pulumi/pulumi-terraform-bridge/testing => ./testing
+	github.com/pulumi/pulumi-terraform-bridge/x/muxer => ./x/muxer
+)
 
 require (
 	github.com/apparentlymart/go-cidr v1.1.0
@@ -36,6 +39,7 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2
 	github.com/pkg/errors v0.9.1
 	github.com/pulumi/pulumi-java/pkg v0.8.0
+	github.com/pulumi/pulumi-terraform-bridge/testing v0.0.1
 	github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.1
 	github.com/pulumi/pulumi-yaml v1.0.4
 	github.com/pulumi/schema-tools v0.1.2

--- a/pf/go.sum
+++ b/pf/go.sum
@@ -1614,6 +1614,7 @@ github.com/prometheus/prometheus v0.37.0/go.mod h1:egARUgz+K93zwqsVIAneFlLZefyGO
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/pulumi/pulumi-java/pkg v0.8.0 h1:b81/D/dk5/9OEH1k5BJxhqYiQc7Y4TPDbHVGBvJU1GE=
 github.com/pulumi/pulumi-java/pkg v0.8.0/go.mod h1:x7/J1GCJ+hHFBEgnMr4QpsTfjXUNHccAHJ9gvFfmAFU=
+github.com/pulumi/pulumi-terraform-bridge/testing v0.0.1 h1:SCg1gjfY9N4yn8U8peIUYATifjoDABkyR7H9lmefsfc=
 github.com/pulumi/pulumi-yaml v1.0.4 h1:p+989rW3AqkkxbzxtxccHKAN4xCJi3K2cRpvA2K84tw=
 github.com/pulumi/pulumi-yaml v1.0.4/go.mod h1:Szj8ud4Vqyq3oO1n3kzIUfaP3AiCjYZM4FYjOVWwJn8=
 github.com/pulumi/pulumi/pkg/v3 v3.59.0 h1:RlY3FnW7gEyLEbdNlJBE0mpOX4H5NtF7eOqDxfl/Juc=

--- a/pf/tests/go.mod
+++ b/pf/tests/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
 	github.com/hashicorp/terraform-provider-tls/shim v0.0.0-00010101000000-000000000000
 	github.com/pulumi/pulumi-terraform-bridge/pf v0.0.0
-	github.com/pulumi/pulumi-terraform-bridge/testing v0.0.0-00010101000000-000000000000
+	github.com/pulumi/pulumi-terraform-bridge/testing v0.0.1
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.34.1-0.20221214173921-8e65b1f9fdd5
 	github.com/stretchr/testify v1.8.2
 	github.com/terraform-providers/terraform-provider-random/randomshim v0.0.0

--- a/pkg/tests/go.mod
+++ b/pkg/tests/go.mod
@@ -11,7 +11,7 @@ replace (
 
 require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.19.0
-	github.com/pulumi/pulumi-terraform-bridge/testing v0.0.0-00010101000000-000000000000
+	github.com/pulumi/pulumi-terraform-bridge/testing v0.0.1
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.41.0
 )
 

--- a/pkg/tfbridge/config_encoding.go
+++ b/pkg/tfbridge/config_encoding.go
@@ -127,7 +127,7 @@ func (enc *configEncoding) UnmarshalProperties(props *structpb.Struct,
 	return result, nil
 }
 
-// Invesrse of UnmarshalProperties.
+// Inverse of UnmarshalProperties.
 func (enc *configEncoding) MarshalProperties(props resource.PropertyMap,
 	opts plugin.MarshalOptions) (*structpb.Struct, error) {
 	copy := make(resource.PropertyMap)

--- a/pkg/tfbridge/config_encoding.go
+++ b/pkg/tfbridge/config_encoding.go
@@ -1,0 +1,150 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfbridge
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/golang/protobuf/ptypes/struct"
+
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
+)
+
+type configEncoding struct {
+	fieldTypes map[resource.PropertyKey]shim.ValueType
+}
+
+func newConfigEncoding(config shim.SchemaMap, configInfos map[string]*SchemaInfo) *configEncoding {
+	var tfKeys []string
+	config.Range(func(tfKey string, value shim.Schema) bool {
+		tfKeys = append(tfKeys, tfKey)
+		return true
+	})
+	fieldTypes := make(map[resource.PropertyKey]shim.ValueType)
+	for _, tfKey := range tfKeys {
+		pulumiKey := resource.PropertyKey(TerraformToPulumiNameV2(tfKey, config, configInfos))
+		fieldTypes[pulumiKey] = config.Get(tfKey).Type()
+	}
+	return &configEncoding{fieldTypes: fieldTypes}
+}
+
+func (*configEncoding) convertStringToPropertyValue(s string, typ shim.ValueType) (resource.PropertyValue, error) {
+	// If the schema expects a string, we can just return this as-is.
+	if typ == shim.TypeString {
+		return resource.NewStringProperty(s), nil
+	}
+
+	// Otherwise, we will attempt to deserialize the input string as JSON and convert the result into a Pulumi
+	// property. If the input string is empty, we will return an appropriate zero value.
+	if s == "" {
+		switch typ {
+		case shim.TypeBool:
+			return resource.NewPropertyValue(false), nil
+		case shim.TypeInt, shim.TypeFloat:
+			return resource.NewPropertyValue(0), nil
+		case shim.TypeList, shim.TypeSet:
+			return resource.NewPropertyValue([]interface{}{}), nil
+		default:
+			return resource.NewPropertyValue(map[string]interface{}{}), nil
+		}
+	}
+
+	var jsonValue interface{}
+	if err := json.Unmarshal([]byte(s), &jsonValue); err != nil {
+		return resource.PropertyValue{}, err
+	}
+	return resource.NewPropertyValue(jsonValue), nil
+}
+
+// Like plugin.UnmarhsalPropertyValue but overrides string parsing with convertStringToPropertyValue.
+func (enc *configEncoding) UnmarshalPropertyValue(key resource.PropertyKey, v *structpb.Value,
+	opts plugin.MarshalOptions) (*resource.PropertyValue, error) {
+
+	shimType, gotShimType := enc.fieldTypes[key]
+	_, vIsString := v.GetKind().(*structpb.Value_StringValue)
+
+	if vIsString && gotShimType {
+		v, err := enc.convertStringToPropertyValue(v.GetStringValue(), shimType)
+		if err != nil {
+			return nil, fmt.Errorf("error unmarshalling property %q: %w", key, err)
+		}
+		return &v, nil
+	}
+
+	return plugin.UnmarshalPropertyValue(key, v, opts)
+}
+
+// Inline from plugin.UnmarhsalProperties substituting plugin.UnmarshalPropertyValue.
+func (enc *configEncoding) UnmarshalProperties(props *structpb.Struct,
+	opts plugin.MarshalOptions) (resource.PropertyMap, error) {
+
+	result := make(resource.PropertyMap)
+
+	// First sort the keys so we enumerate them in order (in case errors happen, we want determinism).
+	var keys []string
+	if props != nil {
+		for k := range props.Fields {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+	}
+
+	// And now unmarshal every field it into the map.
+	for _, key := range keys {
+		pk := resource.PropertyKey(key)
+		v, err := enc.UnmarshalPropertyValue(pk, props.Fields[key], opts)
+		if err != nil {
+			return nil, err
+		} else if v != nil {
+			logging.V(9).Infof("Unmarshaling property for RPC[%s]: %s=%v", opts.Label, key, v)
+			if opts.SkipNulls && v.IsNull() {
+				logging.V(9).Infof("Skipping unmarshaling for RPC[%s]: %s is null", opts.Label, key)
+			} else if opts.SkipInternalKeys && resource.IsInternalPropertyKey(pk) {
+				logging.V(9).Infof("Skipping unmarshaling for RPC[%s]: %s is internal", opts.Label, key)
+			} else {
+				result[pk] = *v
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// Invesrse of UnmarshalProperties.
+func (enc *configEncoding) MarshalProperties(props resource.PropertyMap,
+	opts plugin.MarshalOptions) (*structpb.Struct, error) {
+	copy := make(resource.PropertyMap)
+	for k, v := range props {
+		_, knownKey := enc.fieldTypes[k]
+		switch {
+		case knownKey && v.IsNull():
+			copy[k] = resource.NewStringProperty("")
+		case knownKey && !v.IsNull() && !v.IsString():
+			encoded, err := json.Marshal(v.Mappable())
+			if err != nil {
+				return nil, fmt.Errorf("JSON encoding error while marshalling property %q: %w", k, err)
+			}
+			copy[k] = resource.NewStringProperty(string(encoded))
+		default:
+			copy[k] = v
+		}
+	}
+	return plugin.MarshalProperties(copy, opts)
+}

--- a/pkg/tfbridge/config_encoding.go
+++ b/pkg/tfbridge/config_encoding.go
@@ -73,7 +73,7 @@ func (*configEncoding) convertStringToPropertyValue(s string, typ shim.ValueType
 	return resource.NewPropertyValue(jsonValue), nil
 }
 
-// Like plugin.UnmarhsalPropertyValue but overrides string parsing with convertStringToPropertyValue.
+// Like plugin.UnmarshalPropertyValue but overrides string parsing with convertStringToPropertyValue.
 func (enc *configEncoding) UnmarshalPropertyValue(key resource.PropertyKey, v *structpb.Value,
 	opts plugin.MarshalOptions) (*resource.PropertyValue, error) {
 

--- a/pkg/tfbridge/config_encoding.go
+++ b/pkg/tfbridge/config_encoding.go
@@ -91,7 +91,7 @@ func (enc *configEncoding) UnmarshalPropertyValue(key resource.PropertyKey, v *s
 	return plugin.UnmarshalPropertyValue(key, v, opts)
 }
 
-// Inline from plugin.UnmarhsalProperties substituting plugin.UnmarshalPropertyValue.
+// Inline from plugin.UnmarshalProperties substituting plugin.UnmarshalPropertyValue.
 func (enc *configEncoding) UnmarshalProperties(props *structpb.Struct,
 	opts plugin.MarshalOptions) (resource.PropertyMap, error) {
 

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -173,14 +173,8 @@ func (p *Provider) pkg() tokens.Package {
 	return tokens.NewPackageToken(tokens.PackageName(tokens.IntoQName(p.module)))
 }
 
-func (p *Provider) baseConfigMod() tokens.Module {
-	return tokens.NewModuleToken(p.pkg(), tokens.ModuleName("config"))
-}
 func (p *Provider) baseDataMod() tokens.Module {
 	return tokens.NewModuleToken(p.pkg(), tokens.ModuleName("data"))
-}
-func (p *Provider) configMod() tokens.Module {
-	return tokens.NewModuleToken(p.pkg(), tokens.ModuleName("config/vars"))
 }
 
 func (p *Provider) Attach(context context.Context, req *pulumirpc.PluginAttach) (*emptypb.Empty, error) {

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -706,8 +706,8 @@ func TestProviderReadNestedSecretV2(t *testing.T) {
 
 func TestCheckConfig(t *testing.T) {
 	t.Run("minimal", func(t *testing.T) {
-		// Ensure the method is minimally implemented. Pulumi will be passing a provider verison. Make sure it
-		// is mirrorred back.
+		// Ensure the method is minimally implemented. Pulumi will be passing a provider version. Make sure it
+		// is mirrored back.
 		provider := &Provider{
 			tf:     shimv2.NewProvider(testTFProviderV2),
 			config: shimv2.NewSchemaMap(testTFProviderV2.Schema),


### PR DESCRIPTION
Re-enables CheckConfig for bridged providers and permits PreConfigureCallback to modify the provider configuration.

- New functionality: PreCofnigureCallback and PreConfigureCallbackWithLogger can now modify provider configuration (or add new keys), by editing their `vars` parameter in-place. 

- Refactors validation code and invoking PreConfigureCallback moving them from Configure to CheckConfig implementation; there should not be a visible change since Pulumi CLI always invokes CheckConfig first and passes its results to Configure


Fixes: https://github.com/pulumi/pulumi-terraform-bridge/issues/955



## Motivation


For example extend pulumi-gcp with:

```
func preConfigureCallbackWithLogger(ctx context.Context, host *provider.HostClient, vars resource.PropertyMap, c shim.ResourceConfig) error {
	foo := os.Getenv("PULUMI_CONFIG")
	fmt.Println("PULUMI_CONFIG: " + foo)
	var blob map[string]string
	err := json.Unmarshal([]byte(foo), &blob)
	if err != nil {
		return fmt.Errorf("failed to load shared config in preconfigureCallback: %w", err)
	}
	for k, v := range blob {
		pk := resource.PropertyKey(k)
		if _, has := vars[pk]; !has {
			vars[pk] = resource.NewStringProperty(v)
		}
	}
	fmt.Printf("updated vars in preconfigureCallback: %s\n", vars)
       ...
```

Program:

```
import * as gcp from "@pulumi/gcp";

const provider = new gcp.Provider("test", {});

const bucket = new gcp.storage.Bucket("auto-expire", {
    forceDestroy: true,
    location: "US",
    publicAccessPrevention: "enforced",
}, {provider});


// Export the DNS name of the bucket
export const bucketName = bucket.url;
```

Config (Pulumi.dev.yaml):

```
config:
  gcp:project: "pulumi-development"
  gcp:redisCustomEndpoint: "http://redis.local/"
```

This now succeeds through pulumi up and writes the correct provider to the state.

Latest Pulumi passes PULUMI_CONFIG variable to provider with the information from `pulumi config` stack configuration already, and if preConfigureCallbackWithLogger uses that information to *modify* configuration at CheckConfig time it all works out as expected.
