### PR TITLE
[converter] Remove trivia from single token map keys

### DIFF
--- a/pkg/tf2pulumi/convert/testdata/simple-map/experimental_pcl/main.pp
+++ b/pkg/tf2pulumi/convert/testdata/simple-map/experimental_pcl/main.pp
@@ -1,0 +1,6 @@
+vpcToAvailabilityZonesWest = {
+  0 = {
+    public = "1.2.3.4"
+  }
+}
+

--- a/pkg/tf2pulumi/convert/testdata/simple-map/main.tf
+++ b/pkg/tf2pulumi/convert/testdata/simple-map/main.tf
@@ -1,0 +1,7 @@
+locals {
+  vpc_to_availability_zones_west = {
+    0 = {
+      public   = "1.2.3.4"
+    }
+  }
+}

--- a/pkg/tf2pulumi/convert/testdata/simple-map/pcl/main.pp
+++ b/pkg/tf2pulumi/convert/testdata/simple-map/pcl/main.pp
@@ -1,0 +1,5 @@
+  vpcToAvailabilityZonesWest = {
+    0 = {
+      public   = "1.2.3.4"
+    }
+  }

--- a/pkg/tf2pulumi/convert/tf.go
+++ b/pkg/tf2pulumi/convert/tf.go
@@ -207,6 +207,16 @@ func getTrivia(sources map[string][]byte, r hcl.Range) (hclwrite.Tokens, hclwrit
 		}
 	}
 
+	if len(tokens) > 0 && first == last {
+		// edge case for single-digit numerical map keys,
+		// where the first and last are the same index
+		// do not carry over the trivia
+		// TODO: fix this in getTrivaFromIndex
+		leading := make(hclwrite.Tokens, 0)
+		trailing := make(hclwrite.Tokens, 0)
+		return leading, trailing
+	}
+
 	return getTrivaFromIndex(tokens, first, last)
 }
 


### PR DESCRIPTION
When encountering a map with integer keys and those keys are single digits, then `getTrivia` would return trailing tokens that include the digit itself. This causes the map key tokens to be written twice: once from the value tokens and another time from the trailing trivia tokens. 

This terraform snippet:
```tf
locals {
  vpc_to_availability_zones_west = {
    0 = {
      public   = "1.2.3.4"
    }
  }
}
```
would generate this PCL
```
vpcToAvailabilityZonesWest = {
  0 0 = {
    public = "1.2.3.4"
  }
}
```
I believe this to be an off-by-one issue in `getTrivaFromIndex` where `first` and `last` indeces are equal. 

I couldn't really fix the underlying issue but worked around it by excluding the trivia from this edge case. 

The original issue in https://github.com/pulumi/pulumi/issues/13173