### PR TITLE
Fix returning secret values out of Plugin Framework based functions

### DIFF
--- a/pf/tests/integration/program_test.go
+++ b/pf/tests/integration/program_test.go
@@ -121,9 +121,7 @@ func ensureTestBridgeProviderCompiled(wd string) error {
 func validateExpectedVsActual(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 	expects := map[string]interface{}{}
 	actuals := map[string]interface{}{}
-	all := []string{}
 	for n, output := range stack.Outputs {
-		all = append(all, n)
 		if strings.HasSuffix(n, "__actual") {
 			actuals[strings.TrimSuffix(n, "__actual")] = output
 		}

--- a/pf/tests/integration/program_test.go
+++ b/pf/tests/integration/program_test.go
@@ -121,7 +121,9 @@ func ensureTestBridgeProviderCompiled(wd string) error {
 func validateExpectedVsActual(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 	expects := map[string]interface{}{}
 	actuals := map[string]interface{}{}
+	all := []string{}
 	for n, output := range stack.Outputs {
+		all = append(all, n)
 		if strings.HasSuffix(n, "__actual") {
 			actuals[strings.TrimSuffix(n, "__actual")] = output
 		}
@@ -129,7 +131,11 @@ func validateExpectedVsActual(t *testing.T, stack integration.RuntimeValidationS
 			expects[strings.TrimSuffix(n, "__expect")] = output
 		}
 	}
+	keys := []string{}
 	for k := range expects {
+		keys = append(keys, k)
+	}
+	for _, k := range keys {
 		k := k
 		t.Run(k, func(t *testing.T) {
 			assert.Equal(t, expects[k], actuals[k])

--- a/pf/tests/integration/program_test.go
+++ b/pf/tests/integration/program_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
+	"sort"
 )
 
 func TestBasicProgram(t *testing.T) {
@@ -133,6 +134,7 @@ func validateExpectedVsActual(t *testing.T, stack integration.RuntimeValidationS
 	for k := range expects {
 		keys = append(keys, k)
 	}
+	sort.Strings(keys)
 	for _, k := range keys {
 		k := k
 		t.Run(k, func(t *testing.T) {

--- a/pf/tests/internal/testprovider/cmd/pulumi-resource-testbridge/bridge-metadata.json
+++ b/pf/tests/internal/testprovider/cmd/pulumi-resource-testbridge/bridge-metadata.json
@@ -6,6 +6,9 @@
             "testbridge:index/testres:Testcompres": "testbridge_testcompres",
             "testbridge:index/testres:Testres": "testbridge_testres"
         },
+        "functions": {
+            "testbridge:index/echo:Echo": "testbridge_echo"
+        },
         "renamedProperties": {
             "testbridge:index/TestnestRule:TestnestRule": {
                 "actionParameters": "action_parameters"

--- a/pf/tests/internal/testprovider/cmd/pulumi-resource-testbridge/schema.json
+++ b/pf/tests/internal/testprovider/cmd/pulumi-resource-testbridge/schema.json
@@ -481,5 +481,42 @@
                 "type": "object"
             }
         }
+    },
+    "functions": {
+        "testbridge:index/echo:Echo": {
+            "inputs": {
+                "description": "A collection of arguments for invoking Echo.\n",
+                "properties": {
+                    "input": {
+                        "type": "string"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "input"
+                ]
+            },
+            "outputs": {
+                "description": "A collection of values returned by Echo.\n",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "The provider-assigned unique ID for this managed resource.\n"
+                    },
+                    "input": {
+                        "type": "string"
+                    },
+                    "output": {
+                        "type": "string"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "input",
+                    "output",
+                    "id"
+                ]
+            }
+        }
     }
 }

--- a/pf/tests/internal/testprovider/cmd/pulumi-resource-testbridge/schema.json
+++ b/pf/tests/internal/testprovider/cmd/pulumi-resource-testbridge/schema.json
@@ -508,12 +508,17 @@
                     },
                     "output": {
                         "type": "string"
+                    },
+                    "sensitive": {
+                        "type": "string",
+                        "secret": true
                     }
                 },
                 "type": "object",
                 "required": [
                     "input",
                     "output",
+                    "sensitive",
                     "id"
                 ]
             }

--- a/pf/tests/internal/testprovider/testbridge.go
+++ b/pf/tests/internal/testprovider/testbridge.go
@@ -69,6 +69,9 @@ func SyntheticTestBridgeProvider() tfpf.ProviderInfo {
 			"testbridge_testcompres":   {Tok: "testbridge:index/testres:Testcompres"},
 			"testbridge_testconfigres": {Tok: "testbridge:index/testres:TestConfigRes"},
 		},
+		DataSources: map[string]*tfbridge.DataSourceInfo{
+			"testbridge_echo": {Tok: "testbridge:index/echo:Echo"},
+		},
 		MetadataInfo: tfbridge.NewProviderMetadata(testBridgeMetadata),
 	}
 	return tfpf.ProviderInfo{
@@ -105,7 +108,9 @@ func (p *syntheticProvider) Configure(ctx context.Context, req provider.Configur
 }
 
 func (p *syntheticProvider) DataSources(context.Context) []func() datasource.DataSource {
-	return []func() datasource.DataSource{}
+	return []func() datasource.DataSource{
+		newEchoDataSource,
+	}
 }
 
 func (p *syntheticProvider) Resources(context.Context) []func() resource.Resource {

--- a/pf/tests/internal/testprovider/testbridge_datasource_echo.go
+++ b/pf/tests/internal/testprovider/testbridge_datasource_echo.go
@@ -36,8 +36,9 @@ func (*echoDataSource) Metadata(ctx context.Context, req datasource.MetadataRequ
 func (*echoDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
-			"input":  schema.StringAttribute{Required: true},
-			"output": schema.StringAttribute{Computed: true},
+			"input":     schema.StringAttribute{Required: true},
+			"output":    schema.StringAttribute{Computed: true},
+			"sensitive": schema.StringAttribute{Computed: true, Sensitive: true},
 		},
 	}
 }
@@ -50,4 +51,8 @@ func (*echoDataSource) Read(ctx context.Context, req datasource.ReadRequest, res
 	output := input
 	diags2 := resp.State.SetAttribute(ctx, path.Root("output"), output)
 	resp.Diagnostics.Append(diags2...)
+
+	sensitive := input
+	diags3 := resp.State.SetAttribute(ctx, path.Root("sensitive"), sensitive)
+	resp.Diagnostics.Append(diags3...)
 }

--- a/pf/tests/internal/testprovider/testbridge_datasource_echo.go
+++ b/pf/tests/internal/testprovider/testbridge_datasource_echo.go
@@ -1,0 +1,53 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testprovider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+)
+
+func newEchoDataSource() datasource.DataSource {
+	return &echoDataSource{}
+}
+
+type echoDataSource struct{}
+
+func (*echoDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest,
+	resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_echo"
+}
+
+func (*echoDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"input":  schema.StringAttribute{Required: true},
+			"output": schema.StringAttribute{Computed: true},
+		},
+	}
+}
+
+func (*echoDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var input string
+	diags := req.Config.GetAttribute(ctx, path.Root("input"), &input)
+	resp.Diagnostics.Append(diags...)
+
+	output := input
+	diags2 := resp.State.SetAttribute(ctx, path.Root("output"), output)
+	resp.Diagnostics.Append(diags2...)
+}

--- a/pf/tests/testdata/basicprogram/Pulumi.yaml
+++ b/pf/tests/testdata/basicprogram/Pulumi.yaml
@@ -173,7 +173,6 @@ outputs:
         protocol: ssh
 
   # TODO this is currently failing.
-  #
   # tupleElementAttrRes__actual: ${tupleElementAttrRes.tuplesOptionals}
   # tupleElementAttrRes__expect:
   #   - { t0: false, t1: "no" }
@@ -194,4 +193,6 @@ outputs:
     input:
       "Hello"
     output:
+      "Hello"
+    sensitive:
       "Hello"

--- a/pf/tests/testdata/basicprogram/Pulumi.yaml
+++ b/pf/tests/testdata/basicprogram/Pulumi.yaml
@@ -171,11 +171,27 @@ outputs:
               - sshd
             port: 22
         protocol: ssh
-  tupleElementAttrRes__actual: ${tupleElementAttrRes.tuplesOptionals}
-  tupleElementAttrRes__expected:
-    - { t0: false, t1: "no" }
-    - { t0: true, t1: "yes"}
+
+  # TODO this is currently failing.
+  #
+  # tupleElementAttrRes__actual: ${tupleElementAttrRes.tuplesOptionals}
+  # tupleElementAttrRes__expect:
+  #   - { t0: false, t1: "no" }
+  #   - { t0: true, t1: "yes"}
+
   setElementAttrRes__actual: ${setElementAttrRes.setOptionals}
-  setElementAttrRes__expected: [ "hi", "bye" ]
+  setElementAttrRes__expect: [ "hi", "bye" ]
+
   setElementRevAttrRes__actual: ${setElementRevAttrRes.setOptionals}
-  setElementRevAttrRes__expected: [ "bye", "hi" ]
+  setElementRevAttrRes__expect: [ "bye", "hi" ]
+
+  testEcho__actual:
+    fn::invoke:
+      function: testbridge:index/echo:Echo
+      arguments:
+        input: "Hello"
+  testEcho__expect:
+    input:
+      "Hello"
+    output:
+      "Hello"

--- a/pf/tfbridge/provider_invoke.go
+++ b/pf/tfbridge/provider_invoke.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/pulumi/pulumi-terraform-bridge/pf/internal/convert"
 	"github.com/pulumi/pulumi-terraform-bridge/pf/internal/propertyvalue"
@@ -100,7 +101,16 @@ func (p *provider) readDataSource(ctx context.Context, handle datasourceHandle,
 	// TODO[pulumi/pulumi#12710] consuming programs (at lest in Go and YAML) are unable to accept secrets from an
 	// Invoke response at the moment. Replace secrets with underlying plain values.
 	for k, v := range propertyMap {
-		propertyMap[k] = propertyvalue.RemoveSecrets(v)
+		if v.ContainsSecrets() {
+			tflog.Debug(ctx, "[pf/tfbridge] Ignoring secret in Invoke result due to pulumi/pulumi#12710",
+				map[string]any{
+					"property": k,
+					"token":    handle.token,
+				})
+			propertyMap[k] = propertyvalue.RemoveSecrets(v)
+		} else {
+			propertyMap[k] = v
+		}
 	}
 
 	return propertyMap, nil, nil

--- a/pf/tfbridge/provider_invoke.go
+++ b/pf/tfbridge/provider_invoke.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
 	"github.com/pulumi/pulumi-terraform-bridge/pf/internal/convert"
+	"github.com/pulumi/pulumi-terraform-bridge/pf/internal/propertyvalue"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -94,6 +95,12 @@ func (p *provider) readDataSource(ctx context.Context, handle datasourceHandle,
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot decode state from a call to ReadDataSource for %q: %w",
 			handle.terraformDataSourceName, err)
+	}
+
+	// TODO[pulumi/pulumi#12710] consuming programs (at lest in Go and YAML) are unable to accept secrets from an
+	// Invoke response at the moment. Replace secrets with underlying plain values.
+	for k, v := range propertyMap {
+		propertyMap[k] = propertyvalue.RemoveSecrets(v)
 	}
 
 	return propertyMap, nil, nil

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -1144,7 +1144,11 @@ func (p *Provider) Invoke(ctx context.Context, req *pulumirpc.InvokeRequest) (*p
 	// First, create the inputs.
 	tfname := ds.TFName
 	inputs, _, err := MakeTerraformInputs(
-		&PulumiResource{Properties: args}, p.configValues, nil, args, ds.TF.Schema(), ds.Schema.Fields)
+		&PulumiResource{Properties: args},
+		p.configValues,
+		nil, args,
+		ds.TF.Schema(),
+		ds.Schema.Fields)
 	if err != nil {
 		return nil, errors.Wrapf(err, "couldn't prepare resource %v input state", tfname)
 	}


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/998

The fix works around what appears to be the underlying problem in Pulumi SDKs at least for Go and YAML: https://github.com/pulumi/pulumi/issues/12710

I would love some feedback from platform team on whether we can fix it in a different way before proceeding with the workaround, as the workaround can lose secret-bits that are intentionally marked as such in the schema.