### PR TITLE
Allow users to override .MaxItems() == 1 for pluralization

### DIFF
--- a/pkg/tfbridge/names_test.go
+++ b/pkg/tfbridge/names_test.go
@@ -276,6 +276,17 @@ func TestBijectiveNameConversion(t *testing.T) {
 				"galleryApplications": "gallery_applications",
 			},
 		},
+		{ // Check that users can override .MaxItems() == 1
+			schema: map[string]*schemav2.Schema{
+				"value": {Type: schemav2.TypeList, MaxItems: 1},
+			},
+			info: map[string]*SchemaInfo{
+				"value": {MaxItemsOne: ref(false)},
+			},
+			expected: map[string]string{
+				"values": "value",
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Pulumi automatically pluralizes list and set fields when they will be projected into the Pulumi type system as a list. For backwards compatibility reasons, Pulumi needs the `MaxItemsOne` value to be sticky between updates, this extends to type decisions `List[T]->T` as well as naming decisions `singular->plural`.

That means we cannot take into account the value of `.MaxItems()` when deciding if we should pluralize a name. This PR changes our pluralization logic to consult `.MaxItems()==1` only if `SchemaInfo.MaxItemsOne==nil`.

This brings our pluralization logic inline with our type projection logic.