### PR TITLE
Fix #1040: correctly handle secret nested configure properties

### DIFF
--- a/pkg/tfbridge/config_encoding.go
+++ b/pkg/tfbridge/config_encoding.go
@@ -127,22 +127,43 @@ func (enc *configEncoding) MarkSecrets(secrets map[resource.PropertyKey]struct{}
 func (enc *configEncoding) UnmarshalPropertyValue(key resource.PropertyKey, v *structpb.Value,
 	opts plugin.MarshalOptions) (*resource.PropertyValue, error) {
 
-	opts.KeepSecrets = false
-
 	pv, err := plugin.UnmarshalPropertyValue(key, v, opts)
 	if err != nil {
 		return nil, fmt.Errorf("error unmarshalling property %q: %w", key, err)
 	}
 	shimType, gotShimType := enc.fieldTypes[key]
 
-	if pv.IsString() && gotShimType {
-		s := pv.StringValue()
-		v, err := enc.convertStringToPropertyValue(s, shimType)
+	// Only apply JSON-encoded recognition for known fields.
+	if !gotShimType {
+		return pv, nil
+	}
+
+	var jsonString string
+	var jsonStringDetected, jsonStringSecret bool
+
+	if pv.IsString() {
+		jsonString = pv.StringValue()
+		jsonStringDetected = true
+	}
+
+	if opts.KeepSecrets && pv.IsSecret() && pv.SecretValue().Element.IsString() {
+		jsonString = pv.SecretValue().Element.StringValue()
+		jsonStringDetected = true
+		jsonStringSecret = true
+	}
+
+	if jsonStringDetected {
+		v, err := enc.convertStringToPropertyValue(jsonString, shimType)
 		if err != nil {
 			return nil, fmt.Errorf("error unmarshalling property %q: %w", key, err)
 		}
+		if jsonStringSecret {
+			s := resource.MakeSecret(v)
+			return &s, nil
+		}
 		return &v, nil
 	}
+
 	return pv, nil
 }
 

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -1049,6 +1049,77 @@ func TestCheckConfig(t *testing.T) {
 	})
 }
 
+func TestConfigure(t *testing.T) {
+	t.Run("handle_secret_nested_objects", func(t *testing.T) {
+		p := testprovider.ProviderV2()
+
+		p.ConfigureContextFunc = func(_ context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
+			batching, ok := d.GetOk("batching")
+			require.Truef(t, ok, "Configure expected to receive batching data but did not")
+			batchingList, ok := batching.([]any)
+			require.Truef(t, ok, "Configure expected to receive batching as a slice but got #%T", batching)
+			assert.Equalf(t, 1, len(batchingList), "len(batchingList)==1")
+			b0 := batchingList[0]
+			bm, ok := b0.(map[string]any)
+			require.Truef(t, ok, "Configure expected to receive batching slice elements as maps but got #%T", bm)
+			assert.Equal(t, true, bm["enable_batching"])
+			assert.Equal(t, "5s", bm["send_after"])
+			return nil, nil
+		}
+
+		p.Schema["scopes"] = &schema.Schema{
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+		}
+
+		p.Schema["batching"] = &schema.Schema{
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"send_after": {
+						Type:      schema.TypeString,
+						Sensitive: true,
+						Optional:  true,
+					},
+					"enable_batching": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+				},
+			},
+		}
+
+		provider := &Provider{
+			tf:     shimv2.NewProvider(p),
+			config: shimv2.NewSchemaMap(p.Schema),
+		}
+
+		testutils.Replay(t, provider, `
+			{
+			  "method": "/pulumirpc.ResourceProvider/Configure",
+			  "request": {
+			    "variables": {
+			      "gcp:config:batching": "{\"enableBatching\":true,\"sendAfter\":\"5s\"}"
+			    },
+			    "args": {
+				"batching": {
+				  "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
+				  "value": "{\"enableBatching\":true,\"sendAfter\":\"5s\"}"
+				}
+			    },
+			    "acceptSecrets": true,
+			    "acceptResources": true
+			  },
+			  "response": {
+			    "supportsPreview": true
+			  }
+			}`)
+	})
+}
+
 func TestPreConfigureCallback(t *testing.T) {
 	t.Run("PreConfigureCallback called by CheckConfig", func(t *testing.T) {
 		callCounter := 0


### PR DESCRIPTION
Fixes an issue introduced in v3.44.3 where secret nested provider-level properties stopped working.

Fixes #1040 
