### PR TITLE
Fix no longer being able to place types in top-level modules #1300

### DIFF
--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -1005,12 +1005,12 @@ func modulePlacementForType(pkg tokens.Package, path paths.TypePath) tokens.Modu
 		// Supplementary types are typically defined one level up from the module defining the resource, but may
 		// also be defined in the same module.
 		m := res.Token().Module()
-		return parentModuleOrDefault(m, m)
+		return parentModuleOrSelf(m)
 	case *paths.DataSourceMemberPath:
 		// Supplementary types are typically defined one level up from the module defining the data source, but
 		// may also be defined in the same module.
 		m := pp.DataSourcePath.Token().Module()
-		return parentModuleOrDefault(m, m)
+		return parentModuleOrSelf(m)
 	case *paths.ConfigPath:
 		return tokens.NewModuleToken(pkg, configMod)
 	default:
@@ -1019,11 +1019,11 @@ func modulePlacementForType(pkg tokens.Package, path paths.TypePath) tokens.Modu
 	}
 }
 
-func parentModuleOrDefault(m tokens.Module, def tokens.Module) tokens.Module {
-	if m, ok := parentModule(m); ok {
+func parentModuleOrSelf(self tokens.Module) tokens.Module {
+	if m, ok := parentModule(self); ok {
 		return m
 	}
-	return def
+	return self
 }
 
 func parentModule(m tokens.Module) (tokens.Module, bool) {


### PR DESCRIPTION
Fixes #1300 

This restores the ability to place resources into top-level modules by making tokens like "myprovider:mymodule:MyResource", something that accidentally regressed and was not caught as most Pulumi-managed providers opt for a submodule scheme like "myprovider:mymodule/mysubmodule:MyResource", and the code started to accidentally assume this scheme.