### PR TITLE
Enable validating provider config for Plugin Framework providers

### DIFF
--- a/pf/internal/convert/string.go
+++ b/pf/internal/convert/string.go
@@ -40,6 +40,12 @@ func (*stringEncoder) fromPropertyValue(p resource.PropertyValue) (tftypes.Value
 	if p.IsNull() {
 		return tftypes.NewValue(tftypes.String, nil), nil
 	}
+
+	// Special-case to tolerate booleans.
+	if p.IsBool() {
+		return tftypes.NewValue(tftypes.String, fmt.Sprintf("%v", p.BoolValue())), nil
+	}
+
 	if !p.IsString() {
 		return tftypes.NewValue(tftypes.String, nil),
 			fmt.Errorf("Expected a string, got: %v", p)

--- a/pf/tests/internal/providerbuilder/build_provider.go
+++ b/pf/tests/internal/providerbuilder/build_provider.go
@@ -1,0 +1,50 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package providerbuilder
+
+import (
+	"context"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+type Provider struct {
+	TypeName       string
+	Version        string
+	ProviderSchema schema.Schema
+}
+
+var _ provider.Provider = (*Provider)(nil)
+
+func (impl *Provider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
+	resp.TypeName = impl.TypeName
+	resp.Version = impl.Version
+}
+
+func (impl *Provider) Schema(ctx context.Context, req provider.SchemaRequest, resp *provider.SchemaResponse) {
+	resp.Schema = impl.ProviderSchema
+}
+
+func (*Provider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
+}
+
+func (*Provider) DataSources(ctx context.Context) []func() datasource.DataSource {
+	return []func() datasource.DataSource{}
+}
+
+func (*Provider) Resources(ctx context.Context) []func() resource.Resource {
+	return []func() resource.Resource{}
+}

--- a/pf/tests/internal/testprovider/cmd/pulumi-resource-testbridge/schema.json
+++ b/pf/tests/internal/testprovider/cmd/pulumi-resource-testbridge/schema.json
@@ -37,10 +37,7 @@
                 "description": "Used for testing DefaultInfo default application support\n",
                 "default": "DEFAULT"
             }
-        },
-        "defaults": [
-            "stringConfigProp"
-        ]
+        }
     },
     "types": {
         "testbridge:index/TestnestRule:TestnestRule": {
@@ -152,6 +149,9 @@
                 "type": "boolean",
                 "description": "Example taken from pulumi-aws; used to validate string properties remapped to bool type during briding\n"
             },
+            "stringConfigProp": {
+                "type": "string"
+            },
             "stringDefaultinfoConfigProp": {
                 "type": "string",
                 "description": "Used for testing DefaultInfo default application support\n"
@@ -165,6 +165,9 @@
                 "type": "boolean",
                 "description": "Example taken from pulumi-aws; used to validate string properties remapped to bool type during briding\n",
                 "default": true
+            },
+            "stringConfigProp": {
+                "type": "string"
             },
             "stringDefaultinfoConfigProp": {
                 "type": "string",

--- a/pf/tests/internal/testprovider/testbridge.go
+++ b/pf/tests/internal/testprovider/testbridge.go
@@ -139,7 +139,9 @@ func (p *syntheticProvider) Metadata(_ context.Context, _ provider.MetadataReque
 func (p *syntheticProvider) Schema(_ context.Context, _ provider.SchemaRequest, resp *provider.SchemaResponse) {
 	resp.Schema = pschema.Schema{
 		Attributes: map[string]pschema.Attribute{
-			"string_config_prop": pschema.StringAttribute{},
+			"string_config_prop": pschema.StringAttribute{
+				Optional: true,
+			},
 			"bool_config_prop": pschema.BoolAttribute{
 				Optional: true,
 			},

--- a/pf/tests/provider_checkconfig_test.go
+++ b/pf/tests/provider_checkconfig_test.go
@@ -163,8 +163,6 @@ func TestCheckConfig(t *testing.T) {
 	})
 
 	t.Run("invalid_config_value", func(t *testing.T) {
-		t.Skip("Looks like extra values are silently filtered out currently; need to make sure they generate check failures instead")
-
 		// Test error reporting when an unrecognized property is sent.
 		schema := schema.Schema{}
 		provider := makeProviderServer(t, schema)
@@ -181,7 +179,7 @@ func TestCheckConfig(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 1, len(resp.Failures))
 		assert.Equal(t, "could not validate provider configuration: "+
-			"Invalid or unknown key. Check `pulumi config get cloudflare:requiredprop`.",
+			"Invalid or unknown key. Check `pulumi config get testprovider:requiredprop`.",
 			resp.Failures[0].Reason)
 		// Explicit provider.
 		resp, err = provider.CheckConfig(ctx, &pulumirpc.CheckRequest{
@@ -191,7 +189,7 @@ func TestCheckConfig(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 1, len(resp.Failures))
 		assert.Equal(t, "could not validate provider configuration: "+
-			"Invalid or unknown key. Examine values at 'explicitprovider.Requiredprop'.",
+			"Invalid or unknown key. Examine values at 'explicitprovider.requiredprop'.",
 			resp.Failures[0].Reason)
 	})
 
@@ -593,7 +591,11 @@ func TestPreConfigureCallback(t *testing.T) {
 	})
 }
 
-func makeProviderServer(t *testing.T, schema schema.Schema, customize ...func(*tfbridge.ProviderInfo)) pulumirpc.ResourceProviderServer {
+func makeProviderServer(
+	t *testing.T,
+	schema schema.Schema,
+	customize ...func(*tfbridge.ProviderInfo),
+) pulumirpc.ResourceProviderServer {
 	testProvider := &providerbuilder.Provider{
 		TypeName:       "testprovider",
 		Version:        "0.0.1",

--- a/pf/tests/provider_checkconfig_test.go
+++ b/pf/tests/provider_checkconfig_test.go
@@ -1,0 +1,582 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfbridgetests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+
+	"github.com/pulumi/pulumi-terraform-bridge/pf/tests/internal/providerbuilder"
+	"github.com/pulumi/pulumi-terraform-bridge/pf/tfbridge"
+	testutils "github.com/pulumi/pulumi-terraform-bridge/testing/x"
+	tfbridge3 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+)
+
+func TestCheckConfig(t *testing.T) {
+
+	makeProviderServer := func(t *testing.T, schema schema.Schema) pulumirpc.ResourceProviderServer {
+		testProvider := &providerbuilder.Provider{
+			TypeName:       "testprovider",
+			Version:        "0.0.1",
+			ProviderSchema: schema,
+		}
+
+		providerInfo := tfbridge.ProviderInfo{
+			ProviderInfo: tfbridge3.ProviderInfo{
+				Name:         "testprovider",
+				Version:      "0.0.1",
+				MetadataInfo: &tfbridge3.MetadataInfo{},
+			},
+			NewProvider: func() provider.Provider {
+				return testProvider
+			},
+		}
+
+		return newProviderServer(t, providerInfo)
+	}
+
+	t.Run("minimal", func(t *testing.T) {
+		schema := schema.Schema{}
+		testutils.Replay(t, makeProviderServer(t, schema), `
+		{
+		  "method": "/pulumirpc.ResourceProvider/CheckConfig",
+		  "request": {
+		    "urn": "urn:pulumi:dev::teststack::pulumi:providers:testprovider::test",
+		    "olds": {},
+		    "news": {
+		      "version": "6.54.0"
+		    }
+		  },
+		  "response": {
+		    "inputs": {
+		      "version": "6.54.0"
+		    }
+		  }
+		}`)
+	})
+
+	t.Run("config_value", func(t *testing.T) {
+		schema := schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"config_value": schema.StringAttribute{
+					Optional: true,
+				},
+			},
+		}
+
+		// Ensure Pulumi can configure config_value in the testprovider.
+		testutils.Replay(t, makeProviderServer(t, schema), `
+		{
+		  "method": "/pulumirpc.ResourceProvider/CheckConfig",
+		  "request": {
+		    "urn": "urn:pulumi:dev::teststack::pulumi:providers:testprovider::test",
+		    "olds": {},
+		    "news": {
+	              "configValue": "foo",
+		      "version": "6.54.0"
+		    }
+		  },
+		  "response": {
+		    "inputs": {
+	              "configValue": "foo",
+		      "version": "6.54.0"
+		    }
+		  }
+		}`)
+	})
+
+	t.Run("unknown_config_value", func(t *testing.T) {
+		// Currently if a top-level config property is a Computed value, or it's a composite value with any
+		// Computed values inside, the engine sends a sentinel string. Ensure that CheckConfig propagates the
+		// same sentinel string back to the engine.
+
+		schema := schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"scopes": schema.ListAttribute{
+					Optional:    true,
+					ElementType: types.StringType,
+				},
+			},
+		}
+
+		assert.Equal(t, "04da6b54-80e4-46f7-96ec-b56ff0331ba9", plugin.UnknownStringValue)
+		testutils.Replay(t, makeProviderServer(t, schema), `
+		{
+		  "method": "/pulumirpc.ResourceProvider/CheckConfig",
+		  "request": {
+		    "urn": "urn:pulumi:dev::teststack::pulumi:providers:testprovider::test",
+		    "olds": {},
+		    "news": {
+	              "configValue": "04da6b54-80e4-46f7-96ec-b56ff0331ba9",
+	              "scopes": "04da6b54-80e4-46f7-96ec-b56ff0331ba9",
+		      "version": "6.54.0"
+		    }
+		  },
+		  "response": {
+		    "inputs": {
+	              "configValue": "04da6b54-80e4-46f7-96ec-b56ff0331ba9",
+	              "scopes": "04da6b54-80e4-46f7-96ec-b56ff0331ba9",
+		      "version": "6.54.0"
+		    }
+		  }
+		}`)
+	})
+
+	t.Run("config_changed", func(t *testing.T) {
+		// In this scenario Pulumi plans an update plan when a config has changed on an existing stack.
+		schema := schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"config_value": schema.StringAttribute{
+					Optional: true,
+				},
+			},
+		}
+
+		testutils.Replay(t, makeProviderServer(t, schema), `
+		{
+		  "method": "/pulumirpc.ResourceProvider/CheckConfig",
+		  "request": {
+		    "urn": "urn:pulumi:dev::teststack::pulumi:providers:testprovider::test",
+		    "olds": {
+	              "config_value": "foo",
+		      "version": "6.54.0"
+	            },
+		    "news": {
+	              "config_value": "bar",
+		      "version": "6.54.0"
+		    }
+		  },
+		  "response": {
+		    "inputs": {
+	              "config_value": "bar",
+		      "version": "6.54.0"
+		    }
+		  }
+		}`)
+	})
+
+	t.Run("invalid_config_value", func(t *testing.T) {
+		t.Skip("Looks like extra values are silently filtered out currently; need to make sure they generate check failures instead")
+
+		// Test error reporting when an unrecognized property is sent.
+		schema := schema.Schema{}
+		provider := makeProviderServer(t, schema)
+		ctx := context.Background()
+		args, err := structpb.NewStruct(map[string]interface{}{
+			"requiredprop": "baz",
+		})
+		require.NoError(t, err)
+		// Default provider.
+		resp, err := provider.CheckConfig(ctx, &pulumirpc.CheckRequest{
+			Urn:  "urn:pulumi:r::cloudflare-record-ts::pulumi:providers:cloudflare::default_5_2_1",
+			News: args,
+		})
+		require.NoError(t, err)
+		require.Equal(t, 1, len(resp.Failures))
+		assert.Equal(t, "could not validate provider configuration: "+
+			"Invalid or unknown key. Check `pulumi config get cloudflare:requiredprop`.",
+			resp.Failures[0].Reason)
+		// Explicit provider.
+		resp, err = provider.CheckConfig(ctx, &pulumirpc.CheckRequest{
+			Urn:  "urn:pulumi:r::cloudflare-record-ts::pulumi:providers:cloudflare::explicitprovider",
+			News: args,
+		})
+		require.NoError(t, err)
+		require.Equal(t, 1, len(resp.Failures))
+		assert.Equal(t, "could not validate provider configuration: "+
+			"Invalid or unknown key. Examine values at 'explicitprovider.Requiredprop'.",
+			resp.Failures[0].Reason)
+	})
+
+	t.Run("missing_required_config_value", func(t *testing.T) {
+		desc := "A very important required attribute"
+		schema := schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"req_prop": schema.StringAttribute{
+					Required:    true,
+					Description: desc,
+				},
+			},
+		}
+		provider := makeProviderServer(t, schema)
+		ctx := context.Background()
+		args, err := structpb.NewStruct(map[string]any{"version": "6.54.0"})
+		require.NoError(t, err)
+		_, err = provider.CheckConfig(ctx, &pulumirpc.CheckRequest{News: args})
+		require.Error(t, err)
+		status, ok := status.FromError(err)
+		require.True(t, ok)
+		require.Equal(t, codes.InvalidArgument, status.Code())
+		require.Equal(t, "required configuration keys were missing", status.Message())
+		require.Equal(t, 1, len(status.Details()))
+		missingKeys := status.Details()[0].(*pulumirpc.ConfigureErrorMissingKeys)
+		require.Equal(t, 1, len(missingKeys.MissingKeys))
+		missingKey := missingKeys.MissingKeys[0]
+		require.Equal(t, "reqProp", missingKey.Name)
+		require.Equal(t, desc, missingKey.Description)
+	})
+
+	// t.Run("flattened_compound_values", func(t *testing.T) {
+	// 	// Providers may have nested objects or arrays in their configuration space. As of Pulumi v3.63.0 these
+	// 	// may be coming over the wire under a flattened JSON-in-protobuf encoding. This test makes sure they
+	// 	// are recognized correctly.
+
+	// 	p := testprovider.ProviderV2()
+
+	// 	// Examples here are taken from pulumi-gcp, scopes is a list and batching is a nested object.
+	// 	p.Schema["scopes"] = &schema.Schema{
+	// 		Type:     schema.TypeList,
+	// 		Optional: true,
+	// 		Elem:     &schema.Schema{Type: schema.TypeString},
+	// 	}
+
+	// 	p.Schema["batching"] = &schema.Schema{
+	// 		Type:     schema.TypeList,
+	// 		Optional: true,
+	// 		MaxItems: 1,
+	// 		Elem: &schema.Resource{
+	// 			Schema: map[string]*schema.Schema{
+	// 				"send_after": {
+	// 					Type:     schema.TypeString,
+	// 					Optional: true,
+	// 				},
+	// 				"enable_batching": {
+	// 					Type:     schema.TypeBool,
+	// 					Optional: true,
+	// 				},
+	// 			},
+	// 		},
+	// 	}
+
+	// 	provider := &Provider{
+	// 		tf:     shimv2.NewProvider(p),
+	// 		config: shimv2.NewSchemaMap(p.Schema),
+	// 	}
+
+	// 	testutils.Replay(t, provider, `
+	// 	{
+	// 	  "method": "/pulumirpc.ResourceProvider/CheckConfig",
+	// 	  "request": {
+	// 	    "urn": "urn:pulumi:dev::testcfg::pulumi:providers:gcp::test",
+	// 	    "olds": {},
+	// 	    "news": {
+	// 	      "batching": "{\"enableBatching\":true,\"sendAfter\":\"1s\"}",
+	// 	      "scopes": "[\"a\",\"b\"]",
+	// 	      "version": "6.54.0"
+	// 	    }
+	// 	  },
+	// 	  "response": {
+	//             "inputs": {
+	// 	      "batching": "{\"enableBatching\":true,\"sendAfter\":\"1s\"}",
+	// 	      "scopes": "[\"a\",\"b\"]",
+	// 	      "version": "6.54.0"
+	//             }
+	//           }
+	// 	}`)
+	// })
+
+	// t.Run("enforce_schema_secrets", func(t *testing.T) {
+	// 	// If the schema marks a config property as sensitive, enforce the secret bit on that property.
+	// 	p := testprovider.ProviderV2()
+
+	// 	p.Schema["mysecret"] = &schema.Schema{
+	// 		Type:      schema.TypeString,
+	// 		Optional:  true,
+	// 		Sensitive: true,
+	// 	}
+
+	// 	provider := &Provider{
+	// 		tf:     shimv2.NewProvider(p),
+	// 		config: shimv2.NewSchemaMap(p.Schema),
+	// 	}
+
+	// 	testutils.Replay(t, provider, `
+	// 	{
+	// 	  "method": "/pulumirpc.ResourceProvider/CheckConfig",
+	// 	  "request": {
+	// 	    "urn": "urn:pulumi:dev::teststack::pulumi:providers:testprovider::test",
+	// 	    "olds": {},
+	// 	    "news": {
+	//               "mysecret": "foo",
+	// 	      "version": "6.54.0"
+	// 	    }
+	// 	  },
+	// 	  "response": {
+	// 	    "inputs": {
+	//               "mysecret": {
+	// 		"4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
+	//                 "value": "foo"
+	//               },
+	// 	      "version": "6.54.0"
+	// 	    }
+	// 	  }
+	// 	}`)
+	// })
+
+	// t.Run("enforce_schema_nested_secrets", func(t *testing.T) {
+	// 	// Flattened compound values may encode that some nested properties are sensitive. There is currently no
+	// 	// way to preserve the secret-ness accurately in the JSON-in-proto encoding. Instead of this, bridged
+	// 	// providers approximate and mark the entire property as secret when any of the components are
+	// 	// sensitive.
+	// 	p := testprovider.ProviderV2()
+
+	// 	p.Schema["scopes"] = &schema.Schema{
+	// 		Type:     schema.TypeList,
+	// 		Optional: true,
+	// 		Elem:     &schema.Schema{Type: schema.TypeString},
+	// 	}
+
+	// 	p.Schema["batching"] = &schema.Schema{
+	// 		Type:     schema.TypeList,
+	// 		Optional: true,
+	// 		MaxItems: 1,
+	// 		Elem: &schema.Resource{
+	// 			Schema: map[string]*schema.Schema{
+	// 				"send_after": {
+	// 					Type:      schema.TypeString,
+	// 					Sensitive: true,
+	// 					Optional:  true,
+	// 				},
+	// 				"enable_batching": {
+	// 					Type:     schema.TypeBool,
+	// 					Optional: true,
+	// 				},
+	// 			},
+	// 		},
+	// 	}
+
+	// 	provider := &Provider{
+	// 		tf:     shimv2.NewProvider(p),
+	// 		config: shimv2.NewSchemaMap(p.Schema),
+	// 	}
+
+	// 	testutils.Replay(t, provider, `
+	//         {
+	//           "method": "/pulumirpc.ResourceProvider/CheckConfig",
+	//           "request": {
+	//             "urn": "urn:pulumi:dev::testcfg::pulumi:providers:gcp::test",
+	//             "olds": {},
+	//             "news": {
+	//               "batching": "{\"enableBatching\":true,\"sendAfter\":\"1s\"}",
+	//               "scopes": "[\"a\",\"b\"]",
+	//               "version": "6.54.0"
+	//             }
+	//           },
+	//           "response": {
+	//             "inputs": {
+	//               "batching": {
+	//                 "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
+	//                 "value": "{\"enableBatching\":true,\"sendAfter\":\"1s\"}"
+	//               },
+	//               "scopes": "[\"a\",\"b\"]",
+	//               "version": "6.54.0"
+	//             }
+	//           }
+	//         }`)
+	// })
+}
+
+// func TestPreConfigureCallback(t *testing.T) {
+// 	t.Run("PreConfigureCallback called by CheckConfig", func(t *testing.T) {
+// 		callCounter := 0
+// 		provider := &Provider{
+// 			tf:     shimv2.NewProvider(testTFProviderV2),
+// 			config: shimv2.NewSchemaMap(testTFProviderV2.Schema),
+// 			info: ProviderInfo{
+// 				PreConfigureCallback: func(vars resource.PropertyMap, config shim.ResourceConfig) error {
+// 					require.Equal(t, "bar", vars["config_value"].StringValue())
+// 					require.Truef(t, config.IsSet("config_value"), "config_value should be set")
+// 					require.Falsef(t, config.IsSet("unknown_prop"), "unknown_prop should not be set")
+// 					callCounter++
+// 					return nil
+// 				},
+// 			},
+// 		}
+// 		testutils.Replay(t, provider, `
+// 		{
+// 		  "method": "/pulumirpc.ResourceProvider/CheckConfig",
+// 		  "request": {
+// 		    "urn": "urn:pulumi:dev::teststack::pulumi:providers:testprovider::test",
+// 		    "olds": {},
+// 		    "news": {
+//                       "config_value": "bar",
+// 		      "version": "6.54.0"
+// 		    }
+// 		  },
+// 		  "response": {
+// 		    "inputs": {
+//                       "config_value": "bar",
+// 		      "version": "6.54.0"
+// 		    }
+// 		  }
+// 		}`)
+// 		require.Equalf(t, 1, callCounter, "PreConfigureCallback should be called once")
+// 	})
+// 	t.Run("PreConfigureCallbackWithLoggger called by CheckConfig", func(t *testing.T) {
+// 		callCounter := 0
+// 		provider := &Provider{
+// 			tf:     shimv2.NewProvider(testTFProviderV2),
+// 			config: shimv2.NewSchemaMap(testTFProviderV2.Schema),
+// 			info: ProviderInfo{
+// 				PreConfigureCallbackWithLogger: func(
+// 					ctx context.Context,
+// 					host *hostclient.HostClient,
+// 					vars resource.PropertyMap,
+// 					config shim.ResourceConfig,
+// 				) error {
+// 					require.Equal(t, "bar", vars["config_value"].StringValue())
+// 					require.Truef(t, config.IsSet("config_value"), "config_value should be set")
+// 					require.Falsef(t, config.IsSet("unknown_prop"), "unknown_prop should not be set")
+// 					callCounter++
+// 					return nil
+// 				},
+// 			},
+// 		}
+// 		testutils.Replay(t, provider, `
+// 		{
+// 		  "method": "/pulumirpc.ResourceProvider/CheckConfig",
+// 		  "request": {
+// 		    "urn": "urn:pulumi:dev::teststack::pulumi:providers:testprovider::test",
+// 		    "olds": {},
+// 		    "news": {
+//                       "config_value": "bar",
+// 		      "version": "6.54.0"
+// 		    }
+// 		  },
+// 		  "response": {
+// 		    "inputs": {
+//                       "config_value": "bar",
+// 		      "version": "6.54.0"
+// 		    }
+// 		  }
+// 		}`)
+// 		require.Equalf(t, 1, callCounter, "PreConfigureCallbackWithLogger should be called once")
+// 	})
+// 	t.Run("PreConfigureCallback can modify config values", func(t *testing.T) {
+// 		provider := &Provider{
+// 			tf:     shimv2.NewProvider(testTFProviderV2),
+// 			config: shimv2.NewSchemaMap(testTFProviderV2.Schema),
+// 			info: ProviderInfo{
+// 				PreConfigureCallback: func(vars resource.PropertyMap, config shim.ResourceConfig) error {
+// 					vars["config_value"] = resource.NewStringProperty("updated")
+// 					return nil
+// 				},
+// 			},
+// 		}
+// 		testutils.Replay(t, provider, `
+// 		{
+// 		  "method": "/pulumirpc.ResourceProvider/CheckConfig",
+// 		  "request": {
+// 		    "urn": "urn:pulumi:dev::teststack::pulumi:providers:testprovider::test",
+// 		    "olds": {},
+// 		    "news": {
+// 		      "version": "6.54.0"
+// 		    }
+// 		  },
+// 		  "response": {
+// 		    "inputs": {
+//                       "config_value": "updated",
+// 		      "version": "6.54.0"
+// 		    }
+// 		  }
+// 		}`)
+// 	})
+// 	t.Run("PreConfigureCallbackWithLogger can modify config values", func(t *testing.T) {
+// 		provider := &Provider{
+// 			tf:     shimv2.NewProvider(testTFProviderV2),
+// 			config: shimv2.NewSchemaMap(testTFProviderV2.Schema),
+// 			info: ProviderInfo{
+// 				PreConfigureCallbackWithLogger: func(
+// 					ctx context.Context,
+// 					host *hostclient.HostClient,
+// 					vars resource.PropertyMap,
+// 					config shim.ResourceConfig,
+// 				) error {
+// 					vars["config_value"] = resource.NewStringProperty("updated")
+// 					return nil
+// 				},
+// 			},
+// 		}
+// 		testutils.Replay(t, provider, `
+// 		{
+// 		  "method": "/pulumirpc.ResourceProvider/CheckConfig",
+// 		  "request": {
+// 		    "urn": "urn:pulumi:dev::teststack::pulumi:providers:testprovider::test",
+// 		    "olds": {},
+// 		    "news": {
+// 		      "version": "6.54.0"
+// 		    }
+// 		  },
+// 		  "response": {
+// 		    "inputs": {
+//                       "config_value": "updated",
+// 		      "version": "6.54.0"
+// 		    }
+// 		  }
+// 		}`)
+// 	})
+// 	t.Run("PreConfigureCallback not called at preview with unknown values", func(t *testing.T) {
+// 		provider := &Provider{
+// 			tf:     shimv2.NewProvider(testTFProviderV2),
+// 			config: shimv2.NewSchemaMap(testTFProviderV2.Schema),
+// 			info: ProviderInfo{
+// 				PreConfigureCallbackWithLogger: func(
+// 					ctx context.Context,
+// 					host *hostclient.HostClient,
+// 					vars resource.PropertyMap,
+// 					config shim.ResourceConfig,
+// 				) error {
+// 					if cv, ok := vars["configValue"]; ok {
+// 						// This used to panic when cv is a resource.Computed.
+// 						cv.StringValue()
+// 					}
+// 					// PreConfigureCallback should not even be called.
+// 					t.FailNow()
+// 					return nil
+// 				},
+// 			},
+// 		}
+// 		testutils.Replay(t, provider, `
+// 		{
+// 		  "method": "/pulumirpc.ResourceProvider/CheckConfig",
+// 		  "request": {
+// 		    "urn": "urn:pulumi:dev::teststack::pulumi:providers:testprovider::test",
+// 		    "olds": {},
+// 		    "news": {
+// 		      "version": "6.54.0",
+//                       "configValue": "04da6b54-80e4-46f7-96ec-b56ff0331ba9"
+// 		    }
+// 		  },
+// 		  "response": {
+// 		    "inputs": {
+// 		      "version": "6.54.0",
+//                       "configValue": "04da6b54-80e4-46f7-96ec-b56ff0331ba9"
+// 		    }
+// 		  }
+// 		}`)
+// 	})
+// }

--- a/pf/tests/provider_checkconfig_test.go
+++ b/pf/tests/provider_checkconfig_test.go
@@ -99,6 +99,9 @@ func TestCheckConfig(t *testing.T) {
 
 		schema := schema.Schema{
 			Attributes: map[string]schema.Attribute{
+				"config_value": schema.StringAttribute{
+					Optional: true,
+				},
 				"scopes": schema.ListAttribute{
 					Optional:    true,
 					ElementType: types.StringType,

--- a/pf/tests/provider_checkconfig_test.go
+++ b/pf/tests/provider_checkconfig_test.go
@@ -37,28 +37,6 @@ import (
 )
 
 func TestCheckConfig(t *testing.T) {
-
-	makeProviderServer := func(t *testing.T, schema schema.Schema) pulumirpc.ResourceProviderServer {
-		testProvider := &providerbuilder.Provider{
-			TypeName:       "testprovider",
-			Version:        "0.0.1",
-			ProviderSchema: schema,
-		}
-
-		providerInfo := tfbridge.ProviderInfo{
-			ProviderInfo: tfbridge3.ProviderInfo{
-				Name:         "testprovider",
-				Version:      "0.0.1",
-				MetadataInfo: &tfbridge3.MetadataInfo{},
-			},
-			NewProvider: func() provider.Provider {
-				return testProvider
-			},
-		}
-
-		return newProviderServer(t, providerInfo)
-	}
-
 	t.Run("minimal", func(t *testing.T) {
 		schema := schema.Schema{}
 		testutils.Replay(t, makeProviderServer(t, schema), `
@@ -548,3 +526,24 @@ func TestCheckConfig(t *testing.T) {
 // 		}`)
 // 	})
 // }
+
+func makeProviderServer(t *testing.T, schema schema.Schema) pulumirpc.ResourceProviderServer {
+	testProvider := &providerbuilder.Provider{
+		TypeName:       "testprovider",
+		Version:        "0.0.1",
+		ProviderSchema: schema,
+	}
+
+	providerInfo := tfbridge.ProviderInfo{
+		ProviderInfo: tfbridge3.ProviderInfo{
+			Name:         "testprovider",
+			Version:      "0.0.1",
+			MetadataInfo: &tfbridge3.MetadataInfo{},
+		},
+		NewProvider: func() provider.Provider {
+			return testProvider
+		},
+	}
+
+	return newProviderServer(t, providerInfo)
+}

--- a/pf/tests/schemas.go
+++ b/pf/tests/schemas.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -48,8 +49,12 @@ func testSink(t *testing.T) diag.Sink {
 	})
 
 	t.Cleanup(func() {
-		t.Logf("%s\n", stdout.String())
-		t.Logf("%s\n", stderr.String())
+		if strings.TrimSpace(stdout.String()) != "" {
+			t.Logf("%s\n", stdout.String())
+		}
+		if strings.TrimSpace(stderr.String()) != "" {
+			t.Logf("%s\n", stderr.String())
+		}
 	})
 
 	return testSink

--- a/pf/tfbridge/provider_checkconfig.go
+++ b/pf/tfbridge/provider_checkconfig.go
@@ -15,18 +15,28 @@
 package tfbridge
 
 import (
+	"bytes"
 	"context"
+	"fmt"
+	"strings"
 
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"google.golang.org/grpc/codes"
+
+	rprovider "github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil/rpcerror"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 
-	"fmt"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/pulumi/pulumi-terraform-bridge/pf/internal/convert"
 	"github.com/pulumi/pulumi-terraform-bridge/pf/internal/defaults"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
-	rprovider "github.com/pulumi/pulumi/pkg/v3/resource/provider"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/walk"
 )
 
 // CheckConfig validates the configuration for this resource provider.
@@ -84,9 +94,16 @@ func (p *provider) CheckConfigWithContext(
 	// Store for use in subsequent ApplyDefaultInfoValues.
 	p.lastKnownProviderConfig = news
 
-	checkFailures, err := p.validateProviderConfig(ctx, news)
+	missingKeys, checkFailures, err := p.validateProviderConfig(ctx, news)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	if len(missingKeys) > 0 {
+		err := rpcerror.WithDetails(
+			rpcerror.New(codes.InvalidArgument, "required configuration keys were missing"),
+			&pulumirpc.ConfigureErrorMissingKeys{MissingKeys: missingKeys})
+		return nil, checkFailures, err
 	}
 
 	// Ensure propreties marked secret in the schema have secret values.
@@ -99,25 +116,126 @@ func (p *provider) CheckConfigWithContext(
 func (p *provider) validateProviderConfig(
 	ctx context.Context,
 	inputs resource.PropertyMap,
-) ([]plugin.CheckFailure, error) {
+) ([]*pulumirpc.ConfigureErrorMissingKeys_MissingKey, []plugin.CheckFailure, error) {
 	config, err := convert.EncodePropertyMapToDynamic(p.configEncoder, p.configType, inputs)
 	if err != nil {
-		return nil, fmt.Errorf("cannot encode provider configuration to call ValidateProviderConfig: %w", err)
+		return nil, nil, fmt.Errorf("cannot encode provider configuration to call ValidateProviderConfig: %w", err)
 	}
 	req := &tfprotov6.ValidateProviderConfigRequest{
 		Config: config,
 	}
 	resp, err := p.tfServer.ValidateProviderConfig(ctx, req)
-	// According to the docs on resp.PrepareConfig for new providers it typicaly is equal to config passed in
-	// ValidateProviderConfigRequest so the code here ignores it for now.
 	if err != nil {
-		return nil, fmt.Errorf("error calling ValidateProviderConfig: %w", err)
+		return nil, nil, fmt.Errorf("error calling ValidateProviderConfig: %w", err)
 	}
-	/* Instead of typical processDiagnsotics, should we be interpreting these messages as validation failures? */
-	if err := p.processDiagnostics(resp.Diagnostics); err != nil {
-		return nil, err
+
+	// Note: according to the docs on resp.PrepareConfig for new providers it typicaly is equal to config passed in
+	// ValidateProviderConfigRequest so the code here ignores it for now.
+
+	missingKeys := []*pulumirpc.ConfigureErrorMissingKeys_MissingKey{}
+	remainingDiagnostics := []*tfprotov6.Diagnostic{}
+
+	schemaMap := p.schemaOnlyProvider.Schema()
+	schemaInfos := p.info.Config
+
+	for _, diag := range resp.Diagnostics {
+		if k := detectMissingKey(ctx, schemaMap, schemaInfos, diag); k != nil {
+			missingKeys = append(missingKeys, k)
+			continue
+		}
+		// TODO handle invalid keys here.
+		remainingDiagnostics = append(remainingDiagnostics, diag)
 	}
-	return nil, nil
+
+	if err := p.processDiagnostics(remainingDiagnostics); err != nil {
+		return nil, nil, err
+	}
+	return missingKeys, nil, nil
+}
+
+func detectMissingKey(
+	ctx context.Context,
+	schemaMap shim.SchemaMap,
+	schemaInfos map[string]*tfbridge.SchemaInfo,
+	diag *tfprotov6.Diagnostic,
+) *pulumirpc.ConfigureErrorMissingKeys_MissingKey {
+	if diag.Summary != "Missing Configuration for Required Attribute" {
+		return nil
+	}
+	if len(diag.Attribute.Steps()) < 1 {
+		return nil
+	}
+
+	mk := pulumirpc.ConfigureErrorMissingKeys_MissingKey{}
+
+	if diag.Attribute != nil {
+		path, err := formatAttributePathAsPulumiPath(schemaMap, schemaInfos, diag.Attribute)
+		if err != nil {
+			tflog.Debug(ctx, fmt.Sprintf("detectMissingKey ignored an error: %v", err))
+		} else {
+			mk.Name = path
+		}
+
+		s, err := walk.LookupSchemaMapPath(attrPathToSchemaPath(diag.Attribute), schemaMap)
+		if err == nil && s != nil {
+			// TF descriptions often have newlines in inopportune positions. This makes them present a
+			// little better in our console output.
+			mk.Description = strings.ReplaceAll(s.Description(), "\n", " ")
+		}
+	}
+
+	return &mk
+}
+
+func formatAttributePathAsPulumiPath(
+	schemaMap shim.SchemaMap,
+	schemaInfos map[string]*tfbridge.SchemaInfo,
+	attrPath *tftypes.AttributePath,
+) (string, error) {
+	steps := attrPath.Steps()
+
+	var buf bytes.Buffer
+	for i, s := range steps {
+		switch s := s.(type) {
+		case tftypes.AttributeName:
+			here := tftypes.NewAttributePathWithSteps(steps[0 : i+1])
+			schPath := attrPathToSchemaPath(here)
+			name, err := tfbridge.TerraformToPulumiNameAtPath(schPath, schemaMap, schemaInfos)
+			if err != nil {
+				return "", err
+			}
+			if i > 0 {
+				fmt.Fprintf(&buf, ".")
+			}
+			fmt.Fprintf(&buf, name)
+		case tftypes.ElementKeyInt:
+			fmt.Fprintf(&buf, "[%d]", int64(s))
+		case tftypes.ElementKeyString:
+			fmt.Fprintf(&buf, "[%q]", string(s))
+		case tftypes.ElementKeyValue:
+			// Sets will be represented as lists in Pulumi; more could be done here to find the right index.
+			fmt.Fprintf(&buf, "[?]")
+		default:
+			contract.Failf("Unhandled match case for tftypes.AttributePathStep")
+		}
+	}
+
+	return buf.String(), nil
+}
+
+func attrPathToSchemaPath(attrPath *tftypes.AttributePath) walk.SchemaPath {
+	p := walk.NewSchemaPath()
+	for _, s := range attrPath.Steps() {
+		switch s := s.(type) {
+		case tftypes.AttributeName:
+			p = p.GetAttr(string(s))
+		case tftypes.ElementKeyInt, tftypes.ElementKeyString, tftypes.ElementKeyValue:
+			p = p.Element()
+		default:
+			contract.Failf("Unhandled match case for tftypes.AttributePathStep")
+		}
+	}
+	return p
 }
 
 type wrappedConfig struct {

--- a/pf/tfbridge/provider_checkconfig.go
+++ b/pf/tfbridge/provider_checkconfig.go
@@ -245,7 +245,7 @@ func (p *provider) formatFailureReason(
 
 	attributePath, err := formatAttributePathAsPulumiPath(schemaMap, schemaInfos, diag.Attribute)
 	if err != nil {
-		tflog.Debug(ctx, fmt.Sprintf("Ignoring error from formatAttributePathAsPulumiPath: %w", err))
+		tflog.Debug(ctx, fmt.Sprintf("Ignoring error from formatAttributePathAsPulumiPath: %v", err))
 	}
 
 	if isProvider {

--- a/pf/tfbridge/provider_checkconfig.go
+++ b/pf/tfbridge/provider_checkconfig.go
@@ -158,6 +158,10 @@ func (p *provider) validateProviderConfig(
 		if strings.HasPrefix(string(k), "__") {
 			continue
 		}
+		// Ignoring version key as it seems to be special.
+		if k == "version" {
+			continue
+		}
 		n := tfbridge.PulumiToTerraformName(string(k), p.schemaOnlyProvider.Schema(), p.info.GetConfig())
 		_, known := p.configType.AttributeTypes[n]
 		if !known {

--- a/pf/tfbridge/provider_checkconfig.go
+++ b/pf/tfbridge/provider_checkconfig.go
@@ -129,7 +129,7 @@ func (p *provider) validateProviderConfig(
 		return nil, nil, fmt.Errorf("error calling ValidateProviderConfig: %w", err)
 	}
 
-	// Note: according to the docs on resp.PrepareConfig for new providers it typicaly is equal to config passed in
+	// Note: according to the docs on resp.PrepareConfig for new providers it typically is equal to config passed in
 	// ValidateProviderConfigRequest so the code here ignores it for now.
 
 	missingKeys := []*pulumirpc.ConfigureErrorMissingKeys_MissingKey{}
@@ -300,7 +300,7 @@ func formatAttributePathAsPulumiPath(
 			if i > 0 {
 				fmt.Fprintf(&buf, ".")
 			}
-			fmt.Fprintf(&buf, name)
+			fmt.Fprintf(&buf, "%s", name)
 		case tftypes.ElementKeyInt:
 			fmt.Fprintf(&buf, "[%d]", int64(s))
 		case tftypes.ElementKeyString:

--- a/pf/tfbridge/provider_checkconfig.go
+++ b/pf/tfbridge/provider_checkconfig.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2022, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,24 +20,114 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/pulumi/pulumi-terraform-bridge/pf/internal/convert"
 	"github.com/pulumi/pulumi-terraform-bridge/pf/internal/defaults"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	rprovider "github.com/pulumi/pulumi/pkg/v3/resource/provider"
 )
 
 // CheckConfig validates the configuration for this resource provider.
-func (p *provider) CheckConfigWithContext(ctx context.Context, urn resource.URN,
-	olds, news resource.PropertyMap, allowUnknowns bool) (resource.PropertyMap, []plugin.CheckFailure, error) {
+func (p *provider) CheckConfigWithContext(
+	ctx context.Context,
+	urn resource.URN,
+	_ resource.PropertyMap, // olds aka priorState, not used currently
+	inputs resource.PropertyMap, // aka news
+	_ bool, // a flag that is always true, historical artifact, ignore here
+) (resource.PropertyMap, []plugin.CheckFailure, error) {
 	ctx = p.initLogging(ctx, p.logSink, urn)
 
-	// Transform checkedInputs to apply Pulumi-level defaults.
-	newsWithDefaults := defaults.ApplyDefaultInfoValues(ctx, defaults.ApplyDefaultInfoValuesArgs{
+	// Transform news to apply Pulumi-level defaults.
+	news := defaults.ApplyDefaultInfoValues(ctx, defaults.ApplyDefaultInfoValuesArgs{
 		SchemaMap:      p.schemaOnlyProvider.Schema(),
 		SchemaInfos:    p.info.Config,
-		PropertyMap:    news,
-		ProviderConfig: news,
+		PropertyMap:    inputs,
+		ProviderConfig: inputs,
 	})
 
-	p.lastKnownProviderConfig = newsWithDefaults
+	// It is currently a breaking change to call PreConfigureCallback with unknown values. The user code does not
+	// expect them and may panic.
+	//
+	// Currently we do not call it at all if there are any unknowns.
+	//
+	// See pulumi/pulumi-terraform-bridge#1087
+	if !news.ContainsUnknowns() {
+		wc := &wrappedConfig{news}
 
-	// TODO[pulumi/pulumi-terraform-bridge#821] validate provider config
-	return newsWithDefaults, []plugin.CheckFailure{}, nil
+		if p.info.PreConfigureCallback != nil {
+			// NOTE: the user code may modify news in-place.
+			validationErrors := p.info.PreConfigureCallback(news, wc)
+			if validationErrors != nil {
+				return nil, nil, validationErrors
+			}
+		}
+
+		if p.info.PreConfigureCallbackWithLogger != nil {
+			// Usually logSink is a HostClient; PreConfigureCallbackWithLogger type should have better been
+			// expressed in terms of a diag.Sink.
+			hc, ok := p.logSink.(*rprovider.HostClient)
+			if !ok {
+				hc = &rprovider.HostClient{}
+			}
+			// NOTE: the user code may modify news in-place.
+			validationErrors := p.info.PreConfigureCallbackWithLogger(ctx, hc, news, wc)
+			if validationErrors != nil {
+				return nil, nil, validationErrors
+			}
+		}
+	}
+
+	/* now: validateProviderConfig */
+
+	// Store for use in subsequent ApplyDefaultInfoValues.
+	p.lastKnownProviderConfig = news
+
+	checkFailures, err := p.validateProviderConfig(ctx, news)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Ensure propreties marked secret in the schema have secret values.
+	secretNews := tfbridge.MarkSchemaSecrets(ctx, p.schemaOnlyProvider.Schema(), p.info.Config,
+		resource.NewObjectProperty(news)).ObjectValue()
+
+	return secretNews, checkFailures, nil
 }
+
+func (p *provider) validateProviderConfig(
+	ctx context.Context,
+	inputs resource.PropertyMap,
+) ([]plugin.CheckFailure, error) {
+	config, err := convert.EncodePropertyMapToDynamic(p.configEncoder, p.configType, inputs)
+	if err != nil {
+		return nil, fmt.Errorf("cannot encode provider configuration to call ValidateProviderConfig: %w", err)
+	}
+	req := &tfprotov6.ValidateProviderConfigRequest{
+		Config: config,
+	}
+	resp, err := p.tfServer.ValidateProviderConfig(ctx, req)
+	// According to the docs on resp.PrepareConfig for new providers it typicaly is equal to config passed in
+	// ValidateProviderConfigRequest so the code here ignores it for now.
+	if err != nil {
+		return nil, fmt.Errorf("error calling ValidateProviderConfig: %w", err)
+	}
+	/* Instead of typical processDiagnsotics, should we be interpreting these messages as validation failures? */
+	if err := p.processDiagnostics(resp.Diagnostics); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+type wrappedConfig struct {
+	config resource.PropertyMap
+}
+
+func (wc *wrappedConfig) IsSet(key string) bool {
+	pk := resource.PropertyKey(key)
+	_, isSet := wc.config[pk]
+	return isSet
+}
+
+var _ shim.ResourceConfig = &wrappedConfig{}

--- a/pf/tfgen/not_supported.go
+++ b/pf/tfgen/not_supported.go
@@ -81,9 +81,6 @@ func notSupported(sink diag.Sink, prov tfbridge.ProviderInfo) error {
 				u.schema("config:"+path, ds)
 			}
 		}
-
-		u.assertIsZero("PreConfigureCallback", prov.PreConfigureCallback)
-		u.assertIsZero("PreConfigureCallbackWithLogger", prov.PreConfigureCallbackWithLogger)
 	}
 
 	if len(u.autoNamedResources) > 0 {


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/821 https://github.com/pulumi/pulumi-terraform-bridge/issues/935 

With these changes, Plugin Framework based providers now:

- validate configuration via the upstream ValidateProviderConfig
- run PreConfigureCallback if supplied to ProviderInfo
- detect invalid or unknown keys

Care is taken to report errors gracefully. 
