### PR TITLE
Docs include post argument strings

### DIFF
--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -18,6 +18,8 @@ package tfgen
 import (
 	"bytes"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"text/template"
@@ -266,14 +268,12 @@ func TestArgumentRegex(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		parser := &tfMarkdownParser{
-			ret: entityDocs{
-				Arguments: make(map[string]*argumentDocs),
-			},
+		ret := entityDocs{
+			Arguments: make(map[string]*argumentDocs),
 		}
-		parser.parseArgReferenceSection(tt.input)
+		parseArgReferenceSection(tt.input, &ret)
 
-		assert.Equal(t, tt.expected, parser.ret.Arguments)
+		assert.Equal(t, tt.expected, ret.Arguments)
 
 		//assert.Len(t, parser.ret.Arguments, len(tt.expected))
 		//for k, v := range tt.expected {
@@ -625,20 +625,19 @@ func TestParseArgFromMarkdownLine(t *testing.T) {
 }
 
 func TestParseAttributesReferenceSection(t *testing.T) {
-	p := tfMarkdownParser{}
-	p.ret = entityDocs{
+	ret := entityDocs{
 		Arguments:  make(map[string]*argumentDocs),
 		Attributes: make(map[string]string),
 	}
-	p.parseAttributesReferenceSection([]string{
+	parseAttributesReferenceSection([]string{
 		"The following attributes are exported:",
 		"",
 		"* `id` - The ID of the Droplet",
 		"* `urn` - The uniform resource name of the Droplet",
 		"* `name`- The name of the Droplet",
 		"* `region` - The region of the Droplet",
-	})
-	assert.Len(t, p.ret.Attributes, 4)
+	}, &ret)
+	assert.Len(t, ret.Attributes, 4)
 }
 
 func TestGetNestedBlockName(t *testing.T) {
@@ -965,6 +964,42 @@ This is a test for CUSTOM_REPLACES.`)
 			c.providerInfo.DocRules = &tfbridge.DocRuleInfo{
 				EditRules: func(defaults []tfbridge.DocsEdit) []tfbridge.DocsEdit {
 					return append([]tfbridge.DocsEdit{rule}, defaults...)
+				},
+			}
+		}),
+
+		tc(func(c *testCase) {
+			var err error
+			c.fileContents, err = os.ReadFile(filepath.Join("test_data", "azurerm-sql-firewall-rule.md"))
+			require.NoError(t, err)
+
+			c.expected = entityDocs{
+				Import:      "## Import\n\nSQL Firewall Rules can be imported using the `resource id`, e.g. <break><break>```sh<break> $ pulumi import MISSING_TOK rule1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Sql/servers/myserver/firewallRules/rule1 <break>```<break><break>",
+				Description: "Allows you to manage an Azure SQL Firewall Rule.\n\n> **Note:** The `azurerm_sql_firewall_rule` resource is deprecated in version 3.0 of the AzureRM provider and will be removed in version 4.0. Please use the `azurerm_mssql_firewall_rule` resource instead.\n\n## Example Usage\n\n```hcl\nresource \"azurerm_resource_group\" \"example\" {\n  name     = \"example-resources\"\n  location = \"West Europe\"\n}\n\nresource \"azurerm_sql_server\" \"example\" {\n  name                         = \"mysqlserver\"\n  resource_group_name          = azurerm_resource_group.example.name\n  location                     = azurerm_resource_group.example.location\n  version                      = \"12.0\"\n  administrator_login          = \"4dm1n157r470r\"\n  administrator_login_password = \"4-v3ry-53cr37-p455w0rd\"\n}\n\nresource \"azurerm_sql_firewall_rule\" \"example\" {\n  name                = \"FirewallRule1\"\n  resource_group_name = azurerm_resource_group.example.name\n  server_name         = azurerm_sql_server.example.name\n  start_ip_address    = \"10.0.17.62\"\n  end_ip_address      = \"10.0.17.62\"\n}\n```",
+				Arguments: map[string]*argumentDocs{
+					"name": {
+						description: "The name of the firewall rule. Changing this forces a new resource to be created.",
+						arguments:   map[string]string{},
+					},
+					"resource_group_name": {
+						description: "The name of the resource group in which to create the SQL Server. Changing this forces a new resource to be created.",
+						arguments:   map[string]string{},
+					},
+					"server_name": {
+						description: "The name of the SQL Server on which to create the Firewall Rule. Changing this forces a new resource to be created.",
+						arguments:   map[string]string{},
+					},
+					"start_ip_address": {
+						description: "The starting IP address to allow through the firewall for this rule.",
+						arguments:   map[string]string{},
+					},
+					"end_ip_address": {
+						description: "The ending IP address to allow through the firewall for this rule.\n\n> **NOTE:** The Azure feature `Allow access to Azure services` can be enabled by setting `start_ip_address` and `end_ip_address` to `0.0.0.0` which ([is documented in the Azure API Docs](https://docs.microsoft.com/rest/api/sql/firewallrules/createorupdate)).",
+						arguments:   map[string]string{},
+					},
+				},
+				Attributes: map[string]string{
+					"id": "The SQL Firewall Rule ID.",
 				},
 			}
 		}),

--- a/pkg/tfgen/test_data/azurerm-sql-firewall-rule.md
+++ b/pkg/tfgen/test_data/azurerm-sql-firewall-rule.md
@@ -1,0 +1,78 @@
+---
+subcategory: "Database"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_sql_firewall_rule"
+description: |-
+  Manages a SQL Firewall Rule.
+---
+
+# azurerm_sql_firewall_rule
+
+Allows you to manage an Azure SQL Firewall Rule.
+
+-> **Note:** The `azurerm_sql_firewall_rule` resource is deprecated in version 3.0 of the AzureRM provider and will be removed in version 4.0. Please use the [`azurerm_mssql_firewall_rule`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mssql_firewall_rule) resource instead.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_sql_server" "example" {
+  name                         = "mysqlserver"
+  resource_group_name          = azurerm_resource_group.example.name
+  location                     = azurerm_resource_group.example.location
+  version                      = "12.0"
+  administrator_login          = "4dm1n157r470r"
+  administrator_login_password = "4-v3ry-53cr37-p455w0rd"
+}
+
+resource "azurerm_sql_firewall_rule" "example" {
+  name                = "FirewallRule1"
+  resource_group_name = azurerm_resource_group.example.name
+  server_name         = azurerm_sql_server.example.name
+  start_ip_address    = "10.0.17.62"
+  end_ip_address      = "10.0.17.62"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the firewall rule. Changing this forces a new resource to be created.
+
+* `resource_group_name` - (Required) The name of the resource group in which to create the SQL Server. Changing this forces a new resource to be created.
+
+* `server_name` - (Required) The name of the SQL Server on which to create the Firewall Rule. Changing this forces a new resource to be created.
+
+* `start_ip_address` - (Required) The starting IP address to allow through the firewall for this rule.
+
+* `end_ip_address` - (Required) The ending IP address to allow through the firewall for this rule.
+
+-> **NOTE:** The Azure feature `Allow access to Azure services` can be enabled by setting `start_ip_address` and `end_ip_address` to `0.0.0.0` which ([is documented in the Azure API Docs](https://docs.microsoft.com/rest/api/sql/firewallrules/createorupdate)).
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The SQL Firewall Rule ID.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the SQL Firewall Rule.
+* `update` - (Defaults to 30 minutes) Used when updating the SQL Firewall Rule.
+* `read` - (Defaults to 5 minutes) Used when retrieving the SQL Firewall Rule.
+* `delete` - (Defaults to 30 minutes) Used when deleting the SQL Firewall Rule.
+
+## Import
+
+SQL Firewall Rules can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_sql_firewall_rule.rule1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Sql/servers/myserver/firewallRules/rule1
+```


### PR DESCRIPTION
I'm trying have our resource docs generation include trailing `**Note**` in our generated docs.

This PR changes how our argument parsing works so that all text after argument `n` but before argument `n+1` is part of the description for argument `n`.

This allows us to recover the argument notes such as 
<img width="711" alt="Screenshot 2023-05-11 at 1 43 21 PM" src="https://github.com/pulumi/pulumi-terraform-bridge/assets/22222529/0cfd7f43-f11f-49d8-973e-065b744dd28c">
(from https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/sql_firewall_rule)

With this change, the new schema description for `"endIpAddress"` looks like this:
```
Specifies the End IP Address associated with this Firewall Rule. 

> **NOTE:** The Azure feature `Allow access to Azure services` can be enabled by setting `start_ip_address` and `end_ip_address` to `0.0.0.0` which ([is documented in the Azure API Docs](https://docs.microsoft.com/rest/api/sql/firewallrules/createorupdate)).
```

Fixes https://github.com/pulumi/pulumi-azure/issues/1256