### PR TITLE
Remove broken downstream testing for `pulumi-azure`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        provider: [ "gcp", "azure", "azuread", "random", ]
+        provider: [ "gcp", "azuread", "random", ]
     steps:
       - name: Install Node.js
         uses: actions/setup-node@v1


### PR DESCRIPTION
Our downstream testing action doesn't account for patch based providers.