### PR TITLE
[Muxer] Allow non disjoint augmented provider

### DIFF
--- a/pf/internal/muxer/muxer.go
+++ b/pf/internal/muxer/muxer.go
@@ -45,7 +45,9 @@ func AugmentShimWithPF(ctx context.Context, shim shim.Provider, pf provider.Prov
 	return p
 }
 
-func augmentShimWithPF(ctx context.Context, shim shim.Provider, pf provider.Provider) (*ProviderShim, []string, []string) {
+func augmentShimWithPF(
+	ctx context.Context, shim shim.Provider, pf provider.Provider,
+) (*ProviderShim, []string, []string) {
 	var p ProviderShim
 	if alreadyMerged, ok := shim.(*ProviderShim); ok {
 		p = *alreadyMerged

--- a/pf/tests/internal/testprovider/cmd/pulumi-resource-muxedrandom/main.go
+++ b/pf/tests/internal/testprovider/cmd/pulumi-resource-muxedrandom/main.go
@@ -27,6 +27,6 @@ import (
 var schema []byte
 
 func main() {
-	tfbridge.MainWithMuxer(context.Background(), schema,
-		testprovider.MuxedRandomProvider())
+	tfbridge.MainWithMuxer(context.Background(), "muxedrandom",
+		testprovider.MuxedRandomProvider(), schema)
 }

--- a/pf/tests/internal/testprovider/cmd/pulumi-tfgen-muxedrandom/main.go
+++ b/pf/tests/internal/testprovider/cmd/pulumi-tfgen-muxedrandom/main.go
@@ -22,5 +22,5 @@ import (
 )
 
 func main() {
-	tfgen.MainWithMuxer(testprovider.MuxedRandomProvider())
+	tfgen.MainWithMuxer("muxedrandom", testprovider.MuxedRandomProvider())
 }

--- a/pf/tests/provider_get_mapping_test.go
+++ b/pf/tests/provider_get_mapping_test.go
@@ -64,7 +64,7 @@ func TestMuxedGetMapping(t *testing.T) {
 
 	info := testprovider.MuxedRandomProvider()
 
-	server, err := tfbridge.MakeMuxedServer(ctx, genSDKSchema(t, info), info)(nil)
+	server, err := tfbridge.MakeMuxedServer(ctx, "muxedrandom", info, genSDKSchema(t, info))(nil)
 	require.NoError(t, err)
 
 	req := func(key string) (context.Context, *pulumirpc.GetMappingRequest) {

--- a/pf/tests/util.go
+++ b/pf/tests/util.go
@@ -38,7 +38,7 @@ func newProviderServer(t *testing.T, info tfbridge.ProviderInfo) pulumirpc.Resou
 func newMuxedProviderServer(t *testing.T, info tfbridge0.ProviderInfo) pulumirpc.ResourceProviderServer {
 	ctx := context.Background()
 	meta := genSDKSchema(t, info)
-	p, err := tfbridge.MakeMuxedServer(ctx, meta, info)(nil)
+	p, err := tfbridge.MakeMuxedServer(ctx, info.Name, info, meta)(nil)
 	require.NoError(t, err)
 	return p
 }

--- a/pf/tfbridge/extend.go
+++ b/pf/tfbridge/extend.go
@@ -29,7 +29,18 @@ func SchemaOnlyPluginFrameworkProvider(ctx context.Context, p pfprovider.Provide
 
 // MuxShimWithPF initializes a shim.Provider that will server resources from both shim and p.
 //
+// If shim and p both define the same token, then the value from shim will be used.
+//
 // To create a muxed provider, ProviderInfo.P must be the result of this function.
 func MuxShimWithPF(ctx context.Context, shim shim.Provider, p pfprovider.Provider) shim.Provider {
 	return muxer.AugmentShimWithPF(ctx, shim, p)
+}
+
+// MuxShimWithDisjointgPF initializes a shim.Provider that will server resources from both shim and p.
+//
+// This function will panic if shim and p both define the same token.
+//
+// To create a muxed provider, ProviderInfo.P must be the result of this function.
+func MuxShimWithDisjointgPF(ctx context.Context, shim shim.Provider, p pfprovider.Provider) shim.Provider {
+	return muxer.AugmentShimWithDisjointPF(ctx, shim, p)
 }

--- a/pf/tfgen/main.go
+++ b/pf/tfgen/main.go
@@ -73,11 +73,11 @@ func Main(provider string, info tfbridge.ProviderInfo) {
 // This is an experimental API.
 //
 // [Pulumi Package Schema]: https://www.pulumi.com/docs/guides/pulumi-packages/schema/
-func MainWithMuxer(info sdkBridge.ProviderInfo) {
+func MainWithMuxer(provider string, info sdkBridge.ProviderInfo) {
 	shim, ok := info.P.(*pfmuxer.ProviderShim)
 	contract.Assertf(ok, "MainWithMuxer must have a ProviderInfo.P created with AugmentShimWithPF")
 
-	tfgen.MainWithCustomGenerate(info.Name, info.Version, info, func(opts tfgen.GeneratorOptions) error {
+	tfgen.MainWithCustomGenerate(provider, info.Version, info, func(opts tfgen.GeneratorOptions) error {
 
 		if info.MetadataInfo == nil {
 			return fmt.Errorf("ProviderInfo.MetadataInfo is required and cannot be nil")


### PR DESCRIPTION
This is necessary to build `pulumi-gcp` due to backported resources.

This PR is based on https://github.com/pulumi/pulumi-terraform-bridge/pull/1062, but will  merge separately.