### PR TITLE
Deprecate pkg/tfshim/sdk-v1

### DIFF
--- a/pkg/tfshim/sdk-v1/instance_state.go
+++ b/pkg/tfshim/sdk-v1/instance_state.go
@@ -16,10 +16,12 @@ type v1InstanceState struct {
 	diff *terraform.InstanceDiff
 }
 
+// Deprecated: shimv1 will be dropped in future versions. Please upgrade to shimv2.
 func NewInstanceState(s *terraform.InstanceState) shim.InstanceState {
 	return v1InstanceState{s, nil}
 }
 
+// Deprecated: shimv1 will be dropped in future versions. Please upgrade to shimv2.
 func IsInstanceState(s shim.InstanceState) (*terraform.InstanceState, bool) {
 	if is, ok := s.(v1InstanceState); ok {
 		return is.tf, true

--- a/pkg/tfshim/sdk-v1/provider.go
+++ b/pkg/tfshim/sdk-v1/provider.go
@@ -52,6 +52,7 @@ type v1Provider struct {
 	tf *schema.Provider
 }
 
+// Deprecated: shimv1 will be dropped in future versions. Please upgrade to shimv2.
 func NewProvider(p *schema.Provider) shim.Provider {
 	return v1Provider{p}
 }

--- a/pkg/tfshim/sdk-v1/resource.go
+++ b/pkg/tfshim/sdk-v1/resource.go
@@ -15,6 +15,7 @@ type v1Resource struct {
 	tf *schema.Resource
 }
 
+// Deprecated: shimv1 will be dropped in future versions. Please upgrade to shimv2.
 func NewResource(r *schema.Resource) shim.Resource {
 	return v1Resource{r}
 }

--- a/pkg/tfshim/sdk-v1/schema.go
+++ b/pkg/tfshim/sdk-v1/schema.go
@@ -13,12 +13,15 @@ var _ = shim.SchemaMap(v1SchemaMap{})
 // representing a variable whose value is not known at some particular time. The value is duplicated here in
 // order to prevent an additional dependency - it is unlikely to ever change upstream since that would break
 // rather a lot of things.
+
+// Deprecated: shimv1 will be dropped in future versions. Please upgrade to shimv2.
 const UnknownVariableValue = "74D93920-ED26-11E3-AC10-0800200C9A66"
 
 type v1Schema struct {
 	tf *schema.Schema
 }
 
+// Deprecated: shimv1 will be dropped in future versions. Please upgrade to shimv2.
 func NewSchema(s *schema.Schema) shim.Schema {
 	return v1Schema{s}
 }
@@ -186,6 +189,7 @@ func (s v1Schema) SetHash(v interface{}) int {
 
 type v1SchemaMap map[string]*schema.Schema
 
+// Deprecated: shimv1 will be dropped in future versions. Please upgrade to shimv2.
 func NewSchemaMap(m map[string]*schema.Schema) shim.SchemaMap {
 	return v1SchemaMap(m)
 }


### PR DESCRIPTION
This is a helpful exercise as `make lint` exposes all the tests testing SDKv1 shim. We should move them over to SDKv2 shim which we care about a lot more.