### PR TITLE
Use stricter log levels for Plugin Framework

### DIFF
--- a/pf/internal/defaults/defaults.go
+++ b/pf/internal/defaults/defaults.go
@@ -109,7 +109,7 @@ func getDefaultValue(
 
 		// Value is allowed together with EnvVars but serves as a fallback.
 		if defaultInfo.Value != nil {
-			tflog.Info(ctx, "DefaultInfo.Value applied a default value",
+			tflog.Trace(ctx, "DefaultInfo.Value applied a default value",
 				map[string]any{
 					"property": string(property),
 				})
@@ -128,7 +128,7 @@ func getDefaultValue(
 			}
 		}
 	} else if defaultInfo.Value != nil {
-		tflog.Info(ctx, "DefaultInfo.Value applied a default value",
+		tflog.Trace(ctx, "DefaultInfo.Value applied a default value",
 			map[string]any{
 				"property": string(property),
 			})

--- a/pf/internal/logging/logging.go
+++ b/pf/internal/logging/logging.go
@@ -84,9 +84,16 @@ func setupRootLoggers(ctx context.Context, output io.Writer) context.Context {
 	return ctx
 }
 
+// Choose the default level carefully: logs at this level or higher (more severe) will be shown to the user of Pulumi
+// CLI direcrtly by default. Experimentally it seems that Info is too verbose, for example Cloudflare provider emits
+// routine authentication messages at INFO level.
+func defaultTFLogLevel() hclog.Level {
+	return hclog.Warn
+}
+
 func makeLoggerOptions(name string, level hclog.Level, output io.Writer) *hclog.LoggerOptions {
 	if level == hclog.NoLevel {
-		level = hclog.Info
+		level = defaultTFLogLevel()
 	}
 	return &hclog.LoggerOptions{
 		Name:              name,

--- a/pf/internal/logging/logging_test.go
+++ b/pf/internal/logging/logging_test.go
@@ -38,7 +38,7 @@ func TestLogging(t *testing.T) {
 		logs []log
 	}{
 		{
-			name: "INFO and higher propagates by default",
+			name: "WARN and higher propagates by default",
 			opts: LogOptions{},
 			emit: func(ctx context.Context) {
 				tflog.Trace(ctx, "Something went wrong TRACE")
@@ -48,10 +48,6 @@ func TestLogging(t *testing.T) {
 				tflog.Error(ctx, "Something went wrong ERROR ")
 			},
 			logs: []log{
-				{
-					msg: `Something went wrong INFO`,
-					sev: diag.Info,
-				},
 				{
 					msg: `Something went wrong WARN`,
 					sev: diag.Warning,
@@ -66,25 +62,25 @@ func TestLogging(t *testing.T) {
 			name: "URN propagates when set",
 			opts: LogOptions{URN: urn},
 			emit: func(ctx context.Context) {
-				tflog.Info(ctx, "OK")
+				tflog.Warn(ctx, "OK")
 			},
-			logs: []log{{sev: diag.Info, msg: `OK`, urn: urn}},
+			logs: []log{{sev: diag.Warning, msg: `OK`, urn: urn}},
 		},
 		{
 			name: "Provider propagates when set",
 			opts: LogOptions{ProviderName: "random"},
 			emit: func(ctx context.Context) {
-				tflog.Info(ctx, "OK")
+				tflog.Warn(ctx, "OK")
 			},
-			logs: []log{{sev: diag.Info, msg: `provider\=random`}},
+			logs: []log{{sev: diag.Warning, msg: `provider\=random`}},
 		},
 		{
 			name: "ProviderVersion propagates when set",
 			opts: LogOptions{ProviderName: "random", ProviderVersion: "4.12.0"},
 			emit: func(ctx context.Context) {
-				tflog.Info(ctx, "OK")
+				tflog.Warn(ctx, "OK")
 			},
-			logs: []log{{sev: diag.Info, msg: `provider\=random@4.12.0`}},
+			logs: []log{{sev: diag.Warning, msg: `provider\=random@4.12.0`}},
 		},
 	}
 


### PR DESCRIPTION
The default log levels are too chatty and result in a poor default Pulumi CLI experience for providers that use Plugin Framework based resources. This fixes chattiness to default to WARN level messages and send debug traces about default value application at TRACE level instead of INFO.

Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/1135