### PR TITLE
Permit skipping flaky example generation

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -102,6 +102,19 @@ type ProviderInfo struct {
 	MetadataInfo *MetadataInfo
 
 	UpstreamRepoPath string // An optional path that overrides upstream location during docs lookup
+
+	// If set, allows selecting individual examples to skip generating into the PackageSchema (and eventually API
+	// docs). The primary use case for this hook is to ignore problematic or flaky examples temporarily until the
+	// underlying issues are resolved and the examples can be rendered correctly.
+	//
+	// token will be a resource, function, or type token from Pulumi Package Schema. For instance,
+	// "aws:acm/certificate:Certificate" would indicate the example pertains to the Certificate resource in the AWS
+	// provider.
+	//
+	// examplePath will provide even more information on where the example is found. For instance,
+	// "#/resources/aws:acm/certificate:Certificate/arn" would encode that the example pertains to the arn property
+	// of the Certificate resource in the AWS provider.
+	SkipExamples func(token, examplePath string) bool
 }
 
 // TFProviderLicense is a way to be able to pass a license type for the upstream Terraform provider.

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -103,18 +103,12 @@ type ProviderInfo struct {
 
 	UpstreamRepoPath string // An optional path that overrides upstream location during docs lookup
 
+	// EXPERIMENTAL: the signature may change in minor releases.
+	//
 	// If set, allows selecting individual examples to skip generating into the PackageSchema (and eventually API
 	// docs). The primary use case for this hook is to ignore problematic or flaky examples temporarily until the
 	// underlying issues are resolved and the examples can be rendered correctly.
-	//
-	// token will be a resource, function, or type token from Pulumi Package Schema. For instance,
-	// "aws:acm/certificate:Certificate" would indicate the example pertains to the Certificate resource in the AWS
-	// provider.
-	//
-	// examplePath will provide even more information on where the example is found. For instance,
-	// "#/resources/aws:acm/certificate:Certificate/arn" would encode that the example pertains to the arn property
-	// of the Certificate resource in the AWS provider.
-	SkipExamples func(token, examplePath string) bool
+	SkipExamples func(SkipExamplesArgs) bool
 }
 
 // TFProviderLicense is a way to be able to pass a license type for the upstream Terraform provider.
@@ -1005,4 +999,17 @@ type PreStateUpgradeHookArgs struct {
 	PriorState              resource.PropertyMap
 	PriorStateSchemaVersion int64
 	ResourceSchemaVersion   int64
+}
+
+// EXPERIMENTAL: the signature may change in minor releases.
+type SkipExamplesArgs struct {
+	// token will be a resource, function, or type token from Pulumi Package Schema. For instance,
+	// "aws:acm/certificate:Certificate" would indicate the example pertains to the Certificate resource in the AWS
+	// provider.
+	Token string
+
+	// examplePath will provide even more information on where the example is found. For instance,
+	// "#/resources/aws:acm/certificate:Certificate/arn" would encode that the example pertains to the arn property
+	// of the Certificate resource in the AWS provider.
+	ExamplePath string
 }

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -1085,6 +1085,12 @@ func (g *Generator) convertExamples(docs string, path examplePath, stripSubsecti
 		return ""
 	}
 
+	if g.info.SkipExamples != nil {
+		if g.info.SkipExamples(path.Token(), path.String()) {
+			return ""
+		}
+	}
+
 	if strings.Contains(docs, "```typescript") || strings.Contains(docs, "```python") ||
 		strings.Contains(docs, "```go") || strings.Contains(docs, "```yaml") ||
 		strings.Contains(docs, "```csharp") || strings.Contains(docs, "```java") {

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -1086,7 +1086,10 @@ func (g *Generator) convertExamples(docs string, path examplePath, stripSubsecti
 	}
 
 	if g.info.SkipExamples != nil {
-		if g.info.SkipExamples(path.Token(), path.String()) {
+		if g.info.SkipExamples(tfbridge.SkipExamplesArgs{
+			Token:       path.Token(),
+			ExamplePath: path.String(),
+		}) {
 			return ""
 		}
 	}

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -1080,7 +1080,7 @@ func (p *tfMarkdownParser) reformatSubsection(lines []string) ([]string, bool, b
 
 // convertExamples converts any code snippets in a subsection to Pulumi-compatible code. This conversion is done on a
 // per-subsection basis; subsections with failing examples will be elided upon the caller's request.
-func (g *Generator) convertExamples(docs, name string, stripSubsectionsWithErrors bool) string {
+func (g *Generator) convertExamples(docs string, path examplePath, stripSubsectionsWithErrors bool) string {
 	if docs == "" {
 		return ""
 	}
@@ -1147,7 +1147,7 @@ func (g *Generator) convertExamples(docs, name string, stripSubsectionsWithError
 						hcl := strings.Join(subsection[codeBlockStart+1:i], "\n")
 
 						// We've got some code -- assume it's HCL and try to convert it.
-						g.coverageTracker.foundExample(name, hcl)
+						g.coverageTracker.foundExample(path.String(), hcl)
 
 						exampleTitle := ""
 						if strings.Contains(subsection[0], "###") {
@@ -1155,7 +1155,7 @@ func (g *Generator) convertExamples(docs, name string, stripSubsectionsWithError
 						}
 
 						langs := genLanguageToSlice(g.language)
-						codeBlock, err := g.convertHCL(hcl, name, exampleTitle, langs)
+						codeBlock, err := g.convertHCL(hcl, path.String(), exampleTitle, langs)
 
 						if err != nil {
 							skippedExamples = true

--- a/pkg/tfgen/example_path.go
+++ b/pkg/tfgen/example_path.go
@@ -21,41 +21,73 @@ import (
 // examplePath explains where in Pulumi Schema the example is found. For instance,
 // "#/resources/aws:acm/certificate:Certificate/arn" would encode that the example pertains to the arn property of the
 // Certificate resource.
-type examplePath string
+type examplePath struct {
+	token    string
+	fullPath string
+}
+
+func (path examplePath) Token() string {
+	return path.token
+}
 
 func (path examplePath) String() string {
-	return string(path)
+	return string(path.fullPath)
 }
 
 func (path examplePath) Property(pulumiName string) examplePath {
-	return examplePath(fmt.Sprintf("%s/%s", string(path), pulumiName))
+	return examplePath{
+		fullPath: fmt.Sprintf("%s/%s", path.String(), pulumiName),
+		token:    path.token,
+	}
 }
 
 func (path examplePath) Inputs() examplePath {
-	return examplePath(fmt.Sprintf("%s/inputs", string(path)))
+	return examplePath{
+		token:    path.token,
+		fullPath: fmt.Sprintf("%s/inputs", path.String()),
+	}
+}
+
+func (path examplePath) StateInputs() examplePath {
+	return examplePath{
+		token:    path.token,
+		fullPath: fmt.Sprintf("%s/stateInputs", path.String()),
+	}
 }
 
 func (path examplePath) Outputs() examplePath {
-	return examplePath(fmt.Sprintf("%s/outputs", string(path)))
+	return examplePath{
+		token:    path.token,
+		fullPath: fmt.Sprintf("%s/outputs", path.String()),
+	}
 }
 
 func newExamplePathForResource(pulumiResourceToken string) examplePath {
-	return examplePath(fmt.Sprintf("#/resources/" + pulumiResourceToken))
+	return examplePath{
+		token:    pulumiResourceToken,
+		fullPath: fmt.Sprintf("#/resources/" + pulumiResourceToken),
+	}
 }
 
 func newExamplePathForFunction(pulumiFuncToken string) examplePath {
-	return examplePath(fmt.Sprintf("#/functions/" + pulumiFuncToken))
+	return examplePath{
+		token:    pulumiFuncToken,
+		fullPath: fmt.Sprintf("#/functions/" + pulumiFuncToken),
+	}
 }
 
 func newExamplePathForProvider() examplePath {
-	return examplePath("#/provider")
+	return examplePath{fullPath: "#/provider"}
 }
 
 func newExamplePathForNamedType(pulumiTypeToken string) examplePath {
-	return examplePath("#/types/" + pulumiTypeToken)
+	return examplePath{
+		token:    pulumiTypeToken,
+		fullPath: "#/types/" + pulumiTypeToken,
+	}
 }
 
 func newExamplePathForProviderConfigVariable(pulumiConfigVariableName string) examplePath {
 	// This is a bit odd that it is unprefixed; preserving for backwards compatibility.
-	return examplePath(pulumiConfigVariableName)
+	return examplePath{fullPath: pulumiConfigVariableName}
 }

--- a/pkg/tfgen/example_path.go
+++ b/pkg/tfgen/example_path.go
@@ -31,7 +31,7 @@ func (path examplePath) Token() string {
 }
 
 func (path examplePath) String() string {
-	return string(path.fullPath)
+	return path.fullPath
 }
 
 func (path examplePath) Property(pulumiName string) examplePath {

--- a/pkg/tfgen/example_path.go
+++ b/pkg/tfgen/example_path.go
@@ -1,0 +1,61 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfgen
+
+import (
+	"fmt"
+)
+
+// examplePath explains where in Pulumi Schema the example is found. For instance,
+// "#/resources/aws:acm/certificate:Certificate/arn" would encode that the example pertains to the arn property of the
+// Certificate resource.
+type examplePath string
+
+func (path examplePath) String() string {
+	return string(path)
+}
+
+func (path examplePath) Property(pulumiName string) examplePath {
+	return examplePath(fmt.Sprintf("%s/%s", string(path), pulumiName))
+}
+
+func (path examplePath) Inputs() examplePath {
+	return examplePath(fmt.Sprintf("%s/inputs", string(path)))
+}
+
+func (path examplePath) Outputs() examplePath {
+	return examplePath(fmt.Sprintf("%s/outputs", string(path)))
+}
+
+func newExamplePathForResource(pulumiResourceToken string) examplePath {
+	return examplePath(fmt.Sprintf("#/resources/" + pulumiResourceToken))
+}
+
+func newExamplePathForFunction(pulumiFuncToken string) examplePath {
+	return examplePath(fmt.Sprintf("#/functions/" + pulumiFuncToken))
+}
+
+func newExamplePathForProvider() examplePath {
+	return examplePath("#/provider")
+}
+
+func newExamplePathForNamedType(pulumiTypeToken string) examplePath {
+	return examplePath("#/types/" + pulumiTypeToken)
+}
+
+func newExamplePathForProviderConfigVariable(pulumiConfigVariableName string) examplePath {
+	// This is a bit odd that it is unprefixed; preserving for backwards compatibility.
+	return examplePath(pulumiConfigVariableName)
+}

--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -825,7 +825,7 @@ func (g *Generator) convertExamplesInResourceSpec(path examplePath, spec pschema
 		spec.InputProperties[name] = g.convertExamplesInPropertySpec(path.Property(name), prop)
 	}
 	if spec.StateInputs != nil {
-		stateInputs := g.convertExamplesInObjectSpec(path+"/stateInputs", *spec.StateInputs)
+		stateInputs := g.convertExamplesInObjectSpec(path.StateInputs(), *spec.StateInputs)
 		spec.StateInputs = &stateInputs
 	}
 	return spec


### PR DESCRIPTION
Resolves an AWS build P1: https://github.com/pulumi/pulumi-aws/issues/2477

Add a hook to permit bypassing examples when flaky example generation causes entire provider build to fail, case in point being pulumi-aws builds becoming flaky because of one resource.