### PR TITLE
Implement MarkSchemaSecrets

### DIFF
--- a/pkg/tfbridge/walk/walk.go
+++ b/pkg/tfbridge/walk/walk.go
@@ -115,6 +115,19 @@ func propertyPathToSchemaPathInner(
 	return nil
 }
 
+// Convenience method to lookup both a Schema and a SchemaInfo by path.
+func LookupSchemas(schemaPath walk.SchemaPath,
+	schemaMap shim.SchemaMap,
+	schemaInfos map[string]*tfbridge.SchemaInfo) (shim.Schema, *tfbridge.SchemaInfo, error) {
+
+	s, err := walk.LookupSchemaMapPath(schemaPath, schemaMap)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return s, LookupSchemaInfoMapPath(schemaPath, schemaInfos), nil
+}
+
 // Drill down a path from a map of SchemaInfo objects and find a matching SchemaInfo if any.
 func LookupSchemaInfoMapPath(
 	schemaPath SchemaPath,

--- a/pkg/tfbridge/x/secrets.go
+++ b/pkg/tfbridge/x/secrets.go
@@ -1,0 +1,101 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package x
+
+import (
+	"context"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/walk"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
+// Ensures resource.MakeSecret is used to wrap any nested values that correspond to secret properties in the schema. A
+// property is considered secret if it is declared Sensitive in the SchemaMap in the upstream provider. Users may also
+// override a matching SchemaInfo.Secret setting to force a property to be considered secret or non-secret.
+func MarkSchemaSecrets(ctx context.Context, schemaMap shim.SchemaMap, configInfos map[string]*tfbridge.SchemaInfo,
+	pv resource.PropertyValue) resource.PropertyValue {
+	ss := &schemaSecrets{schemaMap, configInfos}
+	return ss.markSchemaSecretsTransform(make(resource.PropertyPath, 0), pv)
+}
+
+type schemaSecrets struct {
+	schemaMap   shim.SchemaMap
+	schemaInfos map[string]*tfbridge.SchemaInfo
+}
+
+func (ss *schemaSecrets) shouldBeSecret(path resource.PropertyPath) bool {
+	schemaPath := walk.PropertyPathToSchemaPath(path, ss.schemaMap, ss.schemaInfos)
+	s, info, err := walk.LookupSchemas(schemaPath, ss.schemaMap, ss.schemaInfos)
+	if err != nil {
+		return false
+	}
+	secret := false
+	if info != nil && info.Secret != nil {
+		secret = *info.Secret
+	} else if s != nil {
+		secret = s.Sensitive()
+	}
+	return secret
+}
+
+func (ss *schemaSecrets) markSchemaSecretsTransform(
+	path resource.PropertyPath,
+	value resource.PropertyValue,
+) resource.PropertyValue {
+	switch {
+	case value.IsArray():
+		av := value.ArrayValue()
+		tvs := make([]resource.PropertyValue, 0, len(av))
+		for i, v := range av {
+			subPath := append(path, i)
+			tv := ss.markSchemaSecretsTransform(subPath, v)
+			tvs = append(tvs, tv)
+		}
+		value = resource.NewArrayProperty(tvs)
+	case value.IsObject():
+		pm := make(resource.PropertyMap)
+		for k, v := range value.ObjectValue() {
+			subPath := append(path, string(k))
+			tv := ss.markSchemaSecretsTransform(subPath, v)
+			pm[k] = tv
+		}
+		value = resource.NewObjectProperty(pm)
+	case value.IsOutput():
+		o := value.OutputValue()
+		if o.Secret {
+			// short-circuit instead of marking nested secrets
+			return value
+		}
+
+		tv := ss.markSchemaSecretsTransform(path, o.Element)
+		value = resource.NewOutputProperty(resource.Output{
+			Element:      tv,
+			Known:        o.Known,
+			Secret:       o.Secret,
+			Dependencies: o.Dependencies,
+		})
+	case value.IsSecret():
+		// short-circuit instead of marking nested secrets
+		return value
+	}
+
+	if !value.IsSecret() && ss.shouldBeSecret(path) {
+		value = resource.MakeSecret(value)
+	}
+
+	return value
+}

--- a/pkg/tfbridge/x/secrets_test.go
+++ b/pkg/tfbridge/x/secrets_test.go
@@ -1,0 +1,127 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package x
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
+)
+
+func TestMarkSchemaSecrets(t *testing.T) {
+	type testCase struct {
+		name   string
+		pv     resource.PropertyValue
+		expect resource.PropertyValue
+	}
+
+	schemaMap := schema.SchemaMap{
+		"simple_string_prop": (&schema.Schema{
+			Type:     shim.TypeString,
+			Optional: true,
+		}).Shim(),
+		"unsecret_string_prop": (&schema.Schema{
+			Type:      shim.TypeString,
+			Sensitive: true,
+			Optional:  true,
+		}).Shim(),
+		"sensitive_string_prop": (&schema.Schema{
+			Type:      shim.TypeString,
+			Optional:  true,
+			Sensitive: true,
+		}).Shim(),
+		"list_with_sensitive_elem": (&schema.Schema{
+			Type:     shim.TypeList,
+			Optional: true,
+			Elem: (&schema.Schema{
+				Type:      shim.TypeString,
+				Optional:  true,
+				Sensitive: true,
+			}).Shim(),
+		}).Shim(),
+	}
+
+	yes, no := true, false
+
+	configInfos := map[string]*tfbridge.SchemaInfo{
+		"simple_string_prop": {
+			Secret: &yes,
+		},
+		"unsecret_string_prop": {
+			Secret: &no,
+		},
+	}
+
+	obj1 := func(name string, v resource.PropertyValue) resource.PropertyValue {
+		return resource.NewObjectProperty(resource.PropertyMap{
+			resource.PropertyKey(name): v,
+		})
+	}
+
+	arr := func(v ...resource.PropertyValue) resource.PropertyValue {
+		return resource.NewArrayProperty(v)
+	}
+
+	str := resource.NewStringProperty
+	sec := resource.MakeSecret
+
+	testCases := []testCase{
+		{
+			"marks sensitive string prop as secret",
+			obj1("sensitiveStringProp", str("secret")),
+			obj1("sensitiveStringProp", sec(str("secret"))),
+		},
+		{
+			"does not double-mark secrets",
+			obj1("sensitiveStringProp", sec(str("secret"))),
+			obj1("sensitiveStringProp", sec(str("secret"))),
+		},
+		{
+			"marks sensitive list elements as secret",
+			obj1("listWithSensitiveElems", arr(str("secret1"), str("secret2"))),
+			obj1("listWithSensitiveElems", arr(sec(str("secret1")), sec(str("secret2")))),
+		},
+		{
+			"respects secret overrides",
+			obj1("simpleStringProp", str("secret")),
+			obj1("simpleStringProp", sec(str("secret"))),
+		},
+		{
+			"respects no-secret overrides",
+			obj1("unsecretStringProp", str("secret")),
+			obj1("unsecretStringProp", str("secret")),
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			actual := MarkSchemaSecrets(
+				context.Background(),
+				schemaMap,
+				configInfos,
+				tc.pv)
+			assert.Equal(t, tc.expect, actual)
+		})
+	}
+}


### PR DESCRIPTION
It is the responsibility of the bridged providers to ensure that any PropertyValue data returned to the engine is marked with resource.MakeSecret when it corresponds to a secret property in the schema. Previously this responsibility was carried by the serializers, but it can be more convenient to reuse if expressed as a pure PropertyValue based transformation pass. This is added now as a new function MarkSchemaSecrets.

On top of #1076 