### PR TITLE
Fix recognition of deeply nested block schema for Plugin Framework

### DIFF
--- a/pf/internal/schemashim/attr_schema.go
+++ b/pf/internal/schemashim/attr_schema.go
@@ -93,7 +93,7 @@ func (s *attrSchema) Elem() interface{} {
 	//
 	// See also: documentation on shim.Schema.Elem().
 	if tt, ok := t.(basetypes.ObjectTypable); ok {
-		var res shim.Resource = newObjectPseudoResource(tt, s.attr.Nested())
+		var res shim.Resource = newObjectPseudoResource(tt, s.attr.Nested(), nil)
 		return res
 	}
 	if tt, ok := t.(pfattr.TypeWithElementTypes); ok {

--- a/pf/internal/schemashim/block_schema.go
+++ b/pf/internal/schemashim/block_schema.go
@@ -29,6 +29,11 @@ type blockSchema struct {
 	block pfutils.Block
 }
 
+func newBlockSchema(key string, block pfutils.Block) *blockSchema {
+	fmt.Println("newBlockSchema", key, block)
+	return &blockSchema{key, block}
+}
+
 var _ shim.Schema = (*blockSchema)(nil)
 
 func (s *blockSchema) Type() shim.ValueType {
@@ -52,7 +57,9 @@ func (s *blockSchema) Elem() interface{} {
 
 	asObjectType := func(typ any) (shim.Resource, bool) {
 		if tt, ok := typ.(basetypes.ObjectTypable); ok {
-			var res shim.Resource = newObjectPseudoResource(tt, s.block.NestedAttrs())
+			var res shim.Resource = newObjectPseudoResource(tt,
+				s.block.NestedAttrs(),
+				s.block.NestedBlocks())
 			return res, true
 		}
 		return nil, false

--- a/pf/internal/schemashim/object_type_test.go
+++ b/pf/internal/schemashim/object_type_test.go
@@ -80,6 +80,45 @@ func TestSetNestedBlock(t *testing.T) {
 	assertHasSimpleObjectAttributes(t, r)
 }
 
+func TestDeeplyNestedBlock(t *testing.T) {
+	b := schema.ListNestedBlock{
+		NestedObject: schema.NestedBlockObject{
+			Blocks: map[string]schema.Block{
+				"action_parameters": schema.ListNestedBlock{
+					NestedObject: schema.NestedBlockObject{
+						Blocks: map[string]schema.Block{
+							"phases": schema.ListNestedBlock{
+								NestedObject: schema.NestedBlockObject{
+									Attributes: map[string]schema.Attribute{
+										"p1": schema.BoolAttribute{
+											Optional: true,
+										},
+										"p2": schema.BoolAttribute{
+											Optional: true,
+										},
+									},
+								},
+							},
+						},
+						Attributes: map[string]schema.Attribute{
+							"automatic_https_rewrites": schema.BoolAttribute{
+								Optional: true,
+							},
+							"bic": schema.BoolAttribute{
+								Optional: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	shimmed := newBlockSchema("key", pfutils.FromResourceBlock(b))
+	phasesType := "list[obj[p1=bool,p2=bool]]"
+	topType := fmt.Sprintf("list[obj[action_parameters=list[obj[automatic_https_rewrites=bool,bic=bool,phases=%s]]]]", phasesType)
+	assert.Equal(t, topType, schemaLogicalType(shimmed).String())
+}
+
 func simpleObjectAttributes() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"o": schema.StringAttribute{

--- a/pf/internal/schemashim/schema_map.go
+++ b/pf/internal/schemashim/schema_map.go
@@ -63,7 +63,7 @@ func (m *schemaMap) GetOk(key string) (shim.Schema, bool) {
 		if !ok {
 			return nil, false
 		}
-		return &blockSchema{key: key, block: block}, true
+		return newBlockSchema(key, block), true
 	}
 	return &attrSchema{key: key, attr: attr}, true
 }

--- a/pf/internal/schemashim/type_schema.go
+++ b/pf/internal/schemashim/type_schema.go
@@ -58,7 +58,7 @@ func (*typeSchema) Sensitive() bool { return false }
 func (s *typeSchema) Elem() interface{} {
 	switch tt := s.t.(type) {
 	case types.ObjectType:
-		var pseudoResource shim.Resource = newObjectPseudoResource(tt, s.nested)
+		var pseudoResource shim.Resource = newObjectPseudoResource(tt, s.nested, nil)
 		return pseudoResource
 	case types.ListType:
 		contract.Assertf(s.nested == nil || len(s.nested) == 0,

--- a/pf/tests/internal/testprovider/cmd/pulumi-resource-testbridge/schema.json
+++ b/pf/tests/internal/testprovider/cmd/pulumi-resource-testbridge/schema.json
@@ -36,10 +36,7 @@
                     "$ref": "#/types/testbridge:index/TestnestRuleActionParameters:TestnestRuleActionParameters"
                 }
             },
-            "type": "object",
-            "required": [
-                "actionParameters"
-            ]
+            "type": "object"
         },
         "testbridge:index/TestnestRuleActionParameters:TestnestRuleActionParameters": {
             "properties": {
@@ -50,11 +47,7 @@
                     "type": "boolean"
                 }
             },
-            "type": "object",
-            "required": [
-                "automaticHttpsRewrites",
-                "bic"
-            ]
+            "type": "object"
         },
         "testbridge:index/TestresService:TestresService": {
             "properties": {


### PR DESCRIPTION
There was a bug with losing track of nested block information leading to incorrect MaxItemOne=1 and field optional status recognition for schemas that nest attributes-in blocks at levels 2-3 deep.