### PR TITLE
Remove confusing key suggestions on invalid keys

### DIFF
--- a/pkg/tfbridge/check_failures.go
+++ b/pkg/tfbridge/check_failures.go
@@ -240,6 +240,9 @@ func keySuggestions(
 	})
 	similar := []resource.PropertyKey{}
 	for _, c := range allKeys {
+		if string(k) == string(c) {
+			continue
+		}
 		if levenshtein.Distance(string(k), string(c), levenshtein.NewParams()) <= 2 {
 			similar = append(similar, c)
 		}

--- a/pkg/tfbridge/check_failures_test.go
+++ b/pkg/tfbridge/check_failures_test.go
@@ -1,0 +1,38 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfbridge
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
+func TestKeySuggestions(t *testing.T) {
+	schemaMap := &schema.SchemaMap{
+		"my_prop": (&schema.Schema{
+			Type:     shim.TypeString,
+			Optional: true,
+		}).Shim(),
+	}
+
+	assert.Empty(t, keySuggestions(NewCheckFailurePath(schemaMap, nil, "my_prop"), schemaMap, nil))
+	assert.Contains(t, keySuggestions(NewCheckFailurePath(schemaMap, nil, "myprop"), schemaMap, nil),
+		resource.PropertyKey("myProp"))
+}


### PR DESCRIPTION
Currently TF providers may emit error messages that conflate two conditions: a key being passed that is not understood by the provider (unknown key) and a value being passed to a key that has invalid content. In the second case, the bridge provides confusing typo-correction suggestions that do not make sense. This is now fixed. Easiest to illustrate by an example:

Before the change:

  pulumi:providers:aws (default_5_41_0):
    error: pulumi:providers:aws resource 'default_5_41_0' has a problem: could not validate provider configuration:
    Invalid or unknown key. Check `pulumi config get aws:endpoints`. Did you mean `aws:endpoints`?

After the change:

  pulumi:providers:aws (default_5_41_0):
    error: pulumi:providers:aws resource 'default_5_41_0' has a problem: could not validate provider configuration:
    Invalid or unknown key. Check `pulumi config get aws:endpoints`.