### PR TITLE
Add coverage for XComputedInputs

### DIFF
--- a/pkg/tfbridge/diff.go
+++ b/pkg/tfbridge/diff.go
@@ -170,7 +170,7 @@ func makePropertyDiff(name, path string, v resource.PropertyValue, tfDiff shim.I
 		case v.IsObject():
 			// If this value has a diff and is considered computed by Terraform, the diff will be woefully incomplete. In
 			// this case, do not recurse into the array; instead, just use the count diff for the details.
-			if d := tfDiff.Attribute(name + ".%"); d == nil || !d.NewComputed {
+			if d := tfDiff.Attribute(name + ".%"); d == nil || (!d.NewComputed && !isComputedInput) {
 				return true
 			}
 			name += ".%"


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/1260

Follows #1251 with extending coverage for every changed line.

One line is re-added as it apparently was lost in a bad merge - but is crucial for this to work correctly. 