### PR TITLE
Remove index from collections that have max items = 1

### DIFF
--- a/pkg/tf2pulumi/convert/testdata/mappings/maxItemsOne.json
+++ b/pkg/tf2pulumi/convert/testdata/mappings/maxItemsOne.json
@@ -63,6 +63,19 @@
             }
           }
         },
+        "innerResourceOutput": {
+          "type": 5,
+          "computed": true,
+          "maxItems": 1,
+          "element": {
+            "resource": {
+              "someInput": {
+                "type": 1,
+                "optional": true
+              }
+            }
+          }
+        },
         "result": {
           "type": 4,
           "computed": true

--- a/pkg/tf2pulumi/convert/testdata/max_items_one_setting/experimental_pcl/main.pp
+++ b/pkg/tf2pulumi/convert/testdata/max_items_one_setting/experimental_pcl/main.pp
@@ -10,6 +10,16 @@ resource "resourceList" "maxItemsOne:index/index:resource" {
     someInput = true
   }
 }
+// Here, the target expression on the right hand side already marked with max items = 1
+// so we will not have to project it into a singleton. The translation keeps this as is.
+resource "resourceFromOutputField" "maxItemsOne:index/index:resource" {
+  innerResource = resourceList.innerResourceOutput
+}
+// Indexing the field innerResourceOutput at zero should just remove the index
+// since this field is marked with max items = 1
+resource "resourceFromOutputFieldIndexed" "maxItemsOne:index/index:resource" {
+  innerResource = resourceList.innerResourceOutput
+}
 resource "resourceVar" "maxItemsOne:index/index:resource" {
   innerResource = listInput[0]
 }

--- a/pkg/tf2pulumi/convert/testdata/max_items_one_setting/main.tf
+++ b/pkg/tf2pulumi/convert/testdata/max_items_one_setting/main.tf
@@ -12,6 +12,20 @@ resource "maxItemsOne_resource" "resource_list" {
 }
 
 #if EXPERIMENTAL
+
+// Here, the target expression on the right hand side already marked with max items = 1
+// so we will not have to project it into a singleton. The translation keeps this as is.
+resource "maxItemsOne_resource" "resource_from_output_field" {
+  innerResource = maxItemsOne_resource.resource_list.innerResourceOutput
+}
+
+// Indexing the field innerResourceOutput at zero should just remove the index
+// since this field is marked with max items = 1
+resource "maxItemsOne_resource" "resource_from_output_field_indexed" {
+  innerResource = maxItemsOne_resource.resource_list.innerResourceOutput[0]
+}
+
+
 resource "maxItemsOne_resource" "resource_var" {
   innerResource = var.list_input
 }

--- a/pkg/tf2pulumi/convert/testdata/schemas/maxItemsOne.json
+++ b/pkg/tf2pulumi/convert/testdata/schemas/maxItemsOne.json
@@ -48,6 +48,14 @@
         }
       },
       "type": "object"
+    },
+    "maxItemsOne:index/resourceInnerResourceOutput:resourceInnerResourceOutput": {
+      "properties": {
+        "someInput": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
     }
   },
   "provider": {
@@ -65,11 +73,15 @@
         "innerResource": {
           "$ref": "#/types/maxItemsOne:index/resourceInnerResource:resourceInnerResource"
         },
+        "innerResourceOutput": {
+          "$ref": "#/types/maxItemsOne:index/resourceInnerResourceOutput:resourceInnerResourceOutput"
+        },
         "result": {
           "type": "string"
         }
       },
       "required": [
+        "innerResourceOutput",
         "result"
       ],
       "inputProperties": {
@@ -94,6 +106,9 @@
           },
           "innerResource": {
             "$ref": "#/types/maxItemsOne:index/resourceInnerResource:resourceInnerResource"
+          },
+          "innerResourceOutput": {
+            "$ref": "#/types/maxItemsOne:index/resourceInnerResourceOutput:resourceInnerResourceOutput"
           },
           "result": {
             "type": "string"

--- a/pkg/tf2pulumi/convert/tf.go
+++ b/pkg/tf2pulumi/convert/tf.go
@@ -935,8 +935,7 @@ func camelCaseName(name string) string {
 	return name
 }
 
-// Returns whether the fully qualified path is being applied for a property
-// for which we can get the `maxItemsOne` field.
+// Returns whether the fully qualified path is being applied for a property.
 func (s *scopes) isPropertyPath(fullyQualifiedPath string) bool {
 	if fullyQualifiedPath == "" {
 		return false


### PR DESCRIPTION
This PR addresses #1145 where we no longer index a collection (removing the index from the traversal) when the collection is marked with max items = 1. 

Also, when the assigning a resource attribute to an expression of which the result is a collection marked with max items = 1, we no longer apply `projectListToSingleton`