### PR TITLE
Upgrade `golangci-lint` to `v1.53`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
             skip-cache: true
             skip-pkg-cache: true
             skip-build-cache: true
-            version: v1.51.2
+            version: v1.53
       - name: Lint
         run: make lint
       - name: Test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,3 +21,7 @@ linters:
     - revive
     - unconvert
     - unused
+issues:
+  exclude:
+    - "unused-parameter: parameter"
+    - "redefines-builtin-id:"

--- a/pf/tests/.golangci.yml
+++ b/pf/tests/.golangci.yml
@@ -16,3 +16,8 @@ linters:
     - revive
     - unconvert
     - unused
+
+issues:
+  exclude:
+    - "unused-parameter: parameter"
+    - "redefines-builtin-id:"

--- a/pf/tests/integration/main_test.go
+++ b/pf/tests/integration/main_test.go
@@ -35,8 +35,5 @@ func setupIntegrationTests() error {
 		return err
 	}
 
-	if err := ensureTestBridgeProviderCompiled(wd); err != nil {
-		return err
-	}
-	return nil
+	return ensureTestBridgeProviderCompiled(wd)
 }

--- a/pf/tfbridge/provider_invoke.go
+++ b/pf/tfbridge/provider_invoke.go
@@ -147,9 +147,8 @@ func (p *provider) parseInvokePropertyCheckFailures(ds datasourceHandle, diags [
 			}
 			failures = append(failures, failure)
 			continue
-		} else {
-			rest = append(rest, d)
 		}
+		rest = append(rest, d)
 	}
 
 	return failures, rest

--- a/pf/tfgen/main.go
+++ b/pf/tfgen/main.go
@@ -53,11 +53,7 @@ func Main(provider string, info sdkBridge.ProviderInfo) {
 			return err
 		}
 
-		if err := g.Generate(); err != nil {
-			return err
-		}
-
-		return nil
+		return g.Generate()
 	})
 }
 
@@ -99,10 +95,6 @@ func MainWithMuxer(provider string, info sdkBridge.ProviderInfo) {
 			return err
 		}
 
-		if err := g.Generate(); err != nil {
-			return err
-		}
-
-		return nil
+		return g.Generate()
 	})
 }

--- a/pkg/tests/.golangci.yml
+++ b/pkg/tests/.golangci.yml
@@ -16,3 +16,8 @@ linters:
     - revive
     - unconvert
     - unused
+
+issues:
+  exclude:
+    - "unused-parameter: parameter"
+    - "redefines-builtin-id:"

--- a/pkg/tests/main_test.go
+++ b/pkg/tests/main_test.go
@@ -42,10 +42,7 @@ func setupIntegrationTests() error {
 		return err
 	}
 
-	if err := ensureCompiledTestProviders(wd); err != nil {
-		return err
-	}
-	return nil
+	return ensureCompiledTestProviders(wd)
 }
 
 func accTestOptions(t *testing.T) *integration.ProgramTestOptions {

--- a/pkg/tfbridge/config_encoding.go
+++ b/pkg/tfbridge/config_encoding.go
@@ -209,10 +209,12 @@ func (enc *ConfigEncoding) UnmarshalProperties(props *structpb.Struct) (resource
 			return nil, err
 		} else if v != nil {
 			if opts.SkipNulls && v.IsNull() {
-			} else if opts.SkipInternalKeys && resource.IsInternalPropertyKey(pk) {
-			} else {
-				result[pk] = *v
+				continue
 			}
+			if opts.SkipInternalKeys && resource.IsInternalPropertyKey(pk) {
+				continue
+			}
+			result[pk] = *v
 		}
 	}
 

--- a/pkg/tfbridge/x/tokens.go
+++ b/pkg/tfbridge/x/tokens.go
@@ -731,6 +731,7 @@ func applyResourceMaxItemsOneAliasing(
 // SchemaInfo and vise versa as necessary to avoid breaking changes in the
 // resulting sdk.
 func applyMaxItemsOneAliasing(schema shim.Schema, h *fieldHistory, info *b.SchemaInfo) (hasH bool, hasI bool) {
+	//revive:disable-next-line:empty-block
 	if schema == nil || (schema.Type() != shim.TypeList && schema.Type() != shim.TypeSet) {
 		// MaxItemsOne does not apply, so do nothing
 	} else if info.MaxItemsOne != nil {

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -688,7 +688,8 @@ func reformatExamples(sections [][]string) [][]string {
 
 				// Copy the section over. Note that we intentionally avoid copying the first line and any whitespace
 				// that follows it, as we will overwrite that content with the canonical header later.
-				for s = s[1:]; len(s) > 0 && isBlank(s[0]); s = s[1:] {
+				for s = s[1:]; len(s) > 0 && isBlank(s[0]); {
+					s = s[1:]
 				}
 
 				sectionCopy := make([]string, len(s)+2)


### PR DESCRIPTION
I am disabling the unused-parameter rule because we violate it many many times.