### PR TITLE
Remove GCP from downstream testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        provider: [ "gcp", "azuread", "random", ]
+        provider: [ "azuread", "random", ]
     steps:
       - name: Install Node.js
         uses: actions/setup-node@v1


### PR DESCRIPTION
This is necessary since our downstream testing action does not accommodate patched providers. GCP introduced patching in pulumi/pulumi-gcp#1103.

Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/1234