### PR TITLE
Don't panic on computed values in non-string sets in Diff

### DIFF
--- a/pkg/tfbridge/diff.go
+++ b/pkg/tfbridge/diff.go
@@ -109,12 +109,12 @@ func visitPropertyValue(name, path string, v resource.PropertyValue, tfs shim.Sc
 					if ev, err = tfs.SetElement(makeConfig(ev)); err != nil {
 						return
 					}
-				}
 
-				if !e.IsComputed() {
 					// We cannot compute the hash for computed values because they are represented by the UnknownVariableValue
 					// sentinel string, which may not be a legal value of the corresponding schema type, and SetHash does not
-					// account for computed values.
+					// account for computed values. Skipping this for unknown values will result in computing a diff only on the
+					// set itself, instead of on the set element, which matches the InstanceDiff returned by Terraform,
+					// which is a diff only on the count (and to an unknown value) of the set.
 					ti = strconv.FormatInt(int64(tfs.SetHash(ev)), 10)
 					if containsComputedValues(e) {
 						// TF adds a '~' prefix to the hash code for any set element that contains computed values.

--- a/pkg/tfbridge/diff.go
+++ b/pkg/tfbridge/diff.go
@@ -111,10 +111,15 @@ func visitPropertyValue(name, path string, v resource.PropertyValue, tfs shim.Sc
 					}
 				}
 
-				ti = strconv.FormatInt(int64(tfs.SetHash(ev)), 10)
-				if containsComputedValues(e) {
-					// TF adds a '~' prefix to the hash code for any set element that contains computed values.
-					ti = "~" + ti
+				if !e.IsComputed() {
+					// We cannot compute the hash for computed values because they are represented by the UnknownVariableValue
+					// sentinel string, which may not be a legal value of the corresponding schema type, and SetHash does not
+					// account for computed values.
+					ti = strconv.FormatInt(int64(tfs.SetHash(ev)), 10)
+					if containsComputedValues(e) {
+						// TF adds a '~' prefix to the hash code for any set element that contains computed values.
+						ti = "~" + ti
+					}
 				}
 			}
 

--- a/pkg/tfbridge/diff_test.go
+++ b/pkg/tfbridge/diff_test.go
@@ -1338,6 +1338,81 @@ func TestNestedComputedSetAdd(t *testing.T) {
 		})
 }
 
+func TestNestedComputedSetUpdateReplace(t *testing.T) {
+	diffTest(t,
+		map[string]*schema.Schema{
+			"prop": {Type: schema.TypeSet, Elem: &schema.Schema{Type: schema.TypeString}, ForceNew: true},
+			"outp": {Type: schema.TypeString, Computed: true},
+		},
+		map[string]*SchemaInfo{},
+		map[string]interface{}{
+			"prop": []interface{}{computedValue},
+		},
+		map[string]interface{}{
+			"prop": []interface{}{"foo"},
+			"outp": "bar",
+		},
+		map[string]DiffKind{
+			"prop": UR,
+		})
+}
+
+func TestNestedComputedSetIntUpdate(t *testing.T) {
+	diffTest(t,
+		map[string]*schema.Schema{
+			"prop": {Type: schema.TypeSet, Elem: &schema.Schema{Type: schema.TypeInt}},
+			"outp": {Type: schema.TypeString, Computed: true},
+		},
+		map[string]*SchemaInfo{},
+		map[string]interface{}{
+			"prop": []interface{}{computedValue},
+		},
+		map[string]interface{}{
+			"prop": []interface{}{42},
+			"outp": "bar",
+		},
+		map[string]DiffKind{
+			"prop": U,
+		})
+}
+
+func TestNestedComputedSetIntUpdateReplace(t *testing.T) {
+	diffTest(t,
+		map[string]*schema.Schema{
+			"prop": {Type: schema.TypeSet, Elem: &schema.Schema{Type: schema.TypeInt}, ForceNew: true},
+			"outp": {Type: schema.TypeString, Computed: true},
+		},
+		map[string]*SchemaInfo{},
+		map[string]interface{}{
+			"prop": []interface{}{computedValue},
+		},
+		map[string]interface{}{
+			"prop": []interface{}{42},
+			"outp": "bar",
+		},
+		map[string]DiffKind{
+			"prop": UR,
+		})
+}
+
+func TestNestedComputedSetIntAdd(t *testing.T) {
+	diffTest(t,
+		map[string]*schema.Schema{
+			"prop": {Type: schema.TypeSet, Elem: &schema.Schema{Type: schema.TypeInt}},
+			"outp": {Type: schema.TypeString, Computed: true},
+		},
+		map[string]*SchemaInfo{},
+		map[string]interface{}{
+			"prop": []interface{}{computedValue},
+		},
+		map[string]interface{}{
+			"outp": "bar",
+		},
+		map[string]DiffKind{
+			"prop": A,
+		})
+}
+
 func TestComputedSetUpdateReplace(t *testing.T) {
 	diffTest(t,
 		map[string]*schema.Schema{

--- a/pkg/tfbridge/diff_test.go
+++ b/pkg/tfbridge/diff_test.go
@@ -1301,6 +1301,43 @@ func TestComputedSetUpdate(t *testing.T) {
 		})
 }
 
+func TestNestedComputedSetUpdate(t *testing.T) {
+	diffTest(t,
+		map[string]*schema.Schema{
+			"prop": {Type: schema.TypeSet, Elem: &schema.Schema{Type: schema.TypeString}},
+			"outp": {Type: schema.TypeString, Computed: true},
+		},
+		map[string]*SchemaInfo{},
+		map[string]interface{}{
+			"prop": []interface{}{computedValue},
+		},
+		map[string]interface{}{
+			"prop": []interface{}{"foo"},
+			"outp": "bar",
+		},
+		map[string]DiffKind{
+			"prop": U,
+		})
+}
+
+func TestNestedComputedSetAdd(t *testing.T) {
+	diffTest(t,
+		map[string]*schema.Schema{
+			"prop": {Type: schema.TypeSet, Elem: &schema.Schema{Type: schema.TypeString}},
+			"outp": {Type: schema.TypeString, Computed: true},
+		},
+		map[string]*SchemaInfo{},
+		map[string]interface{}{
+			"prop": []interface{}{computedValue},
+		},
+		map[string]interface{}{
+			"outp": "bar",
+		},
+		map[string]DiffKind{
+			"prop": A,
+		})
+}
+
 func TestComputedSetUpdateReplace(t *testing.T) {
 	diffTest(t,
 		map[string]*schema.Schema{


### PR DESCRIPTION
As part of Diff, we traverse the inputs, which can involve hashing Set values as part of computing nested path shapes for diffs.  However, the Terraform hashing for Set values does not handle unknown/computed values, and instead interprets the unknown sentinel literally as a string even when being used for a non-string value type.  This leads to a panic.

Instead, we skip hashing set elements that are unknown, and report their diff against the set itself.  This results in reporting the diff against the set itself instead of the (unknown) element - which matches the InstanceDiff that Terraform produces, which renders a diff on the # of elements of the set, but to an unknown value.

Fixes https://github.com/pulumi/pulumi-github/issues/278
Fixes https://github.com/pulumi/pulumi-github/issues/157
Fixes https://github.com/pulumi/pulumi-azuredevops/issues/86
Fixes https://github.com/pulumi/pulumi-hcloud/issues/152
Fixes https://github.com/pulumi/pulumi-digitalocean/issues/256

It doesn't quite fully address https://github.com/pulumi/pulumi-terraform-bridge/issues/352, but it addresses the panic reported there.