### PR TITLE
Encode default values

### DIFF
--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -707,7 +707,12 @@ func (ctx *conversionContext) applyDefaults(result map[string]interface{}, olds,
 					defaultValue, source = tv, "config"
 				}
 			} else if info.Default.Value != nil {
-				defaultValue, source = info.Default.Value, "Pulumi schema"
+				v := resource.NewPropertyValue(info.Default.Value)
+				tv, err := ctx.MakeTerraformInput(name, resource.PropertyValue{}, v, tfi, psi, rawNames)
+				if err != nil {
+					return err
+				}
+				defaultValue, source = tv, "Pulumi schema"
 			} else if compute := info.Default.ComputeDefault; compute != nil {
 				v, err := compute(
 					// Getting the correct context needs to refactor public methods such as


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-aws/issues/2646

This PR makes two distinct changes:
- https://github.com/pulumi/pulumi-terraform-bridge/pull/1322/commits/cd9ad00a72ac00e3f62c24431cd5b9c53ee6db2b: adds an explicit check for accepting a bool that should be a string, changing the return value to `"true"` and `"false"` instead of `true` and `false`.
- https://github.com/pulumi/pulumi-terraform-bridge/pull/1322/commits/796df14c8400440358b5b2075cf16340c2f782b7: calls `MakeTerraformInput` on values drawn from `SchemaInfo.DefaultInfo.Value`. This uses the machinery introduced in the previous commit.


WIP: Still needs tests for both features.