### PR TITLE
Reproduce suppressed tags_all diff

### DIFF
--- a/pkg/tfbridge/diff.go
+++ b/pkg/tfbridge/diff.go
@@ -157,18 +157,19 @@ func makePropertyDiff(name, path string, v resource.PropertyValue, tfDiff shim.I
 	diff map[string]*pulumirpc.PropertyDiff, tfs shim.Schema, ps *SchemaInfo, finalize, rawNames bool) {
 
 	visitor := func(name, path string, v resource.PropertyValue) bool {
+		isComputedInput := ps != nil && ps.ComputedInput
 		switch {
 		case v.IsArray():
 			// If this value has a diff and is considered computed by Terraform, the diff will be woefully incomplete. In
 			// this case, do not recurse into the array; instead, just use the count diff for the details.
-			if d := tfDiff.Attribute(name + ".#"); d == nil || !d.NewComputed {
+			if d := tfDiff.Attribute(name + ".#"); d == nil || (!d.NewComputed && !isComputedInput) {
 				return true
 			}
 			name += ".#"
 		case v.IsObject():
 			// If this value has a diff and is considered computed by Terraform, the diff will be woefully incomplete. In
 			// this case, do not recurse into the array; instead, just use the count diff for the details.
-			if d := tfDiff.Attribute(name + ".%"); d == nil || !d.NewComputed {
+			if d := tfDiff.Attribute(name + ".%"); d == nil || (!d.NewComputed && !isComputedInput) {
 				return true
 			}
 			name += ".%"
@@ -203,6 +204,10 @@ func makePropertyDiff(name, path string, v resource.PropertyValue, tfDiff shim.I
 				if hasOtherDiff &&
 					(other.Kind == pulumirpc.PropertyDiff_ADD || other.Kind == pulumirpc.PropertyDiff_ADD_REPLACE) &&
 					!d.RequiresNew {
+					if isComputedInput {
+						// The value is irrelevant, see forceDiffSomeSymbol
+						diff[forceDiffSomeSymbol] = nil
+					}
 					delete(diff, path)
 				}
 				return false

--- a/pkg/tfbridge/diff_test.go
+++ b/pkg/tfbridge/diff_test.go
@@ -1948,8 +1948,14 @@ func TestChangingTagsAll(t *testing.T) {
 	})
 
 	r := Resource{
-		TF:     shimv2.NewResource(res),
-		Schema: &ResourceInfo{},
+		TF: shimv2.NewResource(res),
+		Schema: &ResourceInfo{
+			Fields: map[string]*SchemaInfo{
+				"tagsall": {
+					ComputedInput: true,
+				},
+			},
+		},
 	}
 
 	tfState, err := MakeTerraformState(r, "id", stateMap)
@@ -1969,7 +1975,7 @@ func TestChangingTagsAll(t *testing.T) {
 	// }},
 
 	// Convert the diff to a detailed diff and check the result.
-	diff := makeDetailedDiff(sch, nil, stateMap, inputsMap, tfDiff)
-
-	assert.Truef(t, len(diff) > 0, "Expected a non-empty diff")
+	diff := makeDetailedDiff(sch, r.Schema.Fields, stateMap, inputsMap, tfDiff)
+	assert.Truef(t, len(diff) == 1, "Expected a non-empty diff")
+	assert.Contains(t, diff, forceDiffSomeSymbol)
 }

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -394,6 +394,10 @@ type SchemaInfo struct {
 
 	// whether or not to treat this property as secret
 	Secret *bool
+
+	// whether to treat this as a computed input for the purpose of diff, i.e.: should trigger an
+	// update even if it appears only as an output property.
+	ComputedInput bool
 }
 
 // ConfigInfo represents a synthetic configuration variable that is Pulumi-only, and not passed to Terraform.


### PR DESCRIPTION
Looking at pulumi/pulumi-aws#1655

Findings so far. https://github.com/pulumi/terraform-provider-aws/blob/a82c36c5556e2b8de91ba2a82a24bcd6074345be/docs/resource-tagging.md#L246 has a special strategy for tags_all property which is computed as a union of provider tags and default tags. https://github.com/pulumi/terraform-provider-aws/blob/a82c36c5556e2b8de91ba2a82a24bcd6074345be/internal/verify/diff.go#L23 uses a diff customizer that computes these tags_all property.

The way the bridge works, we do not in interact with TF code in Check so Check results do not see tags-all; however when calling Diff we do call diff customizers and I've verified this customizer does get run and produces a TF diff that does indicate something is changing in my test:

```
    map[tags_all.tag2:{tag2valueModified tag2value false false <nil> false false 0}]
```

However makeDetailedDiff translates this diff to an empty diff.

Starting with an attempt to reproduce this makeDetailedDiff in a unit test.

