### PR TITLE
Enable non-string config values for Plugin Framework

### DIFF
--- a/pf/internal/plugin/provider_server.go
+++ b/pf/internal/plugin/provider_server.go
@@ -28,6 +28,8 @@ import (
 	pl "github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 )
 
 type providerServer struct {
@@ -36,10 +38,18 @@ type providerServer struct {
 	provider      ProviderWithContext
 	keepSecrets   bool
 	keepResources bool
+
+	configEncoding tfbridge.ConfigEncoding
 }
 
-func NewProviderServerWithContext(provider ProviderWithContext) pulumirpc.ResourceProviderServer {
-	return &providerServer{provider: provider}
+func NewProviderServerWithContext(
+	provider ProviderWithContext,
+	configEncoding *tfbridge.ConfigEncoding,
+) pulumirpc.ResourceProviderServer {
+	return &providerServer{
+		provider:       provider,
+		configEncoding: *configEncoding,
+	}
 }
 
 func (p *providerServer) unmarshalOptions(label string) pl.MarshalOptions {
@@ -175,14 +185,14 @@ func (p *providerServer) CheckConfig(ctx context.Context,
 ) (*pulumirpc.CheckResponse, error) {
 	urn := resource.URN(req.GetUrn())
 
-	state, err := pl.UnmarshalProperties(req.GetOlds(), p.unmarshalOptions("olds"))
+	state, err := p.configEncoding.UnmarshalProperties(req.GetOlds())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("CheckConfig failed to unmarshal olds: %w", err)
 	}
 
-	inputs, err := pl.UnmarshalProperties(req.GetNews(), p.unmarshalOptions("news"))
+	inputs, err := p.configEncoding.UnmarshalProperties(req.GetNews())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("CheckConfig failed to unmarshal news: %w", err)
 	}
 
 	newInputs, failures, err := p.provider.CheckConfigWithContext(ctx, urn, state, inputs, true)
@@ -190,9 +200,9 @@ func (p *providerServer) CheckConfig(ctx context.Context,
 		return nil, p.checkNYI("CheckConfig", err)
 	}
 
-	rpcInputs, err := pl.MarshalProperties(newInputs, p.marshalOptions("inputs"))
+	rpcInputs, err := p.configEncoding.MarshalProperties(newInputs)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("CheckConfig failed to marshal updated news: %w", err)
 	}
 
 	rpcFailures := make([]*pulumirpc.CheckFailure, len(failures))
@@ -206,14 +216,14 @@ func (p *providerServer) CheckConfig(ctx context.Context,
 func (p *providerServer) DiffConfig(ctx context.Context, req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error) {
 	urn := resource.URN(req.GetUrn())
 
-	state, err := pl.UnmarshalProperties(req.GetOlds(), p.unmarshalOptions("state"))
+	state, err := p.configEncoding.UnmarshalProperties(req.GetOlds())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("DiffConfig failed to unmarshal olds: %w", err)
 	}
 
-	inputs, err := pl.UnmarshalProperties(req.GetNews(), p.unmarshalOptions("inputs"))
+	inputs, err := p.configEncoding.UnmarshalProperties(req.GetNews())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("DiffConfig failed to unmarshal news: %w", err)
 	}
 
 	diff, err := p.provider.DiffConfigWithContext(ctx, urn, state, inputs, true, req.GetIgnoreChanges())
@@ -228,9 +238,9 @@ func (p *providerServer) Configure(ctx context.Context,
 ) (*pulumirpc.ConfigureResponse, error) {
 	var inputs resource.PropertyMap
 	if req.GetArgs() != nil {
-		args, err := pl.UnmarshalProperties(req.GetArgs(), p.unmarshalOptions("args"))
+		args, err := p.configEncoding.UnmarshalProperties(req.GetArgs())
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("Configure failed to unmarshal args: %w", err)
 		}
 		inputs = args
 	} else {

--- a/pf/tests/internal/testprovider/cmd/pulumi-resource-testbridge/bridge-metadata.json
+++ b/pf/tests/internal/testprovider/cmd/pulumi-resource-testbridge/bridge-metadata.json
@@ -39,12 +39,12 @@
                 "tuplesOptionals": "tuples_optional"
             },
             "testbridge:index:Provider": {
-                "skipMetadataApiCheck": "skip_metadata_api_check",
+                "boolConfigProp": "bool_config_prop",
                 "stringConfigProp": "string_config_prop"
             }
         },
         "renamedConfigProperties": {
-            "skipMetadataApiCheck": "skip_metadata_api_check",
+            "boolConfigProp": "bool_config_prop",
             "stringConfigProp": "string_config_prop"
         }
     }

--- a/pf/tests/internal/testprovider/cmd/pulumi-resource-testbridge/bridge-metadata.json
+++ b/pf/tests/internal/testprovider/cmd/pulumi-resource-testbridge/bridge-metadata.json
@@ -39,10 +39,12 @@
                 "tuplesOptionals": "tuples_optional"
             },
             "testbridge:index:Provider": {
+                "skipMetadataApiCheck": "skip_metadata_api_check",
                 "stringConfigProp": "string_config_prop"
             }
         },
         "renamedConfigProperties": {
+            "skipMetadataApiCheck": "skip_metadata_api_check",
             "stringConfigProp": "string_config_prop"
         }
     }

--- a/pf/tests/internal/testprovider/cmd/pulumi-resource-testbridge/schema.json
+++ b/pf/tests/internal/testprovider/cmd/pulumi-resource-testbridge/schema.json
@@ -21,7 +21,7 @@
     },
     "config": {
         "variables": {
-            "skipMetadataApiCheck": {
+            "boolConfigProp": {
                 "type": "boolean"
             },
             "stringConfigProp": {
@@ -135,12 +135,12 @@
     "provider": {
         "description": "The provider type for the testbridge package. By default, resources use package-wide configuration\nsettings, however an explicit `Provider` instance may be created and passed during resource\nconstruction to achieve fine-grained programmatic control over provider settings. See the\n[documentation](https://www.pulumi.com/docs/reference/programming-model/#providers) for more information.\n",
         "properties": {
-            "skipMetadataApiCheck": {
+            "boolConfigProp": {
                 "type": "boolean"
             }
         },
         "inputProperties": {
-            "skipMetadataApiCheck": {
+            "boolConfigProp": {
                 "type": "boolean"
             }
         }

--- a/pf/tests/internal/testprovider/cmd/pulumi-resource-testbridge/schema.json
+++ b/pf/tests/internal/testprovider/cmd/pulumi-resource-testbridge/schema.json
@@ -21,6 +21,9 @@
     },
     "config": {
         "variables": {
+            "skipMetadataApiCheck": {
+                "type": "boolean"
+            },
             "stringConfigProp": {
                 "type": "string"
             }
@@ -130,7 +133,17 @@
         }
     },
     "provider": {
-        "description": "The provider type for the testbridge package. By default, resources use package-wide configuration\nsettings, however an explicit `Provider` instance may be created and passed during resource\nconstruction to achieve fine-grained programmatic control over provider settings. See the\n[documentation](https://www.pulumi.com/docs/reference/programming-model/#providers) for more information.\n"
+        "description": "The provider type for the testbridge package. By default, resources use package-wide configuration\nsettings, however an explicit `Provider` instance may be created and passed during resource\nconstruction to achieve fine-grained programmatic control over provider settings. See the\n[documentation](https://www.pulumi.com/docs/reference/programming-model/#providers) for more information.\n",
+        "properties": {
+            "skipMetadataApiCheck": {
+                "type": "boolean"
+            }
+        },
+        "inputProperties": {
+            "skipMetadataApiCheck": {
+                "type": "boolean"
+            }
+        }
     },
     "resources": {
         "testbridge:index/testnest:Testnest": {

--- a/pf/tests/internal/testprovider/testbridge.go
+++ b/pf/tests/internal/testprovider/testbridge.go
@@ -94,7 +94,7 @@ func (p *syntheticProvider) Schema(_ context.Context, _ provider.SchemaRequest, 
 	resp.Schema = pschema.Schema{
 		Attributes: map[string]pschema.Attribute{
 			"string_config_prop": pschema.StringAttribute{},
-			"skip_metadata_api_check": pschema.BoolAttribute{
+			"bool_config_prop": pschema.BoolAttribute{
 				Optional: true,
 			},
 		},

--- a/pf/tests/internal/testprovider/testbridge.go
+++ b/pf/tests/internal/testprovider/testbridge.go
@@ -94,6 +94,9 @@ func (p *syntheticProvider) Schema(_ context.Context, _ provider.SchemaRequest, 
 	resp.Schema = pschema.Schema{
 		Attributes: map[string]pschema.Attribute{
 			"string_config_prop": pschema.StringAttribute{},
+			"skip_metadata_api_check": pschema.BoolAttribute{
+				Optional: true,
+			},
 		},
 	}
 }

--- a/pf/tests/provider_configure_test.go
+++ b/pf/tests/provider_configure_test.go
@@ -69,7 +69,7 @@ func TestConfigure(t *testing.T) {
 		  "method": "/pulumirpc.ResourceProvider/Configure",
 		  "request": {
 		    "args": {
-                      "skipMetadataApiCheck": "true"
+                      "boolConfigProp": "true"
 		    }
 		  },
 		  "response": {

--- a/pf/tests/provider_configure_test.go
+++ b/pf/tests/provider_configure_test.go
@@ -22,36 +22,61 @@ import (
 )
 
 func TestConfigure(t *testing.T) {
-	server := newProviderServer(t, testprovider.SyntheticTestBridgeProvider())
-	testCase := `
-[
-  {
-    "method": "/pulumirpc.ResourceProvider/Configure",
-    "request": {
-      "args": {
-        "stringConfigProp": "example"
-      }
-    },
-    "response": {
-      "supportsPreview": true,
-      "acceptResources": true
-    }
-  },
-  {
-    "method": "/pulumirpc.ResourceProvider/Create",
-    "request": {
-      "urn": "urn:pulumi:test-stack::basicprogram::testbridge:index/testres:TestConfigRes::r1",
-      "preview": false
-    },
-    "response": {
-      "id": "id-1",
-      "properties": {
-        "configCopy": "example",
-        "id": "id-1"
-      }
-    }
-  }
-]
-        `
-	testutils.ReplaySequence(t, server, testCase)
+
+	t.Run("configiure communicates to create", func(t *testing.T) {
+		// Test interaction of Configure and Create.
+		//
+		// TestConfigRes will read stringConfigProp information the provider receives via Configure.
+		server := newProviderServer(t, testprovider.SyntheticTestBridgeProvider())
+		testCase := `
+		[
+		  {
+		    "method": "/pulumirpc.ResourceProvider/Configure",
+		    "request": {
+		      "args": {
+			"stringConfigProp": "example"
+		      }
+		    },
+		    "response": {
+		      "supportsPreview": true,
+		      "acceptResources": true
+		    }
+		  },
+		  {
+		    "method": "/pulumirpc.ResourceProvider/Create",
+		    "request": {
+		      "urn": "urn:pulumi:test-stack::basicprogram::testbridge:index/testres:TestConfigRes::r1",
+		      "preview": false
+		    },
+		    "response": {
+		      "id": "id-1",
+		      "properties": {
+			"configCopy": "example",
+			"id": "id-1"
+		      }
+		    }
+		  }
+		]`
+		testutils.ReplaySequence(t, server, testCase)
+	})
+
+	t.Run("booleans", func(t *testing.T) {
+		// Non-string properties caused trouble at some point, test booleans.
+		server := newProviderServer(t, testprovider.SyntheticTestBridgeProvider())
+
+		testCase := `
+		{
+		  "method": "/pulumirpc.ResourceProvider/Configure",
+		  "request": {
+		    "args": {
+                      "skipMetadataApiCheck": "true"
+		    }
+		  },
+		  "response": {
+		    "supportsPreview": true,
+		    "acceptResources": true
+		  }
+		}`
+		testutils.Replay(t, server, testCase)
+	})
 }

--- a/pf/tfbridge/provider.go
+++ b/pf/tfbridge/provider.go
@@ -40,7 +40,6 @@ import (
 	pl "github.com/pulumi/pulumi-terraform-bridge/pf/internal/plugin"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/metadata"
 )
@@ -64,6 +63,8 @@ type provider struct {
 	configType    tftypes.Object
 	version       semver.Version
 	logSink       logutils.LogSink
+
+	schemaOnlyProvider shim.Provider
 }
 
 var _ pl.ProviderWithContext = &provider{}
@@ -148,6 +149,8 @@ func newProviderWithContext(ctx context.Context, info ProviderInfo,
 		configEncoder: configEncoder,
 		configType:    providerConfigType,
 		version:       semverVersion,
+
+		schemaOnlyProvider: SchemaOnlyPluginFrameworkProvider(ctx, p),
 	}, nil
 }
 
@@ -165,7 +168,7 @@ func NewProviderServer(
 	pp := p.(*provider)
 
 	pp.logSink = logSink
-	configEnc := tfbridge.NewConfigEncoding(pp.schemaOnlyShimProvider.Schema(), pp.info.ProviderInfo.Config)
+	configEnc := tfbridge.NewConfigEncoding(pp.schemaOnlyProvider.Schema(), pp.info.ProviderInfo.Config)
 	return pl.NewProviderServerWithContext(p, configEnc), nil
 }
 

--- a/pf/tfbridge/provider.go
+++ b/pf/tfbridge/provider.go
@@ -38,7 +38,10 @@ import (
 	logutils "github.com/pulumi/pulumi-terraform-bridge/pf/internal/logging"
 	"github.com/pulumi/pulumi-terraform-bridge/pf/internal/pfutils"
 	pl "github.com/pulumi/pulumi-terraform-bridge/pf/internal/plugin"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/metadata"
 )
 
@@ -159,8 +162,11 @@ func NewProviderServer(
 	if err != nil {
 		return nil, err
 	}
-	p.(*provider).logSink = logSink
-	return pl.NewProviderServerWithContext(p), nil
+	pp := p.(*provider)
+
+	pp.logSink = logSink
+	configEnc := tfbridge.NewConfigEncoding(pp.schemaOnlyShimProvider.Schema(), pp.info.ProviderInfo.Config)
+	return pl.NewProviderServerWithContext(p, configEnc), nil
 }
 
 // Closer closes any underlying OS resources associated with this provider (like processes, RPC channels, etc).


### PR DESCRIPTION
On top of https://github.com/pulumi/pulumi-terraform-bridge/pull/1086

Fixes https://github.com/pulumi/pulumi-terraform-bridge/pull/1032

The work on getting ConfigEncoding right in the v3 version of the bridge is here reused for the pf version of the bridge.


