### PR TITLE
ci: Mitigate rate limits acquiring providers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
 
 name: Pull Request & Downstream Testing
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -10,6 +10,9 @@ on:
       - '.github/workflows/update-providers.yml'
       - 'README.md'
 
+env:
+  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+
 jobs:
   build:
     name: Build and Test Bridge


### PR DESCRIPTION
This fixes [failing tests on the main branch](https://github.com/pulumi/pulumi-terraform-bridge/actions/runs/5245796534/jobs/9473746785#step:8:3144): 

```
E0612 16:08:06.920731   21560 log.go:90] GitHub rate limit exceeded for https://api.github.com/repos/pulumi/pulumi-random/releases/latest, try again in 12m47.079276s. You can set GITHUB_TOKEN to make an authenticated request with a higher rate limit.
+ pulumi:pulumi:Stack: (create)
    [urn=urn:pulumi:p-it-mac-168658-provider-c-cb97ba61::provider-config::pulumi:pulumi:Stack::provider-config-p-it-mac-168658-provider-c-cb97ba61]
Error: error resolving type of resource randomString: internal error loading package "random": Could not automatically download and install resource plugin 'pulumi-resource-random', install the plugin using `pulumi plugin install resource random`.

Underlying error: 403 HTTP error fetching plugin from https://api.github.com/repos/pulumi/pulumi-random/releases/latest
```

Using the Pulumi bot's token increases our rate limits relative to using the per-repo token (repo tokens have lower rate limits than personal access tokens).

Though setting the env var at all would likely have addressed this, the higher limit of the bot token is more resilient, and this follows practice in other repositories such as pulumi/pulumi.