### PR TITLE
Tolerate MaxItemsOne mismatches

### DIFF
--- a/pkg/tfshim/shim.go
+++ b/pkg/tfshim/shim.go
@@ -60,6 +60,27 @@ const (
 	TypeSet
 )
 
+func (i ValueType) String() string {
+	switch i {
+	case TypeBool:
+		return "Bool"
+	case TypeInt:
+		return "Int"
+	case TypeFloat:
+		return "Float"
+	case TypeString:
+		return "String"
+	case TypeList:
+		return "List"
+	case TypeMap:
+		return "Map"
+	case TypeSet:
+		return "Set"
+	default:
+		return ""
+	}
+}
+
 type SchemaDefaultFunc func() (interface{}, error)
 
 type SchemaStateFunc func(interface{}) string


### PR DESCRIPTION
Tolerate:
- [x] MaxItemsOne: true -> false
- [x] MaxItemsOne: false -> true

This is an information losing operation, since it doesn't handle the case of `[[T]] <-> [T]`. To simply the fix, I have chosen to do nothing in this situation. This PR will have no effect for nested lists.

Fixes #1295 

We handle the `MaxItemsOne: false -> true` case by default, but the test locks in behavior.