### PR TITLE
Update bridge dependencies in the pf go module

### DIFF
--- a/pf/go.mod
+++ b/pf/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.10.0
 	github.com/hashicorp/terraform-plugin-go v0.14.3
 	github.com/hashicorp/terraform-plugin-log v0.7.0
-	github.com/pulumi/pulumi-terraform-bridge/v3 v3.48.1-0.20230527113951-a0f92e793f31
+	github.com/pulumi/pulumi-terraform-bridge/v3 v3.49.0
 	github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.4
 	github.com/stretchr/testify v1.8.2
 	google.golang.org/grpc v1.54.0

--- a/pf/tests/go.mod
+++ b/pf/tests/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-provider-tls/shim v0.0.0-00010101000000-000000000000
 	github.com/pulumi/pulumi-terraform-bridge/pf v0.0.0
 	github.com/pulumi/pulumi-terraform-bridge/testing v0.0.1
-	github.com/pulumi/pulumi-terraform-bridge/v3 v3.48.1-0.20230527113951-a0f92e793f31
+	github.com/pulumi/pulumi-terraform-bridge/v3 v3.49.0
 	github.com/stretchr/testify v1.8.2
 	github.com/terraform-providers/terraform-provider-random/randomshim v0.0.0
 )


### PR DESCRIPTION
Necessary to avoid end-user issues like this one:

```
# github.com/pulumi/pulumi-terraform-bridge/pf/tfbridge
../../../go/pkg/mod/github.com/pulumi/pulumi-terraform-bridge/pf@v0.11.0/tfbridge/detect_check_failures.go:45:23: undefined: tfbridge.MiscFailure
../../../go/pkg/mod/github.com/pulumi/pulumi-terraform-bridge/pf@v0.11.0/tfbridge/detect_check_failures.go:47:23: undefined: tfbridge.MissingKey
../../../go/pkg/mod/github.com/pulumi/pulumi-terraform-bridge/pf@v0.11.0/tfbridge/detect_check_failures.go:50:23: undefined: tfbridge.InvalidKey
../../../go/pkg/mod/github.com/pulumi/pulumi-terraform-bridge/pf@v0.11.0/tfbridge/detect_check_failures.go:64:17: undefined: tfbridge.NewCheckFailure
../../../go/pkg/mod/github.com/pulumi/pulumi-terraform-bridge/pf@v0.11.0/tfbridge/detect_check_failures.go:72:17: undefined: tfbridge.CheckFailurePath
../../../go/pkg/mod/github.com/pulumi/pulumi-terraform-bridge/pf@v0.11.0/tfbridge/detect_check_failures.go:81:16: undefined: tfbridge.NewCheckFailurePath
../../../go/pkg/mod/github.com/pulumi/pulumi-terraform-bridge/pf@v0.11.0/tfbridge/provider_checkconfig.go:147:19: undefined: tfbridge.NewCheckFailurePath
../../../go/pkg/mod/github.com/pulumi/pulumi-terraform-bridge/pf@v0.11.0/tfbridge/provider_checkconfig.go:149:29: undefined: tfbridge.NewCheckFailure
../../../go/pkg/mod/github.com/pulumi/pulumi-terraform-bridge/pf@v0.11.0/tfbridge/provider_checkconfig.go:150:14: undefined: tfbridge.InvalidKey
make: *** [tfgen] Error 1
```