### PR TITLE
[converter] More test cases for unknown references

### DIFF
--- a/pkg/tf2pulumi/convert/testdata/partial_attribute_lookup/experimental_pcl/main.pp
+++ b/pkg/tf2pulumi/convert/testdata/partial_attribute_lookup/experimental_pcl/main.pp
@@ -2,3 +2,16 @@ resource "example" "simple:index:resource" {
   inputOne = exampledataunknownDataSource.attr
   inputTwo = exampleunknownResourceType.list[0]
 }
+resource "anotherExample" "simple:index:resource" {
+  inputOne = resourceName.someAttribute
+  inputTwo = exampleConfig.testAttribute
+}
+output "testUnknownAlreadyDeclaredDataSource" {
+  value = anotherTestAttribute
+}
+output "testUnknownLocalVariable" {
+  value = someVariableName
+}
+output "testUnknownAlreadyDeclaredLocalVariable" {
+  value = theirexample.anotherTestAttribute
+}

--- a/pkg/tf2pulumi/convert/testdata/partial_attribute_lookup/experimental_pcl/main.pp
+++ b/pkg/tf2pulumi/convert/testdata/partial_attribute_lookup/experimental_pcl/main.pp
@@ -4,14 +4,14 @@ resource "example" "simple:index:resource" {
 }
 resource "anotherExample" "simple:index:resource" {
   inputOne = resourceName.someAttribute
-  inputTwo = exampleConfig.testAttribute
+  inputTwo = someConfig.testAttribute
 }
 output "testUnknownAlreadyDeclaredDataSource" {
-  value = anotherTestAttribute
+  value = exampledataunknownDataSource.anotherTestAttribute
 }
 output "testUnknownLocalVariable" {
   value = someVariableName
 }
-output "testUnknownAlreadyDeclaredLocalVariable" {
+output "testUnknownConflictingLocalVariable" {
   value = theirexample.anotherTestAttribute
 }

--- a/pkg/tf2pulumi/convert/testdata/partial_attribute_lookup/main.tf
+++ b/pkg/tf2pulumi/convert/testdata/partial_attribute_lookup/main.tf
@@ -2,3 +2,20 @@ resource "simple_resource" "example" {
     input_one = data.unknown_data_source.example.attr
     input_two = unknown_resource_type.example.list[0]
 }
+
+resource "simple_resource" "another_example" {
+    input_one = example_resource_type.resource_name.some_attribute
+    input_two = var.example.test_attribute
+}
+
+output "test_unknown_already_declared_data_source" {
+    value = data.example.another_test_attribute
+}
+
+output "test_unknown_local_variable" {
+    value = local.some_variable_name
+}
+
+output "test_unknown_already_declared_local_variable" {
+    value = local.example.another_test_attribute
+}

--- a/pkg/tf2pulumi/convert/testdata/partial_attribute_lookup/main.tf
+++ b/pkg/tf2pulumi/convert/testdata/partial_attribute_lookup/main.tf
@@ -5,17 +5,17 @@ resource "simple_resource" "example" {
 
 resource "simple_resource" "another_example" {
     input_one = example_resource_type.resource_name.some_attribute
-    input_two = var.example.test_attribute
+    input_two = var.some_config.test_attribute
 }
 
 output "test_unknown_already_declared_data_source" {
-    value = data.example.another_test_attribute
+    value = data.unknown_data_source.example.another_test_attribute
 }
 
 output "test_unknown_local_variable" {
     value = local.some_variable_name
 }
 
-output "test_unknown_already_declared_local_variable" {
+output "test_unknown_conflicting_local_variable" {
     value = local.example.another_test_attribute
 }

--- a/pkg/tf2pulumi/convert/testdata/partial_attribute_lookup/pcl/main.pp
+++ b/pkg/tf2pulumi/convert/testdata/partial_attribute_lookup/pcl/main.pp
@@ -2,3 +2,16 @@ resource example "simple:index:resource" {
     inputOne = data.unknown_data_source.example.attr
     inputTwo = unknown_resource_type.example.list[0]
 }
+resource anotherExample "simple:index:resource" {
+    inputOne = example_resource_type.resource_name.some_attribute
+    inputTwo = var.example.test_attribute
+}
+output testUnknownAlreadyDeclaredDataSource {
+    value = data.example.another_test_attribute
+}
+output testUnknownLocalVariable {
+    value = local.some_variable_name
+}
+output testUnknownAlreadyDeclaredLocalVariable {
+    value = local.example.another_test_attribute
+}

--- a/pkg/tf2pulumi/convert/testdata/partial_attribute_lookup/pcl/main.pp
+++ b/pkg/tf2pulumi/convert/testdata/partial_attribute_lookup/pcl/main.pp
@@ -4,14 +4,14 @@ resource example "simple:index:resource" {
 }
 resource anotherExample "simple:index:resource" {
     inputOne = example_resource_type.resource_name.some_attribute
-    inputTwo = var.example.test_attribute
+    inputTwo = var.some_config.test_attribute
 }
 output testUnknownAlreadyDeclaredDataSource {
-    value = data.example.another_test_attribute
+    value = data.unknown_data_source.example.another_test_attribute
 }
 output testUnknownLocalVariable {
     value = local.some_variable_name
 }
-output testUnknownAlreadyDeclaredLocalVariable {
+output testUnknownConflictingLocalVariable {
     value = local.example.another_test_attribute
 }


### PR DESCRIPTION
Closes #1199 as we discussed, it drops the root of the traversal which is correct: the first part of the traversal is a resource type and we drop those when mapping from TF to PCL
