### PR TITLE
Expose backend SDK generation options for each target language

### DIFF
--- a/internal/testprovider_sdkv2/cmd/pulumi-resource-tpsdkv2/schema.json
+++ b/internal/testprovider_sdkv2/cmd/pulumi-resource-tpsdkv2/schema.json
@@ -6,13 +6,14 @@
     },
     "language": {
         "nodejs": {
+            "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-tpsdkv2)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-tpsdkv2` repo](/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-tpsdkv2` repo](https://github.com/terraform-providers/terraform-provider-tpsdkv2/issues).",
             "compatibility": "tfbridge20",
-            "disableUnionOutputTypes": true,
-            "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-tpsdkv2)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-tpsdkv2` repo](/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-tpsdkv2` repo](https://github.com/terraform-providers/terraform-provider-tpsdkv2/issues)."
+            "disableUnionOutputTypes": true
         },
         "python": {
+            "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-tpsdkv2)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-tpsdkv2` repo](/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-tpsdkv2` repo](https://github.com/terraform-providers/terraform-provider-tpsdkv2/issues).",
             "compatibility": "tfbridge20",
-            "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-tpsdkv2)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-tpsdkv2` repo](/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-tpsdkv2` repo](https://github.com/terraform-providers/terraform-provider-tpsdkv2/issues)."
+            "pyproject": {}
         }
     },
     "config": {

--- a/pf/tests/internal/testprovider/cmd/pulumi-resource-muxedrandom/schema.json
+++ b/pf/tests/internal/testprovider/cmd/pulumi-resource-muxedrandom/schema.json
@@ -14,13 +14,15 @@
     },
     "language": {
         "nodejs": {
+            "packageDescription": "A Pulumi package to safely use randomness in Pulumi programs.",
+            "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-muxedrandom)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-muxedrandom` repo](https://github.com/pulumi/pulumi-random/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-muxedrandom` repo](https://github.com/terraform-providers/terraform-provider-muxedrandom/issues).",
             "compatibility": "tfbridge20",
-            "disableUnionOutputTypes": true,
-            "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-muxedrandom)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-muxedrandom` repo](https://github.com/pulumi/pulumi-random/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-muxedrandom` repo](https://github.com/terraform-providers/terraform-provider-muxedrandom/issues)."
+            "disableUnionOutputTypes": true
         },
         "python": {
+            "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-muxedrandom)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-muxedrandom` repo](https://github.com/pulumi/pulumi-random/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-muxedrandom` repo](https://github.com/terraform-providers/terraform-provider-muxedrandom/issues).",
             "compatibility": "tfbridge20",
-            "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-muxedrandom)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-muxedrandom` repo](https://github.com/pulumi/pulumi-random/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-muxedrandom` repo](https://github.com/terraform-providers/terraform-provider-muxedrandom/issues)."
+            "pyproject": {}
         }
     },
     "config": {},

--- a/pf/tests/internal/testprovider/cmd/pulumi-resource-random/schema.json
+++ b/pf/tests/internal/testprovider/cmd/pulumi-resource-random/schema.json
@@ -14,41 +14,38 @@
     },
     "language": {
         "csharp": {
-            "compatibility": "tfbridge20",
+            "packageReferences": {
+                "Pulumi": "3.*"
+            },
             "namespaces": {
                 "random": "Random"
             },
-            "packageReferences": {
-                "Pulumi": "3.*"
-            }
+            "compatibility": "tfbridge20"
         },
         "go": {
-            "generateExtraInputTypes": true,
+            "importBasePath": "github.com/pulumi/pulumi-random/sdk/go/random",
             "generateResourceContainerTypes": true,
-            "importBasePath": "github.com/pulumi/pulumi-random/sdk/go/random"
+            "generateExtraInputTypes": true
         },
         "nodejs": {
-            "compatibility": "tfbridge20",
+            "packageDescription": "A Pulumi package to safely use randomness in Pulumi programs.",
+            "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-random)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-random` repo](https://github.com/pulumi/pulumi-random/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-random` repo](https://github.com/terraform-providers/terraform-provider-random/issues).",
             "dependencies": {
                 "@pulumi/pulumi": "^3.0.0"
             },
             "devDependencies": {
                 "@types/node": "^10.0.0"
             },
-            "disableUnionOutputTypes": true,
-            "packageDescription": "A Pulumi package to safely use randomness in Pulumi programs.",
-            "packageName": "",
-            "pluginName": "",
-            "pluginVersion": "",
-            "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-random)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-random` repo](https://github.com/pulumi/pulumi-random/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-random` repo](https://github.com/terraform-providers/terraform-provider-random/issues).",
-            "typescriptVersion": ""
+            "compatibility": "tfbridge20",
+            "disableUnionOutputTypes": true
         },
         "python": {
-            "compatibility": "tfbridge20",
-            "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-random)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-random` repo](https://github.com/pulumi/pulumi-random/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-random` repo](https://github.com/terraform-providers/terraform-provider-random/issues).",
             "requires": {
                 "pulumi": "\u003e=3.0.0,\u003c4.0.0"
-            }
+            },
+            "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-random)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-random` repo](https://github.com/pulumi/pulumi-random/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-random` repo](https://github.com/terraform-providers/terraform-provider-random/issues).",
+            "compatibility": "tfbridge20",
+            "pyproject": {}
         }
     },
     "config": {},

--- a/pf/tests/internal/testprovider/cmd/pulumi-resource-testbridge/schema.json
+++ b/pf/tests/internal/testprovider/cmd/pulumi-resource-testbridge/schema.json
@@ -10,13 +10,15 @@
     },
     "language": {
         "nodejs": {
+            "packageDescription": "A Pulumi package to test pulumi-terraform-bridge Plugin Framework support.",
+            "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-testbridge)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-testbridge` repo](https://github.com/pulumi/pulumi-terraform-bridge/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-testbridge` repo](https://github.com/terraform-providers/terraform-provider-testbridge/issues).",
             "compatibility": "tfbridge20",
-            "disableUnionOutputTypes": true,
-            "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-testbridge)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-testbridge` repo](https://github.com/pulumi/pulumi-terraform-bridge/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-testbridge` repo](https://github.com/terraform-providers/terraform-provider-testbridge/issues)."
+            "disableUnionOutputTypes": true
         },
         "python": {
+            "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-testbridge)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-testbridge` repo](https://github.com/pulumi/pulumi-terraform-bridge/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-testbridge` repo](https://github.com/terraform-providers/terraform-provider-testbridge/issues).",
             "compatibility": "tfbridge20",
-            "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-testbridge)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-testbridge` repo](https://github.com/pulumi/pulumi-terraform-bridge/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-testbridge` repo](https://github.com/terraform-providers/terraform-provider-testbridge/issues)."
+            "pyproject": {}
         }
     },
     "config": {

--- a/pf/tests/internal/testprovider/cmd/pulumi-resource-tls/schema.json
+++ b/pf/tests/internal/testprovider/cmd/pulumi-resource-tls/schema.json
@@ -14,41 +14,38 @@
     },
     "language": {
         "csharp": {
-            "compatibility": "tfbridge20",
+            "packageReferences": {
+                "Pulumi": "3.*"
+            },
             "namespaces": {
                 "tls": "Tls"
             },
-            "packageReferences": {
-                "Pulumi": "3.*"
-            }
+            "compatibility": "tfbridge20"
         },
         "go": {
-            "generateExtraInputTypes": true,
+            "importBasePath": "github.com/pulumi/pulumi-tls/sdk/v4/go/tls",
             "generateResourceContainerTypes": true,
-            "importBasePath": "github.com/pulumi/pulumi-tls/sdk/v4/go/tls"
+            "generateExtraInputTypes": true
         },
         "nodejs": {
-            "compatibility": "tfbridge20",
+            "packageDescription": "A Pulumi package to create TLS resources in Pulumi programs.",
+            "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-tls)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-tls` repo](https://github.com/pulumi/pulumi-tls/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-tls` repo](https://github.com/terraform-providers/terraform-provider-tls/issues).",
             "dependencies": {
                 "@pulumi/pulumi": "^3.0.0"
             },
             "devDependencies": {
                 "@types/node": "^10.0.0"
             },
-            "disableUnionOutputTypes": true,
-            "packageDescription": "A Pulumi package to create TLS resources in Pulumi programs.",
-            "packageName": "",
-            "pluginName": "",
-            "pluginVersion": "",
-            "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-tls)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-tls` repo](https://github.com/pulumi/pulumi-tls/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-tls` repo](https://github.com/terraform-providers/terraform-provider-tls/issues).",
-            "typescriptVersion": ""
+            "compatibility": "tfbridge20",
+            "disableUnionOutputTypes": true
         },
         "python": {
-            "compatibility": "tfbridge20",
-            "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-tls)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-tls` repo](https://github.com/pulumi/pulumi-tls/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-tls` repo](https://github.com/terraform-providers/terraform-provider-tls/issues).",
             "requires": {
                 "pulumi": "\u003e=3.0.0,\u003c4.0.0"
-            }
+            },
+            "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-tls)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-tls` repo](https://github.com/pulumi/pulumi-tls/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-tls` repo](https://github.com/terraform-providers/terraform-provider-tls/issues).",
+            "compatibility": "tfbridge20",
+            "pyproject": {}
         }
     },
     "config": {

--- a/pkg/tf2pulumi/convert/testdata/schemas/blocks.json
+++ b/pkg/tf2pulumi/convert/testdata/schemas/blocks.json
@@ -6,13 +6,14 @@
   },
   "language": {
     "nodejs": {
+      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-blocks)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-blocks` repo](/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-blocks` repo](https://github.com/terraform-providers/terraform-provider-blocks/issues).",
       "compatibility": "tfbridge20",
-      "disableUnionOutputTypes": true,
-      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-blocks)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-blocks` repo](/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-blocks` repo](https://github.com/terraform-providers/terraform-provider-blocks/issues)."
+      "disableUnionOutputTypes": true
     },
     "python": {
+      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-blocks)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-blocks` repo](/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-blocks` repo](https://github.com/terraform-providers/terraform-provider-blocks/issues).",
       "compatibility": "tfbridge20",
-      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-blocks)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-blocks` repo](/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-blocks` repo](https://github.com/terraform-providers/terraform-provider-blocks/issues)."
+      "pyproject": {}
     }
   },
   "config": {},

--- a/pkg/tf2pulumi/convert/testdata/schemas/complex.json
+++ b/pkg/tf2pulumi/convert/testdata/schemas/complex.json
@@ -6,13 +6,14 @@
   },
   "language": {
     "nodejs": {
+      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-complex)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-complex` repo](/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-complex` repo](https://github.com/terraform-providers/terraform-provider-complex/issues).",
       "compatibility": "tfbridge20",
-      "disableUnionOutputTypes": true,
-      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-complex)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-complex` repo](/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-complex` repo](https://github.com/terraform-providers/terraform-provider-complex/issues)."
+      "disableUnionOutputTypes": true
     },
     "python": {
+      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-complex)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-complex` repo](/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-complex` repo](https://github.com/terraform-providers/terraform-provider-complex/issues).",
       "compatibility": "tfbridge20",
-      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-complex)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-complex` repo](/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-complex` repo](https://github.com/terraform-providers/terraform-provider-complex/issues)."
+      "pyproject": {}
     }
   },
   "config": {},

--- a/pkg/tf2pulumi/convert/testdata/schemas/renames.json
+++ b/pkg/tf2pulumi/convert/testdata/schemas/renames.json
@@ -6,13 +6,14 @@
   },
   "language": {
     "nodejs": {
+      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-renames)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-renames` repo](/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-renames` repo](https://github.com/terraform-providers/terraform-provider-renames/issues).",
       "compatibility": "tfbridge20",
-      "disableUnionOutputTypes": true,
-      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-renames)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-renames` repo](/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-renames` repo](https://github.com/terraform-providers/terraform-provider-renames/issues)."
+      "disableUnionOutputTypes": true
     },
     "python": {
+      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-renames)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-renames` repo](/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-renames` repo](https://github.com/terraform-providers/terraform-provider-renames/issues).",
       "compatibility": "tfbridge20",
-      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-renames)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-renames` repo](/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-renames` repo](https://github.com/terraform-providers/terraform-provider-renames/issues)."
+      "pyproject": {}
     }
   },
   "config": {},

--- a/pkg/tf2pulumi/convert/testdata/schemas/simple.json
+++ b/pkg/tf2pulumi/convert/testdata/schemas/simple.json
@@ -6,13 +6,14 @@
   },
   "language": {
     "nodejs": {
+      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-simple)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-simple` repo](/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-simple` repo](https://github.com/terraform-providers/terraform-provider-simple/issues).",
       "compatibility": "tfbridge20",
-      "disableUnionOutputTypes": true,
-      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-simple)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-simple` repo](/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-simple` repo](https://github.com/terraform-providers/terraform-provider-simple/issues)."
+      "disableUnionOutputTypes": true
     },
     "python": {
+      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-simple)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-simple` repo](/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-simple` repo](https://github.com/terraform-providers/terraform-provider-simple/issues).",
       "compatibility": "tfbridge20",
-      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-simple)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-simple` repo](/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-simple` repo](https://github.com/terraform-providers/terraform-provider-simple/issues)."
+      "pyproject": {}
     }
   },
   "config": {},

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -24,6 +24,7 @@ import (
 	"golang.org/x/net/context"
 
 	gogen "github.com/pulumi/pulumi/pkg/v3/codegen/go"
+	pygen "github.com/pulumi/pulumi/pkg/v3/codegen/python"
 	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -501,6 +502,14 @@ type PythonInfo struct {
 	Overlay       *OverlayInfo      // optional overlay information for augmented code-generation.
 	UsesIOClasses bool              // Deprecated: No longer required, all providers use IO classes.
 	PackageName   string            // Name of the Python package to generate
+
+	// Configures language-specific extensions for Python in the generated Pulumi Package Schema.
+	//
+	// See also https://www.pulumi.com/docs/using-pulumi/pulumi-packages/schema/#language-specific-extensions
+	//
+	// Note that for PythonPackageInfo conflicts with setting top-level properties such as PackageName. Use nested
+	// properties such as PythonPackageInfo.PackageName instead.
+	PythonPackageInfo *pygen.PackageInfo
 }
 
 // GolangInfo contains optional overlay information for Golang code-generation.

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -508,7 +508,7 @@ type JavaScriptInfo struct {
 	ExtraTypeScriptFiles []string
 
 	// Determines whether to make single-return-value methods return an output object or the single value.
-	LiftSingleValueMethodReturns bool `json:"liftSingleValueMethodReturns,omitempty"`
+	LiftSingleValueMethodReturns bool
 
 	// Respect the Pkg.Version field in the schema
 	RespectSchemaVersion bool
@@ -537,7 +537,7 @@ type PythonInfo struct {
 	ModuleNameOverrides map[string]string
 
 	// Determines whether to make single-return-value methods return an output object or the single value.
-	LiftSingleValueMethodReturns bool `json:"liftSingleValueMethodReturns,omitempty"`
+	LiftSingleValueMethodReturns bool
 
 	// Respect the Pkg.Version field for emitted code.
 	RespectSchemaVersion bool

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -23,8 +23,6 @@ import (
 	"github.com/blang/semver"
 	"golang.org/x/net/context"
 
-	gogen "github.com/pulumi/pulumi/pkg/v3/codegen/go"
-	pygen "github.com/pulumi/pulumi/pkg/v3/codegen/python"
 	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -494,6 +492,32 @@ type JavaScriptInfo struct {
 	// different from the package name.  The version of the plugin, which might be
 	// different from the version of the package.
 	PluginVersion string
+
+	// A map containing overrides for module names to package names.
+	ModuleToPackage map[string]string
+
+	// An indicator for whether the package contains enums.
+	ContainsEnums bool
+
+	// A map allowing you to map the name of a provider to the name of the module encapsulating the provider.
+	ProviderNameToModuleName map[string]string
+
+	// Additional files to include in TypeScript compilation. These paths are added to the `files` section of the
+	// generated `tsconfig.json`. A typical use case for this is compiling hand-authored unit test files that check
+	// the generated code.
+	ExtraTypeScriptFiles []string
+
+	// Determines whether to make single-return-value methods return an output object or the single value.
+	LiftSingleValueMethodReturns bool `json:"liftSingleValueMethodReturns,omitempty"`
+
+	// Respect the Pkg.Version field in the schema
+	RespectSchemaVersion bool
+
+	// Experimental flag that permits `import type *` style code to be generated to optimize startup time of
+	// programs consuming the provider by minimizing the set of Node modules loaded at startup. Turning this on may
+	// currently generate non-compiling code for some providers; but if the code compiles it is safe to use. Also,
+	// turning this on requires TypeScript 3.8 or higher to compile the generated code.
+	UseTypeOnlyReferences bool
 }
 
 // PythonInfo contains optional overlay information for Python code-generation.
@@ -503,13 +527,25 @@ type PythonInfo struct {
 	UsesIOClasses bool              // Deprecated: No longer required, all providers use IO classes.
 	PackageName   string            // Name of the Python package to generate
 
-	// Configures language-specific extensions for Python in the generated Pulumi Package Schema.
+	// PythonRequires determines the Python versions that the generated provider supports
+	PythonRequires string
+
+	// Optional overrides for Pulumi module names
 	//
-	// See also https://www.pulumi.com/docs/using-pulumi/pulumi-packages/schema/#language-specific-extensions
+	//    { "flowcontrol.apiserver.k8s.io/v1alpha1": "flowcontrol/v1alpha1" }
 	//
-	// Note that for PythonPackageInfo conflicts with setting top-level properties such as PackageName. Use nested
-	// properties such as PythonPackageInfo.PackageName instead.
-	PythonPackageInfo *pygen.PackageInfo
+	ModuleNameOverrides map[string]string
+
+	// Determines whether to make single-return-value methods return an output object or the single value.
+	LiftSingleValueMethodReturns bool `json:"liftSingleValueMethodReturns,omitempty"`
+
+	// Respect the Pkg.Version field for emitted code.
+	RespectSchemaVersion bool
+
+	// If enabled, a pyproject.toml file will be generated.
+	PyProject struct {
+		Enabled bool
+	}
 }
 
 // GolangInfo contains optional overlay information for Golang code-generation.
@@ -518,13 +554,62 @@ type GolangInfo struct {
 	ImportBasePath                 string       // Base import path for package.
 	Overlay                        *OverlayInfo // optional overlay information for augmented code-generation.
 
-	// Configures language-specific extensions for Go in the generated Pulumi Package Schema.
+	// Module path for go.mod
 	//
-	// See also https://www.pulumi.com/docs/using-pulumi/pulumi-packages/schema/#language-specific-extensions
+	//   go get github.com/pulumi/pulumi-aws-native/sdk/go/aws@v0.16.0
+	//          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ module path
+	//                                                  ~~~~~~ package path - can be any number of path parts
+	//                                                         ~~~~~~~ version
+	ModulePath string
+
+	// Explicit package name, which may be different to the import path.
+	RootPackageName string
+
+	// Map from module -> package name
 	//
-	// Note that for GoPackageInfo conflicts with setting GenerateResourceContainerTypes and ImportBasePath, please
-	// set nested properties such as GoPackageInfo.ImportBasePath instead..
-	GoPackageInfo *gogen.GoPackageInfo
+	//    { "flowcontrol.apiserver.k8s.io/v1alpha1": "flowcontrol/v1alpha1" }
+	//
+	ModuleToPackage map[string]string
+
+	// Map from package name -> package alias
+	//
+	//    { "github.com/pulumi/pulumi-kubernetes/sdk/go/kubernetes/flowcontrol/v1alpha1": "flowcontrolv1alpha1" }
+	//
+	PackageImportAliases map[string]string
+
+	// The version of the Pulumi SDK used with this provider, e.g. 3.
+	// Used to generate doc links for pulumi builtin types. If omitted, the latest SDK version is used.
+	PulumiSDKVersion int
+
+	// Feature flag to disable generating `$fnOutput` invoke
+	// function versions to save space.
+	DisableFunctionOutputVersions bool
+
+	// Determines whether to make single-return-value methods return an output struct or the value.
+	LiftSingleValueMethodReturns bool
+
+	// Feature flag to disable generating input type registration. This is a
+	// space saving measure.
+	DisableInputTypeRegistrations bool
+
+	// Feature flag to disable generating Pulumi object default functions. This is a
+	// space saving measure.
+	DisableObjectDefaults bool
+
+	// GenerateExtraInputTypes determines whether or not the code generator generates input (and output) types for
+	// all plain types, instead of for only types that are used as input/output types.
+	GenerateExtraInputTypes bool
+
+	// omitExtraInputTypes determines whether the code generator generates input (and output) types
+	// for all plain types, instead of for only types that are used as input/output types.
+	OmitExtraInputTypes bool
+
+	// Respect the Pkg.Version field for emitted code.
+	RespectSchemaVersion bool
+
+	// InternalDependencies are blank imports that are emitted in the SDK so that `go mod tidy` does not remove the
+	// associated module dependencies from the SDK's go.mod.
+	InternalDependencies []string
 }
 
 // CSharpInfo contains optional overlay information for C# code-generation.

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -618,6 +618,16 @@ type CSharpInfo struct {
 	Overlay           *OverlayInfo      // optional overlay information for augmented code-generation.
 	Namespaces        map[string]string // Known .NET namespaces with proper capitalization.
 	RootNamespace     string            // The root namespace if setting to something other than Pulumi in the package name
+
+	Compatibility          string
+	DictionaryConstructors bool
+	ProjectReferences      []string
+
+	// Determines whether to make single-return-value methods return an output object or the single value.
+	LiftSingleValueMethodReturns bool
+
+	// Allow the Pkg.Version field to filter down to emitted code.
+	RespectSchemaVersion bool
 }
 
 type JavaInfo struct {

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -630,6 +630,8 @@ type CSharpInfo struct {
 	RespectSchemaVersion bool
 }
 
+// See https://github.com/pulumi/pulumi-java/blob/main/pkg/codegen/java/package_info.go#L35C1-L108C1 documenting
+// supported options.
 type JavaInfo struct {
 	BasePackage string // the Base package for the Java SDK
 
@@ -641,6 +643,10 @@ type JavaInfo struct {
 	// given version of io.github.gradle-nexus.publish-plugin in
 	// the generated Gradle build files.
 	GradleNexusPublishPluginVersion string
+
+	Packages     map[string]string `json:"packages,omitempty"`
+	Dependencies map[string]string `json:"dependencies,omitempty"`
+	GradleTest   string            `json:"gradleTest"`
 }
 
 // PreConfigureCallback is a function to invoke prior to calling the TF provider Configure

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -23,6 +23,7 @@ import (
 	"github.com/blang/semver"
 	"golang.org/x/net/context"
 
+	gogen "github.com/pulumi/pulumi/pkg/v3/codegen/go"
 	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -507,6 +508,14 @@ type GolangInfo struct {
 	GenerateResourceContainerTypes bool         // Generate container types for resources e.g. arrays, maps, pointers etc.
 	ImportBasePath                 string       // Base import path for package.
 	Overlay                        *OverlayInfo // optional overlay information for augmented code-generation.
+
+	// Configures language-specific extensions for Go in the generated Pulumi Package Schema.
+	//
+	// See also https://www.pulumi.com/docs/using-pulumi/pulumi-packages/schema/#language-specific-extensions
+	//
+	// Note that for GoPackageInfo conflicts with setting GenerateResourceContainerTypes and ImportBasePath, please
+	// set nested properties such as GoPackageInfo.ImportBasePath instead..
+	GoPackageInfo *gogen.GoPackageInfo
 }
 
 // CSharpInfo contains optional overlay information for C# code-generation.

--- a/pkg/tfgen/generate_schema_test.go
+++ b/pkg/tfgen/generate_schema_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen/internal/testprovider"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/metadata"
+	csgen "github.com/pulumi/pulumi/pkg/v3/codegen/dotnet"
 	gogen "github.com/pulumi/pulumi/pkg/v3/codegen/go"
 	tsgen "github.com/pulumi/pulumi/pkg/v3/codegen/nodejs"
 	pygen "github.com/pulumi/pulumi/pkg/v3/codegen/python"
@@ -311,6 +312,11 @@ func TestPropagateLanguageOptions(t *testing.T) {
 		RespectSchemaVersion: true,
 	}
 
+	require.Nil(t, provider.CSharp)
+	provider.CSharp = &tfbridge.CSharpInfo{
+		RespectSchemaVersion: true,
+	}
+
 	schema, err := GenerateSchema(provider, diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{
 		Color: colors.Never,
 	}))
@@ -342,4 +348,10 @@ func TestPropagateLanguageOptions(t *testing.T) {
 		assert.True(t, actual.RespectSchemaVersion)
 	})
 
+	t.Run("csharp", func(t *testing.T) {
+		actual := csgen.CSharpPackageInfo{}
+		err = json.Unmarshal(schema.Language["csharp"], &actual)
+		require.NoError(t, err)
+		assert.True(t, actual.RespectSchemaVersion)
+	})
 }

--- a/pkg/tfgen/generate_schema_test.go
+++ b/pkg/tfgen/generate_schema_test.go
@@ -301,9 +301,13 @@ func TestPropagateLanguageOptions(t *testing.T) {
 	schema, err := GenerateSchema(provider, diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{
 		Color: colors.Never,
 	}))
-
 	assert.NoError(t, err)
-	bridgetesting.AssertEqualsJSONFile(t, "test_data/test-propagate-language-options.json", schema)
+
+	t.Run("all-languages", func(t *testing.T) {
+		// If this test fails, you may run the test with PULUMI_ACCEPT=1 environment variable to reset expected
+		// schema file with the actually generated schema.
+		bridgetesting.AssertEqualsJSONFile(t, "test_data/test-propagate-language-options.json", schema)
+	})
 
 	t.Run("golang", func(t *testing.T) {
 		actualGo := gogen.GoPackageInfo{}

--- a/pkg/tfgen/generate_schema_test.go
+++ b/pkg/tfgen/generate_schema_test.go
@@ -313,8 +313,14 @@ func TestPropagateLanguageOptions(t *testing.T) {
 	}
 
 	require.Nil(t, provider.CSharp)
+
 	provider.CSharp = &tfbridge.CSharpInfo{
 		RespectSchemaVersion: true,
+	}
+
+	require.Nil(t, provider.Java)
+	provider.Java = &tfbridge.JavaInfo{
+		BuildFiles: "gradle",
 	}
 
 	schema, err := GenerateSchema(provider, diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{
@@ -353,5 +359,12 @@ func TestPropagateLanguageOptions(t *testing.T) {
 		err = json.Unmarshal(schema.Language["csharp"], &actual)
 		require.NoError(t, err)
 		assert.True(t, actual.RespectSchemaVersion)
+	})
+
+	t.Run("java", func(t *testing.T) {
+		actual := map[string]any{}
+		err = json.Unmarshal(schema.Language["java"], &actual)
+		require.NoError(t, err)
+		assert.Equal(t, "gradle", actual["buildFiles"])
 	})
 }

--- a/pkg/tfgen/test_data/regress-611-schema.json
+++ b/pkg/tfgen/test_data/regress-611-schema.json
@@ -15,13 +15,15 @@
   },
   "language": {
     "nodejs": {
+      "packageDescription": "A Pulumi package for creating and managing Amazon Web Services (AWS) cloud resources.",
+      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/hashicorp/terraform-provider-aws)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-aws` repo](https://github.com/phillipedwards/pulumi-aws/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-aws` repo](https://github.com/hashicorp/terraform-provider-aws/issues).",
       "compatibility": "tfbridge20",
-      "disableUnionOutputTypes": true,
-      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/hashicorp/terraform-provider-aws)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-aws` repo](https://github.com/phillipedwards/pulumi-aws/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-aws` repo](https://github.com/hashicorp/terraform-provider-aws/issues)."
+      "disableUnionOutputTypes": true
     },
     "python": {
+      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/hashicorp/terraform-provider-aws)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-aws` repo](https://github.com/phillipedwards/pulumi-aws/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-aws` repo](https://github.com/hashicorp/terraform-provider-aws/issues).",
       "compatibility": "tfbridge20",
-      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/hashicorp/terraform-provider-aws)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-aws` repo](https://github.com/phillipedwards/pulumi-aws/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-aws` repo](https://github.com/hashicorp/terraform-provider-aws/issues)."
+      "pyproject": {}
     }
   },
   "config": {

--- a/pkg/tfgen/test_data/regress-minicloudflare-schema.json
+++ b/pkg/tfgen/test_data/regress-minicloudflare-schema.json
@@ -14,13 +14,15 @@
   },
   "language": {
     "nodejs": {
+      "packageDescription": "A Pulumi package to safely use cloudflare in Pulumi programs.",
+      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-cloudflare)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-cloudflare` repo](https://github.com/pulumi/pulumi-cloudflare/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-cloudflare` repo](https://github.com/terraform-providers/terraform-provider-cloudflare/issues).",
       "compatibility": "tfbridge20",
-      "disableUnionOutputTypes": true,
-      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-cloudflare)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-cloudflare` repo](https://github.com/pulumi/pulumi-cloudflare/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-cloudflare` repo](https://github.com/terraform-providers/terraform-provider-cloudflare/issues)."
+      "disableUnionOutputTypes": true
     },
     "python": {
+      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-cloudflare)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-cloudflare` repo](https://github.com/pulumi/pulumi-cloudflare/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-cloudflare` repo](https://github.com/terraform-providers/terraform-provider-cloudflare/issues).",
       "compatibility": "tfbridge20",
-      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-cloudflare)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-cloudflare` repo](https://github.com/pulumi/pulumi-cloudflare/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-cloudflare` repo](https://github.com/terraform-providers/terraform-provider-cloudflare/issues)."
+      "pyproject": {}
     }
   },
   "config": {},

--- a/pkg/tfgen/test_data/regress-minirandom-schema.json
+++ b/pkg/tfgen/test_data/regress-minirandom-schema.json
@@ -14,13 +14,15 @@
   },
   "language": {
     "nodejs": {
+      "packageDescription": "A Pulumi package to safely use randomness in Pulumi programs.",
+      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-random)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-random` repo](https://github.com/pulumi/pulumi-random/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-random` repo](https://github.com/terraform-providers/terraform-provider-random/issues).",
       "compatibility": "tfbridge20",
-      "disableUnionOutputTypes": true,
-      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-random)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-random` repo](https://github.com/pulumi/pulumi-random/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-random` repo](https://github.com/terraform-providers/terraform-provider-random/issues)."
+      "disableUnionOutputTypes": true
     },
     "python": {
+      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-random)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-random` repo](https://github.com/pulumi/pulumi-random/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-random` repo](https://github.com/terraform-providers/terraform-provider-random/issues).",
       "compatibility": "tfbridge20",
-      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-random)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-random` repo](https://github.com/pulumi/pulumi-random/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-random` repo](https://github.com/terraform-providers/terraform-provider-random/issues)."
+      "pyproject": {}
     }
   },
   "config": {},

--- a/pkg/tfgen/test_data/test-propagate-language-options.json
+++ b/pkg/tfgen/test_data/test-propagate-language-options.json
@@ -1,0 +1,130 @@
+{
+  "name": "random",
+  "description": "A Pulumi package to safely use randomness in Pulumi programs.",
+  "keywords": [
+    "pulumi",
+    "random"
+  ],
+  "homepage": "https://pulumi.io",
+  "license": "Apache-2.0",
+  "attribution": "This Pulumi package is based on the [`random` Terraform Provider](https://github.com/terraform-providers/terraform-provider-random).",
+  "repository": "https://github.com/pulumi/pulumi-random",
+  "meta": {
+    "moduleFormat": "(.*)(?:/[^/]*)"
+  },
+  "language": {
+    "go": {
+      "disableFunctionOutputVersions": true,
+      "respectSchemaVersion": true
+    },
+    "nodejs": {
+      "compatibility": "tfbridge20",
+      "disableUnionOutputTypes": true,
+      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-random)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-random` repo](https://github.com/pulumi/pulumi-random/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-random` repo](https://github.com/terraform-providers/terraform-provider-random/issues)."
+    },
+    "python": {
+      "compatibility": "tfbridge20",
+      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-random)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-random` repo](https://github.com/pulumi/pulumi-random/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-random` repo](https://github.com/terraform-providers/terraform-provider-random/issues)."
+    }
+  },
+  "config": {},
+  "provider": {
+    "description": "The provider type for the random package. By default, resources use package-wide configuration\nsettings, however an explicit `Provider` instance may be created and passed during resource\nconstruction to achieve fine-grained programmatic control over provider settings. See the\n[documentation](https://www.pulumi.com/docs/reference/programming-model/#providers) for more information.\n"
+  },
+  "resources": {
+    "random:index/randomInteger:RandomInteger": {
+      "properties": {
+        "keepers": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "pulumi.json#/Any"
+          },
+          "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+        },
+        "max": {
+          "type": "integer",
+          "description": "The maximum inclusive value of the range.\n"
+        },
+        "min": {
+          "type": "integer",
+          "description": "The minimum inclusive value of the range.\n"
+        },
+        "result": {
+          "type": "integer",
+          "description": "The random integer result.\n"
+        },
+        "seed": {
+          "type": "string",
+          "description": "A custom seed to always produce the same value.\n"
+        }
+      },
+      "required": [
+        "max",
+        "min",
+        "result"
+      ],
+      "inputProperties": {
+        "keepers": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "pulumi.json#/Any"
+          },
+          "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n",
+          "willReplaceOnChanges": true
+        },
+        "max": {
+          "type": "integer",
+          "description": "The maximum inclusive value of the range.\n",
+          "willReplaceOnChanges": true
+        },
+        "min": {
+          "type": "integer",
+          "description": "The minimum inclusive value of the range.\n",
+          "willReplaceOnChanges": true
+        },
+        "seed": {
+          "type": "string",
+          "description": "A custom seed to always produce the same value.\n",
+          "willReplaceOnChanges": true
+        }
+      },
+      "requiredInputs": [
+        "max",
+        "min"
+      ],
+      "stateInputs": {
+        "description": "Input properties used for looking up and filtering RandomInteger resources.\n",
+        "properties": {
+          "keepers": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "pulumi.json#/Any"
+            },
+            "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n",
+            "willReplaceOnChanges": true
+          },
+          "max": {
+            "type": "integer",
+            "description": "The maximum inclusive value of the range.\n",
+            "willReplaceOnChanges": true
+          },
+          "min": {
+            "type": "integer",
+            "description": "The minimum inclusive value of the range.\n",
+            "willReplaceOnChanges": true
+          },
+          "result": {
+            "type": "integer",
+            "description": "The random integer result.\n"
+          },
+          "seed": {
+            "type": "string",
+            "description": "A custom seed to always produce the same value.\n",
+            "willReplaceOnChanges": true
+          }
+        },
+        "type": "object"
+      }
+    }
+  }
+}

--- a/pkg/tfgen/test_data/test-propagate-language-options.json
+++ b/pkg/tfgen/test_data/test-propagate-language-options.json
@@ -23,8 +23,10 @@
       "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-random)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-random` repo](https://github.com/pulumi/pulumi-random/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-random` repo](https://github.com/terraform-providers/terraform-provider-random/issues)."
     },
     "python": {
+      "readme": "MY README",
       "compatibility": "tfbridge20",
-      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-random)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-random` repo](https://github.com/pulumi/pulumi-random/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-random` repo](https://github.com/terraform-providers/terraform-provider-random/issues)."
+      "respectSchemaVersion": true,
+      "pyproject": {}
     }
   },
   "config": {},

--- a/pkg/tfgen/test_data/test-propagate-language-options.json
+++ b/pkg/tfgen/test_data/test-propagate-language-options.json
@@ -13,6 +13,10 @@
     "moduleFormat": "(.*)(?:/[^/]*)"
   },
   "language": {
+    "csharp": {
+      "compatibility": "tfbridge20",
+      "respectSchemaVersion": true
+    },
     "go": {
       "disableFunctionOutputVersions": true,
       "generateExtraInputTypes": true,

--- a/pkg/tfgen/test_data/test-propagate-language-options.json
+++ b/pkg/tfgen/test_data/test-propagate-language-options.json
@@ -15,15 +15,18 @@
   "language": {
     "go": {
       "disableFunctionOutputVersions": true,
+      "generateExtraInputTypes": true,
       "respectSchemaVersion": true
     },
     "nodejs": {
+      "packageDescription": "A Pulumi package to safely use randomness in Pulumi programs.",
+      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-random)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-random` repo](https://github.com/pulumi/pulumi-random/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-random` repo](https://github.com/terraform-providers/terraform-provider-random/issues).",
       "compatibility": "tfbridge20",
       "disableUnionOutputTypes": true,
-      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-random)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-random` repo](https://github.com/pulumi/pulumi-random/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-random` repo](https://github.com/terraform-providers/terraform-provider-random/issues)."
+      "respectSchemaVersion": true
     },
     "python": {
-      "readme": "MY README",
+      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-random)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-random` repo](https://github.com/pulumi/pulumi-random/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-random` repo](https://github.com/terraform-providers/terraform-provider-random/issues).",
       "compatibility": "tfbridge20",
       "respectSchemaVersion": true,
       "pyproject": {}

--- a/pkg/tfgen/test_data/test-propagate-language-options.json
+++ b/pkg/tfgen/test_data/test-propagate-language-options.json
@@ -22,6 +22,12 @@
       "generateExtraInputTypes": true,
       "respectSchemaVersion": true
     },
+    "java": {
+      "basePackage": "",
+      "buildFiles": "gradle",
+      "gradleNexusPublishPluginVersion": "",
+      "gradleTest": ""
+    },
     "nodejs": {
       "packageDescription": "A Pulumi package to safely use randomness in Pulumi programs.",
       "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-random)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-random` repo](https://github.com/pulumi/pulumi-random/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-random` repo](https://github.com/terraform-providers/terraform-provider-random/issues).",


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/1306

Adding missing language-specific options so that it is easier to configure the .language section of a bridged provider's schema generation. The specific customer ask is around RespectSchemaVersion for Go, but it seems reasonable to expose all of them. 
 