### PR TITLE
Conform to go v1.19.0 in pf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,12 @@ jobs:
     name: Build and Test Bridge
     strategy:
       matrix:
-        go-version: [1.20.x]
+        # To avoid depending on features introduced in newer golang versions, we need to
+        # test our minimum supported golang versions.
+        #
+        # When we decide to bump our minimum go version, we need to remember to bump the
+        # go version in our go.mod files.
+        go-version: [1.19.x, 1.20.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/pf/internal/muxer/muxer.go
+++ b/pf/internal/muxer/muxer.go
@@ -15,7 +15,6 @@
 package muxer
 
 import (
-	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -72,7 +71,14 @@ func AugmentShimWithDisjointPF(ctx context.Context, shim shim.Provider, pf provi
 	if len(resources) > 0 {
 		rErr = fmt.Errorf("ResourcesMap is not disjoint: conflicting keys: %s", strings.Join(resources, ", "))
 	}
-	contract.AssertNoErrorf(errors.Join(rErr, dErr), "providers are not disjoint")
+	switch {
+	case dErr != nil && rErr != nil:
+		contract.Failf("Providers are not disjoint:\n- %s\n- %s", rErr.Error(), dErr.Error())
+	case rErr != nil:
+		contract.Failf("Resources are not disjoint: %s", rErr.Error())
+	case dErr != nil:
+		contract.Failf("Datasources are not disjoint: %s", dErr.Error())
+	}
 
 	return p
 }

--- a/pf/tfbridge/ignore_changes.go
+++ b/pf/tfbridge/ignore_changes.go
@@ -15,9 +15,9 @@
 package tfbridge
 
 import (
-	"errors"
 	"fmt"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
@@ -33,8 +33,8 @@ func applyIgnoreChanges(old, new resource.PropertyMap, ignoreChanges []string) (
 		}
 		paths = append(paths, pp)
 	}
-	if err := errors.Join(errs...); err != nil {
-		return nil, err
+	if len(errs) > 0 {
+		return nil, &multierror.Error{Errors: errs}
 	}
 
 	newValue := resource.NewObjectProperty(new.Copy())

--- a/x/muxer/muxer.go
+++ b/x/muxer/muxer.go
@@ -452,7 +452,8 @@ func (m *muxer) GetMapping(ctx context.Context, req *rpc.GetMappingRequest) (*rp
 	result, err := combineMapping(&args)
 	if err != nil {
 		if args.err != nil {
-			return nil, fmt.Errorf("%w (sub-provider GetMapping call failed: %w)", err, args.err)
+			// go v1.19.0 only accepts a single %w within fmt.Error, so we convert the second call to %s.
+			return nil, fmt.Errorf("%w (sub-provider GetMapping call failed: %s)", err, args.err.Error())
 		}
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #1167 

This PR removes the use of `errors.Join` from the bridge, and adds testing on `go v1.19.x`.

