### PR TITLE
Internal fix: cd pf && make build.testproviders

### DIFF
--- a/pf/tests/internal/testprovider/cmd/pulumi-resource-testbridge/schema.json
+++ b/pf/tests/internal/testprovider/cmd/pulumi-resource-testbridge/schema.json
@@ -50,12 +50,7 @@
                     "$ref": "#/types/testbridge:index/TestnestRuleActionParametersPhases:TestnestRuleActionParametersPhases"
                 }
             },
-            "type": "object",
-            "required": [
-                "automaticHttpsRewrites",
-                "bic",
-                "phases"
-            ]
+            "type": "object"
         },
         "testbridge:index/TestnestRuleActionParametersPhases:TestnestRuleActionParametersPhases": {
             "properties": {
@@ -66,11 +61,7 @@
                     "type": "boolean"
                 }
             },
-            "type": "object",
-            "required": [
-                "p1",
-                "p2"
-            ]
+            "type": "object"
         },
         "testbridge:index/TestresService:TestresService": {
             "properties": {


### PR DESCRIPTION
Looks like CI does not enforce yet that these schemas are in sync.