### PR TITLE
[converter] Fix inferring default value type

### DIFF
--- a/pkg/tf2pulumi/convert/testdata/registry_module_multiple_versions/experimental_pcl/dir_1.0.0/variables.pp
+++ b/pkg/tf2pulumi/convert/testdata/registry_module_multiple_versions/experimental_pcl/dir_1.0.0/variables.pp
@@ -1,7 +1,7 @@
 config "baseDir" "string" {
   description = "The base directory in which this module will search for static files and templates."
 }
-config "templateVars" "object({})" {
+config "templateVars" {
   default     = {}
   description = "Variables to make available for interpolation and other expressions in template files."
 }

--- a/pkg/tf2pulumi/convert/testdata/registry_module_multiple_versions/experimental_pcl/dir_1.0.2/variables.pp
+++ b/pkg/tf2pulumi/convert/testdata/registry_module_multiple_versions/experimental_pcl/dir_1.0.2/variables.pp
@@ -1,7 +1,7 @@
 config "baseDir" "string" {
   description = "The base directory in which this module will search for static files and templates."
 }
-config "templateVars" "object({})" {
+config "templateVars" {
   default     = {}
   description = "Variables to make available for interpolation and other expressions in template files."
 }

--- a/pkg/tf2pulumi/convert/testdata/simple_config/experimental_pcl/main.pp
+++ b/pkg/tf2pulumi/convert/testdata/simple_config/experimental_pcl/main.pp
@@ -9,6 +9,9 @@ config "nullableStringIn" "string" {
 config "optAnyIn" {
   default = null
 }
+config "anyWithDefault" {
+  default = {}
+}
 config "boolIn" "bool" {
 }
 config "stringListIn" "list(string)" {

--- a/pkg/tf2pulumi/convert/testdata/simple_config/main.tf
+++ b/pkg/tf2pulumi/convert/testdata/simple_config/main.tf
@@ -16,6 +16,11 @@ variable "opt_any_in" {
   default = null
 }
 
+variable "any_with_default" {
+  type = any
+  default = {}
+}
+
 variable "bool_in" {
     type = bool
 }

--- a/pkg/tf2pulumi/convert/testdata/simple_config/pcl/main.pp
+++ b/pkg/tf2pulumi/convert/testdata/simple_config/pcl/main.pp
@@ -8,6 +8,9 @@ config nullableStringIn string {
 config optAnyIn {
   default = null
 }
+config anyWithDefault {
+  default = {}
+}
 config boolIn bool {
 }
 config stringListIn "list(string)" {


### PR DESCRIPTION
The PR addresses #1129 where a dynamic variable of type `any` is converted to a type of empty object `object({})` because we try to infer the type from the default value. However, this does not work in practice because the type of default value doesn't account for how the value is used in the main program. 

With this PR we no longer try to infer the type of the default value for dynamic variables, _except_ when it is a primitive value!

After the fix, the program compiles to typescript but there is an issue in TS program-gen still. Will be addressed separately