### PR TITLE
Expand strategy interface

### DIFF
--- a/pkg/tfbridge/tokens/mapped_modules.go
+++ b/pkg/tfbridge/tokens/mapped_modules.go
@@ -51,20 +51,22 @@ func MappedModules(
 
 	return b.Strategy{
 		Resource: knownModules(tfPackagePrefix, defaultModule, mods,
-			func(mod, tk string) (*b.ResourceInfo, error) {
+			func(mod, tk string, r *b.ResourceInfo) error {
 				tk, err := finalize(mod, tk)
 				if err != nil {
-					return nil, err
+					return err
 				}
-				return &b.ResourceInfo{Tok: tokens.Type(tk)}, nil
+				checkedApply(&r.Tok, tokens.Type(tk))
+				return nil
 			}, transform),
 		DataSource: knownModules(tfPackagePrefix, defaultModule, mods,
-			func(mod, tk string) (*b.DataSourceInfo, error) {
+			func(mod, tk string, d *b.DataSourceInfo) error {
 				tk, err := finalize(mod, "get"+tk)
 				if err != nil {
-					return nil, err
+					return err
 				}
-				return &b.DataSourceInfo{Tok: tokens.ModuleMember(tk)}, nil
+				checkedApply(&d.Tok, tokens.ModuleMember(tk))
+				return nil
 			}, transform),
 	}
 }

--- a/pkg/tfbridge/tokens/tokens.go
+++ b/pkg/tfbridge/tokens/tokens.go
@@ -52,3 +52,13 @@ func upperCamelCase(s string) string { return cgstrings.UppercaseFirst(camelCase
 func camelCase(s string) string {
 	return cgstrings.ModifyStringAroundDelimeter(s, "_", cgstrings.UppercaseFirst)
 }
+
+func checkedApply[T comparable](dst *T, src T) {
+	if dst == nil {
+		panic("checkedApply cannot be applied to nil dst")
+	}
+	var empty T
+	if (*dst) == empty {
+		*dst = src
+	}
+}

--- a/pkg/tfbridge/tokens_test.go
+++ b/pkg/tfbridge/tokens_test.go
@@ -42,6 +42,9 @@ func TestTokensSingleModule(t *testing.T) {
 				"foo_very_special_source": nil,
 			},
 		}).Shim(),
+		Resources: map[string]*tfbridge.ResourceInfo{
+			"foo_bar": {Docs: &tfbridge.DocInfo{}},
+		},
 	}
 
 	makeToken := func(module, name string) (string, error) {
@@ -54,7 +57,7 @@ func TestTokensSingleModule(t *testing.T) {
 	expectedResources := map[string]*tfbridge.ResourceInfo{
 		"foo_fizz_buzz":       {Tok: "foo:index:FizzBuzz"},
 		"foo_bar_hello_world": {Tok: "foo:index:BarHelloWorld"},
-		"foo_bar":             {Tok: "foo:index:Bar"},
+		"foo_bar":             {Tok: "foo:index:Bar", Docs: &tfbridge.DocInfo{}},
 	}
 	expectedDatasources := map[string]*tfbridge.DataSourceInfo{
 		"foo_source1":             {Tok: "foo:index:getSource1"},
@@ -165,9 +168,11 @@ func TestUnmappable(t *testing.T) {
 	}, func(module, name string) (string, error) {
 		return fmt.Sprintf("cs101:%s:%s", module, name), nil
 	})
-	strategy = strategy.Unmappable("five", "SomeGoodReason")
+	strategy = strategy.Ignore("five")
 	err := info.ComputeTokens(strategy)
-	assert.ErrorContains(t, err, "SomeGoodReason")
+	assert.NoError(t, err)
+	assert.Nilf(t, info.Resources["cs101_buzz_five"],
+		`We told the strategy to ignore tokens containing "five"`)
 
 	// Override the unmappable resources
 	info.Resources = map[string]*tfbridge.ResourceInfo{


### PR DESCRIPTION
This allows applying a strategy to an already existing mapping, such as `{Doc: ...}`.

Because it is no longer passable to call a generic strategy and then undo it (since strategies are now handed a copy of *T), I have changed `Unmappable` to `Ignore`. If a token is unmapped, it can be caught by our normal mechanism.

This opens up strategies to apply to arbitrary elements of `tfbride.{Resource,DataSource}Info` and to be layered in sequence.