### PR TITLE
Add a TODO for XComputedInput

### DIFF
--- a/pkg/tfbridge/diff.go
+++ b/pkg/tfbridge/diff.go
@@ -157,6 +157,10 @@ func makePropertyDiff(name, path string, v resource.PropertyValue, tfDiff shim.I
 	diff map[string]*pulumirpc.PropertyDiff, forceDiff *bool,
 	tfs shim.Schema, ps *SchemaInfo, finalize, rawNames bool) {
 
+	// TODO isComputedInput is determined from the top-level property ps (SchemaInfo). However it is sampled inside
+	// a visitor function that recurs into sub-properties. Therefore marking sub-properties with XComputedInput is
+	// not currently supported. To fix this, visitor should accept SchemaInfo pertaining to the sub-property being
+	// visited and determine isComputedInput from it.
 	isComputedInput := ps != nil && ps.XComputedInput
 	visitor := func(name, path string, v resource.PropertyValue) bool {
 		switch {


### PR DESCRIPTION
TO follow up on a previous PR #1251 the newly added XComputedInput property modifier does not work for nested properties, but can only be applied to a top-level resource property.