### PR TITLE
Refactor: rename ComputedMapping to DispatchTable

### DIFF
--- a/pf/tfbridge/main.go
+++ b/pf/tfbridge/main.go
@@ -109,7 +109,7 @@ func MakeMuxedServer(
 ) func(host *rprovider.HostClient) (pulumirpc.ResourceProviderServer, error) {
 	version := infos[0].GetInfo().Version
 	schema := string(meta.PackageSchema)
-	mapping, found, err := metadata.Get[muxer.ComputedMapping](infos[0].GetInfo().GetMetadata(), "mux")
+	dispatchTable, found, err := metadata.Get[muxer.DispatchTable](infos[0].GetInfo().GetMetadata(), "mux")
 	if err != nil {
 		cmdutil.ExitError(err.Error())
 	}
@@ -118,8 +118,8 @@ func MakeMuxedServer(
 		os.Exit(1)
 	}
 	m := muxer.Main{
-		ComputedMapping: mapping,
-		Schema:          schema,
+		DispatchTable: dispatchTable,
+		Schema:        schema,
 		GetMappingHandler: map[string]muxer.MultiMappingHandler{
 			"tf":        combineTFGetMappingKey,
 			"terraform": combineTFGetMappingKey,

--- a/pf/tfgen/main.go
+++ b/pf/tfgen/main.go
@@ -132,7 +132,7 @@ func MainWithMuxer(provider string, infos ...tfbridge.Muxed) {
 func UnstableMuxProviderInfo(
 	ctx context.Context, opts tfgen.GeneratorOptions,
 	provider string, infos ...tfbridge.Muxed,
-) (sdkBridge.ProviderInfo, muxer.ComputedMapping, schema.PackageSpec, tfgen.Renames, error) {
+) (sdkBridge.ProviderInfo, muxer.DispatchTable, schema.PackageSpec, tfgen.Renames, error) {
 	if opts.Sink == nil {
 		opts.Sink = cmdutil.Diag()
 	}
@@ -218,7 +218,7 @@ func UnstableMuxProviderInfo(
 	}
 
 	if err := errs.ErrorOrNil(); err != nil {
-		return sdkBridge.ProviderInfo{}, muxer.ComputedMapping{},
+		return sdkBridge.ProviderInfo{}, muxer.DispatchTable{},
 			schema.PackageSpec{}, tfgen.Renames{}, err
 	}
 

--- a/pf/tfgen/main.go
+++ b/pf/tfgen/main.go
@@ -222,7 +222,7 @@ func UnstableMuxProviderInfo(
 			schema.PackageSpec{}, tfgen.Renames{}, err
 	}
 
-	m, s, err := muxer.Mapping(schemas)
+	m, s, err := muxer.MergeSchemasAndComputeDispatchTable(schemas)
 	return muxedInfo, m, s, mergeRenames(renames), err
 }
 

--- a/pkg/tfbridge/serve.go
+++ b/pkg/tfbridge/serve.go
@@ -37,8 +37,8 @@ func Serve(module string, version string, info ProviderInfo, pulumiSchema []byte
 		if len(opts.muxWith) > 0 {
 			// If we have multiple providers to serve, Mux them together.
 
-			var mapping muxer.ComputedMapping
-			if m, found, err := metadata.Get[muxer.ComputedMapping](info.GetMetadata(), "muxer"); err != nil {
+			var mapping muxer.DispatchTable
+			if m, found, err := metadata.Get[muxer.DispatchTable](info.GetMetadata(), "muxer"); err != nil {
 				return nil, err
 			} else if found {
 				mapping = m
@@ -56,9 +56,9 @@ func Serve(module string, version string, info ProviderInfo, pulumiSchema []byte
 			}
 
 			return muxer.Main{
-				Schema:          string(pulumiSchema),
-				ComputedMapping: mapping,
-				Servers:         servers,
+				Schema:        string(pulumiSchema),
+				DispatchTable: mapping,
+				Servers:       servers,
 			}.Server(host, module, version)
 		}
 

--- a/x/muxer/main.go
+++ b/x/muxer/main.go
@@ -86,7 +86,7 @@ type Main struct {
 	Servers []Endpoint
 
 	// An optional pre-computed mapping of functions/resources to servers.
-	ComputedMapping ComputedMapping
+	DispatchTable DispatchTable
 
 	// An optional pre-computed schema. If not provided, then the schema will be
 	// derived from layering underlying server schemas.
@@ -107,7 +107,7 @@ func (m Main) Server(host *provider.HostClient, module, version string) (pulumir
 		}
 	}
 
-	mapping, pulumiSchema := m.ComputedMapping.mapping, m.Schema
+	mapping, pulumiSchema := m.DispatchTable.mapping, m.Schema
 	if mapping.isEmpty() || pulumiSchema == "" {
 		req := &rpc.GetSchemaRequest{Version: SchemaVersion}
 		primary, err := servers[0].GetSchema(context.Background(), req)

--- a/x/muxer/main.go
+++ b/x/muxer/main.go
@@ -91,7 +91,7 @@ type Main struct {
 	// An optional pre-computed schema. If not provided, then the schema will be
 	// derived from layering underlying server schemas.
 	//
-	// If set, ComputedMapping must also be set.
+	// If set, DispatchTable must also be set.
 	Schema string
 
 	GetMappingHandler map[string]MultiMappingHandler
@@ -107,8 +107,8 @@ func (m Main) Server(host *provider.HostClient, module, version string) (pulumir
 		}
 	}
 
-	mapping, pulumiSchema := m.DispatchTable.mapping, m.Schema
-	if mapping.isEmpty() || pulumiSchema == "" {
+	dispatchTable, pulumiSchema := m.DispatchTable.dispatchTable, m.Schema
+	if dispatchTable.isEmpty() || pulumiSchema == "" {
 		req := &rpc.GetSchemaRequest{Version: SchemaVersion}
 		primary, err := servers[0].GetSchema(context.Background(), req)
 		contract.AssertNoErrorf(err, "Muxing requires GetSchema for dispatch")
@@ -126,15 +126,15 @@ func (m Main) Server(host *provider.HostClient, module, version string) (pulumir
 			schemas[i] = o
 		}
 
-		mComputed, muxedSchema, err := Mapping(schemas)
+		mComputed, muxedSchema, err := MergeSchemasAndComputeDispatchTable(schemas)
 		contract.AssertNoErrorf(err, "Failed to compute a muxer mapping")
 		schemaBytes, err := json.Marshal(muxedSchema)
 		contract.AssertNoErrorf(err, "Failed to marshal muxed schema")
 		pulumiSchema = string(schemaBytes)
-		mapping = mComputed.mapping
+		dispatchTable = mComputed.dispatchTable
 	}
 
-	server := mux(host, mapping, pulumiSchema, m.GetMappingHandler, servers...)
+	server := mux(host, dispatchTable, pulumiSchema, m.GetMappingHandler, servers...)
 
 	return server, nil
 }

--- a/x/muxer/mapping.go
+++ b/x/muxer/mapping.go
@@ -21,7 +21,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
-type ComputedMapping struct {
+type DispatchTable struct {
 	// mapping is an implementation detail.
 	//
 	// Right now, we want to expose the same information to the user, but that doesn't
@@ -29,7 +29,7 @@ type ComputedMapping struct {
 	mapping
 }
 
-func Mapping(schemas []schema.PackageSpec) (ComputedMapping, schema.PackageSpec, error) {
+func Mapping(schemas []schema.PackageSpec) (DispatchTable, schema.PackageSpec, error) {
 	// TODO Insert sanity checks and return an error on conflicts:
 	// https://github.com/pulumi/pulumi-terraform-bridge/issues/949 For example right
 	// now, if different schemas define the same type in different ways, which ever
@@ -61,7 +61,7 @@ func Mapping(schemas []schema.PackageSpec) (ComputedMapping, schema.PackageSpec,
 		muxedSchema.Functions = nil
 	}
 
-	return ComputedMapping{mapping}, *muxedSchema, nil
+	return DispatchTable{mapping}, *muxedSchema, nil
 }
 
 type mapping struct {

--- a/x/muxer/mapping.go
+++ b/x/muxer/mapping.go
@@ -26,17 +26,17 @@ type DispatchTable struct {
 	//
 	// Right now, we want to expose the same information to the user, but that doesn't
 	// need to be true forever.
-	mapping
+	dispatchTable
 }
 
-func Mapping(schemas []schema.PackageSpec) (DispatchTable, schema.PackageSpec, error) {
+func MergeSchemasAndComputeDispatchTable(schemas []schema.PackageSpec) (DispatchTable, schema.PackageSpec, error) {
 	// TODO Insert sanity checks and return an error on conflicts:
 	// https://github.com/pulumi/pulumi-terraform-bridge/issues/949 For example right
 	// now, if different schemas define the same type in different ways, which ever
 	// schema comes first dominates.
 
 	muxedSchema := func() *schema.PackageSpec { x := schemas[0]; return &x }()
-	mapping := newMapping()
+	dispatchTable := newDispatchTable()
 
 	// We need to zero these maps out so our normal process can re-add them. This
 	// maintains consistency.
@@ -48,7 +48,7 @@ func Mapping(schemas []schema.PackageSpec) (DispatchTable, schema.PackageSpec, e
 
 	for i, s := range schemas {
 		i, s := i, s
-		mapping.layerSchema(muxedSchema, &s, i)
+		dispatchTable.layerSchema(muxedSchema, &s, i)
 	}
 
 	if len(muxedSchema.Resources) == 0 {
@@ -61,10 +61,10 @@ func Mapping(schemas []schema.PackageSpec) (DispatchTable, schema.PackageSpec, e
 		muxedSchema.Functions = nil
 	}
 
-	return DispatchTable{mapping}, *muxedSchema, nil
+	return DispatchTable{dispatchTable: dispatchTable}, *muxedSchema, nil
 }
 
-type mapping struct {
+type dispatchTable struct {
 	// Resources and functions can only map to a single provider
 	Resources map[string]int `json:"resources"`
 	Functions map[string]int `json:"functions"`
@@ -73,26 +73,26 @@ type mapping struct {
 	Config map[string][]int `json:"config"`
 }
 
-func newMapping() mapping {
-	return mapping{
+func newDispatchTable() dispatchTable {
+	return dispatchTable{
 		Resources: make(map[string]int),
 		Functions: make(map[string]int),
 		Config:    make(map[string][]int),
 	}
 }
 
-func (mapping mapping) isEmpty() bool {
-	return mapping.Resources == nil &&
-		mapping.Functions == nil &&
-		mapping.Config == nil
+func (dispatchTable dispatchTable) isEmpty() bool {
+	return dispatchTable.Resources == nil &&
+		dispatchTable.Functions == nil &&
+		dispatchTable.Config == nil
 }
 
 // Layer `srcSchema` under `dstSchema`, keeping track of where resources and functions
 // were mapped from.
 //
 // `srcIndex` is the index of `srcSchema` and thus its server.
-func (mapping mapping) layerSchema(dstSchema, srcSchema *schema.PackageSpec, srcIndex int) {
-	m := mappingCtx{mapping, dstSchema, srcSchema, srcIndex}
+func (dispatchTable dispatchTable) layerSchema(dstSchema, srcSchema *schema.PackageSpec, srcIndex int) {
+	m := dispatchTableCtx{dispatchTable, dstSchema, srcSchema, srcIndex}
 
 	for tk, r := range m.srcSchema.Resources {
 		m.setResource(tk, r)
@@ -109,7 +109,7 @@ func (mapping mapping) layerSchema(dstSchema, srcSchema *schema.PackageSpec, src
 	}
 
 	for k := range m.srcSchema.Config.Variables {
-		m.mapping.Config[k] = append(m.mapping.Config[k], m.srcIndex)
+		m.dispatchTable.Config[k] = append(m.dispatchTable.Config[k], m.srcIndex)
 	}
 	layerMap(&m.dstSchema.Config.Variables, m.srcSchema.Config.Variables,
 		func(_ string, t schema.PropertySpec) { m.addType(t.TypeSpec) })
@@ -136,7 +136,7 @@ func layerMap[K comparable, V any](dst *map[K]V, src map[K]V, finalize func(k K,
 }
 
 // Layer a provider resource onto another resource.
-func (m *mappingCtx) layerProvider(dst *schema.ResourceSpec, src schema.ResourceSpec) {
+func (m *dispatchTableCtx) layerProvider(dst *schema.ResourceSpec, src schema.ResourceSpec) {
 	// As implemented, this could layer an arbitrary resource onto another arbitrary
 	// resource. The only resource where we want to "merge" instead "pick one" is the
 	// provider resource.
@@ -173,18 +173,18 @@ func appendUnique[T comparable](dst, src []T) []T {
 	return dst
 }
 
-type mappingCtx struct {
-	mapping              mapping
+type dispatchTableCtx struct {
+	dispatchTable        dispatchTable
 	dstSchema, srcSchema *schema.PackageSpec
 	srcIndex             int
 }
 
-func (m *mappingCtx) setResource(token string, resource schema.ResourceSpec) {
-	_, ok := m.mapping.Resources[token]
+func (m *dispatchTableCtx) setResource(token string, resource schema.ResourceSpec) {
+	_, ok := m.dispatchTable.Resources[token]
 	if ok {
 		return
 	}
-	m.mapping.Resources[token] = m.srcIndex
+	m.dispatchTable.Resources[token] = m.srcIndex
 	m.dstSchema.Resources[token] = resource
 	m.addProperties(resource.InputProperties)
 	m.addProperties(resource.Properties)
@@ -193,8 +193,8 @@ func (m *mappingCtx) setResource(token string, resource schema.ResourceSpec) {
 	}
 }
 
-func (m *mappingCtx) setFunction(token string, function schema.FunctionSpec) {
-	_, ok := m.mapping.Functions[token]
+func (m *dispatchTableCtx) setFunction(token string, function schema.FunctionSpec) {
+	_, ok := m.dispatchTable.Functions[token]
 	if ok {
 		return
 	}
@@ -204,13 +204,13 @@ func (m *mappingCtx) setFunction(token string, function schema.FunctionSpec) {
 	m.addObjectType(function.Outputs)
 }
 
-func (m *mappingCtx) addProperties(properties map[string]schema.PropertySpec) {
+func (m *dispatchTableCtx) addProperties(properties map[string]schema.PropertySpec) {
 	for _, t := range properties {
 		m.addType(t.TypeSpec)
 	}
 }
 
-func (m *mappingCtx) addType(t schema.TypeSpec) {
+func (m *dispatchTableCtx) addType(t schema.TypeSpec) {
 	if t.Ref != "" {
 		m.addRefType(t.Ref)
 	}
@@ -236,7 +236,7 @@ func (m *mappingCtx) addType(t schema.TypeSpec) {
 	}
 }
 
-func (m *mappingCtx) addRefType(ref string) {
+func (m *dispatchTableCtx) addRefType(ref string) {
 	// External references don't need to be addressed, since there isn't any
 	// associated data in this schema.
 	//
@@ -271,7 +271,7 @@ func (m *mappingCtx) addRefType(ref string) {
 	m.addComplexType(token, typ)
 }
 
-func (m *mappingCtx) addComplexType(token string, typ schema.ComplexTypeSpec) {
+func (m *dispatchTableCtx) addComplexType(token string, typ schema.ComplexTypeSpec) {
 	m.dstSchema.Types[token] = typ
 
 	if typ.Type != "object" {
@@ -282,7 +282,7 @@ func (m *mappingCtx) addComplexType(token string, typ schema.ComplexTypeSpec) {
 	m.addObjectType(&typ.ObjectTypeSpec)
 }
 
-func (m *mappingCtx) addObjectType(typ *schema.ObjectTypeSpec) {
+func (m *dispatchTableCtx) addObjectType(typ *schema.ObjectTypeSpec) {
 	if typ == nil {
 		return
 	}

--- a/x/muxer/mapping_test.go
+++ b/x/muxer/mapping_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 )
 
-func TestMapping(t *testing.T) {
+func TestMergeSchemasAndComputeDispatchTable(t *testing.T) {
 	s1 := schema.PackageSpec{
 		Name: "pkg",
 		Resources: map[string]schema.ResourceSpec{
@@ -97,7 +97,7 @@ func TestMapping(t *testing.T) {
 		},
 	}
 
-	computedMapping, sMuxed, err := Mapping([]schema.PackageSpec{s1, s2})
+	computedDT, sMuxed, err := MergeSchemasAndComputeDispatchTable([]schema.PackageSpec{s1, s2})
 	require.NoError(t, err)
 
 	assert.Equal(t, schema.PackageSpec{
@@ -158,7 +158,7 @@ func TestMapping(t *testing.T) {
 		},
 	}, sMuxed)
 
-	assert.Equal(t, mapping{
+	assert.Equal(t, dispatchTable{
 		Resources: map[string]int{
 			"pkg:mod:ResA": 0,
 			"pkg:mod:ResB": 1,
@@ -170,5 +170,5 @@ func TestMapping(t *testing.T) {
 			"var2": {0, 1},
 			"var3": {1},
 		},
-	}, computedMapping.mapping)
+	}, computedDT.dispatchTable)
 }

--- a/x/muxer/tests/muxer_test.go
+++ b/x/muxer/tests/muxer_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 func TestSimpleDispatch(t *testing.T) {
-	var m muxer.ComputedMapping
+	var m muxer.DispatchTable
 	m.Resources = map[string]int{
 		"test:mod:A": 0,
 		"test:mod:B": 1,
@@ -69,7 +69,7 @@ func TestSimpleDispatch(t *testing.T) {
 }
 
 func TestConfigure(t *testing.T) {
-	var m muxer.ComputedMapping
+	var m muxer.DispatchTable
 	m.Resources = map[string]int{
 		"test:mod:A": 0,
 		"test:mod:B": 1,
@@ -113,7 +113,7 @@ func TestConfigure(t *testing.T) {
 
 func TestGetMapping(t *testing.T) {
 	t.Run("single-responding-server", func(t *testing.T) {
-		var m muxer.ComputedMapping
+		var m muxer.DispatchTable
 		m.Resources = map[string]int{
 			"test:mod:A": 0,
 			"test:mod:B": 1,
@@ -138,7 +138,7 @@ func TestGetMapping(t *testing.T) {
 }`)))
 	})
 	t.Run("merged-responding-server", func(t *testing.T) {
-		var m muxer.ComputedMapping
+		var m muxer.DispatchTable
 		m.Resources = map[string]int{
 			"test:mod:A": 0,
 			"test:mod:B": 1,
@@ -174,11 +174,11 @@ func TestGetMapping(t *testing.T) {
 
 type testMuxer struct {
 	t                  *testing.T
-	mapping            muxer.ComputedMapping
+	mapping            muxer.DispatchTable
 	getMappingHandlers map[string]muxer.MultiMappingHandler
 }
 
-func mux(t *testing.T, mapping muxer.ComputedMapping) testMuxer {
+func mux(t *testing.T, mapping muxer.DispatchTable) testMuxer {
 	return testMuxer{t, mapping, nil}
 }
 
@@ -262,7 +262,7 @@ func part(provider int, request, response string) ExchangePart {
 }
 
 func buildMux(
-	t *testing.T, mapping muxer.ComputedMapping,
+	t *testing.T, mapping muxer.DispatchTable,
 	getMappings map[string]muxer.MultiMappingHandler,
 	servers ...rpc.ResourceProviderServer,
 ) rpc.ResourceProviderServer {
@@ -278,7 +278,7 @@ func buildMux(
 	}
 	s, err := muxer.Main{
 		Servers:           endpoints,
-		ComputedMapping:   mapping,
+		DispatchTable:     mapping,
 		Schema:            "some-schema",
 		GetMappingHandler: getMappings,
 	}.Server(nil, "test", "0.0.0")


### PR DESCRIPTION
Noticing we were getting confused between this mapping and GetMapping call. A new name. Mechanical rename PR, no behavior changes.