### PR TITLE
fix: Enable control of docs by provider authors

### DIFF
--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -1085,6 +1085,12 @@ func (g *Generator) convertExamples(docs, name string, stripSubsectionsWithError
 		return ""
 	}
 
+	if strings.Contains(docs, "{{% examples %}}") {
+		// The provider author has explicitly written an entire markdown document including examples.
+		// We'll just return it as is.
+		return docs
+	}
+
 	if strings.Contains(docs, "```typescript") || strings.Contains(docs, "```python") ||
 		strings.Contains(docs, "```go") || strings.Contains(docs, "```yaml") ||
 		strings.Contains(docs, "```csharp") || strings.Contains(docs, "```java") {


### PR DESCRIPTION
This enables the Docker provider to explicitly embed `{{% examples %}}` after introductory text, unblocking:
- pulumi/pulumi-docker#592
- pulumi/pulumi-docker#588

This fix addresses this issue:
- pulumi/pulumi-docker#600

All of these might be fixed by a change to Docker that added introductory text above examples, but as observed in pulumi/pulumi-docker#600, it's not currently possible to render text outside of an examples block.

This change to docs rendering allows us to explicitly add the examples shortcode block in the input docs, and pass-through tfgen rendering entirely.