### PR TITLE
Support for default provider blocks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -247,7 +247,7 @@ require (
 	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 	lukechampine.com/frand v1.4.2 // indirect
 	sourcegraph.com/sourcegraph/appdash v0.0.0-20211028080628-e2786a622600 // indirect
 )

--- a/pkg/tf2pulumi/convert/convert.go
+++ b/pkg/tf2pulumi/convert/convert.go
@@ -92,7 +92,7 @@ func Convert(opts Options) (map[string][]byte, Diagnostics, error) {
 		TerraformVersion:           opts.TerraformVersion,
 	}
 
-	tfFiles, program, diagnostics, err := internalEject("/", ejectOpts)
+	_, tfFiles, program, diagnostics, err := internalEject("/", ejectOpts)
 
 	if err != nil {
 		return nil, Diagnostics{All: diagnostics, files: tfFiles}, err

--- a/pkg/tf2pulumi/convert/testdata/mappings/configured.json
+++ b/pkg/tf2pulumi/convert/testdata/mappings/configured.json
@@ -1,0 +1,71 @@
+{
+    "name": "configured",
+    "provider": {
+        "schema": {
+            "string_config": {
+                "type": 4,
+                "optional": true
+            },
+            "list_config": {
+                "type": 7,
+                "optional": true,
+                "element": {
+                    "schema": {
+                        "type": 4
+                    }
+                }
+            },
+            "renamed_config": {
+                "type": 4,
+                "optional": true
+            }
+        },
+        "dataSources": {
+            "configured_data_source": {
+                "input_one": {
+                    "type": 4,
+                    "optional": true
+                },
+                "input_two": {
+                    "type": 2,
+                    "optional": true
+                },
+                "result": {
+                    "type": 4,
+                    "computed": true
+                }
+            }
+        },
+        "resources": {
+            "configured_resource": {
+                "input_one": {
+                    "type": 4,
+                    "optional": true
+                },
+                "input_two": {
+                    "type": 2,
+                    "optional": true
+                },
+                "result": {
+                    "type": 4,
+                    "computed": true
+                }
+            }
+        }
+    },
+    "dataSources": {
+        "configured_data_source": {
+            "tok": "configured:index:data_source"
+        }
+    },
+    "resources": {
+        "configured_resource": {
+            "tok":  "configured:index:resource"
+        }
+    },
+    "config": {
+        "renamed_config": {
+            "name": "anotherName"
+        }
+    }
+}

--- a/pkg/tf2pulumi/convert/testdata/provider_config/experimental_pcl/Pulumi.yaml
+++ b/pkg/tf2pulumi/convert/testdata/provider_config/experimental_pcl/Pulumi.yaml
@@ -1,0 +1,11 @@
+name: provider_config
+runtime: ""
+config:
+    configured:anotherName:
+        value: a different pulumi name
+    configured:listConfig:
+        value:
+            - a
+            - list
+    configured:stringConfig:
+        value: a string

--- a/pkg/tf2pulumi/convert/testdata/provider_config/experimental_pcl/main.pp
+++ b/pkg/tf2pulumi/convert/testdata/provider_config/experimental_pcl/main.pp
@@ -1,0 +1,3 @@
+resource "aDefaultResource" "configured:index:resource" {
+  inputOne = "hi"
+}

--- a/pkg/tf2pulumi/convert/testdata/provider_config/main.tf
+++ b/pkg/tf2pulumi/convert/testdata/provider_config/main.tf
@@ -1,0 +1,11 @@
+# Test for provider blocks feature in Terraform https://developer.hashicorp.com/terraform/language/providers/configuration
+
+provider "configured" {
+    string_config = "a string"
+    list_config = ["a", "list"]
+    renamed_config = "a different pulumi name"
+}
+
+resource "configured_resource" "a_default_resource" {
+    input_one = "hi"
+}

--- a/pkg/tf2pulumi/convert/testdata/provider_config/pcl/main.pp
+++ b/pkg/tf2pulumi/convert/testdata/provider_config/pcl/main.pp
@@ -1,0 +1,3 @@
+resource aDefaultResource "configured:index:resource" {
+    inputOne = "hi"
+}

--- a/pkg/tf2pulumi/convert/testdata/schemas/configured.json
+++ b/pkg/tf2pulumi/convert/testdata/schemas/configured.json
@@ -1,0 +1,145 @@
+{
+  "name": "configured",
+  "attribution": "This Pulumi package is based on the [`configured` Terraform Provider](https://github.com/terraform-providers/terraform-provider-configured).",
+  "meta": {
+    "moduleFormat": "(.*)(?:/[^/]*)"
+  },
+  "language": {
+    "nodejs": {
+      "compatibility": "tfbridge20",
+      "disableUnionOutputTypes": true,
+      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-configured)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-configured` repo](/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-configured` repo](https://github.com/terraform-providers/terraform-provider-configured/issues)."
+    },
+    "python": {
+      "compatibility": "tfbridge20",
+      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-configured)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-configured` repo](/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-configured` repo](https://github.com/terraform-providers/terraform-provider-configured/issues)."
+    }
+  },
+  "config": {
+    "variables": {
+      "anotherName": {
+        "type": "string"
+      },
+      "listConfigs": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "stringConfig": {
+        "type": "string"
+      }
+    }
+  },
+  "provider": {
+    "description": "The provider type for the configured package. By default, resources use package-wide configuration\nsettings, however an explicit `Provider` instance may be created and passed during resource\nconstruction to achieve fine-grained programmatic control over provider settings. See the\n[documentation](https://www.pulumi.com/docs/reference/programming-model/#providers) for more information.\n",
+    "properties": {
+      "anotherName": {
+        "type": "string"
+      },
+      "listConfigs": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "stringConfig": {
+        "type": "string"
+      }
+    },
+    "inputProperties": {
+      "anotherName": {
+        "type": "string"
+      },
+      "listConfigs": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "stringConfig": {
+        "type": "string"
+      }
+    }
+  },
+  "resources": {
+    "configured:index:resource": {
+      "properties": {
+        "inputOne": {
+          "type": "string"
+        },
+        "inputTwo": {
+          "type": "integer"
+        },
+        "result": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "result"
+      ],
+      "inputProperties": {
+        "inputOne": {
+          "type": "string"
+        },
+        "inputTwo": {
+          "type": "integer"
+        }
+      },
+      "stateInputs": {
+        "description": "Input properties used for looking up and filtering resource resources.\n",
+        "properties": {
+          "inputOne": {
+            "type": "string"
+          },
+          "inputTwo": {
+            "type": "integer"
+          },
+          "result": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      }
+    }
+  },
+  "functions": {
+    "configured:index:data_source": {
+      "inputs": {
+        "description": "A collection of arguments for invoking data_source.\n",
+        "properties": {
+          "inputOne": {
+            "type": "string"
+          },
+          "inputTwo": {
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "outputs": {
+        "description": "A collection of values returned by data_source.\n",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The provider-assigned unique ID for this managed resource.\n"
+          },
+          "inputOne": {
+            "type": "string"
+          },
+          "inputTwo": {
+            "type": "integer"
+          },
+          "result": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": [
+          "result",
+          "id"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Had to make a few changes to the test system and eject data flow for this.

The test system now writes and checks Pulumi.yaml iff any config is set.
The eject data flow now returns Projects from the new converter, the old converter continues to just return what was returned before (a project with just the name set).

Apart from that the main change is fairly simple, just grab any provider blocks try to evaluate their settings and save that to the project config with pulumi style names.