### PR TITLE
Remove nested secrets sent as JSON-in-proto to CheckConfig

### DIFF
--- a/pkg/tfbridge/config_encoding_test.go
+++ b/pkg/tfbridge/config_encoding_test.go
@@ -366,6 +366,39 @@ func TestConfigEncoding(t *testing.T) {
 		})
 	})
 
+	regressUnmarshalTestCases := []testCase{
+		{
+			shim.TypeList,
+			makeValue(`
+			[
+			  {
+			    "address": "somewhere.org",
+			    "password": {
+			      "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
+			      "value": "some-password"
+			    },
+			    "username": "some-user"
+			  }
+			]`),
+			resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewObjectProperty(resource.PropertyMap{
+					"address":  resource.NewStringProperty("somewhere.org"),
+					"password": resource.NewStringProperty("some-password"),
+					"username": resource.NewStringProperty("some-user"),
+				}),
+			}),
+		},
+	}
+
+	t.Run("regress-unmarshal", func(t *testing.T) {
+		for i, tc := range regressUnmarshalTestCases {
+			tc := tc
+			t.Run(fmt.Sprintf("UnmarshalPropertyValue/%d", i), func(t *testing.T) {
+				checkUnmarshal(t, tc)
+			})
+		}
+	})
+
 	// NOTE about the PropertyValue cases not tested here.
 	//
 	// NewAssetProperty, NewArchiveProperty are skipped because MarshalOptions sets RejectAssets: true, which will


### PR DESCRIPTION
As became evident in pulumi/pulumi-docker#640 v3.68.0 version of Pulumi and .NET SDK may be sending nested values marked as secret using an object wrapper and a secret sentinel "1b47061264138c4ac30d75fd1eb44270" while encoding the result in JSON. Currently this defeats the assumptions made in the bridge and leads to panics. Bridged providers need to at least tolerate such input while the underyling issues are being fixed.

The fix here makes config_encoding recognize secrets nested in JSON-in-proto encoding and strip them away. This is part of the fix for the panic in pulumi/pulumi-docker#640 but further work is needed to ensure these secret values are encrypted in the state file as the engine does not recognize them.