### PR TITLE
Fixes #1231 panic when accessing GetRawState

### DIFF
--- a/pkg/tfshim/sdk-v2/provider_diff.go
+++ b/pkg/tfshim/sdk-v2/provider_diff.go
@@ -84,7 +84,7 @@ func (p v2Provider) simpleDiff(
 			// SimpleDiff may read RawPlan and panic if it is nil; while in the case of ClassicDiff we do
 			// not yet do what TF CLI does (that is PlanState), it is better to approximate and assume that
 			// the RawPlan is the same as RawConfig than to have the code panic.
-			state.RawConfig = rawConfigVal
+			state.RawPlan = rawConfigVal
 		}
 		if state.RawState.IsNull() {
 			// Same trick as for nil RawPlan.


### PR DESCRIPTION
Fixes #1231 (panic)

Diff customizers can request access to RawState, which prior to this PR was always set to null, causing a panic.