### PR TITLE
Implement path translation and SchemaInfo walking

### DIFF
--- a/pkg/tfbridge/walk/walk.go
+++ b/pkg/tfbridge/walk/walk.go
@@ -40,10 +40,11 @@ func PropertyPathToSchemaPath(
 }
 
 func propertyPathToSchemaPath(
-	basePath walk.SchemaPath,
+	basePath SchemaPath,
 	propertyPath resource.PropertyPath,
 	schemaMap shim.SchemaMap,
-	schemaInfos map[string]*tfbridge.SchemaInfo) walk.SchemaPath {
+	schemaInfos map[string]*tfbridge.SchemaInfo,
+) SchemaPath {
 
 	if len(propertyPath) == 0 {
 		return basePath
@@ -69,10 +70,11 @@ func propertyPathToSchemaPath(
 }
 
 func propertyPathToSchemaPathInner(
-	basePath walk.SchemaPath,
+	basePath SchemaPath,
 	propertyPath resource.PropertyPath,
 	schema shim.Schema,
-	schemaInfo *tfbridge.SchemaInfo) walk.SchemaPath {
+	schemaInfo *tfbridge.SchemaInfo,
+) SchemaPath {
 
 	if len(propertyPath) == 0 {
 		return basePath
@@ -114,8 +116,10 @@ func propertyPathToSchemaPathInner(
 }
 
 // Drill down a path from a map of SchemaInfo objects and find a matching SchemaInfo if any.
-func LookupSchemaInfoMapPath(schemaPath walk.SchemaPath,
-	schemaInfos map[string]*tfbridge.SchemaInfo) *tfbridge.SchemaInfo {
+func LookupSchemaInfoMapPath(
+	schemaPath SchemaPath,
+	schemaInfos map[string]*tfbridge.SchemaInfo,
+) *tfbridge.SchemaInfo {
 
 	if len(schemaPath) == 0 {
 		return nil
@@ -136,7 +140,7 @@ func LookupSchemaInfoMapPath(schemaPath walk.SchemaPath,
 }
 
 // Drill down a path from a  SchemaInfo object and find a matching SchemaInfo if any.
-func LookupSchemaInfoPath(schemaPath walk.SchemaPath, schemaInfo *tfbridge.SchemaInfo) *tfbridge.SchemaInfo {
+func LookupSchemaInfoPath(schemaPath SchemaPath, schemaInfo *tfbridge.SchemaInfo) *tfbridge.SchemaInfo {
 	if len(schemaPath) == 0 {
 		return schemaInfo
 	}

--- a/pkg/tfbridge/walk/walk.go
+++ b/pkg/tfbridge/walk/walk.go
@@ -1,0 +1,154 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package walk
+
+import (
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/walk"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
+type SchemaPath = walk.SchemaPath
+
+// Translate a Pulumi property path to a bridged provider schema path.
+//
+// The function hides the complexity of mapping Pulumi property names to Terraform names, joining Schema with user
+// overrides in SchemaInfos, and accounting for MaxItems=1 situations where Pulumi flattens collections to plain values.
+// and therefore SchemaPath values are longer than the PropertyPath values.
+//
+// PropertyPathToSchemaPath may return nil if there is no matching schema found. This may happen when drilling down to
+// values of unknown type, attributes not tracked in schema, or when there is a type mismatch between the path and the
+// schema.
+func PropertyPathToSchemaPath(
+	propertyPath resource.PropertyPath,
+	schemaMap shim.SchemaMap,
+	schemaInfos map[string]*tfbridge.SchemaInfo) SchemaPath {
+	return propertyPathToSchemaPath(walk.NewSchemaPath(), propertyPath, schemaMap, schemaInfos)
+}
+
+func propertyPathToSchemaPath(
+	basePath walk.SchemaPath,
+	propertyPath resource.PropertyPath,
+	schemaMap shim.SchemaMap,
+	schemaInfos map[string]*tfbridge.SchemaInfo) walk.SchemaPath {
+
+	if len(propertyPath) == 0 {
+		return basePath
+	}
+
+	if schemaInfos == nil {
+		schemaInfos = make(map[string]*tfbridge.SchemaInfo)
+	}
+
+	firstStep, ok := propertyPath[0].(string)
+	if !ok {
+		return nil
+	}
+
+	firstStepTF := tfbridge.PulumiToTerraformName(firstStep, schemaMap, schemaInfos)
+
+	fieldSchema, found := schemaMap.GetOk(firstStepTF)
+	if !found {
+		return nil
+	}
+	fieldInfo := schemaInfos[firstStepTF]
+	return propertyPathToSchemaPathInner(basePath.GetAttr(firstStepTF), propertyPath[1:], fieldSchema, fieldInfo)
+}
+
+func propertyPathToSchemaPathInner(
+	basePath walk.SchemaPath,
+	propertyPath resource.PropertyPath,
+	schema shim.Schema,
+	schemaInfo *tfbridge.SchemaInfo) walk.SchemaPath {
+
+	if len(propertyPath) == 0 {
+		return basePath
+	}
+
+	if schemaInfo == nil {
+		schemaInfo = &tfbridge.SchemaInfo{}
+	}
+
+	// Detect single-nested blocks (object types).
+	if res, isRes := schema.Elem().(shim.Resource); schema.Type() == shim.TypeMap && isRes {
+		return propertyPathToSchemaPath(basePath, propertyPath, res.Schema(), schemaInfo.Fields)
+	}
+
+	// Detect collections.
+	switch schema.Type() {
+	case shim.TypeList, shim.TypeMap, shim.TypeSet:
+		var elemPP resource.PropertyPath
+		if tfbridge.IsMaxItemsOne(schema, schemaInfo) {
+			// Pulumi flattens MaxItemsOne values, so the element path is the same as the current path.
+			elemPP = propertyPath
+		} else {
+			// For normal collections the first element drills down into the collection, skip it.
+			elemPP = propertyPath[1:]
+		}
+		switch e := schema.Elem().(type) {
+		case shim.Resource: // object element type
+			return propertyPathToSchemaPath(basePath.Element(), elemPP, e.Schema(), schemaInfo.Fields)
+		case shim.Schema: // non-object element type
+			return propertyPathToSchemaPathInner(basePath.Element(), elemPP, e, schemaInfo.Elem)
+		case nil: // unknown element type
+			// Cannot drill down further, but len(propertyPath)>0.
+			return nil
+		}
+	}
+
+	// Cannot drill down further, but len(propertyPath)>0.
+	return nil
+}
+
+// Drill down a path from a map of SchemaInfo objects and find a matching SchemaInfo if any.
+func LookupSchemaInfoMapPath(schemaPath walk.SchemaPath,
+	schemaInfos map[string]*tfbridge.SchemaInfo) *tfbridge.SchemaInfo {
+
+	if len(schemaPath) == 0 {
+		return nil
+	}
+
+	if schemaInfos == nil {
+		return nil
+	}
+
+	switch step := schemaPath[0].(type) {
+	case walk.ElementStep:
+		return nil
+	case walk.GetAttrStep:
+		return LookupSchemaInfoPath(schemaPath[1:], schemaInfos[step.Name])
+	}
+
+	return nil
+}
+
+// Drill down a path from a  SchemaInfo object and find a matching SchemaInfo if any.
+func LookupSchemaInfoPath(schemaPath walk.SchemaPath, schemaInfo *tfbridge.SchemaInfo) *tfbridge.SchemaInfo {
+	if len(schemaPath) == 0 {
+		return schemaInfo
+	}
+	if schemaInfo == nil {
+		return nil
+	}
+	switch schemaPath[0].(type) {
+	case walk.ElementStep:
+		return LookupSchemaInfoPath(schemaPath[1:], schemaInfo.Elem)
+	case walk.GetAttrStep:
+		return LookupSchemaInfoMapPath(schemaPath, schemaInfo.Fields)
+	default:
+		return nil
+	}
+}

--- a/pkg/tfbridge/walk/walk_test.go
+++ b/pkg/tfbridge/walk/walk_test.go
@@ -165,6 +165,16 @@ func TestLookupSchemaInfoMapPath(t *testing.T) {
 				},
 			},
 		},
+		"max_items_one_prop": {
+			MaxItemsOne: &yes,
+			Elem: &tfbridge.SchemaInfo{
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"sub_prop": {
+						Secret: &yes,
+					},
+				},
+			},
+		},
 	}
 
 	type testCase struct {
@@ -188,6 +198,11 @@ func TestLookupSchemaInfoMapPath(t *testing.T) {
 			"nested object",
 			walk.NewSchemaPath().GetAttr("nested_obj_prop").GetAttr("sub_prop").GetAttr("p"),
 			schemaInfos["nested_obj_prop"].Fields["sub_prop"].Fields["p"],
+		},
+		{
+			"oblivious to maxitemsone",
+			walk.NewSchemaPath().GetAttr("max_items_one_prop").Element().GetAttr("sub_prop"),
+			schemaInfos["max_items_one_prop"].Elem.Fields["sub_prop"],
 		},
 	}
 

--- a/pkg/tfbridge/walk/walk_test.go
+++ b/pkg/tfbridge/walk/walk_test.go
@@ -1,0 +1,201 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package walk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/walk"
+)
+
+func TestPropertyPathToSchemaPath(t *testing.T) {
+	strSchema := (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim()
+
+	xySchema := (&schema.Resource{
+		Schema: schema.SchemaMap{
+			"x_prop": strSchema,
+			"y_prop": strSchema,
+		},
+	}).Shim()
+
+	schemaMap := &schema.SchemaMap{
+		"string_prop": strSchema,
+		"list_str": (&schema.Schema{
+			Type: shim.TypeList,
+			Elem: strSchema,
+		}).Shim(),
+		"list_unknowns": (&schema.Schema{
+			Type: shim.TypeList,
+		}).Shim(),
+		"flat_list": (&schema.Schema{
+			Type:     shim.TypeList,
+			Elem:     xySchema,
+			MaxItems: 1,
+		}).Shim(),
+		"obj_set": (&schema.Schema{
+			Type: shim.TypeSet,
+			Elem: xySchema,
+		}).Shim(),
+		"single_obj": (&schema.Schema{
+			Type: shim.TypeMap,
+			Elem: xySchema,
+		}).Shim(),
+	}
+
+	type testCase struct {
+		name        string
+		pp          resource.PropertyPath
+		schemaInfos map[string]*tfbridge.SchemaInfo
+		expected    walk.SchemaPath
+	}
+
+	cases := []testCase{
+		{
+			name:     "simple string property",
+			pp:       []any{"stringProp"},
+			expected: walk.NewSchemaPath().GetAttr("string_prop"),
+		},
+		{
+			name:     "simple not found property",
+			pp:       []any{"notFoundProp"},
+			expected: nil,
+		},
+		{
+			name:     "simple not found drill-down property",
+			pp:       []any{"stringProp", "notFoundProp"},
+			expected: nil,
+		},
+		{
+			name:     "list",
+			pp:       []any{"listStr"},
+			expected: walk.NewSchemaPath().GetAttr("list_str"),
+		},
+		{
+			name:     "list element",
+			pp:       []any{"listStr", 3},
+			expected: walk.NewSchemaPath().GetAttr("list_str").Element(),
+		},
+		{
+			name:     "list of unknowns",
+			pp:       []any{"listUnknowns"},
+			expected: walk.NewSchemaPath().GetAttr("list_unknowns"),
+		},
+		{
+			name:     "list of unknowns element",
+			pp:       []any{"listUnknowns", 3},
+			expected: nil,
+		},
+		{
+			name:     "single-nested block",
+			pp:       []any{"singleObj", "xProp"},
+			expected: walk.NewSchemaPath().GetAttr("single_obj").GetAttr("x_prop"),
+		},
+		{
+			name:     "set-nested block 1",
+			pp:       []any{"objSet"},
+			expected: walk.NewSchemaPath().GetAttr("obj_set"),
+		},
+		{
+			name:     "set-nested block 2",
+			pp:       []any{"objSet", 0},
+			expected: walk.NewSchemaPath().GetAttr("obj_set").Element(),
+		},
+		{
+			name:     "set-nested block 3",
+			pp:       []any{"objSet", 0, "xProp"},
+			expected: walk.NewSchemaPath().GetAttr("obj_set").Element().GetAttr("x_prop"),
+		},
+		{
+			name:     "max-items-1 list 1",
+			pp:       []any{"flatList"},
+			expected: walk.NewSchemaPath().GetAttr("flat_list"),
+		},
+		{
+			name:     "max-items-1 list 3",
+			pp:       []any{"flatList", "xProp"},
+			expected: walk.NewSchemaPath().GetAttr("flat_list").Element().GetAttr("x_prop"),
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			pp := PropertyPathToSchemaPath(tc.pp, schemaMap, tc.schemaInfos)
+			assert.Equal(t, tc.expected, pp)
+		})
+	}
+}
+
+func TestLookupSchemaInfoMapPath(t *testing.T) {
+	yes := true
+
+	schemaInfos := map[string]*tfbridge.SchemaInfo{
+		"list_prop": {
+			Elem: &tfbridge.SchemaInfo{
+				Secret: &yes,
+			},
+		},
+		"nested_obj_prop": {
+			Fields: map[string]*tfbridge.SchemaInfo{
+				"sub_prop": {
+					Fields: map[string]*tfbridge.SchemaInfo{
+						"p": {
+							Secret: &yes,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	type testCase struct {
+		name     string
+		path     walk.SchemaPath
+		expected *tfbridge.SchemaInfo
+	}
+
+	testCases := []testCase{
+		{
+			"not-found",
+			walk.NewSchemaPath().Element(),
+			nil,
+		},
+		{
+			"list",
+			walk.NewSchemaPath().GetAttr("list_prop").Element(),
+			schemaInfos["list_prop"].Elem,
+		},
+		{
+			"nested object",
+			walk.NewSchemaPath().GetAttr("nested_obj_prop").GetAttr("sub_prop").GetAttr("p"),
+			schemaInfos["nested_obj_prop"].Fields["sub_prop"].Fields["p"],
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			actual := LookupSchemaInfoMapPath(tc.path, schemaInfos)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}

--- a/pkg/tfbridge/walk/walk_test.go
+++ b/pkg/tfbridge/walk/walk_test.go
@@ -65,7 +65,7 @@ func TestPropertyPathToSchemaPath(t *testing.T) {
 		name        string
 		pp          resource.PropertyPath
 		schemaInfos map[string]*tfbridge.SchemaInfo
-		expected    walk.SchemaPath
+		expected    SchemaPath
 	}
 
 	cases := []testCase{
@@ -169,7 +169,7 @@ func TestLookupSchemaInfoMapPath(t *testing.T) {
 
 	type testCase struct {
 		name     string
-		path     walk.SchemaPath
+		path     SchemaPath
 		expected *tfbridge.SchemaInfo
 	}
 


### PR DESCRIPTION
New function PropertyPathToSchemaPath allows converting paths describing nested locations in Pulumi values (resource.PropertyValue) to matching schema paths.

New function LookupSchemaInfoMapPath allows finding a nested SchemaInfo object.

These functions in combination are useful for schema-aware transformations on Pulumi values.

On top of https://github.com/pulumi/pulumi-terraform-bridge/pull/1075