### PR TITLE
Fix pf GetMapping function

### DIFF
--- a/pf/tfbridge/main.go
+++ b/pf/tfbridge/main.go
@@ -141,8 +141,12 @@ func MakeMuxedServer(
 		info := info
 		marshalled := tfbridge.MarshalProviderInfo(&info)
 		data, err := json.Marshal(marshalled)
+		mapped := info.ResourcePrefix
+		if mapped == "" {
+			mapped = info.Name
+		}
 		return muxer.GetMappingResponse{
-			Provider: pkg,
+			Provider: mapped,
 			Data:     data,
 		}, err
 	}


### PR DESCRIPTION
Similar fix as https://github.com/pulumi/pulumi-terraform-bridge/pull/1212 except for the plugin framework bridge.

This used to return the pulumi package name, which was generally right (because normally it matches the tf name) but wasn't correct and lead to bugs like https://github.com/pulumi/pulumi-terraform-bridge/issues/1209.