### PR TITLE
Update Muxer Deps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/pulumi/pulumi-java/pkg v0.8.0
 	github.com/pulumi/pulumi-terraform-bridge/testing v0.0.1
-	github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.1
+	github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.3
 	github.com/pulumi/pulumi-yaml v1.0.4
 	github.com/pulumi/schema-tools v0.1.2
 	github.com/pulumi/terraform-diff-reader v0.0.0-20201211191010-ad4715e9285e

--- a/pf/go.mod
+++ b/pf/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.14.3
 	github.com/hashicorp/terraform-plugin-log v0.7.0
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.34.1-0.20221214173921-8e65b1f9fdd5
-	github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.1
+	github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.3
 	github.com/stretchr/testify v1.8.2
 	google.golang.org/grpc v1.53.0
 	pgregory.net/rapid v0.5.5

--- a/pf/tests/go.mod
+++ b/pf/tests/go.mod
@@ -196,7 +196,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/posener/complete v1.2.3 // indirect
 	github.com/pulumi/pulumi-java/pkg v0.8.0 // indirect
-	github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.1 // indirect
+	github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.3 // indirect
 	github.com/pulumi/pulumi-yaml v1.0.4 // indirect
 	github.com/pulumi/pulumi/pkg/v3 v3.59.0
 	github.com/pulumi/pulumi/sdk/v3 v3.59.0

--- a/pkg/tests/go.mod
+++ b/pkg/tests/go.mod
@@ -71,7 +71,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/term v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.1 // indirect
+	github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.3 // indirect
 	github.com/pulumi/pulumi/pkg/v3 v3.59.0 // indirect
 	github.com/pulumi/pulumi/sdk/v3 v3.59.0 // indirect
 	github.com/pulumi/terraform-diff-reader v0.0.0-20201211191010-ad4715e9285e // indirect

--- a/x/muxer/tests/go.mod
+++ b/x/muxer/tests/go.mod
@@ -6,7 +6,7 @@ replace github.com/pulumi/pulumi-terraform-bridge/x/muxer => ../
 
 require (
 	github.com/pulumi/pulumi-terraform-bridge/testing v0.0.0-20230406212415-0b560771908d
-	github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.1
+	github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.3
 	github.com/pulumi/pulumi/pkg/v3 v3.62.0
 	github.com/pulumi/pulumi/sdk/v3 v3.62.0
 	github.com/stretchr/testify v1.8.2


### PR DESCRIPTION
The muxer is consumed by proxy in bridged providers. If we make breaking changes, we need to update the dependency reference for it to trickle down to downstream providers.