### PR TITLE
Fix panic on empty collections

### DIFF
--- a/pkg/tf2pulumi/convert/testdata/object_config_rename/experimental_pcl/main.pp
+++ b/pkg/tf2pulumi/convert/testdata/object_config_rename/experimental_pcl/main.pp
@@ -10,6 +10,9 @@ config "objectListConfig" "list(object({firstMember=number, secondMember=string}
     secondMember = "hello"
   }]
 }
+config "objectListConfigEmpty" "list(object({firstMember=number, secondMember=string}))" {
+  default = []
+}
 config "objectMapConfig" "map(object({firstMember=number, secondMember=string}))" {
   default = {
     hello = {
@@ -17,6 +20,9 @@ config "objectMapConfig" "map(object({firstMember=number, secondMember=string}))
       secondMember = "hello"
     }
   }
+}
+config "objectMapConfigEmpty" "map(object({firstMember=number, secondMember=string}))" {
+  default = {}
 }
 resource "usingSimpleObjectConfig" "simple:index:resource" {
   inputOne = simpleObjectConfig.firstMember

--- a/pkg/tf2pulumi/convert/testdata/object_config_rename/main.tf
+++ b/pkg/tf2pulumi/convert/testdata/object_config_rename/main.tf
@@ -24,6 +24,15 @@ variable "object_list_config" {
     }]
 }
 
+variable "object_list_config_empty" {
+    type = list(object({
+        first_member = number,
+        second_member = string
+    }))
+
+    default = []
+}
+
 variable "object_map_config" {
     type = map(object({
         first_member = number,
@@ -36,6 +45,15 @@ variable "object_map_config" {
              second_member = "hello"
         }
     }
+}
+
+variable "object_map_config_empty" {
+    type = map(object({
+        first_member = number,
+        second_member = string
+    }))
+
+    default = {}
 }
 
 resource "simple_resource" "using_simple_object_config" {


### PR DESCRIPTION
This change fixes a panic in `camelCaseObjectAttributes` when the collection is empty. I was hitting this when trying to convert the `terraform-aws-github-runner` example.

Fixes #1053