### PR TITLE
[Muxer] Update and standardize public API

### DIFF
--- a/pf/tests/internal/testprovider/cmd/pulumi-resource-muxedrandom/main.go
+++ b/pf/tests/internal/testprovider/cmd/pulumi-resource-muxedrandom/main.go
@@ -27,6 +27,6 @@ import (
 var schema []byte
 
 func main() {
-	tfbridge.MainWithMuxer(context.Background(), schema,
-		testprovider.MuxedRandomProvider())
+	tfbridge.MainWithMuxer(context.Background(), "muxedrandom",
+		testprovider.MuxedRandomProvider(), schema)
 }

--- a/pf/tests/internal/testprovider/cmd/pulumi-tfgen-muxedrandom/main.go
+++ b/pf/tests/internal/testprovider/cmd/pulumi-tfgen-muxedrandom/main.go
@@ -22,5 +22,5 @@ import (
 )
 
 func main() {
-	tfgen.MainWithMuxer(testprovider.MuxedRandomProvider())
+	tfgen.MainWithMuxer("muxedrandom", testprovider.MuxedRandomProvider())
 }

--- a/pf/tests/provider_get_mapping_test.go
+++ b/pf/tests/provider_get_mapping_test.go
@@ -64,7 +64,7 @@ func TestMuxedGetMapping(t *testing.T) {
 
 	info := testprovider.MuxedRandomProvider()
 
-	server, err := tfbridge.MakeMuxedServer(ctx, genSDKSchema(t, info), info)(nil)
+	server, err := tfbridge.MakeMuxedServer(ctx, "muxedrandom", info, genSDKSchema(t, info))(nil)
 	require.NoError(t, err)
 
 	req := func(key string) (context.Context, *pulumirpc.GetMappingRequest) {

--- a/pf/tests/util.go
+++ b/pf/tests/util.go
@@ -38,7 +38,7 @@ func newProviderServer(t *testing.T, info tfbridge.ProviderInfo) pulumirpc.Resou
 func newMuxedProviderServer(t *testing.T, info tfbridge0.ProviderInfo) pulumirpc.ResourceProviderServer {
 	ctx := context.Background()
 	meta := genSDKSchema(t, info)
-	p, err := tfbridge.MakeMuxedServer(ctx, meta, info)(nil)
+	p, err := tfbridge.MakeMuxedServer(ctx, info.Name, info, meta)(nil)
 	require.NoError(t, err)
 	return p
 }

--- a/pf/tfgen/main.go
+++ b/pf/tfgen/main.go
@@ -73,11 +73,11 @@ func Main(provider string, info tfbridge.ProviderInfo) {
 // This is an experimental API.
 //
 // [Pulumi Package Schema]: https://www.pulumi.com/docs/guides/pulumi-packages/schema/
-func MainWithMuxer(info sdkBridge.ProviderInfo) {
+func MainWithMuxer(provider string, info sdkBridge.ProviderInfo) {
 	shim, ok := info.P.(*pfmuxer.ProviderShim)
 	contract.Assertf(ok, "MainWithMuxer must have a ProviderInfo.P created with AugmentShimWithPF")
 
-	tfgen.MainWithCustomGenerate(info.Name, info.Version, info, func(opts tfgen.GeneratorOptions) error {
+	tfgen.MainWithCustomGenerate(provider, info.Version, info, func(opts tfgen.GeneratorOptions) error {
 
 		if info.MetadataInfo == nil {
 			return fmt.Errorf("ProviderInfo.MetadataInfo is required and cannot be nil")


### PR DESCRIPTION
This change is necessary because some providers have a different `provider` argument then their `ProviderInfo.Name` value. The previous API assumed they were the same.