### PR TITLE
Fix DiffStrategy=PlanState handling of unknowns

### DIFF
--- a/pkg/tests/regress_hcloud_175_test.go
+++ b/pkg/tests/regress_hcloud_175_test.go
@@ -29,9 +29,6 @@ func TestRegressHCloud175(t *testing.T) {
 
 	subnetResource := func() *schema.Resource {
 		return &schema.Resource{
-			// CreateContext: resourceNetworkSubnetCreate,
-			// ReadContext:   resourceNetworkSubnetRead,
-			// DeleteContext: resourceNetworkSubnetDelete,
 			Importer: &schema.ResourceImporter{
 				StateContext: schema.ImportStatePassthroughContext,
 			},

--- a/pkg/tests/regress_hcloud_175_test.go
+++ b/pkg/tests/regress_hcloud_175_test.go
@@ -118,10 +118,14 @@ func TestRegressHCloud175(t *testing.T) {
 	    },
 	    "preview": true
 	  },
-	  "errors": [
-	    "rpc error: code = Unknown desc = diffing urn:pulumi:dev::repro-175::hcloud:index/networkSubnet:NetworkSubnet::subnet: value is not known"
-	  ]
+	  "response": {
+            "properties": {
+	      "id": "*",
+	      "ipRange": "10.0.1.0/24",
+	      "networkZone": "eu-central",
+	      "type": "cloud"
+            }
+	  }
 	}`
 	testutils.Replay(t, server, testCase)
-
 }

--- a/pkg/tests/regress_hcloud_175_test.go
+++ b/pkg/tests/regress_hcloud_175_test.go
@@ -1,0 +1,127 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	testutils "github.com/pulumi/pulumi-terraform-bridge/testing/x"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
+)
+
+func TestRegressHCloud175(t *testing.T) {
+	ctx := context.Background()
+
+	subnetResource := func() *schema.Resource {
+		return &schema.Resource{
+			// CreateContext: resourceNetworkSubnetCreate,
+			// ReadContext:   resourceNetworkSubnetRead,
+			// DeleteContext: resourceNetworkSubnetDelete,
+			Importer: &schema.ResourceImporter{
+				StateContext: schema.ImportStatePassthroughContext,
+			},
+			Schema: map[string]*schema.Schema{
+				"network_id": {
+					Type:     schema.TypeInt,
+					Required: true,
+					ForceNew: true,
+				},
+				"type": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+					// ValidateFunc: validation.StringInSlice([]string{
+					// 	"cloud",
+					// 	"server",
+					// 	"vswitch",
+					// }, false),
+				},
+				"network_zone": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"ip_range": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"gateway": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"vswitch_id": {
+					Type:     schema.TypeInt,
+					Optional: true,
+					ForceNew: true,
+				},
+			},
+		}
+	}
+
+	tfProvider := &schema.Provider{
+		Schema: map[string]*schema.Schema{},
+		ResourcesMap: map[string]*schema.Resource{
+			"hcloud_subnet": subnetResource(),
+		},
+	}
+
+	p := shimv2.NewProvider(tfProvider, shimv2.WithDiffStrategy(shimv2.PlanState))
+
+	info := tfbridge.ProviderInfo{
+		P:           p,
+		Name:        "hcloud",
+		Description: "etc",
+		Keywords:    []string{"pulumi", "hcloud"},
+		License:     "Apache-2.0",
+		Version:     "0.0.1",
+		Resources: map[string]*tfbridge.ResourceInfo{
+			"hcloud_subnet": {Tok: "hcloud:index/networkSubnet:NetworkSubnet"},
+		},
+	}
+
+	server := tfbridge.NewProvider(ctx,
+		nil,      /* hostClient */
+		"hcloud", /* module */
+		"",       /* version */
+		p,        /* tf */
+		info,     /* info */
+		[]byte{}, /* pulumiSchema */
+	)
+
+	testCase := `
+	{
+	  "method": "/pulumirpc.ResourceProvider/Create",
+	  "request": {
+	    "urn": "urn:pulumi:dev::repro-175::hcloud:index/networkSubnet:NetworkSubnet::subnet",
+	    "properties": {
+	      "__defaults": [],
+	      "ipRange": "10.0.1.0/24",
+	      "networkId": "04da6b54-80e4-46f7-96ec-b56ff0331ba9",
+	      "networkZone": "eu-central",
+	      "type": "cloud"
+	    },
+	    "preview": true
+	  },
+	  "errors": [
+	    "rpc error: code = Unknown desc = diffing urn:pulumi:dev::repro-175::hcloud:index/networkSubnet:NetworkSubnet::subnet: value is not known"
+	  ]
+	}`
+	testutils.Replay(t, server, testCase)
+
+}

--- a/pkg/tests/regress_hcloud_175_test.go
+++ b/pkg/tests/regress_hcloud_175_test.go
@@ -42,11 +42,6 @@ func TestRegressHCloud175(t *testing.T) {
 					Type:     schema.TypeString,
 					Required: true,
 					ForceNew: true,
-					// ValidateFunc: validation.StringInSlice([]string{
-					// 	"cloud",
-					// 	"server",
-					// 	"vswitch",
-					// }, false),
 				},
 				"network_zone": {
 					Type:     schema.TypeString,

--- a/pkg/tfshim/sdk-v2/proposed_new.go
+++ b/pkg/tfshim/sdk-v2/proposed_new.go
@@ -15,8 +15,6 @@
 package sdkv2
 
 import (
-	"reflect"
-
 	hcty "github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/zclconf/go-cty/cty"
@@ -39,7 +37,7 @@ func proposedNew(res *schema.Resource, prior, config hcty.Value) (hcty.Value, er
 func htype2ctype(t hcty.Type) cty.Type {
 	// Used t.HasDynamicTypes() as an example of how to pattern-match types.
 	switch {
-	case reflect.DeepEqual(t, hcty.NilType):
+	case t == hcty.NilType:
 		return cty.NilType
 	case t == hcty.DynamicPseudoType:
 		return cty.DynamicPseudoType
@@ -176,7 +174,7 @@ func hcty2ctyWithType(ty cty.Type, val hcty.Value) cty.Value {
 func ctype2htype(t cty.Type) hcty.Type {
 	// Used t.HasDynamicTypes() as an example of how to pattern-match types.
 	switch {
-	case reflect.DeepEqual(t, cty.NilType):
+	case t == cty.NilType:
 		return hcty.NilType
 	case t == cty.DynamicPseudoType:
 		return hcty.DynamicPseudoType

--- a/pkg/tfshim/sdk-v2/proposed_new.go
+++ b/pkg/tfshim/sdk-v2/proposed_new.go
@@ -127,6 +127,8 @@ func hcty2ctyWithType(ty cty.Type, val hcty.Value) cty.Value {
 			newAVs[name] = newAV
 		}
 		return cty.ObjectVal(newAVs)
+	case ty.IsCapsuleType():
+		contract.Assertf(false, "Capsule types are not yet supported")
 	}
 	contract.Assertf(false, "match failure on hcty.Value: %v", val.GoString())
 	return cty.DynamicVal
@@ -223,6 +225,8 @@ func cty2hctyWithType(ty hcty.Type, val cty.Value) hcty.Value {
 			newAVs[name] = newAV
 		}
 		return hcty.ObjectVal(newAVs)
+	case ty.IsCapsuleType():
+		contract.Assertf(false, "Capsule types are not yet supported")
 	}
 	contract.Assertf(false, "match failure on cty.Value")
 	return hcty.DynamicVal

--- a/pkg/tfshim/sdk-v2/proposed_new.go
+++ b/pkg/tfshim/sdk-v2/proposed_new.go
@@ -50,7 +50,7 @@ func htype2ctype(t hcty.Type) cty.Type {
 		case t.Equals(hcty.Number):
 			return cty.Number
 		default:
-			contract.Assertf(false, "Match failure on hcty.Type with t.IsPrimitiveType()")
+			contract.Failf("Match failure on hcty.Type with t.IsPrimitiveType()")
 		}
 	case t.IsListType():
 		return cty.List(htype2ctype(*t.ListElementType()))

--- a/pkg/tfshim/sdk-v2/proposed_new_test.go
+++ b/pkg/tfshim/sdk-v2/proposed_new_test.go
@@ -80,7 +80,6 @@ func TestCtyTurnaround(t *testing.T) {
 	}
 
 	testCases := []testCase{
-		{cty.NilVal},
 		{cty.BoolVal(false)},
 		{cty.BoolVal(true)},
 		{cty.NumberIntVal(0)},
@@ -99,6 +98,19 @@ func TestCtyTurnaround(t *testing.T) {
 		{cty.MapVal(map[string]cty.Value{"0": cty.False, "1": cty.True})},
 		{cty.SetVal([]cty.Value{cty.Zero, cty.NumberIntVal(42)})},
 	}
+
+	for _, tc := range testCases {
+		testCases = append(testCases,
+			testCase{cty.ListVal([]cty.Value{tc.value})},
+			testCase{cty.MapVal(map[string]cty.Value{"x": tc.value})},
+			testCase{cty.SetVal([]cty.Value{tc.value})},
+			testCase{cty.TupleVal([]cty.Value{tc.value})},
+			testCase{cty.ObjectVal(map[string]cty.Value{"x": tc.value})})
+	}
+
+	// Assuming that NilVal should not be nested in real-world use cases so it is added here after the nesting
+	// cases. It is slightly problematic to test as it can makes Equals() and other methods panic.
+	testCases = append(testCases, testCase{cty.NilVal})
 
 	for i, tc := range testCases {
 		tc := tc


### PR DESCRIPTION
This change is aimed at fixing pulumi/pulumi-hcloud#175

This provider is early in adopting a feature-flagged change in https://github.com/pulumi/pulumi-terraform-bridge/issues/866 and uncovered an issue.

Due to technicalities this project is linking code from TF plugins and TF CLI proper and they do not agree on the dependency "github.com/hashicorp/go-cty/cty" vs "github.com/zclconf/go-cty/cty/json", and it looks like the bug was in the "trivial" adapter between cty.Value objects from these two packages. 

This is now fixed by expanding the adapter to handle each case explicitly and adding some turnaround cases. 