### PR TITLE
Move schema post-processing hook to ProviderInfo

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -112,6 +112,13 @@ type ProviderInfo struct {
 	// docs). The primary use case for this hook is to ignore problematic or flaky examples temporarily until the
 	// underlying issues are resolved and the examples can be rendered correctly.
 	SkipExamples func(SkipExamplesArgs) bool
+
+	// EXPERIMENTAL: the signature may change in minor releases.
+	//
+	// Optional function to post-process the generated schema spec after
+	// the bridge completed its original version based on the TF schema.
+	// A hook to enable custom schema modifications specific to a provider.
+	SchemaPostProcessor func(spec *pschema.PackageSpec)
 }
 
 func (info *ProviderInfo) GetConfig() map[string]*SchemaInfo {

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -57,12 +57,7 @@ const (
 )
 
 type Generator struct {
-	// Optional function to post-process the generated schema spec after
-	// the bridge completed its original version based on the TF schema.
-	// A hook to enable custom schema modifications specific to a provider.
-	SchemaPostProcessor func(spec *pschema.PackageSpec)
-
-	pkg              tokens.Package        // the Pulum package name (e.g. `gcp`)
+	pkg              tokens.Package        // the Pulumi package name (e.g. `gcp`)
 	version          string                // the package version.
 	language         Language              // the language runtime to generate.
 	info             tfbridge.ProviderInfo // the provider info for customizing code generation
@@ -864,8 +859,8 @@ func (g *Generator) Generate() error {
 	}
 
 	// Apply schema post-processing if defined in the provider.
-	if g.SchemaPostProcessor != nil {
-		g.SchemaPostProcessor(&pulumiPackageSpec)
+	if g.info.SchemaPostProcessor != nil {
+		g.info.SchemaPostProcessor(&pulumiPackageSpec)
 	}
 
 	// As a side-effect genPulumiSchema also populated rename tables.


### PR DESCRIPTION
Remake of #1248

I need to use the hook from a muxed provider which doesn't play nicely with my current API. So I suppose ProviderInfo is a more natural place to do so.