### PR TITLE
Support maxItemsOne for dynamic blocks

### DIFF
--- a/pkg/tf2pulumi/convert/testdata/dynamic_max_items_one/experimental_pcl/main.pp
+++ b/pkg/tf2pulumi/convert/testdata/dynamic_max_items_one/experimental_pcl/main.pp
@@ -1,0 +1,5 @@
+resource "main" "maxItemsOne:index/index:resource" {
+  innerResource = [for entry in entries([true]) : {
+    someInput = true
+  }][0]
+}

--- a/pkg/tf2pulumi/convert/testdata/dynamic_max_items_one/main.tf
+++ b/pkg/tf2pulumi/convert/testdata/dynamic_max_items_one/main.tf
@@ -1,0 +1,11 @@
+
+#if EXPERIMENTAL
+resource "maxItemsOne_resource" "main" {
+    dynamic "innerResource" {
+        for_each = [true]
+        content {
+            someInput = true
+        }
+    }
+}
+#endif


### PR DESCRIPTION
This isn't ideal. But it will get the binder happy with these expression until we can add an intrinsic to deal with these correctly.