### PR TITLE
Implement tfshim addressing and tree-walking facilities

### DIFF
--- a/pkg/tfshim/walk/walk.go
+++ b/pkg/tfshim/walk/walk.go
@@ -22,7 +22,7 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
 )
 
-// Represents locations in a Schema value as a sequence of steps to locate it.
+// Represents locations in a tfshim.Schema value as a sequence of steps to locate it.
 //
 // An empty SchemaPath represents the current location.
 //

--- a/pkg/tfshim/walk/walk.go
+++ b/pkg/tfshim/walk/walk.go
@@ -170,15 +170,15 @@ type SchemaVisitor = func(SchemaPath, shim.Schema)
 
 // Visit all nested schemas, including the current one.
 func VisitSchema(schema shim.Schema, visitor SchemaVisitor) {
-	walkSchemaInner(NewSchemaPath(), schema, visitor)
+	visitSchemaInner(NewSchemaPath(), schema, visitor)
 }
 
 // Visit all nested schemas in a SchemaMap, keeping track of SchemaPath location.
 func VisitSchemaMap(schemaMap shim.SchemaMap, visitor SchemaVisitor) {
-	walkSchemaMapInner(NewSchemaPath(), schemaMap, visitor)
+	visitSchemaMapInner(NewSchemaPath(), schemaMap, visitor)
 }
 
-func walkSchemaInner(path SchemaPath, schema shim.Schema, visitor SchemaVisitor) {
+func visitSchemaInner(path SchemaPath, schema shim.Schema, visitor SchemaVisitor) {
 	visitor(path, schema)
 	switch elem := schema.Elem().(type) {
 	case shim.Resource:
@@ -190,15 +190,15 @@ func walkSchemaInner(path SchemaPath, schema shim.Schema, visitor SchemaVisitor)
 		} else {
 			nestedPath = path.Element()
 		}
-		walkSchemaMapInner(nestedPath, elem.Schema(), visitor)
+		visitSchemaMapInner(nestedPath, elem.Schema(), visitor)
 	case shim.Schema:
-		walkSchemaInner(path.Element(), elem, visitor)
+		visitSchemaInner(path.Element(), elem, visitor)
 	}
 }
 
-func walkSchemaMapInner(path SchemaPath, schemaMap shim.SchemaMap, visitor SchemaVisitor) {
+func visitSchemaMapInner(path SchemaPath, schemaMap shim.SchemaMap, visitor SchemaVisitor) {
 	schemaMap.Range(func(key string, schema shim.Schema) bool {
-		walkSchemaInner(path.GetAttr(key), schema, visitor)
+		visitSchemaInner(path.GetAttr(key), schema, visitor)
 		return true
 	})
 }

--- a/pkg/tfshim/walk/walk.go
+++ b/pkg/tfshim/walk/walk.go
@@ -29,7 +29,7 @@ import (
 // Values of this type are immutable by convention, use Copy as necessary for local mutations.
 type SchemaPath []SchemaPathStep
 
-func (p SchemaPath) String() string {
+func (p SchemaPath) GoString() string {
 	parts := []string{"walk", "NewSchemaPath()"}
 	for _, e := range p {
 		switch ee := e.(type) {
@@ -79,7 +79,7 @@ func LookupSchemaPath(path SchemaPath, schema shim.Schema) (shim.Schema, error) 
 		}
 		nextResult, err := p[0].Lookup(result)
 		if err != nil {
-			return nil, fmt.Errorf("LookupSchemaPath failed at %s: %w", current, err)
+			return nil, fmt.Errorf("LookupSchemaPath failed at %s: %w", current.GoString(), err)
 		}
 		result, p, current = nextResult, p[1:], current.WithStep(p[0])
 	}
@@ -94,7 +94,7 @@ func LookupSchemaMapPath(path SchemaPath, schemaMap shim.SchemaMap) (shim.Schema
 //
 // This interface is closed, the only the implementations given in the current package are allowed.
 type SchemaPathStep interface {
-	String() string
+	GoString() string
 	Lookup(shim.Schema) (shim.Schema, error)
 }
 
@@ -103,7 +103,7 @@ type GetAttrStep struct {
 	Name string
 }
 
-func (step GetAttrStep) String() string {
+func (step GetAttrStep) GoString() string {
 	return fmt.Sprintf("walk.GetAttrStep{%q}", step.Name)
 }
 
@@ -111,17 +111,17 @@ func (step GetAttrStep) Lookup(s shim.Schema) (shim.Schema, error) {
 	if sm, ok := UnwrapSchemaMap(s); ok {
 		s, found := sm.GetOk(step.Name)
 		if !found {
-			return nil, fmt.Errorf("%s not found", step.String())
+			return nil, fmt.Errorf("%s not found", step.GoString())
 		}
 		return s, nil
 	}
-	return nil, fmt.Errorf("%s is not applicable", step.String())
+	return nil, fmt.Errorf("%s is not applicable", step.GoString())
 }
 
 // Drill down into a Map, Set or List element schema.
 type ElementStep struct{}
 
-func (step ElementStep) String() string {
+func (step ElementStep) GoString() string {
 	return "walk.ElementStep{}"
 }
 
@@ -130,16 +130,16 @@ func (step ElementStep) Lookup(s shim.Schema) (shim.Schema, error) {
 	case shim.Resource:
 		switch s.Type() {
 		case shim.TypeMap:
-			return nil, fmt.Errorf("%s is not applicable to object types", step.String())
+			return nil, fmt.Errorf("%s is not applicable to object types", step.GoString())
 		case shim.TypeList, shim.TypeSet:
 			return wrapSchemaMap(elem.Schema()), nil
 		default:
-			return nil, fmt.Errorf("%s is not applicable", step.String())
+			return nil, fmt.Errorf("%s is not applicable", step.GoString())
 		}
 	case shim.Schema:
 		return elem, nil
 	default:
-		return nil, fmt.Errorf("%s is not applicable", step.String())
+		return nil, fmt.Errorf("%s is not applicable", step.GoString())
 	}
 }
 

--- a/pkg/tfshim/walk/walk.go
+++ b/pkg/tfshim/walk/walk.go
@@ -34,12 +34,12 @@ type SchemaPath []SchemaPathStep
 
 func (p SchemaPath) GoString() string {
 	parts := []string{"walk", "NewSchemaPath()"}
-	for _, e := range p {
-		switch ee := e.(type) {
+	for _, step := range p {
+		switch s := step.(type) {
 		case ElementStep:
 			parts = append(parts, "Element()")
 		case GetAttrStep:
-			parts = append(parts, fmt.Sprintf("GetAttr(%q)", ee.Name))
+			parts = append(parts, fmt.Sprintf("GetAttr(%q)", s.Name))
 		}
 	}
 	return strings.Join(parts, ".")
@@ -206,8 +206,8 @@ func visitSchemaMapInner(path SchemaPath, schemaMap shim.SchemaMap, visitor Sche
 	})
 }
 
-// Converts a value path to a Schema Path (hashicorp/go-cty representation).
-func FromHCtyPath(path cty.Path) SchemaPath {
+// Converts a value path to a Schema Path (zclconf package representation).
+func FromCtyPath(path cty.Path) SchemaPath {
 	p := NewSchemaPath()
 	for _, subPath := range path {
 		switch s := subPath.(type) {
@@ -220,8 +220,8 @@ func FromHCtyPath(path cty.Path) SchemaPath {
 	return p
 }
 
-// Converts a value path to a Schema Path (zclconf package representation).
-func FromCtyPath(path hcty.Path) SchemaPath {
+// Converts a value path to a Schema Path (hashicorp/go-cty representation).
+func FromHCtyPath(path hcty.Path) SchemaPath {
 	p := NewSchemaPath()
 	for _, subPath := range path {
 		switch s := subPath.(type) {

--- a/pkg/tfshim/walk/walk.go
+++ b/pkg/tfshim/walk/walk.go
@@ -18,6 +18,9 @@ import (
 	"fmt"
 	"strings"
 
+	hcty "github.com/hashicorp/go-cty/cty"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
 )
@@ -201,4 +204,32 @@ func visitSchemaMapInner(path SchemaPath, schemaMap shim.SchemaMap, visitor Sche
 		visitSchemaInner(path.GetAttr(key), schema, visitor)
 		return true
 	})
+}
+
+// Converts a value path to a Schema Path (hashicorp/go-cty representation).
+func FromHCtyPath(path cty.Path) SchemaPath {
+	p := NewSchemaPath()
+	for _, subPath := range path {
+		switch s := subPath.(type) {
+		case cty.IndexStep:
+			p = p.Element()
+		case cty.GetAttrStep:
+			p = p.GetAttr(s.Name)
+		}
+	}
+	return p
+}
+
+// Converts a value path to a Schema Path (zclconf package representation).
+func FromCtyPath(path hcty.Path) SchemaPath {
+	p := NewSchemaPath()
+	for _, subPath := range path {
+		switch s := subPath.(type) {
+		case hcty.IndexStep:
+			p = p.Element()
+		case hcty.GetAttrStep:
+			p = p.GetAttr(s.Name)
+		}
+	}
+	return p
 }

--- a/pkg/tfshim/walk/walk.go
+++ b/pkg/tfshim/walk/walk.go
@@ -1,0 +1,198 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package walk
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
+)
+
+// Represents locations in a Schema value as a sequence of steps to locate it.
+//
+// An empty SchemaPath represents the current location.
+//
+// Values of this type are immutable by convention, use Copy as necessary for local mutations.
+type SchemaPath []SchemaPathStep
+
+func (p SchemaPath) String() string {
+	parts := []string{"walk", "NewSchemaPath()"}
+	for _, e := range p {
+		switch ee := e.(type) {
+		case ElementStep:
+			parts = append(parts, "Element()")
+		case GetAttrStep:
+			parts = append(parts, fmt.Sprintf("GetAttr(%q)", ee.Name))
+		}
+	}
+	return strings.Join(parts, ".")
+}
+
+func (p SchemaPath) Copy() SchemaPath {
+	ret := make(SchemaPath, len(p))
+	copy(ret, p)
+	return ret
+}
+
+func (p SchemaPath) Element() SchemaPath {
+	return p.WithStep(ElementStep{})
+}
+
+func (p SchemaPath) GetAttr(name string) SchemaPath {
+	return p.WithStep(GetAttrStep{name})
+}
+
+func (p SchemaPath) WithStep(suffix SchemaPathStep) SchemaPath {
+	ret := make(SchemaPath, len(p)+1)
+	copy(ret, p)
+	ret[len(p)] = suffix
+	return ret
+}
+
+// Builds a new empty SchemaPath.
+func NewSchemaPath() SchemaPath {
+	return make(SchemaPath, 0)
+}
+
+// Finds a nested Schema at a given path.
+func LookupSchemaPath(path SchemaPath, schema shim.Schema) (shim.Schema, error) {
+	p := path
+	current := NewSchemaPath()
+	result := schema
+	for {
+		if len(p) == 0 {
+			return result, nil
+		}
+		nextResult, err := p[0].Lookup(result)
+		if err != nil {
+			return nil, fmt.Errorf("LookupSchemaPath failed at %s: %w", current, err)
+		}
+		result, p, current = nextResult, p[1:], current.WithStep(p[0])
+	}
+}
+
+// Similar to LookupSchemaPath but starts the initial step from a SchemaMap.
+func LookupSchemaMapPath(path SchemaPath, schemaMap shim.SchemaMap) (shim.Schema, error) {
+	return LookupSchemaPath(path, wrapSchemaMap(schemaMap))
+}
+
+// Represents elements of a SchemaPath.
+//
+// This interface is closed, the only the implementations given in the current package are allowed.
+type SchemaPathStep interface {
+	String() string
+	Lookup(shim.Schema) (shim.Schema, error)
+}
+
+// Drill down into an attribute by the given attribute name.
+type GetAttrStep struct {
+	Name string
+}
+
+func (step GetAttrStep) String() string {
+	return fmt.Sprintf("walk.GetAttrStep{%q}", step.Name)
+}
+
+func (step GetAttrStep) Lookup(s shim.Schema) (shim.Schema, error) {
+	if sm, ok := UnwrapSchemaMap(s); ok {
+		s, found := sm.GetOk(step.Name)
+		if !found {
+			return nil, fmt.Errorf("%s not found", step.String())
+		}
+		return s, nil
+	}
+	return nil, fmt.Errorf("%s is not applicable", step.String())
+}
+
+// Drill down into a Map, Set or List element schema.
+type ElementStep struct{}
+
+func (step ElementStep) String() string {
+	return "walk.ElementStep{}"
+}
+
+func (step ElementStep) Lookup(s shim.Schema) (shim.Schema, error) {
+	switch elem := s.Elem().(type) {
+	case shim.Resource:
+		switch s.Type() {
+		case shim.TypeMap:
+			return nil, fmt.Errorf("%s is not applicable to object types", step.String())
+		case shim.TypeList, shim.TypeSet:
+			return wrapSchemaMap(elem.Schema()), nil
+		default:
+			return nil, fmt.Errorf("%s is not applicable", step.String())
+		}
+	case shim.Schema:
+		return elem, nil
+	default:
+		return nil, fmt.Errorf("%s is not applicable", step.String())
+	}
+}
+
+func wrapSchemaMap(sm shim.SchemaMap) shim.Schema {
+	return (&schema.Schema{
+		Type: shim.TypeMap,
+		Elem: (&schema.Resource{Schema: sm}).Shim(),
+	}).Shim()
+}
+
+// Utility function to recognize nested object field type schemas encoded in shim.Schema.
+func UnwrapSchemaMap(s shim.Schema) (shim.SchemaMap, bool) {
+	switch elem := s.Elem().(type) {
+	case shim.Resource:
+		return elem.Schema(), true
+	default:
+		return nil, false
+	}
+}
+
+type SchemaVisitor = func(SchemaPath, shim.Schema)
+
+// Visit all nested schemas, including the current one.
+func VisitSchema(schema shim.Schema, visitor SchemaVisitor) {
+	walkSchemaInner(NewSchemaPath(), schema, visitor)
+}
+
+// Visit all nested schemas in a SchemaMap, keeping track of SchemaPath location.
+func VisitSchemaMap(schemaMap shim.SchemaMap, visitor SchemaVisitor) {
+	walkSchemaMapInner(NewSchemaPath(), schemaMap, visitor)
+}
+
+func walkSchemaInner(path SchemaPath, schema shim.Schema, visitor SchemaVisitor) {
+	visitor(path, schema)
+	switch elem := schema.Elem().(type) {
+	case shim.Resource:
+		var nestedPath SchemaPath
+		if schema.Type() == shim.TypeMap {
+			// Single-nested blocks are special, drilling down into the elements of the block's object type
+			// can begin immediately without an Element step.
+			nestedPath = path
+		} else {
+			nestedPath = path.Element()
+		}
+		walkSchemaMapInner(nestedPath, elem.Schema(), visitor)
+	case shim.Schema:
+		walkSchemaInner(path.Element(), elem, visitor)
+	}
+}
+
+func walkSchemaMapInner(path SchemaPath, schemaMap shim.SchemaMap, visitor SchemaVisitor) {
+	schemaMap.Range(func(key string, schema shim.Schema) bool {
+		walkSchemaInner(path.GetAttr(key), schema, visitor)
+		return true
+	})
+}

--- a/pkg/tfshim/walk/walk.go
+++ b/pkg/tfshim/walk/walk.go
@@ -112,7 +112,7 @@ func (step GetAttrStep) GoString() string {
 }
 
 func (step GetAttrStep) Lookup(s shim.Schema) (shim.Schema, error) {
-	if sm, ok := UnwrapSchemaMap(s); ok {
+	if sm, ok := unwrapSchemaMap(s); ok {
 		s, found := sm.GetOk(step.Name)
 		if !found {
 			return nil, fmt.Errorf("%s not found", step.GoString())
@@ -157,7 +157,7 @@ func wrapSchemaMap(sm shim.SchemaMap) shim.Schema {
 }
 
 // Utility function to recognize nested object field type schemas encoded in shim.Schema.
-func UnwrapSchemaMap(s shim.Schema) (shim.SchemaMap, bool) {
+func unwrapSchemaMap(s shim.Schema) (shim.SchemaMap, bool) {
 	switch elem := s.Elem().(type) {
 	case shim.Resource:
 		return elem.Schema(), true

--- a/pkg/tfshim/walk/walk.go
+++ b/pkg/tfshim/walk/walk.go
@@ -94,6 +94,8 @@ func LookupSchemaMapPath(path SchemaPath, schemaMap shim.SchemaMap) (shim.Schema
 //
 // This interface is closed, the only the implementations given in the current package are allowed.
 type SchemaPathStep interface {
+	isSchemaPathStep()
+
 	GoString() string
 	Lookup(shim.Schema) (shim.Schema, error)
 }
@@ -102,6 +104,8 @@ type SchemaPathStep interface {
 type GetAttrStep struct {
 	Name string
 }
+
+func (GetAttrStep) isSchemaPathStep() {}
 
 func (step GetAttrStep) GoString() string {
 	return fmt.Sprintf("walk.GetAttrStep{%q}", step.Name)
@@ -120,6 +124,8 @@ func (step GetAttrStep) Lookup(s shim.Schema) (shim.Schema, error) {
 
 // Drill down into a Map, Set or List element schema.
 type ElementStep struct{}
+
+func (ElementStep) isSchemaPathStep() {}
 
 func (step ElementStep) GoString() string {
 	return "walk.ElementStep{}"

--- a/pkg/tfshim/walk/walk_test.go
+++ b/pkg/tfshim/walk/walk_test.go
@@ -15,11 +15,11 @@
 package walk
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
-	"fmt"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
 )
@@ -63,8 +63,6 @@ func TestLookupSchemaPath(t *testing.T) {
 		path   SchemaPath
 		expect any
 	}
-
-	/* this is still confusing */
 
 	testCases := []testCase{
 		{

--- a/pkg/tfshim/walk/walk_test.go
+++ b/pkg/tfshim/walk/walk_test.go
@@ -1,0 +1,136 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package walk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"fmt"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
+)
+
+var strSchema = (&schema.Schema{
+	Type:     shim.TypeString,
+	Optional: true,
+}).Shim()
+
+var testSchemaMap shim.SchemaMap = schema.SchemaMap{
+	"x": (&schema.Schema{
+		Type: shim.TypeMap,
+		Elem: (&schema.Resource{
+			Schema: schema.SchemaMap{
+				"y": strSchema,
+			},
+		}).Shim(),
+	}).Shim(),
+
+	"list": (&schema.Schema{
+		Type: shim.TypeList,
+		Elem: strSchema,
+	}).Shim(),
+
+	"batching": (&schema.Schema{
+		Type:     shim.TypeList,
+		MaxItems: 1,
+		Elem: (&schema.Resource{
+			Schema: schema.SchemaMap{
+				"send_after": strSchema,
+			},
+		}).Shim(),
+	}).Shim(),
+}
+
+func TestLookupSchemaPath(t *testing.T) {
+	s := testSchemaMap
+
+	type testCase struct {
+		name   string
+		path   SchemaPath
+		expect any
+	}
+
+	/* this is still confusing */
+
+	testCases := []testCase{
+		{
+			"single-nested block object",
+			NewSchemaPath().GetAttr("x"),
+			s.Get("x"),
+		},
+		{
+			"cannot do Element on an object",
+			NewSchemaPath().GetAttr("x").Element(),
+			fmt.Errorf(`LookupSchemaPath failed at walk.NewSchemaPath().GetAttr("x"): ` +
+				`walk.ElementStep{} is not applicable to object types`),
+		},
+		{
+			"nested x.y prop",
+			NewSchemaPath().GetAttr("x").GetAttr("y"),
+			strSchema,
+		},
+		{
+			"list elem",
+			NewSchemaPath().GetAttr("list").Element(),
+			strSchema,
+		},
+		{
+			"regress batching.send_after",
+			NewSchemaPath().GetAttr("batching").Element().GetAttr("send_after"),
+			strSchema,
+		},
+		{
+			"list element object properties",
+			NewSchemaPath().GetAttr("batching").Element(),
+			wrapSchemaMap(s.Get("batching").Elem().(shim.Resource).Schema()),
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := LookupSchemaMapPath(tc.path, s)
+			switch eerr := tc.expect.(type) {
+			case error:
+				assert.Error(t, err)
+				assert.Equal(t, eerr.Error(), err.Error())
+			default:
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expect, actual)
+			}
+		})
+	}
+}
+
+func TestVisitSchemaMap(t *testing.T) {
+	expectPaths := []SchemaPath{
+		NewSchemaPath().GetAttr("x"),
+		NewSchemaPath().GetAttr("x").GetAttr("y"),
+		NewSchemaPath().GetAttr("list"),
+		NewSchemaPath().GetAttr("list").Element(),
+		NewSchemaPath().GetAttr("batching"),
+		NewSchemaPath().GetAttr("batching").Element().GetAttr("send_after"),
+	}
+
+	VisitSchemaMap(testSchemaMap, func(p SchemaPath, s shim.Schema) {
+		assert.Contains(t, expectPaths, p)
+		ss, err := LookupSchemaMapPath(p, testSchemaMap)
+		assert.NoError(t, err)
+		assert.Equal(t, ss, s)
+	})
+}


### PR DESCRIPTION
Add walk.SchemaPath to represent locations within a Schema tree.

Add LookupSchemaPath to find a nested Schema.

Add VisitSchema to traverse the tree with a visitor.

These functions take care of object type encodigs, so schema paths naturally correspond to value paths for TF-based values. They are intended to use later on to simplify some recursive traversal code and reporting error locations.