### PR TITLE
Allow Docs Rule based Overrides

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -115,6 +115,7 @@ type ProviderInfo struct {
 }
 
 type DocRuleInfo struct {
+	// A list of replace rules to apply.
 	ReplaceRules []ReplaceRule
 
 	// A function to suggest alternative file names for a TF element.
@@ -127,7 +128,12 @@ type DocsPathInfo struct {
 
 type ReplaceRule struct {
 	// The path at which this rule applies. Paths are matched via filepath.Match.
-	Path    string
+	//
+	// To match all files, supply "*".
+	Path string
+	// The function that performs the replace on the byte string.
+	//
+	// Must not be nil.
 	Replace func(path string, content []byte) ([]byte, error)
 }
 

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -159,13 +159,6 @@ type DocRuleInfo struct {
 	AlternativeNames func(DocsPathInfo) []string
 }
 
-// PreAppendEdits is a MakeEditRules that applies custom edits before default edits.
-func PreAppendEdits(edits ...DocsEdit) MakeEditRules {
-	return func(defaults []DocsEdit) []DocsEdit {
-		return append(edits, defaults...)
-	}
-}
-
 // Information for file lookup.
 type DocsPathInfo struct {
 	TfToken string

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -101,7 +101,7 @@ type ProviderInfo struct {
 	// See NewProviderMetadata for in-place construction of a *MetadataInfo.
 	MetadataInfo *MetadataInfo
 
-	// Rules that control discovery and replacement for docs.
+	// Rules that control file discovery and edits for any subset of docs in a provider.
 	DocRules *DocRuleInfo
 
 	UpstreamRepoPath string // An optional path that overrides upstream location during docs lookup
@@ -114,27 +114,29 @@ type ProviderInfo struct {
 	SkipExamples func(SkipExamplesArgs) bool
 }
 
+// DocRuleInfo controls file discovery and edits for any subset of docs in a provider.
 type DocRuleInfo struct {
-	// A list of replace rules to apply.
-	ReplaceRules []ReplaceRule
+	// A list of edit rules to apply.
+	EditRules []DocsEdit
 
 	// A function to suggest alternative file names for a TF element.
 	AlternativeNames func(DocsPathInfo) []string
 }
 
+// Information for file lookup.
 type DocsPathInfo struct {
 	Resource string
 }
 
-type ReplaceRule struct {
+type DocsEdit struct {
 	// The path at which this rule applies. Paths are matched via filepath.Match.
 	//
 	// To match all files, supply "*".
 	Path string
-	// The function that performs the replace on the byte string.
+	// The function that performs the edit on the file bytes.
 	//
 	// Must not be nil.
-	Replace func(path string, content []byte) ([]byte, error)
+	Edit func(path string, content []byte) ([]byte, error)
 }
 
 // TFProviderLicense is a way to be able to pass a license type for the upstream Terraform provider.

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -120,18 +120,47 @@ type DocRuleInfo struct {
 	EditRules []DocsEdit
 
 	// A function to suggest alternative file names for a TF element.
+	//
+	// When the bridge loads the documentation for a resource or a datasource, it
+	// infers the name of the file that contains the documentation. AlternativeNames
+	// allows you to provide a provider specific extension to the override list.
+	//
+	// For example, when attempting to find the documentation for the resource token
+	// aws_waf_instances, the bridge will check the following files (in order):
+	//
+	//	"waf_instance.html.markdown"
+	//	"waf_instance.markdown"
+	//	"waf_instance.html.md"
+	//	"waf_instance.md"
+	//	"aws_waf_instance.html.markdown"
+	//	"aws_waf_instance.markdown"
+	//	"aws_waf_instance.html.md"
+	//	"aws_waf_instance.md"
+	//
+	// The bridge will check any file names returned by AlternativeNames before
+	// checking it's standard list.
 	AlternativeNames func(DocsPathInfo) []string
 }
 
 // Information for file lookup.
 type DocsPathInfo struct {
-	Resource string
+	TfToken string
 }
 
 type DocsEdit struct {
-	// The path at which this rule applies. Paths are matched via filepath.Match.
+	// The file name at which this rule applies. File names are matched via filepath.Match.
 	//
 	// To match all files, supply "*".
+	//
+	// All 4 of these names will match "waf_instances.html.markdown":
+	//
+	// - "waf_instances.html.markdown"
+	// - "waf_instances.*"
+	// - "waf*"
+	// - "*"
+	//
+	// Provider resources are sourced directly from the TF schema, and as such have an
+	// empty path.
 	Path string
 	// The function that performs the edit on the file bytes.
 	//

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -101,6 +101,9 @@ type ProviderInfo struct {
 	// See NewProviderMetadata for in-place construction of a *MetadataInfo.
 	MetadataInfo *MetadataInfo
 
+	// Rules that control discovery and replacement for docs.
+	DocRules *DocRuleInfo
+
 	UpstreamRepoPath string // An optional path that overrides upstream location during docs lookup
 
 	// EXPERIMENTAL: the signature may change in minor releases.
@@ -109,6 +112,23 @@ type ProviderInfo struct {
 	// docs). The primary use case for this hook is to ignore problematic or flaky examples temporarily until the
 	// underlying issues are resolved and the examples can be rendered correctly.
 	SkipExamples func(SkipExamplesArgs) bool
+}
+
+type DocRuleInfo struct {
+	ReplaceRules []ReplaceRule
+
+	// A function to suggest alternative file names for a TF element.
+	AlternativeNames func(DocsPathInfo) []string
+}
+
+type DocsPathInfo struct {
+	Resource string
+}
+
+type ReplaceRule struct {
+	// The path at which this rule applies. Paths are matched via filepath.Match.
+	Path    string
+	Replace func(path string, content []byte) ([]byte, error)
 }
 
 // TFProviderLicense is a way to be able to pass a license type for the upstream Terraform provider.

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -317,10 +317,10 @@ func getEditRules(info *tfbridge.DocRuleInfo) editRules {
 			},
 		},
 	}
-	if info == nil {
+	if info == nil || info.EditRules == nil {
 		return defaults
 	}
-	return append(info.EditRules, defaults...)
+	return info.EditRules(defaults)
 }
 
 func (k DocKind) String() string {

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -545,7 +545,7 @@ func parseTFMarkdown(g *Generator, info tfbridge.ResourceOrDataSourceInfo, kind 
 			pkg:      g.pkg,
 			info:     g.info,
 		},
-		docRules: g.info.DocRules,
+		editRules: g.editRules,
 	}
 	return p.parse(markdown)
 }
@@ -563,8 +563,8 @@ type tfMarkdownParser struct {
 	markdownFileName string
 	rawname          string
 
-	infoCtx  infoContext
-	docRules *tfbridge.DocRuleInfo
+	infoCtx   infoContext
+	editRules editRules
 
 	ret entityDocs
 }
@@ -599,7 +599,7 @@ func (p *tfMarkdownParser) parse(tfMarkdown []byte) (entityDocs, error) {
 		Attributes: make(map[string]string),
 	}
 	var err error
-	tfMarkdown, err = getEditRules(p.docRules).apply(p.markdownFileName, tfMarkdown)
+	tfMarkdown, err = p.editRules.apply(p.markdownFileName, tfMarkdown)
 	if err != nil {
 		return entityDocs{}, fmt.Errorf("file %s: %w", p.markdownFileName, err)
 	}

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -1871,6 +1871,13 @@ func reformatText(g *Generator, text string, footerLinks map[string]string) (str
 		text = strings.TrimPrefix(text, "\n(Required)\n")
 		text = strings.TrimPrefix(text, "\n(Optional)\n")
 
+		// Find markdown Terraform docs site reference links.
+		text = markdownPageReferenceLink.ReplaceAllStringFunc(text, func(referenceLink string) string {
+			parts := strings.Split(referenceLink, " ")
+			// Add Terraform domain to avoid broken links.
+			return fmt.Sprintf("%s https://www.terraform.io%s", parts[0], parts[1])
+		})
+
 		// Find links from the footer links.
 		text = replaceFooterLinks(text, footerLinks)
 

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -201,32 +201,28 @@ func findRepoPath(repoPathsEnvVar string, moduleCoordinates string) string {
 	return ""
 }
 
-func getMarkdownNames(resourcePrefix, rawName string, globalInfo *tfbridge.DocRuleInfo) (names []string) {
-	postfixes := []string{
-		".html.markdown",
-		".markdown",
-		".html.md",
-		".md",
-	}
-	resNames := []string{
+func getMarkdownNames(resourcePrefix, rawName string, globalInfo *tfbridge.DocRuleInfo) []string {
+	possibleMarkdownNames := []string{
 		// Most frequently, docs leave off the provider prefix
-		withoutPackageName(resourcePrefix, rawName),
+		withoutPackageName(resourcePrefix, rawName) + ".html.markdown",
+		withoutPackageName(resourcePrefix, rawName) + ".markdown",
+		withoutPackageName(resourcePrefix, rawName) + ".html.md",
+		withoutPackageName(resourcePrefix, rawName) + ".md",
 		// But for some providers, the prefix is included in the name of the doc file
-		rawName,
-	}
-	for _, res := range resNames {
-		for _, postfix := range postfixes {
-			names = append(names, res+postfix)
-		}
+		rawName + ".html.markdown",
+		rawName + ".markdown",
+		rawName + ".html.md",
+		rawName + ".md",
 	}
 
 	if globalInfo != nil && globalInfo.AlternativeNames != nil {
-		names = append(globalInfo.AlternativeNames(tfbridge.DocsPathInfo{
+		// We look at user generated names before we look at default names
+		possibleMarkdownNames = append(globalInfo.AlternativeNames(tfbridge.DocsPathInfo{
 			Resource: rawName,
-		}), names...)
+		}), possibleMarkdownNames...)
 	}
 
-	return names
+	return possibleMarkdownNames
 }
 
 func getMarkdownDetails(sink diag.Sink, repoPath, org, provider string,

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -965,9 +965,7 @@ This is a test for CUSTOM_REPLACES.`)
 			}
 
 			c.docRules = &tfbridge.DocRuleInfo{
-				EditRules: []tfbridge.DocsEdit{
-					rule,
-				},
+				EditRules: tfbridge.PreAppendEdits(rule),
 			}
 		}),
 	}

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -906,8 +906,6 @@ func TestParseTFMarkdown(t *testing.T) {
 		kind                    DocKind
 		resourcePrefix, rawName string
 
-		docRules *tfbridge.DocRuleInfo
-
 		fileName     string
 		fileContents []byte
 
@@ -964,8 +962,10 @@ This is a test for CUSTOM_REPLACES.`)
 				},
 			}
 
-			c.docRules = &tfbridge.DocRuleInfo{
-				EditRules: tfbridge.PreAppendEdits(rule),
+			c.providerInfo.DocRules = &tfbridge.DocRuleInfo{
+				EditRules: func(defaults []tfbridge.DocsEdit) []tfbridge.DocsEdit {
+					return append([]tfbridge.DocsEdit{rule}, defaults...)
+				},
 			}
 		}),
 	}
@@ -985,7 +985,7 @@ This is a test for CUSTOM_REPLACES.`)
 					pkg:      "pkg",
 					info:     tt.providerInfo,
 				},
-				docRules: tt.docRules,
+				editRules: getEditRules(tt.providerInfo.DocRules),
 			}
 
 			actual, err := p.parse(tt.fileContents)

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -945,9 +945,11 @@ This is a document for the pkg_mod1_res1 resource. To create this resource, run 
 
 This is a document for the pkg_mod1_res1 resource. To create this resource, run "pulumi preview" then "pulumi up".`,
 		),
+
 		desc(`
 This is a test that we [correctly](https://www.terraform.io/docs/pkg/some-resource) strip TF doc links.
 `, "## \n\nThis is a test that we correctly strip TF doc links."),
+
 		tc(func(c *testCase) {
 			c.fileContents = []byte(`
 This is a test for CUSTOM_REPLACES.`)

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -1198,7 +1198,7 @@ func (g *Generator) gatherResource(rawname string,
 	// Collect documentation information
 	var entityDocs entityDocs
 	if !isProvider {
-		pd, err := getDocsForProvider(g, g.info.GetGitHubOrg(), g.info.Name,
+		pd, err := getDocsForResource(g, g.info.GetGitHubOrg(), g.info.Name,
 			g.info.GetResourcePrefix(), ResourceDocs, rawname, info, g.info.GetProviderModuleVersion(),
 			g.info.GetGitHubHost())
 		if err != nil {
@@ -1392,7 +1392,7 @@ func (g *Generator) gatherDataSource(rawname string,
 	g.renamesBuilder.registerDataSource(dataSourcePath)
 
 	// Collect documentation information for this data source.
-	entityDocs, err := getDocsForProvider(g, g.info.GetGitHubOrg(), g.info.Name,
+	entityDocs, err := getDocsForResource(g, g.info.GetGitHubOrg(), g.info.Name,
 		g.info.GetResourcePrefix(), DataSourceDocs, rawname, info, g.info.GetProviderModuleVersion(),
 		g.info.GetGitHubHost())
 	if err != nil {

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -72,6 +72,7 @@ type Generator struct {
 	skipExamples     bool
 	coverageTracker  *CoverageTracker
 	renamesBuilder   *renamesBuilder
+	editRules        editRules
 
 	convertedCode map[string][]byte
 }
@@ -817,6 +818,7 @@ func NewGenerator(opts GeneratorOptions) (*Generator, error) {
 		skipExamples:     opts.SkipExamples,
 		coverageTracker:  opts.CoverageTracker,
 		renamesBuilder:   newRenamesBuilder(pkg, opts.ProviderInfo.GetResourcePrefix()),
+		editRules:        getEditRules(info.DocRules),
 	}, nil
 }
 


### PR DESCRIPTION
This PR allows providers to specify arbitrary rule based docs replace directives. The obvious use case is to avoid docs elisions by replacing phrases such as `"The resource ID in terraform of "` with `"The resource ID in Pulumi of "`.

This PR also includes 3 rules that are applied to all providers:
1. Replacing `terraform plan` with `pulumi preview`.
2. Replacing `terraform apply` with `pulumi up`.
3. Stripping markdown links to `terraform.*`.

For an example PR that consumes this API, see https://github.com/pulumi/pulumi-alicloud/pull/398.

---

Applies a stop-gap fix for https://github.com/pulumi/pulumi-terraform-bridge/issues/658.