### PR TITLE
Ensure replay tests use exact same server as prod code

### DIFF
--- a/pf/tests/provider_configure_test.go
+++ b/pf/tests/provider_configure_test.go
@@ -33,7 +33,6 @@ func TestConfigure(t *testing.T) {
       }
     },
     "response": {
-      "acceptSecrets": true,
       "supportsPreview": true,
       "acceptResources": true
     }

--- a/pf/tests/provider_read_test.go
+++ b/pf/tests/provider_read_test.go
@@ -44,7 +44,6 @@ func TestReadFromRefresh(t *testing.T) {
 	    "acceptResources": true
 	  },
 	  "response": {
-	    "acceptSecrets": true,
 	    "supportsPreview": true,
 	    "acceptResources": true
 	  },

--- a/pf/tests/testdata/genrandom/random-delete-update.json
+++ b/pf/tests/testdata/genrandom/random-delete-update.json
@@ -53,7 +53,6 @@
       "acceptResources": true
     },
     "response": {
-      "acceptSecrets": true,
       "supportsPreview": true,
       "acceptResources": true
     },

--- a/pf/tests/testdata/genrandom/random-empty-preview.json
+++ b/pf/tests/testdata/genrandom/random-empty-preview.json
@@ -53,7 +53,6 @@
       "acceptResources": true
     },
     "response": {
-      "acceptSecrets": true,
       "supportsPreview": true,
       "acceptResources": true
     },

--- a/pf/tests/testdata/genrandom/random-empty-update.json
+++ b/pf/tests/testdata/genrandom/random-empty-update.json
@@ -53,7 +53,6 @@
       "acceptResources": true
     },
     "response": {
-      "acceptSecrets": true,
       "supportsPreview": true,
       "acceptResources": true
     },

--- a/pf/tests/testdata/genrandom/random-initial-preview.json
+++ b/pf/tests/testdata/genrandom/random-initial-preview.json
@@ -115,7 +115,6 @@
       "acceptResources": true
     },
     "response": {
-      "acceptSecrets": true,
       "supportsPreview": true,
       "acceptResources": true
     },

--- a/pf/tests/testdata/genrandom/random-initial-update.json
+++ b/pf/tests/testdata/genrandom/random-initial-update.json
@@ -115,7 +115,6 @@
       "acceptResources": true
     },
     "response": {
-      "acceptSecrets": true,
       "supportsPreview": true,
       "acceptResources": true
     },

--- a/pf/tests/testdata/genrandom/random-replace-preview.json
+++ b/pf/tests/testdata/genrandom/random-replace-preview.json
@@ -53,7 +53,6 @@
       "acceptResources": true
     },
     "response": {
-      "acceptSecrets": true,
       "supportsPreview": true,
       "acceptResources": true
     },

--- a/pf/tests/testdata/genrandom/random-replace-update.json
+++ b/pf/tests/testdata/genrandom/random-replace-update.json
@@ -53,7 +53,6 @@
       "acceptResources": true
     },
     "response": {
-      "acceptSecrets": true,
       "supportsPreview": true,
       "acceptResources": true
     },

--- a/pf/tests/testdata/updateprogram.json
+++ b/pf/tests/testdata/updateprogram.json
@@ -120,7 +120,6 @@
       "acceptResources": true
     },
     "response": {
-      "acceptSecrets": true,
       "supportsPreview": true,
       "acceptResources": true
     },
@@ -370,7 +369,6 @@
       "acceptResources": true
     },
     "response": {
-      "acceptSecrets": true,
       "supportsPreview": true,
       "acceptResources": true
     },
@@ -553,7 +551,6 @@
       "acceptResources": true
     },
     "response": {
-      "acceptSecrets": true,
       "supportsPreview": true,
       "acceptResources": true
     },
@@ -834,11 +831,9 @@
     "method": "/pulumirpc.ResourceProvider/Configure",
     "request": {
       "args": {},
-      "acceptSecrets": true,
       "acceptResources": true
     },
     "response": {
-      "acceptSecrets": true,
       "supportsPreview": true,
       "acceptResources": true
     },
@@ -1091,7 +1086,6 @@
       "acceptResources": true
     },
     "response": {
-      "acceptSecrets": true,
       "supportsPreview": true,
       "acceptResources": true
     },
@@ -1193,7 +1187,6 @@
       "acceptResources": true
     },
     "response": {
-      "acceptSecrets": true,
       "supportsPreview": true,
       "acceptResources": true
     },
@@ -1518,7 +1511,6 @@
       "acceptResources": true
     },
     "response": {
-      "acceptSecrets": true,
       "supportsPreview": true,
       "acceptResources": true
     },
@@ -1810,7 +1802,6 @@
       "acceptResources": true
     },
     "response": {
-      "acceptSecrets": true,
       "supportsPreview": true,
       "acceptResources": true
     },

--- a/pf/tests/util.go
+++ b/pf/tests/util.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 
 	"github.com/pulumi/pulumi-terraform-bridge/pf/tfbridge"
@@ -30,9 +29,9 @@ import (
 func newProviderServer(t *testing.T, info tfbridge.ProviderInfo) pulumirpc.ResourceProviderServer {
 	ctx := context.Background()
 	meta := genMetadata(t, info)
-	p, err := tfbridge.NewProvider(ctx, info, meta)
+	srv, err := tfbridge.NewProviderServer(ctx, nil, info, meta)
 	require.NoError(t, err)
-	return plugin.NewProviderServer(p)
+	return srv
 }
 
 func newMuxedProviderServer(t *testing.T, info tfbridge0.ProviderInfo) pulumirpc.ResourceProviderServer {

--- a/pf/tfbridge/main.go
+++ b/pf/tfbridge/main.go
@@ -162,7 +162,7 @@ func MakeMuxedServer(
 			case *schemashim.SchemaOnlyProvider:
 				m.Servers = append(m.Servers, muxer.Endpoint{
 					Server: func(host *rprovider.HostClient) (pulumirpc.ResourceProviderServer, error) {
-						return newProviderServer(ctx, host, ProviderInfo{
+						return NewProviderServer(ctx, host, ProviderInfo{
 							ProviderInfo: info,
 							NewProvider:  prov.PfProvider,
 						}, ProviderMetadata{PackageSchema: schema})

--- a/pf/tfbridge/provider.go
+++ b/pf/tfbridge/provider.go
@@ -148,6 +148,7 @@ func newProviderWithContext(ctx context.Context, info ProviderInfo,
 	}, nil
 }
 
+// Internal. The signature of this function can change between major releases. Exposed to facilitate testing.
 func NewProviderServer(
 	ctx context.Context,
 	logSink logutils.LogSink,

--- a/pf/tfbridge/provider.go
+++ b/pf/tfbridge/provider.go
@@ -148,7 +148,7 @@ func newProviderWithContext(ctx context.Context, info ProviderInfo,
 	}, nil
 }
 
-func newProviderServer(
+func NewProviderServer(
 	ctx context.Context,
 	logSink logutils.LogSink,
 	info ProviderInfo,

--- a/pf/tfbridge/serve.go
+++ b/pf/tfbridge/serve.go
@@ -23,6 +23,6 @@ import (
 
 func serve(ctx context.Context, pkg string, prov ProviderInfo, meta ProviderMetadata) error {
 	return rprovider.Main(pkg, func(host *rprovider.HostClient) (pulumirpc.ResourceProviderServer, error) {
-		return newProviderServer(ctx, host, prov, meta)
+		return NewProviderServer(ctx, host, prov, meta)
 	})
 }


### PR DESCRIPTION
We started making changes to provider_server.go to customize the translation of messages from protobuf layer talking the ResourceProvider Pulumi gRPC protocol to the resource.PropertyValue layer. In particular we updated Configure to signal to the engine that the bridged providers do not accept secrets. The tests did not reflect this due to a peculiarity - the tests were not using the same gRPC server. This is now fixed in the PR so the tests are representative of real use.