### PR TITLE
Autonaming: deprecate DefaultInfo.From

### DIFF
--- a/pf/internal/defaults/defaults.go
+++ b/pf/internal/defaults/defaults.go
@@ -196,15 +196,6 @@ type defaultsTransform struct {
 	providerConfig   resource.PropertyMap            // optional
 }
 
-// Returns a non-nil resourceInstance only if the defaults are being applied to a resource at the top level.
-func (du *defaultsTransform) resourceByPath(path resource.PropertyPath) *tfbridge.PulumiResource {
-	var res *tfbridge.PulumiResource
-	if len(path) == 0 {
-		res = du.resourceInstance
-	}
-	return res
-}
-
 // Returns matching object schema for a context determined by the PropertyPath, if any.
 func (du *defaultsTransform) lookupSchemaByContext(
 	path resource.PropertyPath,
@@ -273,7 +264,7 @@ func (du *defaultsTransform) extendPropertyMapWithDefaults(
 		// using default value for empty property
 		pv, gotDefault := getDefaultValue(ctx,
 			pk,
-			du.resourceByPath(path),
+			du.resourceInstance,
 			fieldSchema,
 			fld.Default,
 			du.providerConfig)

--- a/pf/internal/defaults/defaults.go
+++ b/pf/internal/defaults/defaults.go
@@ -134,7 +134,7 @@ func getDefaultValue(
 			})
 		return recoverDefaultValue(defaultInfo.Value), true
 	} else if defaultInfo.ComputeDefault != nil {
-		raw, err := defaultInfo.ComputeDefault(cdOptions)
+		raw, err := defaultInfo.ComputeDefault(ctx, cdOptions)
 		if err != nil {
 			msg := fmt.Errorf("Failed computing a default value for property '%s': %w",
 				string(property), err)

--- a/pf/internal/defaults/defaults_test.go
+++ b/pf/internal/defaults/defaults_test.go
@@ -67,7 +67,10 @@ func TestApplyDefaultInfoValues(t *testing.T) {
 		return resource.NewStringProperty(unique), err
 	}
 
-	testComputeDefaults := func(opts tfbridge.ComputeDefaultOptions) (interface{}, error) {
+	testComputeDefaults := func(
+		_ context.Context,
+		opts tfbridge.ComputeDefaultOptions,
+	) (interface{}, error) {
 		n := string(opts.URN.Name()) + "-"
 		a := []rune("12345")
 		unique, err := resource.NewUniqueName(opts.Seed, n, 3, 12, a)

--- a/pf/internal/defaults/defaults_test.go
+++ b/pf/internal/defaults/defaults_test.go
@@ -185,14 +185,21 @@ func TestApplyDefaultInfoValues(t *testing.T) {
 				"string_prop": {
 					Default: &tfbridge.DefaultInfo{
 						From: func(res *tfbridge.PulumiResource) (interface{}, error) {
-							return resource.NewStringProperty("OK"), nil
+							n := string(res.URN.Name()) + "-"
+							a := []rune("12345")
+							unique, err := resource.NewUniqueName(res.Seed, n, 3, 12, a)
+							return resource.NewStringProperty(unique), err
 						},
 					},
 				},
 			},
-			resourceInstance: &tfbridge.PulumiResource{},
+			resourceInstance: &tfbridge.PulumiResource{
+				URN:        "urn:pulumi:test::test::pkgA:index:t1::n1",
+				Properties: resource.PropertyMap{},
+				Seed:       []byte(`123`),
+			},
 			expected: resource.PropertyMap{
-				"stringProp": resource.NewStringProperty("OK"),
+				"stringProp": resource.NewStringProperty("n1-453"),
 			},
 		},
 		{

--- a/pf/tfbridge/provider_check.go
+++ b/pf/tfbridge/provider_check.go
@@ -50,7 +50,7 @@ func (p *provider) CheckWithContext(
 	news := defaults.ApplyDefaultInfoValues(ctx, defaults.ApplyDefaultInfoValuesArgs{
 		SchemaMap:   rh.schemaOnlyShimResource.Schema(),
 		SchemaInfos: rh.pulumiResourceInfo.Fields,
-		ResourceInstance: &tfbridge.PulumiResource{
+		ComputeDefaultOptions: tfbridge.ComputeDefaultOptions{
 			URN:        urn,
 			Properties: checkedInputs,
 			Seed:       randomSeed,

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -947,7 +947,7 @@ func (m *MarshallableDefaultInfo) Unmarshal() *DefaultInfo {
 	}
 
 	if m.IsFunc {
-		defInfo.ComputeDefault = func(_ ComputeDefaultOptions) (interface{}, error) {
+		defInfo.ComputeDefault = func(ComputeDefaultOptions) (interface{}, error) {
 			panic("transforms cannot be run on unmarshaled DefaultInfo values")
 		}
 	}

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -461,7 +461,7 @@ type DefaultInfo struct {
 
 	// ComputeDefault specifies how to compute a default value for the given property by consulting other properties
 	// such as the resource's URN. See [ComputeDefaultOptions] for all available information.
-	ComputeDefault func(opts ComputeDefaultOptions) (interface{}, error)
+	ComputeDefault func(ctx context.Context, opts ComputeDefaultOptions) (interface{}, error)
 
 	// Value injects a raw literal value as the default.
 	Value interface{}
@@ -947,7 +947,7 @@ func (m *MarshallableDefaultInfo) Unmarshal() *DefaultInfo {
 	}
 
 	if m.IsFunc {
-		defInfo.ComputeDefault = func(ComputeDefaultOptions) (interface{}, error) {
+		defInfo.ComputeDefault = func(context.Context, ComputeDefaultOptions) (interface{}, error) {
 			panic("transforms cannot be run on unmarshaled DefaultInfo values")
 		}
 	}

--- a/pkg/tfbridge/names.go
+++ b/pkg/tfbridge/names.go
@@ -15,6 +15,7 @@
 package tfbridge
 
 import (
+	"context"
 	"fmt"
 	"unicode"
 
@@ -287,8 +288,8 @@ func AutoName(name string, maxlength int, separator string) *SchemaInfo {
 		Name: name,
 		Default: &DefaultInfo{
 			AutoNamed: true,
-			ComputeDefault: func(opts ComputeDefaultOptions) (interface{}, error) {
-				return ComputeAutoNameDefault(autoNameOptions, opts)
+			ComputeDefault: func(ctx context.Context, opts ComputeDefaultOptions) (interface{}, error) {
+				return ComputeAutoNameDefault(ctx, autoNameOptions, opts)
 			},
 		},
 	}
@@ -300,8 +301,8 @@ func AutoNameWithCustomOptions(name string, options AutoNameOptions) *SchemaInfo
 		Name: name,
 		Default: &DefaultInfo{
 			AutoNamed: true,
-			ComputeDefault: func(opts ComputeDefaultOptions) (interface{}, error) {
-				return ComputeAutoNameDefault(options, opts)
+			ComputeDefault: func(ctx context.Context, opts ComputeDefaultOptions) (interface{}, error) {
+				return ComputeAutoNameDefault(ctx, options, opts)
 			},
 		},
 	}
@@ -322,8 +323,8 @@ func AutoNameTransform(name string, maxlen int, transform func(string) string) *
 		Name: name,
 		Default: &DefaultInfo{
 			AutoNamed: true,
-			ComputeDefault: func(opts ComputeDefaultOptions) (interface{}, error) {
-				return ComputeAutoNameDefault(autoNameOptions, opts)
+			ComputeDefault: func(ctx context.Context, opts ComputeDefaultOptions) (interface{}, error) {
+				return ComputeAutoNameDefault(ctx, autoNameOptions, opts)
 			},
 		},
 	}
@@ -332,7 +333,7 @@ func AutoNameTransform(name string, maxlen int, transform func(string) string) *
 // FromName automatically propagates a resource's URN onto the resulting default info.
 func FromName(options AutoNameOptions) func(res *PulumiResource) (interface{}, error) {
 	return func(res *PulumiResource) (interface{}, error) {
-		return ComputeAutoNameDefault(options, ComputeDefaultOptions{
+		return ComputeAutoNameDefault(context.Background(), options, ComputeDefaultOptions{
 			URN:        res.URN,
 			Properties: res.Properties,
 			Seed:       res.Seed,
@@ -340,7 +341,11 @@ func FromName(options AutoNameOptions) func(res *PulumiResource) (interface{}, e
 	}
 }
 
-func ComputeAutoNameDefault(options AutoNameOptions, defaultOptions ComputeDefaultOptions) (interface{}, error) {
+func ComputeAutoNameDefault(
+	ctx context.Context,
+	options AutoNameOptions,
+	defaultOptions ComputeDefaultOptions,
+) (interface{}, error) {
 	if defaultOptions.URN == "" {
 		return nil, fmt.Errorf("AutoName is onnly supported for resources, expected Resource URN to be set")
 	}

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -683,6 +683,16 @@ func (ctx *conversionContext) applyDefaults(result map[string]interface{}, olds,
 				}
 			} else if info.Default.Value != nil {
 				defaultValue, source = info.Default.Value, "Pulumi schema"
+			} else if compute := info.Default.ComputeDefault; compute != nil {
+				v, err := compute(ComputeDefaultOptions{
+					URN:        ctx.Instance.URN,
+					Properties: ctx.Instance.Properties,
+					Seed:       ctx.Instance.Seed,
+				})
+				if err != nil {
+					return err
+				}
+				defaultValue, source = v, "func"
 			} else if from := info.Default.From; from != nil {
 				v, err := from(ctx.Instance)
 				if err != nil {
@@ -690,7 +700,6 @@ func (ctx *conversionContext) applyDefaults(result map[string]interface{}, olds,
 				}
 				defaultValue, source = v, "func"
 			}
-
 			if defaultValue != nil {
 				glog.V(9).Infof("Created Terraform input: %v = %v (from %s)", name, defaultValue, source)
 				result[name] = defaultValue

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -15,6 +15,7 @@
 package tfbridge
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -684,11 +685,15 @@ func (ctx *conversionContext) applyDefaults(result map[string]interface{}, olds,
 			} else if info.Default.Value != nil {
 				defaultValue, source = info.Default.Value, "Pulumi schema"
 			} else if compute := info.Default.ComputeDefault; compute != nil {
-				v, err := compute(ComputeDefaultOptions{
-					URN:        ctx.Instance.URN,
-					Properties: ctx.Instance.Properties,
-					Seed:       ctx.Instance.Seed,
-				})
+				v, err := compute(
+					// Getting the correct context needs to refactor public methods such as
+					// MakeTerraformInput to MakeTerraformInputWithContext.
+					context.TODO(),
+					ComputeDefaultOptions{
+						URN:        ctx.Instance.URN,
+						Properties: ctx.Instance.Properties,
+						Seed:       ctx.Instance.Seed,
+					})
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
This PR is the first in a series of changes to get Autonaming working for Plugin Framework providers; broken down into commits for easier review. The key change is to move from DefaultInfo.From to DefaultInfo.ComputeDefault. The ComputeDefaultOptions structure is there to extend with further context on the location where defaults are being computed, which is needed in subsequent PRs.