### PR TITLE
Validate resource inputs for Plugin Framework based resources

### DIFF
--- a/pf/tests/internal/providerbuilder/build_provider.go
+++ b/pf/tests/internal/providerbuilder/build_provider.go
@@ -25,6 +25,7 @@ type Provider struct {
 	TypeName       string
 	Version        string
 	ProviderSchema schema.Schema
+	AllResources   []Resource
 }
 
 var _ provider.Provider = (*Provider)(nil)
@@ -45,6 +46,13 @@ func (*Provider) DataSources(ctx context.Context) []func() datasource.DataSource
 	return []func() datasource.DataSource{}
 }
 
-func (*Provider) Resources(ctx context.Context) []func() resource.Resource {
-	return []func() resource.Resource{}
+func (impl *Provider) Resources(ctx context.Context) []func() resource.Resource {
+	r := make([]func() resource.Resource, len(impl.AllResources))
+	for i := 0; i < len(impl.AllResources); i++ {
+		i := i
+		r[i] = func() resource.Resource {
+			return &impl.AllResources[i]
+		}
+	}
+	return r
 }

--- a/pf/tests/internal/providerbuilder/build_resource.go
+++ b/pf/tests/internal/providerbuilder/build_resource.go
@@ -1,0 +1,42 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package providerbuilder
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+)
+
+type Resource struct {
+	Name           string
+	ResourceSchema schema.Schema
+}
+
+func (r *Resource) Metadata(ctx context.Context, req resource.MetadataRequest, re *resource.MetadataResponse) {
+	re.TypeName = req.ProviderTypeName + "_" + r.Name
+}
+
+func (r *Resource) Schema(ctx context.Context, _ resource.SchemaRequest, re *resource.SchemaResponse) {
+	re.Schema = r.ResourceSchema
+}
+
+func (*Resource) Create(context.Context, resource.CreateRequest, *resource.CreateResponse) {}
+func (*Resource) Read(context.Context, resource.ReadRequest, *resource.ReadResponse)       {}
+func (*Resource) Update(context.Context, resource.UpdateRequest, *resource.UpdateResponse) {}
+func (*Resource) Delete(context.Context, resource.DeleteRequest, *resource.DeleteResponse) {}
+
+var _ resource.Resource = &Resource{}

--- a/pf/tests/provider_check_test.go
+++ b/pf/tests/provider_check_test.go
@@ -61,11 +61,11 @@ func TestCheck(t *testing.T) {
 			}`,
 		},
 		{
-			"config_value",
+			"prop",
 			schema.Schema{
 				Attributes: map[string]schema.Attribute{
-					"id":           schema.StringAttribute{Computed: true},
-					"config_value": schema.StringAttribute{Optional: true},
+					"id":   schema.StringAttribute{Computed: true},
+					"prop": schema.StringAttribute{Optional: true},
 				},
 			},
 			`
@@ -74,11 +74,11 @@ func TestCheck(t *testing.T) {
 			  "request": {
 			    "urn": "urn:pulumi:st::pg::testprovider:index/res:Res::r",
 			    "olds": {},
-			    "news": {"configValue": "foo"},
+			    "news": {"prop": "foo"},
 			    "randomSeed": "wqZZaHWVfsS1ozo3bdauTfZmjslvWcZpUjn7BzpS79c="
 			  },
 			  "response": {
-			    "inputs": {"configValue": "foo"}
+			    "inputs": {"prop": "foo"}
 			  }
 			}`,
 		},
@@ -87,7 +87,7 @@ func TestCheck(t *testing.T) {
 			schema.Schema{
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{Computed: true},
-					"config_value": schema.StringAttribute{
+					"prop": schema.StringAttribute{
 						Optional: true,
 						Validators: []validator.String{
 							stringvalidator.LengthAtLeast(2),
@@ -101,22 +101,22 @@ func TestCheck(t *testing.T) {
 			  "request": {
 			    "urn": "urn:pulumi:st::pg::testprovider:index/res:Res::r",
 			    "olds": {},
-			    "news": {"configValue": "f"},
+			    "news": {"prop": "f"},
 			    "randomSeed": "wqZZaHWVfsS1ozo3bdauTfZmjslvWcZpUjn7BzpS79c="
 			  },
 			  "response": {
-                            "inputs": {"configValue": "f"},
+                            "inputs": {"prop": "f"},
 			    "failures": [{"reason": "%s"}]
 			  }
-			}`, "Invalid Attribute Value Length. Attribute config_value string length must be "+
-				"at least 2, got: 1. Examine values at 'r.configValue'."),
+			}`, "Invalid Attribute Value Length. Attribute prop string length must be "+
+				"at least 2, got: 1. Examine values at 'r.prop'."),
 		},
 		{
-			"missing_required_config_value",
+			"missing_required_prop",
 			schema.Schema{
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{Computed: true},
-					"config_value": schema.StringAttribute{
+					"prop": schema.StringAttribute{
 						Required: true,
 					},
 				},
@@ -132,14 +132,14 @@ func TestCheck(t *testing.T) {
 			  },
 			  "response": {
                             "inputs": {},
-                            "failures": [{"property": "configValue", "reason": "Missing a required property"}]
+                            "failures": [{"property": "prop", "reason": "Missing a required property"}]
 			  }
 			}`,
 		},
 		{
 			// Unlike CheckConfig, unrecognized values are passed through without warning so that Pulumi
 			// resources can extend the protocol without triggering warnings.
-			"unrecognized_config_value_passed_through",
+			"unrecognized_prop_passed_through",
 			schema.Schema{
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{Computed: true},
@@ -151,11 +151,11 @@ func TestCheck(t *testing.T) {
 			  "request": {
 			    "urn": "urn:pulumi:st::pg::testprovider:index/res:Res::r",
 			    "olds": {},
-			    "news": {"configValue": "foo"},
+			    "news": {"prop": "foo"},
 			    "randomSeed": "wqZZaHWVfsS1ozo3bdauTfZmjslvWcZpUjn7BzpS79c="
 			  },
 			  "response": {
-                            "inputs": {"configValue": "foo"}
+                            "inputs": {"prop": "foo"}
 			  }
 			}`,
 		},

--- a/pf/tests/provider_check_test.go
+++ b/pf/tests/provider_check_test.go
@@ -136,6 +136,29 @@ func TestCheck(t *testing.T) {
 			  }
 			}`,
 		},
+		{
+			// Unlike CheckConfig, unrecognized values are passed through without warning so that Pulumi
+			// resources can extend the protocol without triggering warnings.
+			"unrecognized_config_value_passed_through",
+			schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"id": schema.StringAttribute{Computed: true},
+				},
+			},
+			`
+			{
+			  "method": "/pulumirpc.ResourceProvider/Check",
+			  "request": {
+			    "urn": "urn:pulumi:st::pg::testprovider:index/res:Res::r",
+			    "olds": {},
+			    "news": {"configValue": "foo"},
+			    "randomSeed": "wqZZaHWVfsS1ozo3bdauTfZmjslvWcZpUjn7BzpS79c="
+			  },
+			  "response": {
+                            "inputs": {"configValue": "foo"}
+			  }
+			}`,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pf/tests/provider_check_test.go
+++ b/pf/tests/provider_check_test.go
@@ -111,6 +111,31 @@ func TestCheck(t *testing.T) {
 			}`, "Invalid Attribute Value Length. Attribute config_value string length must be "+
 				"at least 2, got: 1. Examine values at 'r.configValue'."),
 		},
+		{
+			"missing_required_config_value",
+			schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"id": schema.StringAttribute{Computed: true},
+					"config_value": schema.StringAttribute{
+						Required: true,
+					},
+				},
+			},
+			`
+			{
+			  "method": "/pulumirpc.ResourceProvider/Check",
+			  "request": {
+			    "urn": "urn:pulumi:st::pg::testprovider:index/res:Res::r",
+			    "olds": {},
+			    "news": {},
+			    "randomSeed": "wqZZaHWVfsS1ozo3bdauTfZmjslvWcZpUjn7BzpS79c="
+			  },
+			  "response": {
+                            "inputs": {},
+                            "failures": [{"property": "configValue", "reason": "Missing a required property"}]
+			  }
+			}`,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -131,7 +156,12 @@ func TestCheck(t *testing.T) {
 				Version:      "0.0.1",
 				MetadataInfo: &tfbridge3.MetadataInfo{},
 				Resources: map[string]*tfbridge3.ResourceInfo{
-					"testprovider_res": {Tok: "testprovider:index/res:Res"},
+					"testprovider_res": {
+						Tok: "testprovider:index/res:Res",
+						Docs: &tfbridge3.DocInfo{
+							Markdown: []byte("OK"),
+						},
+					},
 				},
 			}
 			providerInfo := tfbridge.ProviderInfo{

--- a/pf/tests/provider_check_test.go
+++ b/pf/tests/provider_check_test.go
@@ -1,0 +1,150 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfbridgetests
+
+import (
+	"fmt"
+	"testing"
+
+	pschema "github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/pulumi/pulumi-terraform-bridge/pf/tests/internal/providerbuilder"
+	"github.com/pulumi/pulumi-terraform-bridge/pf/tfbridge"
+	testutils "github.com/pulumi/pulumi-terraform-bridge/testing/x"
+	tfbridge3 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+)
+
+func TestCheck(t *testing.T) {
+
+	type testCase struct {
+		name   string
+		schema schema.Schema
+		replay string
+	}
+
+	testCases := []testCase{
+		{
+			"minimal",
+			schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"id": schema.StringAttribute{Computed: true},
+				},
+			},
+			`
+			{
+			  "method": "/pulumirpc.ResourceProvider/Check",
+			  "request": {
+			    "urn": "urn:pulumi:st::pg::testprovider:index/res:Res::r",
+			    "olds": {},
+			    "news": {},
+			    "randomSeed": "wqZZaHWVfsS1ozo3bdauTfZmjslvWcZpUjn7BzpS79c="
+			  },
+			  "response": {
+			    "inputs": {}
+			  }
+			}`,
+		},
+		{
+			"config_value",
+			schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"id":           schema.StringAttribute{Computed: true},
+					"config_value": schema.StringAttribute{Optional: true},
+				},
+			},
+			`
+			{
+			  "method": "/pulumirpc.ResourceProvider/Check",
+			  "request": {
+			    "urn": "urn:pulumi:st::pg::testprovider:index/res:Res::r",
+			    "olds": {},
+			    "news": {"configValue": "foo"},
+			    "randomSeed": "wqZZaHWVfsS1ozo3bdauTfZmjslvWcZpUjn7BzpS79c="
+			  },
+			  "response": {
+			    "inputs": {"configValue": "foo"}
+			  }
+			}`,
+		},
+		{
+			"validators",
+			schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"id": schema.StringAttribute{Computed: true},
+					"config_value": schema.StringAttribute{
+						Optional: true,
+						Validators: []validator.String{
+							stringvalidator.LengthAtLeast(2),
+						},
+					},
+				},
+			},
+			fmt.Sprintf(`
+			{
+			  "method": "/pulumirpc.ResourceProvider/Check",
+			  "request": {
+			    "urn": "urn:pulumi:st::pg::testprovider:index/res:Res::r",
+			    "olds": {},
+			    "news": {"configValue": "f"},
+			    "randomSeed": "wqZZaHWVfsS1ozo3bdauTfZmjslvWcZpUjn7BzpS79c="
+			  },
+			  "response": {
+                            "inputs": {"configValue": "f"},
+			    "failures": [{"reason": "%s"}]
+			  }
+			}`, "Invalid Attribute Value Length. Attribute config_value string length must be "+
+				"at least 2, got: 1. Examine values at 'r.configValue'."),
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			testProvider := &providerbuilder.Provider{
+				TypeName:       "testprovider",
+				Version:        "0.0.1",
+				ProviderSchema: pschema.Schema{},
+				AllResources: []providerbuilder.Resource{{
+					Name:           "res",
+					ResourceSchema: tc.schema,
+				}},
+			}
+			info := tfbridge3.ProviderInfo{
+				Name:         "testprovider",
+				Version:      "0.0.1",
+				MetadataInfo: &tfbridge3.MetadataInfo{},
+				Resources: map[string]*tfbridge3.ResourceInfo{
+					"testprovider_res": {Tok: "testprovider:index/res:Res"},
+				},
+			}
+			providerInfo := tfbridge.ProviderInfo{
+				ProviderInfo: info,
+				NewProvider: func() provider.Provider {
+					return testProvider
+				},
+			}
+			s := newProviderServer(t, providerInfo)
+
+			if tc.replay != "" {
+				testutils.Replay(t, s, tc.replay)
+			}
+		})
+	}
+}

--- a/pf/tfbridge/provider_check.go
+++ b/pf/tfbridge/provider_check.go
@@ -62,6 +62,11 @@ func (p *provider) CheckWithContext(
 	})
 
 	checkFailures, err := p.validateResourceConfig(ctx, urn, rh, news)
+
+	schemaMap := rh.schemaOnlyShimResource.Schema()
+	schemaInfos := rh.pulumiResourceInfo.GetFields()
+	news = tfbridge.MarkSchemaSecrets(ctx, schemaMap, schemaInfos, resource.NewObjectProperty(news)).ObjectValue()
+
 	if err != nil {
 		return news, checkFailures, err
 	}


### PR DESCRIPTION
With these change resource inputs to Plugin Framework based resources are now validated by calling upstream validators and mapping errors back to Pulumi.

Fixes #822