### PR TITLE
Add support for computed inputs in diff

### DIFF
--- a/pkg/tfbridge/diff.go
+++ b/pkg/tfbridge/diff.go
@@ -157,7 +157,7 @@ func makePropertyDiff(name, path string, v resource.PropertyValue, tfDiff shim.I
 	diff map[string]*pulumirpc.PropertyDiff, forceDiff *bool,
 	tfs shim.Schema, ps *SchemaInfo, finalize, rawNames bool) {
 
-	isComputedInput := ps != nil && ps.ComputedInput
+	isComputedInput := ps != nil && ps.XComputedInput
 	visitor := func(name, path string, v resource.PropertyValue) bool {
 		switch {
 		case v.IsArray():

--- a/pkg/tfbridge/diff.go
+++ b/pkg/tfbridge/diff.go
@@ -154,7 +154,8 @@ func visitPropertyValue(name, path string, v resource.PropertyValue, tfs shim.Sc
 }
 
 func makePropertyDiff(name, path string, v resource.PropertyValue, tfDiff shim.InstanceDiff,
-	diff map[string]*pulumirpc.PropertyDiff, tfs shim.Schema, ps *SchemaInfo, finalize, rawNames bool) {
+	diff map[string]*pulumirpc.PropertyDiff, forceDiff *bool,
+	tfs shim.Schema, ps *SchemaInfo, finalize, rawNames bool) {
 
 	isComputedInput := ps != nil && ps.ComputedInput
 	visitor := func(name, path string, v resource.PropertyValue) bool {
@@ -169,7 +170,7 @@ func makePropertyDiff(name, path string, v resource.PropertyValue, tfDiff shim.I
 		case v.IsObject():
 			// If this value has a diff and is considered computed by Terraform, the diff will be woefully incomplete. In
 			// this case, do not recurse into the array; instead, just use the count diff for the details.
-			if d := tfDiff.Attribute(name + ".%"); d == nil || (!d.NewComputed && !isComputedInput) {
+			if d := tfDiff.Attribute(name + ".%"); d == nil || !d.NewComputed {
 				return true
 			}
 			name += ".%"
@@ -205,8 +206,7 @@ func makePropertyDiff(name, path string, v resource.PropertyValue, tfDiff shim.I
 					(other.Kind == pulumirpc.PropertyDiff_ADD || other.Kind == pulumirpc.PropertyDiff_ADD_REPLACE) &&
 					!d.RequiresNew {
 					if isComputedInput {
-						// The value is irrelevant, see forceDiffSomeSymbol
-						diff[forceDiffSomeSymbol] = nil
+						*forceDiff = true
 					}
 					delete(diff, path)
 				}
@@ -276,32 +276,43 @@ func doIgnoreChanges(tfs shim.SchemaMap, ps map[string]*SchemaInfo, olds, news r
 // makeDetailedDiff converts the given state (olds), config (news), and InstanceDiff to a Pulumi property diff.
 //
 // See makePropertyDiff for more details.
-func makeDetailedDiff(tfs shim.SchemaMap, ps map[string]*SchemaInfo, olds, news resource.PropertyMap,
-	tfDiff shim.InstanceDiff) map[string]*pulumirpc.PropertyDiff {
+func makeDetailedDiff(
+	tfs shim.SchemaMap,
+	ps map[string]*SchemaInfo,
+	olds, news resource.PropertyMap,
+	tfDiff shim.InstanceDiff,
+) (map[string]*pulumirpc.PropertyDiff, pulumirpc.DiffResponse_DiffChanges) {
 
 	if tfDiff == nil {
-		return map[string]*pulumirpc.PropertyDiff{}
+		return map[string]*pulumirpc.PropertyDiff{}, pulumirpc.DiffResponse_DIFF_NONE
 	}
 
 	// Check both the old state and the new config for diffs and report them as necessary.
 	//
 	// There is a minor complication here: Terraform has no concept of an "add" diff. Instead, adds are recorded as
-	// updates with an old property value of the empty string. In order to detect adds--and to ensure that all diffs in
-	// the InstanceDiff are reflected in the resulting Pulumi property diff--we first call this function with each
-	// property in a resource's state, then with each property in its config. Any diffs that only appear in the config
-	// are treated as adds; diffs that appear in both the state and config are treated as updates.
+	// updates with an old property value of the empty string. In order to detect adds--and to ensure that all diffs
+	// in the InstanceDiff are reflected in the resulting Pulumi property diff--we first call this function with
+	// each property in a resource's state, then with each property in its config. Any diffs that only appear in the
+	// config are treated as adds; diffs that appear in both the state and config are treated as updates.
+
+	forceDiff := new(bool)
 	diff := map[string]*pulumirpc.PropertyDiff{}
 	for k, v := range olds {
 		en, etf, eps := getInfoFromPulumiName(k, tfs, ps, false)
-		makePropertyDiff(en, string(k), v, tfDiff, diff, etf, eps, false, useRawNames(etf))
+		makePropertyDiff(en, string(k), v, tfDiff, diff, forceDiff, etf, eps, false, useRawNames(etf))
 	}
 	for k, v := range news {
 		en, etf, eps := getInfoFromPulumiName(k, tfs, ps, false)
-		makePropertyDiff(en, string(k), v, tfDiff, diff, etf, eps, false, useRawNames(etf))
+		makePropertyDiff(en, string(k), v, tfDiff, diff, forceDiff, etf, eps, false, useRawNames(etf))
 	}
 	for k, v := range olds {
 		en, etf, eps := getInfoFromPulumiName(k, tfs, ps, false)
-		makePropertyDiff(en, string(k), v, tfDiff, diff, etf, eps, true, useRawNames(etf))
+		makePropertyDiff(en, string(k), v, tfDiff, diff, forceDiff, etf, eps, true, useRawNames(etf))
 	}
-	return diff
+
+	changes := pulumirpc.DiffResponse_DIFF_NONE
+	if len(diff) > 0 || *forceDiff {
+		changes = pulumirpc.DiffResponse_DIFF_SOME
+	}
+	return diff, changes
 }

--- a/pkg/tfbridge/diff_test.go
+++ b/pkg/tfbridge/diff_test.go
@@ -1905,3 +1905,77 @@ func TestListNestedAddMaxItemsOne(t *testing.T) {
 			"prop.nest": AR,
 		})
 }
+
+func TestChangingTagsAll(t *testing.T) {
+	stateMap := resource.PropertyMap{
+		"tagsall": resource.NewObjectProperty(
+			resource.PropertyMap{
+				"tag1": resource.NewStringProperty("tag1value"),
+				"tag2": resource.NewStringProperty("tag2value"),
+			},
+		),
+	}
+
+	inputsMap := resource.PropertyMap{}
+
+	tfs := map[string]*v2Schema.Schema{
+		"tagsall": {
+			Type:     v2Schema.TypeMap,
+			Computed: true,
+			Elem: &v2Schema.Schema{
+				Type:     v2Schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+
+	sch := shimv2.NewSchemaMap(tfs)
+
+	res := &v2Schema.Resource{
+		Schema: tfs,
+		CustomizeDiff: func(_ context.Context, d *v2Schema.ResourceDiff, _ interface{}) error {
+			return d.SetNew("tagsall", map[string]string{
+				"tag1": "tag1value",
+				"tag2": "tag2valueModified",
+			})
+		},
+	}
+
+	provider := shimv2.NewProvider(&v2Schema.Provider{
+		ResourcesMap: map[string]*v2Schema.Resource{
+			"resource": res,
+		},
+	})
+
+	r := Resource{
+		TF: shimv2.NewResource(res),
+		Schema: &ResourceInfo{
+			Fields: map[string]*SchemaInfo{
+				"tagsall": {
+					ComputedInput: true,
+				},
+			},
+		},
+	}
+
+	tfState, err := MakeTerraformState(r, "id", stateMap)
+	assert.NoError(t, err)
+
+	config, _, err := MakeTerraformConfig(&Provider{tf: provider}, inputsMap, sch, nil)
+	assert.NoError(t, err)
+
+	tfDiff, err := provider.Diff("resource", tfState, config)
+	assert.NoError(t, err)
+
+	// t.Logf("tfDiff = %v", valast.String(tfDiff)) ==>
+	//
+	// Attributes: map[string]*terraform.ResourceAttrDiff{"tagsall.tag2": &terraform.ResourceAttrDiff{
+	//         Old: "tag2value",
+	//         New: "tag2valueModified",
+	// }},
+
+	// Convert the diff to a detailed diff and check the result.
+	diff := makeDetailedDiff(sch, r.Schema.Fields, stateMap, inputsMap, tfDiff)
+	assert.Truef(t, len(diff) == 1, "Expected a non-empty diff")
+	assert.Contains(t, diff, forceDiffSomeSymbol)
+}

--- a/pkg/tfbridge/diff_test.go
+++ b/pkg/tfbridge/diff_test.go
@@ -1783,7 +1783,6 @@ func TestCollectionsWithMultipleItems(t *testing.T) {
 		},
 	}
 
-	//nolint:lll
 	runTestCase := func(t *testing.T, name string, typ schema.ValueType, inputs, state []interface{},
 		expected map[string]DiffKind, expectedChanges pulumirpc.DiffResponse_DiffChanges) {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/tfbridge/diff_test.go
+++ b/pkg/tfbridge/diff_test.go
@@ -2058,7 +2058,7 @@ func TestChangingTagsAll(t *testing.T) {
 		Schema: &ResourceInfo{
 			Fields: map[string]*SchemaInfo{
 				"tagsall": {
-					ComputedInput: true,
+					XComputedInput: true,
 				},
 			},
 		},

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -394,6 +394,10 @@ type SchemaInfo struct {
 
 	// whether or not to treat this property as secret
 	Secret *bool
+
+	// whether to treat this as a computed input for the purpose of diff, i.e.: should trigger an
+	// update even if it appears only as an output property.
+	ComputedInput bool
 }
 
 // ConfigInfo represents a synthetic configuration variable that is Pulumi-only, and not passed to Terraform.

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -395,9 +395,12 @@ type SchemaInfo struct {
 	// whether or not to treat this property as secret
 	Secret *bool
 
-	// whether to treat this as a computed input for the purpose of diff, i.e.: should trigger an
-	// update even if it appears only as an output property.
-	ComputedInput bool
+	// experimental workaround to treat this as a computed input for the purpose of diff, i.e.: should
+	// trigger an update even if it appears only as an output property.
+	//
+	// used to address pulumi/pulumi-aws#1655 - however we may need to refine the behavior in the
+	// future, and so we will not reserve the field name ComputedInput at this time.
+	XComputedInput bool
 }
 
 // ConfigInfo represents a synthetic configuration variable that is Pulumi-only, and not passed to Terraform.

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -600,11 +600,6 @@ func (p *Provider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (*pul
 	return &pulumirpc.CheckResponse{Inputs: minputs, Failures: failures}, nil
 }
 
-// When this key occurs in the detailed diff, report DIFF_SOME even if no other details are
-// available. This is a side channel used for computed inputs that aren't handled correctly - as
-// they don't appear in `news` and are an output of TF planning.
-var forceDiffSomeSymbol = "7586a3a2-98aa-45c3-9ec9-0e40d168e90c"
-
 // Diff checks what impacts a hypothetical update will have on the resource's properties.
 func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error) {
 	p.setLoggingContext(ctx)
@@ -645,20 +640,14 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 	}
 
 	doIgnoreChanges(res.TF.Schema(), res.Schema.Fields, olds, news, req.GetIgnoreChanges(), diff)
-	detailedDiff := makeDetailedDiff(res.TF.Schema(), res.Schema.Fields, olds, news, diff)
+	detailedDiff, changes := makeDetailedDiff(res.TF.Schema(), res.Schema.Fields, olds, news, diff)
 
 	// If there were changes in this diff, check to see if we have a replacement.
 	var replaces []string
 	var replaced map[string]bool
-	var changes pulumirpc.DiffResponse_DiffChanges
 	var properties []string
-	hasChanges := len(detailedDiff) > 0
-	if _, ok := detailedDiff[forceDiffSomeSymbol]; ok {
-		hasChanges = true
-		delete(detailedDiff, forceDiffSomeSymbol)
-	}
-	if hasChanges {
-		changes = pulumirpc.DiffResponse_DIFF_SOME
+
+	if changes == pulumirpc.DiffResponse_DIFF_SOME {
 		for k, d := range detailedDiff {
 			// Turn the attribute name into a top-level property name by trimming everything after the first dot.
 			if firstSep := strings.IndexAny(k, ".["); firstSep != -1 {
@@ -678,8 +667,6 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 				replaced[k] = true
 			}
 		}
-	} else {
-		changes = pulumirpc.DiffResponse_DIFF_NONE
 	}
 
 	// For all properties that are ForceNew, but didn't change, assume they are stable.  Also recognize


### PR DESCRIPTION
This is intended to enable closing:
- pulumi/pulumi-aws#1655

We add a new flag on fields, `ComputedInput`, which indicates that the value will only appear as a result of a tf diff computation or planning, and not in `news`. This computed _input_ would ordinarily be computed during `Check()` in our lifecycle model.

For reasons unclear to me, we don't include computed properties in detailed diffs, and in stepping through `makeDetailedDiff`, we found that the visitor never saw properties such as `tags_all.foo` when that property was new and computed.

With this change, we can mark the `tags_all` field as a `ComputedInput`, and trigger updates on default tags changing:

```
pulumi up --skip-preview
Updating (test-aws-1655)

View in Browser (Ctrl+O): https://app.pulumi.com/pulumi/simple-yaml/test-aws-1655/updates/9

     Type                     Name                       Status              Info
     pulumi:pulumi:Stack      simple-yaml-test-aws-1655
 ~   ├─ pulumi:providers:aws  aws-provider               updated (0.13s)     [diff: ~defaultTags]
 ~   ├─ aws:s3:Bucket         my-bucket                  updated (0.87s)
 ~   └─ aws:s3:BucketObject   index.html                 updated (0.24s)
```