### PR TITLE
remove errors.Join for backwards compat with providers using Go < 1.20

### DIFF
--- a/pf/internal/muxer/muxer.go
+++ b/pf/internal/muxer/muxer.go
@@ -15,7 +15,6 @@
 package muxer
 
 import (
-	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -72,8 +71,7 @@ func AugmentShimWithDisjointPF(ctx context.Context, shim shim.Provider, pf provi
 	if len(resources) > 0 {
 		rErr = fmt.Errorf("ResourcesMap is not disjoint: conflicting keys: %s", strings.Join(resources, ", "))
 	}
-	contract.AssertNoErrorf(errors.Join(rErr, dErr), "providers are not disjoint")
-
+	contract.AssertNoErrorf(fmt.Errorf("%v; %v", rErr, dErr), "providers are not disjoint")
 	return p
 }
 

--- a/pf/internal/muxer/muxer.go
+++ b/pf/internal/muxer/muxer.go
@@ -71,7 +71,7 @@ func AugmentShimWithDisjointPF(ctx context.Context, shim shim.Provider, pf provi
 	if len(resources) > 0 {
 		rErr = fmt.Errorf("ResourcesMap is not disjoint: conflicting keys: %s", strings.Join(resources, ", "))
 	}
-	contract.AssertNoErrorf(fmt.Errorf("%v; %v", rErr, dErr), "providers are not disjoint")
+	contract.AssertNoErrorf(multierror.Append(rErr, dErr), "providers are not disjoint")
 	return p
 }
 

--- a/pf/tests/main_test.go
+++ b/pf/tests/main_test.go
@@ -15,7 +15,6 @@
 package tfbridgetests
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -43,7 +42,7 @@ func testMain(m *testing.M) (exitCode int, err error) {
 			panicError = fmt.Errorf("Ignoring panic in tests: %v", panicResult)
 		}
 		teardownError := teardownUnitTests()
-		err = errors.Join(panicError, teardownError)
+		err = fmt.Errorf("%v; %v", panicError, teardownError)
 	}()
 
 	exitCode = m.Run()

--- a/pf/tests/main_test.go
+++ b/pf/tests/main_test.go
@@ -16,6 +16,7 @@ package tfbridgetests
 
 import (
 	"fmt"
+	"github.com/hashicorp/go-multierror"
 	"log"
 	"os"
 	"testing"
@@ -42,7 +43,7 @@ func testMain(m *testing.M) (exitCode int, err error) {
 			panicError = fmt.Errorf("Ignoring panic in tests: %v", panicResult)
 		}
 		teardownError := teardownUnitTests()
-		err = fmt.Errorf("%v; %v", panicError, teardownError)
+		err = multierror.Append(panicError, teardownError)
 	}()
 
 	exitCode = m.Run()

--- a/pf/tfbridge/ignore_changes.go
+++ b/pf/tfbridge/ignore_changes.go
@@ -16,26 +16,25 @@ package tfbridge
 
 import (
 	"fmt"
-	"strings"
-
+	"github.com/hashicorp/go-multierror"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
 func applyIgnoreChanges(old, new resource.PropertyMap, ignoreChanges []string) (resource.PropertyMap, error) {
 	var paths []resource.PropertyPath
-	var errMsgs []string
+	var errs error
 	for i, p := range ignoreChanges {
 		pp, err := resource.ParsePropertyPath(p)
 		if err != nil {
-			errMsgs = append(errMsgs,
-				fmt.Sprintf("failed to parse property path %d: %s", i, p))
+			errs = multierror.Append(errs,
+				fmt.Errorf("failed to parse property path %d: %s", i, p))
 			continue
 		}
 		paths = append(paths, pp)
 	}
 
-	if err := fmt.Errorf(strings.Join(errMsgs, ",")); err != nil {
-		return nil, err
+	if errs != nil {
+		return nil, errs
 	}
 
 	newValue := resource.NewObjectProperty(new.Copy())

--- a/pf/tfbridge/ignore_changes.go
+++ b/pf/tfbridge/ignore_changes.go
@@ -15,25 +15,26 @@
 package tfbridge
 
 import (
-	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
 func applyIgnoreChanges(old, new resource.PropertyMap, ignoreChanges []string) (resource.PropertyMap, error) {
 	var paths []resource.PropertyPath
-	var errs []error
+	var errMsgs []string
 	for i, p := range ignoreChanges {
 		pp, err := resource.ParsePropertyPath(p)
 		if err != nil {
-			errs = append(errs,
-				fmt.Errorf("failed to parse property path %d: %s", i, p))
+			errMsgs = append(errMsgs,
+				fmt.Sprintf("failed to parse property path %d: %s", i, p))
 			continue
 		}
 		paths = append(paths, pp)
 	}
-	if err := errors.Join(errs...); err != nil {
+
+	if err := fmt.Errorf(strings.Join(errMsgs, ",")); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
This is a quick and dirty fix for #1167.
This PR replaces any usage of errors.Join() (available in Go 1.20+) for an alternative using strings and error formatting.

Not all providers are on Go 1.20 at the moment; this unblocks them for now.
