### PR TITLE
Support AutoName for Plugin Framework

### DIFF
--- a/pf/internal/defaults/defaults_test.go
+++ b/pf/internal/defaults/defaults_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 
@@ -67,11 +68,17 @@ func TestApplyDefaultInfoValues(t *testing.T) {
 		return resource.NewStringProperty(unique), err
 	}
 
-	testComputeDefaults := func(opts tfbridge.ComputeDefaultOptions) (interface{}, error) {
-		n := string(opts.URN.Name()) + "-"
-		a := []rune("12345")
-		unique, err := resource.NewUniqueName(opts.Seed, n, 3, 12, a)
-		return resource.NewStringProperty(unique), err
+	testComputeDefaults := func(
+		t *testing.T,
+		expectPath resource.PropertyPath,
+	) func(tfbridge.ComputeDefaultOptions) (interface{}, error) {
+		return func(opts tfbridge.ComputeDefaultOptions) (interface{}, error) {
+			require.Equal(t, expectPath, opts.PropertyPath)
+			n := string(opts.URN.Name()) + "-"
+			a := []rune("12345")
+			unique, err := resource.NewUniqueName(opts.Seed, n, 3, 12, a)
+			return resource.NewStringProperty(unique), err
+		}
 	}
 
 	testCases := []testCase{
@@ -198,7 +205,7 @@ func TestApplyDefaultInfoValues(t *testing.T) {
 			fieldInfos: map[string]*tfbridge.SchemaInfo{
 				"string_prop": {
 					Default: &tfbridge.DefaultInfo{
-						ComputeDefault: testComputeDefaults,
+						ComputeDefault: testComputeDefaults(t, resource.PropertyPath{"stringProp"}),
 					},
 				},
 			},
@@ -236,7 +243,8 @@ func TestApplyDefaultInfoValues(t *testing.T) {
 					Fields: map[string]*tfbridge.SchemaInfo{
 						"y_prop": {
 							Default: &tfbridge.DefaultInfo{
-								ComputeDefault: testComputeDefaults,
+								ComputeDefault: testComputeDefaults(t,
+									resource.PropertyPath{"objectProp", "yProp"}),
 							},
 						},
 					},

--- a/pf/tests/integration/program_test.go
+++ b/pf/tests/integration/program_test.go
@@ -132,6 +132,22 @@ func TestPrivateState(t *testing.T) {
 	})
 }
 
+func TestAutoName(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping on Windows due to a PATH setup issue where the test cannot find pulumi-resource-testbridge.exe")
+	}
+
+	wd, err := os.Getwd()
+	assert.NoError(t, err)
+	bin := filepath.Join(wd, "..", "bin")
+
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Env:                    []string{fmt.Sprintf("PATH=%s", bin)},
+		Dir:                    filepath.Join("..", "testdata", "autoname-program"),
+		ExtraRuntimeValidation: validateExpectedVsActual,
+	})
+}
+
 // Test skip_metadata_api_check example from pulumi-aws that is unusual in remapping a string prop to boolean.
 func TestRegressSMAC(t *testing.T) {
 	if runtime.GOOS == "windows" {

--- a/pf/tests/internal/testprovider/cmd/pulumi-resource-testbridge/bridge-metadata.json
+++ b/pf/tests/internal/testprovider/cmd/pulumi-resource-testbridge/bridge-metadata.json
@@ -2,6 +2,7 @@
     "renames": {
         "resources": {
             "testbridge:index/testnest:Testnest": "testbridge_testnest",
+            "testbridge:index/testres:AutoNameRes": "testbridge_autoname_res",
             "testbridge:index/testres:Privst": "testbridge_privst",
             "testbridge:index/testres:TestConfigRes": "testbridge_testconfigres",
             "testbridge:index/testres:TestDefaultInfoRes": "testbridge_test_default_info_res",

--- a/pf/tests/internal/testprovider/cmd/pulumi-resource-testbridge/schema.json
+++ b/pf/tests/internal/testprovider/cmd/pulumi-resource-testbridge/schema.json
@@ -212,6 +212,33 @@
                 "type": "object"
             }
         },
+        "testbridge:index/testres:AutoNameRes": {
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Test AutoNaming; Pulumi makes this property optional\n"
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "inputProperties": {
+                "name": {
+                    "type": "string",
+                    "description": "Test AutoNaming; Pulumi makes this property optional\n"
+                }
+            },
+            "stateInputs": {
+                "description": "Input properties used for looking up and filtering AutoNameRes resources.\n",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Test AutoNaming; Pulumi makes this property optional\n"
+                    }
+                },
+                "type": "object"
+            }
+        },
         "testbridge:index/testres:Privst": {
             "properties": {
                 "observedPrivateStateAfter": {

--- a/pf/tests/internal/testprovider/testbridge.go
+++ b/pf/tests/internal/testprovider/testbridge.go
@@ -34,7 +34,7 @@ var testBridgeMetadata []byte
 // Synthetic provider is specifically constructed to test various
 // features of tfbridge and is the core of pulumi-resource-testbridge.
 func SyntheticTestBridgeProvider() tfbridge.ProviderInfo {
-	return tfbridge.ProviderInfo{
+	info := tfbridge.ProviderInfo{
 		Name:        "testbridge",
 		P:           tfpf.ShimProvider(&syntheticProvider{}),
 		Description: "A Pulumi package to test pulumi-terraform-bridge Plugin Framework support.",
@@ -93,7 +93,8 @@ func SyntheticTestBridgeProvider() tfbridge.ProviderInfo {
 				},
 			},
 
-			"testbridge_privst": {Tok: "testbridge:index/testres:Privst"},
+			"testbridge_privst":       {Tok: "testbridge:index/testres:Privst"},
+			"testbridge_autoname_res": {Tok: "testbridge:index/testres:AutoNameRes"},
 		},
 
 		DataSources: map[string]*tfbridge.DataSourceInfo{
@@ -115,6 +116,10 @@ func SyntheticTestBridgeProvider() tfbridge.ProviderInfo {
 
 		MetadataInfo: tfbridge.NewProviderMetadata(testBridgeMetadata),
 	}
+
+	info.SetAutonaming(255, "-")
+
+	return info
 }
 
 type syntheticProvider struct{}
@@ -198,5 +203,6 @@ func (p *syntheticProvider) Resources(context.Context) []func() resource.Resourc
 		newTestConfigRes,
 		newTestDefaultInfoRes,
 		newPrivst,
+		newAutoNameRes,
 	}
 }

--- a/pf/tests/internal/testprovider/testbridge_resource_autoname.go
+++ b/pf/tests/internal/testprovider/testbridge_resource_autoname.go
@@ -1,0 +1,89 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testprovider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+type autoNameRes struct{}
+
+var _ resource.Resource = &autoNameRes{}
+
+func newAutoNameRes() resource.Resource {
+	return &autoNameRes{}
+}
+
+func (*autoNameRes) schema() rschema.Schema {
+	return rschema.Schema{
+		Attributes: map[string]rschema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"name": schema.StringAttribute{
+				Required:    true,
+				Description: "Test AutoNaming; Pulumi makes this property optional",
+			},
+		},
+	}
+}
+
+func (e *autoNameRes) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_autoname_res"
+}
+
+func (e *autoNameRes) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = e.schema()
+}
+
+func (e *autoNameRes) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	resp.State.Raw = req.Plan.Raw.Copy() // Copy plan to state.
+	resp.State.SetAttribute(ctx, path.Root("id"), "some-id")
+}
+
+func (e *autoNameRes) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+}
+
+func (e *autoNameRes) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	resp.State.Raw = req.Plan.Raw.Copy() // Copy plan to state.
+}
+
+func (e *autoNameRes) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	resp.State = e.nilState(ctx)
+}
+
+func (e *autoNameRes) nilState(ctx context.Context) tfsdk.State {
+	typ := e.terraformType(ctx)
+	return tfsdk.State{
+		Raw:    tftypes.NewValue(typ, nil),
+		Schema: e.schema(),
+	}
+}
+
+func (e *autoNameRes) terraformType(ctx context.Context) tftypes.Type {
+	return e.schema().Type().TerraformType(ctx)
+}

--- a/pf/tests/testdata/autoname-program/Pulumi.yaml
+++ b/pf/tests/testdata/autoname-program/Pulumi.yaml
@@ -1,0 +1,24 @@
+name: autoname-program
+runtime: yaml
+resources:
+
+  autonamedResource:
+    type: testbridge:index/testres:AutoNameRes
+
+  manuallyNamedResource:
+    type: testbridge:index/testres:AutoNameRes
+    properties:
+      name: "manualName"
+
+outputs:
+
+  test_autoname_starts_with_resource_name__actual:
+    fn::select:
+      - 0
+      - fn::split:
+        - "-"
+        - ${autonamedResource.name}
+  test_autoname_starts_with_resource_name__expect: "autonamedResource"
+
+  test_autoname_respects_manual__actual: ${manuallyNamedResource.name}
+  test_autoname_respects_manual__expect: "manualName"

--- a/pkg/tfbridge/diff.go
+++ b/pkg/tfbridge/diff.go
@@ -100,7 +100,9 @@ func visitPropertyValue(name, path string, v resource.PropertyValue, tfs shim.Sc
 				// fill in default values for empty fields (note that this is a property of the field reader, not of
 				// the schema) as it does when computing the hash code for a set element.
 				ctx := &conversionContext{}
-				ev, err := ctx.MakeTerraformInput(ep, resource.PropertyValue{}, e, etfs, eps, rawNames)
+				// Lost context on the current path here, unfortunate for ComputedDefaults.
+				pp := resource.PropertyPath{}
+				ev, err := ctx.MakeTerraformInput(ep, resource.PropertyValue{}, e, etfs, eps, rawNames, pp)
 				if err != nil {
 					return
 				}

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -485,6 +485,12 @@ type ComputeDefaultOptions struct {
 	// example, that random values generated across "pulumi preview" and "pulumi up" in the same deployment are
 	// consistent. This currently is only available for resource changes.
 	Seed []byte
+
+	// Path to the sub-property where the default application is happening. For example,
+	// resource.PropertyPath{"propName"} indicates applying defaults to a top-level property, and
+	// resource.PropertyPath{"propName", 1, "subProp"} indicates applying defaults to the "subProp" property of the
+	// second element of the array found under "propName".
+	PropertyPath resource.PropertyPath
 }
 
 // PulumiResource is just a little bundle that carries URN, seed and properties around.

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -733,9 +733,10 @@ func TestCheck(t *testing.T) {
 			tf:     shimv2.NewProvider(testTFProviderV2),
 			config: shimv2.NewSchemaMap(testTFProviderV2.Schema),
 		}
-		computeStringDefault := func(opts ComputeDefaultOptions1) (interface{}, error) {
+		computeStringDefault := func(opts ComputeDefaultOptions) (interface{}, error) {
+			require.Equal(t, resource.PropertyPath{"stringPropertyValue"}, opts.PropertyPath)
 			if v, ok := opts.PriorState["stringPropertyValue"]; ok {
-				return v.StringValue(), nil
+				return v.StringValue() + "!", nil
 			}
 			return nil, nil
 		}
@@ -762,6 +763,7 @@ func TestCheck(t *testing.T) {
 		    "urn": "urn:pulumi:dev::teststack::ExampleResource::exres",
 		    "randomSeed": "ZCiVOcvG/CT5jx4XriguWgj2iMpQEb8P3ZLqU/AS2yg=",
 		    "olds": {
+                     "__defaults": [],
 		     "stringPropertyValue": "oldString"
 		    },
 		    "news": {
@@ -772,7 +774,7 @@ func TestCheck(t *testing.T) {
 		    "inputs": {
                       "__defaults": ["stringPropertyValue"],
 		      "arrayPropertyValues": [],
-		      "stringPropertyValue": "oldString"
+		      "stringPropertyValue": "oldString!"
 		    }
 		  }
 		}

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -306,7 +306,7 @@ func MakeTerraformInputs(instance *PulumiResource, config resource.PropertyMap, 
 		ApplyDefaults:         true,
 		Assets:                AssetTable{},
 	}
-	inputs, err := ctx.MakeTerraformInputs(olds, news, tfs, ps, false)
+	inputs, err := ctx.MakeTerraformInputs(olds, news, tfs, ps, false, resource.PropertyPath{})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -317,7 +317,7 @@ func MakeTerraformInputs(instance *PulumiResource, config resource.PropertyMap, 
 // use by Terraform.  Note that this function may have side effects, for instance if it is necessary to spill an asset
 // to disk in order to create a name out of it.  Please take care not to call it superfluously!
 func (ctx *conversionContext) MakeTerraformInput(name string, old, v resource.PropertyValue,
-	tfs shim.Schema, ps *SchemaInfo, rawNames bool) (interface{}, error) {
+	tfs shim.Schema, ps *SchemaInfo, rawNames bool, path resource.PropertyPath) (interface{}, error) {
 
 	// For TypeList or TypeSet with MaxItems==1, we will have projected as a scalar
 	// nested value, and need to wrap it into a single-element array before passing to
@@ -387,7 +387,8 @@ func (ctx *conversionContext) MakeTerraformInput(name string, old, v resource.Pr
 				oldElem = oldArr[i]
 			}
 			elemName := fmt.Sprintf("%v[%v]", name, i)
-			e, err := ctx.MakeTerraformInput(elemName, oldElem, elem, etfs, eps, rawNames)
+			subPath := append(path, i)
+			e, err := ctx.MakeTerraformInput(elemName, oldElem, elem, etfs, eps, rawNames, subPath)
 			if err != nil {
 				return nil, err
 			}
@@ -442,7 +443,7 @@ func (ctx *conversionContext) MakeTerraformInput(name string, old, v resource.Pr
 		}
 
 		input, err := ctx.MakeTerraformInputs(oldObject, v.ObjectValue(),
-			tfflds, psflds, rawNames || useRawNames(tfs))
+			tfflds, psflds, rawNames || useRawNames(tfs), path)
 		if err != nil {
 			return nil, err
 		}
@@ -471,8 +472,13 @@ func (ctx *conversionContext) MakeTerraformInput(name string, old, v resource.Pr
 // to prepare it for use by Terraform.  Note that this function may have side effects, for instance
 // if it is necessary to spill an asset to disk in order to create a name out of it.  Please take
 // care not to call it superfluously!
-func (ctx *conversionContext) MakeTerraformInputs(olds, news resource.PropertyMap,
-	tfs shim.SchemaMap, ps map[string]*SchemaInfo, rawNames bool) (map[string]interface{}, error) {
+func (ctx *conversionContext) MakeTerraformInputs(
+	olds, news resource.PropertyMap,
+	tfs shim.SchemaMap,
+	ps map[string]*SchemaInfo,
+	rawNames bool,
+	path resource.PropertyPath,
+) (map[string]interface{}, error) {
 
 	result := make(map[string]interface{})
 	tfAttributesToPulumiProperties := make(map[string]string)
@@ -518,7 +524,8 @@ func (ctx *conversionContext) MakeTerraformInputs(olds, news resource.PropertyMa
 		}
 
 		// And then translate the property value.
-		v, err := ctx.MakeTerraformInput(name, old, value, tfi, psi, rawNames)
+		subPath := append(path, string(key))
+		v, err := ctx.MakeTerraformInput(name, old, value, tfi, psi, rawNames, subPath)
 		if err != nil {
 			return nil, err
 		}
@@ -527,7 +534,7 @@ func (ctx *conversionContext) MakeTerraformInputs(olds, news resource.PropertyMa
 	}
 
 	// Now enumerate and propagate defaults if the corresponding values are still missing.
-	if err := ctx.applyDefaults(result, olds, news, tfs, ps, rawNames); err != nil {
+	if err := ctx.applyDefaults(result, olds, news, tfs, ps, rawNames, path); err != nil {
 		return nil, err
 	}
 
@@ -595,8 +602,14 @@ func buildConflictsWith(result map[string]interface{}, tfs shim.SchemaMap) map[s
 	return conflictsWith
 }
 
-func (ctx *conversionContext) applyDefaults(result map[string]interface{}, olds, news resource.PropertyMap,
-	tfs shim.SchemaMap, ps map[string]*SchemaInfo, rawNames bool) error {
+func (ctx *conversionContext) applyDefaults(
+	result map[string]interface{},
+	olds, news resource.PropertyMap,
+	tfs shim.SchemaMap,
+	ps map[string]*SchemaInfo,
+	rawNames bool,
+	path resource.PropertyPath,
+) error {
 
 	if !ctx.ApplyDefaults {
 		return nil
@@ -642,8 +655,13 @@ func (ctx *conversionContext) applyDefaults(result map[string]interface{}, olds,
 
 			// If we already have a default value from a previous version of this resource, use that instead.
 			key, tfi, psi := getInfoFromTerraformName(name, tfs, ps, rawNames)
+
+			subPath := append(path, string(key))
+			fmt.Println("APPLY DEFAULTS", "hasDefault", subPath, key)
+
 			if old, hasold := olds[key]; hasold && useOldDefault(key) {
-				v, err := ctx.MakeTerraformInput(name, resource.PropertyValue{}, old, tfi, psi, rawNames)
+				v, err := ctx.MakeTerraformInput(name, resource.PropertyValue{},
+					old, tfi, psi, rawNames, subPath)
 				if err != nil {
 					return err
 				}
@@ -685,7 +703,8 @@ func (ctx *conversionContext) applyDefaults(result map[string]interface{}, olds,
 				defaultValue, source = v, "env vars"
 			} else if configKey := info.Default.Config; configKey != "" {
 				if v := ctx.ProviderConfig[resource.PropertyKey(configKey)]; !v.IsNull() {
-					tv, err := ctx.MakeTerraformInput(name, resource.PropertyValue{}, v, tfi, psi, rawNames)
+					tv, err := ctx.MakeTerraformInput(name, resource.PropertyValue{},
+						v, tfi, psi, rawNames, subPath)
 					if err != nil {
 						return err
 					}
@@ -694,7 +713,9 @@ func (ctx *conversionContext) applyDefaults(result map[string]interface{}, olds,
 			} else if info.Default.Value != nil {
 				defaultValue, source = info.Default.Value, "Pulumi schema"
 			} else if compute := info.Default.ComputeDefault; compute != nil {
-				v, err := compute(ctx.ComputeDefaultOptions)
+				cdOpts := ctx.ComputeDefaultOptions
+				cdOpts.PropertyPath = subPath
+				v, err := compute(cdOpts)
 				if err != nil {
 					return err
 				}
@@ -784,8 +805,11 @@ func (ctx *conversionContext) applyDefaults(result map[string]interface{}, olds,
 
 				// Next, if we already have a default value from a previous version of this resource, use that instead.
 				key, tfi, psi := getInfoFromTerraformName(name, tfs, ps, rawNames)
+				subPath := append(path, string(key))
+
 				if old, hasold := olds[key]; hasold && useOldDefault(key) {
-					v, err := ctx.MakeTerraformInput(name, resource.PropertyValue{}, old, tfi, psi, rawNames)
+					v, err := ctx.MakeTerraformInput(name, resource.PropertyValue{}, old, tfi, psi,
+						rawNames, subPath)
 					if err != nil {
 						valueErr = err
 						return false
@@ -1058,7 +1082,7 @@ func MakeTerraformConfig(p *Provider, m resource.PropertyMap,
 		ProviderConfig: p.configValues,
 		Assets:         AssetTable{},
 	}
-	inputs, err := ctx.MakeTerraformInputs(nil, m, tfs, ps, false)
+	inputs, err := ctx.MakeTerraformInputs(nil, m, tfs, ps, false, resource.PropertyPath{})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1131,7 +1155,8 @@ func MakeTerraformState(res Resource, id string, m resource.PropertyMap) (shim.I
 	// Mappable, but we use MapReplace because we use float64s and Terraform uses
 	// ints, to represent numbers.
 	ctx := &conversionContext{}
-	inputs, err := ctx.MakeTerraformInputs(nil, m, res.TF.Schema(), res.Schema.Fields, false)
+	inputs, err := ctx.MakeTerraformInputs(nil, m, res.TF.Schema(), res.Schema.Fields,
+		false, resource.PropertyPath{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -657,7 +657,6 @@ func (ctx *conversionContext) applyDefaults(
 			key, tfi, psi := getInfoFromTerraformName(name, tfs, ps, rawNames)
 
 			subPath := append(path, string(key))
-			fmt.Println("APPLY DEFAULTS", "hasDefault", subPath, key)
 
 			if old, hasold := olds[key]; hasold && useOldDefault(key) {
 				v, err := ctx.MakeTerraformInput(name, resource.PropertyValue{},

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -44,7 +44,7 @@ func makeTerraformInputs(olds, news resource.PropertyMap,
 	tfs shim.SchemaMap, ps map[string]*SchemaInfo) (map[string]interface{}, AssetTable, error) {
 
 	ctx := &conversionContext{Assets: AssetTable{}}
-	inputs, err := ctx.MakeTerraformInputs(olds, news, tfs, ps, false)
+	inputs, err := ctx.MakeTerraformInputs(olds, news, tfs, ps, false, resource.PropertyPath{})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -58,7 +58,7 @@ func makeTerraformInputsWithDefaults(olds, news resource.PropertyMap,
 		Assets:        AssetTable{},
 		ApplyDefaults: true,
 	}
-	inputs, err := ctx.MakeTerraformInputs(olds, news, tfs, ps, false)
+	inputs, err := ctx.MakeTerraformInputs(olds, news, tfs, ps, false, resource.PropertyPath{})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -67,7 +67,8 @@ func makeTerraformInputsWithDefaults(olds, news resource.PropertyMap,
 
 func makeTerraformInput(v resource.PropertyValue, tfs shim.Schema, ps *SchemaInfo) (interface{}, error) {
 	ctx := &conversionContext{}
-	return ctx.MakeTerraformInput("v", resource.PropertyValue{}, v, tfs, ps, false)
+	return ctx.MakeTerraformInput("v", resource.PropertyValue{}, v, tfs, ps, false,
+		resource.PropertyPath{})
 }
 
 // TestTerraformInputs verifies that we translate Pulumi inputs into Terraform inputs.


### PR DESCRIPTION
On top of https://github.com/pulumi/pulumi-terraform-bridge/pull/1318

This is the last bit in the AutoName support. AutoName machinery is modified to consult PriorState for the previously allocated name. This makes it work for Plugin Frameworks without __defaults__. 

There is a limitation in this scenario. Suppose you've created a resource with a manual name and then you want to switch to a AutoName (provider upgrade or just user program change). This won't work as the name is too sticky in PF - any updates to the resource will persist the value in the state, unless you change the program to have a non-empty name and then it will use that. You can't "drop to AutoName". In previous discussions with Friel we thought this should be an OK corner case to keep because most of the use cases of this feature require names to persist and changing them causes replace plans which is never what you want, so in cases like this the workaround of tearing down the resource and re-provisioning it should be OK.
