### PR TITLE
Actually set runtime aliases in the underlying provider

### DIFF
--- a/pf/internal/muxer/muxer.go
+++ b/pf/internal/muxer/muxer.go
@@ -121,6 +121,9 @@ func newProviderShim(provider shim.Provider) ProviderShim {
 
 // Assign each Resource and DataSource mapped in `info` whichever runtime provider defines
 // it.
+//
+// For alias based mappings to work correctly at runtime, it is necessary to call
+// `ResolveDispatch` before running the provider.
 func (m *ProviderShim) ResolveDispatch(info *tfbridge.ProviderInfo) (muxer.DispatchTable, error) {
 	var dispatch muxer.DispatchTable
 	dispatch.Resources = map[string]int{}
@@ -194,6 +197,7 @@ func resolveDispatchMap[T interface{ GetTok() tokens.Token }](
 			i, ok := reverseLookupMap[r]
 			if ok {
 				dispatch[string(res.GetTok())] = i
+				mapKind(m.MuxedProviders[i]).Set(tfToken, r)
 				found = true
 			}
 		}

--- a/pf/tests/provider_create_test.go
+++ b/pf/tests/provider_create_test.go
@@ -111,6 +111,44 @@ func TestPreviewCreate(t *testing.T) {
 	testutils.Replay(t, server, testCase)
 }
 
+func TestMuxedAliasCreate(t *testing.T) {
+	server := newMuxedProviderServer(t, testprovider.MuxedRandomProvider())
+
+	testCase := func(typ string) string {
+		return `
+	{
+	  "method": "/pulumirpc.ResourceProvider/Create",
+	  "request": {
+	    "urn": "urn:pulumi:dev::repro::` + typ + `::k"
+	  },
+	  "response": {
+	    "id": "4",
+	    "properties": {
+	      "id": "4",
+	      "fair": true,
+	      "number": 4,
+	      "suggestionUpdated": false
+	    }
+	  },
+	  "metadata": {
+	    "kind": "resource",
+	    "mode": "client",
+	    "name": "muxedrandom"
+	  }
+	}
+`
+	}
+
+	t.Run("new-token", func(t *testing.T) {
+		testutils.Replay(t, server,
+			testCase("muxedrandom:index/randomHumanNumber:RandomHumanNumber"))
+	})
+	t.Run("legacy-token", func(t *testing.T) {
+		testutils.Replay(t, server,
+			testCase("muxedrandom:index/myNumber:MyNumber"))
+	})
+}
+
 func TestCreateWithFirstClassSecrets(t *testing.T) {
 	server := newProviderServer(t, testprovider.RandomProvider())
 	testCase := `

--- a/pf/tests/util.go
+++ b/pf/tests/util.go
@@ -24,12 +24,21 @@ import (
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 
 	"github.com/pulumi/pulumi-terraform-bridge/pf/tfbridge"
+	tfbridge0 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 )
 
 func newProviderServer(t *testing.T, info tfbridge.ProviderInfo) pulumirpc.ResourceProviderServer {
-	ctx := context.TODO()
+	ctx := context.Background()
 	meta := genMetadata(t, info)
 	p, err := tfbridge.NewProvider(ctx, info, meta)
 	require.NoError(t, err)
 	return plugin.NewProviderServer(p)
+}
+
+func newMuxedProviderServer(t *testing.T, info tfbridge0.ProviderInfo) pulumirpc.ResourceProviderServer {
+	ctx := context.Background()
+	meta := genSDKSchema(t, info)
+	p, err := tfbridge.MakeMuxedServer(ctx, meta, info)(nil)
+	require.NoError(t, err)
+	return p
 }

--- a/pf/tfbridge/main.go
+++ b/pf/tfbridge/main.go
@@ -125,6 +125,8 @@ func MakeMuxedServer(
 
 	shim, ok := info.P.(*pfmuxer.ProviderShim)
 	contract.Assertf(ok, "MainWithMuxer must have a ProviderInfo.P created with AugmentShimWithPF")
+	_, err := shim.ResolveDispatch(&info)
+	contract.AssertNoErrorf(err, "Failed to re-apply alias mappings")
 	version := info.Version
 	dispatchTable, found, err := metadata.Get[muxer.DispatchTable](info.GetMetadata(), "mux")
 	if err != nil {


### PR DESCRIPTION
This PR ensures that the underlying providers are informed of aliases at runtime. https://github.com/pulumi/pulumi-terraform-bridge/pull/1017 ensured that the bridge's mappings dispatched correctly, but did not actually get them working at runtime.

This PR also adds a runtime test to ensure that aliased resources work correctly.