### PR TITLE
[converter] Fix for_each scoping in provisioners

### DIFF
--- a/pkg/tf2pulumi/convert/testdata/provisioners_for_each/experimental_pcl/main.pp
+++ b/pkg/tf2pulumi/convert/testdata/provisioners_for_each/experimental_pcl/main.pp
@@ -1,0 +1,24 @@
+# Test for provisioners feature in Terraform https://developer.hashicorp.com/terraform/language/resources/provisioners/syntax
+# In combination with for_each
+
+
+config "echoData" "map(string)" {
+  default = {
+    first  = "First"
+    second = "Second"
+  }
+}
+resource "localExecResource" "simple:index:resource" {
+  options {
+    range = echoData
+  }
+  inputOne = "hello"
+  inputTwo = true
+}
+resource "localExecResourceProvisioner0" "command:local:Command" {
+  options {
+    range     = echoData
+    dependsOn = localExecResource
+  }
+  create = "echo ${range.value}"
+}

--- a/pkg/tf2pulumi/convert/testdata/provisioners_for_each/main.tf
+++ b/pkg/tf2pulumi/convert/testdata/provisioners_for_each/main.tf
@@ -1,0 +1,23 @@
+# Test for provisioners feature in Terraform https://developer.hashicorp.com/terraform/language/resources/provisioners/syntax
+# In combination with for_each
+
+#if EXPERIMENTAL
+
+variable "echo_data" {
+    type = map(string)
+    default = {
+        "first": "First"
+        "second": "Second"
+    }
+}
+
+resource "simple_resource" "local_exec_resource" {
+    for_each = var.echo_data
+    input_one = "hello"
+    input_two = true
+
+    provisioner "local-exec" {
+        command = "echo ${each.value}"
+    }
+}
+#endif


### PR DESCRIPTION
Fixes #1203 because when using `for_each` blocks in a resource with provisioner blocks, we separate out the provisioner block into a resource block on its own but then if we had references to `each.value` or `each.key` coming from the original resource block, then we lose the scopes. This PR fixes this issue. 