### PR TITLE
[x/muxer]: Log instead of failing on divergent CheckConfig results

### DIFF
--- a/x/muxer/muxer.go
+++ b/x/muxer/muxer.go
@@ -20,7 +20,6 @@ import (
 	"sync"
 
 	"github.com/golang/glog"
-	"github.com/golang/protobuf/jsonpb"
 	"github.com/hashicorp/go-multierror"
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
@@ -29,6 +28,7 @@ import (
 	rpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -608,10 +608,9 @@ func (s set[T]) setMinus(other set[T]) set[T] {
 }
 
 func showStruct(value *structpb.Value) string {
-	m := jsonpb.Marshaler{}
-	v, err := m.MarshalToString(value)
+	j, err := protojson.Marshal(value)
 	if err != nil {
 		return err.Error()
 	}
-	return v
+	return string(j)
 }

--- a/x/muxer/tests/muxer_test.go
+++ b/x/muxer/tests/muxer_test.go
@@ -109,7 +109,7 @@ func TestConfigure(t *testing.T) {
 }
 
 func TestDivergentCheckConfig(t *testing.T) {
-	// Early versions of muxer failed hard no divergent responses from CheckConfig. This test ensures that it can
+	// Early versions of muxer failed hard on divergent responses from CheckConfig. This test ensures that it can
 	// tolerate such responses (with logging or warning). The practical case is divergent handling of secret markers
 	// where pf and v3 based providers respond with the same value but do not agree on the secret markers.
 	req := `


### PR DESCRIPTION
This change makes muxer less strict as it is now able to tolerate providers that do not agree on CheckConfig responses. What used to be a hard error is downgraded to logging a message at debug level.

The practical use case driving this is that before pulumi/pulumi-terraform-bridge#821 is implemented, pf vs v3 based providers may not agree on the secret value markers in the CheckConfig response.