### PR TITLE
Ensure that resource group naming is deterministic

### DIFF
--- a/pkg/tf2pulumi/convert/tf12_names.go
+++ b/pkg/tf2pulumi/convert/tf12_names.go
@@ -266,7 +266,15 @@ func assignNames(files []*file) {
 		name := nt.pulumiName(n.name)
 		resourceGroups[name] = append(resourceGroups[name], n)
 	}
-	for name, group := range resourceGroups {
+
+	keys := make([]string, 0, len(resourceGroups))
+	for k := range resourceGroups {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, name := range keys {
+		group := resourceGroups[name]
 		if len(group) == 1 {
 			// If there is only one resource in this group, allow disambiguation to happen normally.
 			nt.assignResource(group[0])


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-gitlab/issues/224

This bug manifested as occasionally missing (or emerging) example blocks in gitlab (and I suspect [aws](https://github.com/pulumi/pulumi-aws/pull/2461#discussion_r1169296239)).