### PR TITLE
Fix provider configuration secrets handling for bridged providers

### DIFF
--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -310,6 +310,8 @@ func (p *Provider) CheckConfig(ctx context.Context, req *pulumirpc.CheckRequest)
 
 	configEnc := newConfigEncoding(p.config, p.info.Config)
 
+	secrets := configEnc.ComputeSecrets(req.GetNews(), marshalOptions)
+
 	news, validationErrors := configEnc.UnmarshalProperties(req.GetNews(), marshalOptions)
 	if validationErrors != nil {
 		return nil, errors.Wrap(validationErrors, "CheckConfig failed because of malformed resource inputs")
@@ -347,7 +349,7 @@ func (p *Provider) CheckConfig(ctx context.Context, req *pulumirpc.CheckRequest)
 	}
 
 	// In case news was modified by pre-configure callbacks, marshal it again to send out the modified value.
-	newsStruct, err := configEnc.MarshalProperties(news, marshalOptions)
+	newsStruct, err := configEnc.MarshalProperties(configEnc.MarkSecrets(secrets, news), marshalOptions)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The results of CheckConfig are written to the state by Pulumi CLI, therfore handling sensitive fields in CheckConfig is important to avoid storing sensitive data in plain-text from in the state file.

Changes:

- If a program uses a secret value when doing explicit provider configuration of a bridged provider, this value is now stored encrypted in the state file.

  See also: https://www.pulumi.com/docs/intro/concepts/resources/providers/#explicit-provider-configuration

- If a value is marked as sensitive in the upstream provider schema, it is now stored encrypted in the Pulumi statefile regardless of whether the provider is explicit or default.

- Providers with nested configuration options now support sensitive sub-properties. Due to limitatios of current design the sub-properties are supported using a conservative approximation. If any sub-properties are passed secret values by the program or marked sensitive in the upstream provider schema, the entire top-level property is stored encrypted in the state file.

The implementation relies on Pulumi engine to respect the results of CheckConfig call when storing provider state.