### PR TITLE
Plugin Framework providers now support pluginDownloadURL

### DIFF
--- a/pf/tests/provider_checkconfig_test.go
+++ b/pf/tests/provider_checkconfig_test.go
@@ -417,6 +417,26 @@ func TestCheckConfig(t *testing.T) {
 	          }
 	        }`)
 	})
+
+	t.Run("tolerate pluginDownloadURL", func(t *testing.T) {
+		schema := schema.Schema{}
+		testutils.Replay(t, makeProviderServer(t, schema), `
+		{
+		  "method": "/pulumirpc.ResourceProvider/CheckConfig",
+		  "request": {
+		    "urn": "urn:pulumi:test1::typescript-example::pulumi:providers:authress::default_1_1_42_dirty_github_/api.github.com/Authress/pulumi-authress",
+		    "olds": {},
+		    "news": {
+		      "pluginDownloadURL": "github://api.github.com/Authress/pulumi-authress",
+		      "version": "1.1.42+dirty"
+		    }
+		  },
+		  "response": {"inputs": {
+		      "pluginDownloadURL": "github://api.github.com/Authress/pulumi-authress",
+		      "version": "1.1.42+dirty"
+		  }}
+		}`)
+	})
 }
 
 func TestPreConfigureCallback(t *testing.T) {

--- a/pf/tfbridge/provider_checkconfig.go
+++ b/pf/tfbridge/provider_checkconfig.go
@@ -160,7 +160,7 @@ func (p *provider) validateProviderConfig(
 			continue
 		}
 		// Ignoring version key as it seems to be special.
-		if k == "version" {
+		if k == "version" || k == "pluginDownloadURL" {
 			continue
 		}
 		n := tfbridge.PulumiToTerraformName(string(k), p.schemaOnlyProvider.Schema(), p.info.GetConfig())


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/1169

Before this change, using pluginDownloadURL feature failed provider configuration validation because this URL is passed to CheckConfig as a special key but was not recognized as such. It is now recognized as a special key so CheckConfig no longer errors out.