### PR TITLE
Autoname implementation alternative: PriorValue

### DIFF
--- a/pf/internal/defaults/defaults_test.go
+++ b/pf/internal/defaults/defaults_test.go
@@ -70,10 +70,10 @@ func TestApplyDefaultInfoValues(t *testing.T) {
 
 	testComputeDefaults := func(
 		t *testing.T,
-		expectPath resource.PropertyPath,
+		expectPriorValue resource.PropertyValue,
 	) func(context.Context, tfbridge.ComputeDefaultOptions) (interface{}, error) {
 		return func(_ context.Context, opts tfbridge.ComputeDefaultOptions) (interface{}, error) {
-			require.Equal(t, expectPath, opts.PropertyPath)
+			require.Equal(t, expectPriorValue, opts.PriorValue)
 			n := string(opts.URN.Name()) + "-"
 			a := []rune("12345")
 			unique, err := resource.NewUniqueName(opts.Seed, n, 3, 12, a)
@@ -205,7 +205,8 @@ func TestApplyDefaultInfoValues(t *testing.T) {
 			fieldInfos: map[string]*tfbridge.SchemaInfo{
 				"string_prop": {
 					Default: &tfbridge.DefaultInfo{
-						ComputeDefault: testComputeDefaults(t, resource.PropertyPath{"stringProp"}),
+						ComputeDefault: testComputeDefaults(t,
+							resource.NewStringProperty("oldString")),
 					},
 				},
 			},
@@ -213,6 +214,9 @@ func TestApplyDefaultInfoValues(t *testing.T) {
 				URN:        "urn:pulumi:test::test::pkgA:index:t1::n1",
 				Properties: resource.PropertyMap{},
 				Seed:       []byte(`123`),
+				PriorState: resource.PropertyMap{
+					"stringProp": resource.NewStringProperty("oldString"),
+				},
 			},
 			expected: resource.PropertyMap{
 				"stringProp": resource.NewStringProperty("n1-453"),
@@ -244,7 +248,7 @@ func TestApplyDefaultInfoValues(t *testing.T) {
 						"y_prop": {
 							Default: &tfbridge.DefaultInfo{
 								ComputeDefault: testComputeDefaults(t,
-									resource.PropertyPath{"objectProp", "yProp"}),
+									resource.NewStringProperty("oldY")),
 							},
 						},
 					},
@@ -259,6 +263,12 @@ func TestApplyDefaultInfoValues(t *testing.T) {
 				URN:        "urn:pulumi:test::test::pkgA:index:t1::n1",
 				Properties: resource.PropertyMap{},
 				Seed:       []byte(`123`),
+				PriorState: resource.PropertyMap{
+					"objectProp": resource.NewObjectProperty(resource.PropertyMap{
+						"xProp": resource.NewStringProperty("oldX"),
+						"yProp": resource.NewStringProperty("oldY"),
+					}),
+				},
 			},
 			expected: resource.PropertyMap{
 				"objectProp": resource.NewObjectProperty(resource.PropertyMap{

--- a/pkg/tfbridge/diff.go
+++ b/pkg/tfbridge/diff.go
@@ -100,10 +100,7 @@ func visitPropertyValue(name, path string, v resource.PropertyValue, tfs shim.Sc
 				// fill in default values for empty fields (note that this is a property of the field reader, not of
 				// the schema) as it does when computing the hash code for a set element.
 				ctx := &conversionContext{}
-				// Since ctx.ApplyDefaults == false, the default application machinery is not invoked
-				// and path resource.PropertyPath can be nil as it is only used for defaults
-				// application.
-				ev, err := ctx.MakeTerraformInput(ep, resource.PropertyValue{}, e, etfs, eps, rawNames, nil)
+				ev, err := ctx.MakeTerraformInput(ep, resource.PropertyValue{}, e, etfs, eps, rawNames)
 				if err != nil {
 					return
 				}

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -488,16 +488,14 @@ type ComputeDefaultOptions struct {
 	// Property map representing prior state, only set for non-Create Resource operations.
 	PriorState resource.PropertyMap
 
+	// PriorValue represents the last value of the current property in PriorState. It will have zero value if there
+	// is no PriorState or if the property did not have a value in PriorState.
+	PriorValue resource.PropertyValue
+
 	// The engine provides a stable seed useful for generating random values consistently. This guarantees, for
 	// example, that random values generated across "pulumi preview" and "pulumi up" in the same deployment are
 	// consistent. This currently is only available for resource changes.
 	Seed []byte
-
-	// Path to the sub-property where the default application is happening. For example,
-	// resource.PropertyPath{"propName"} indicates applying defaults to a top-level property, and
-	// resource.PropertyPath{"propName", 1, "subProp"} indicates applying defaults to the "subProp" property of the
-	// second element of the array found under "propName".
-	PropertyPath resource.PropertyPath
 }
 
 // PulumiResource is just a little bundle that carries URN, seed and properties around.

--- a/pkg/tfbridge/names.go
+++ b/pkg/tfbridge/names.go
@@ -357,11 +357,9 @@ func ComputeAutoNameDefault(
 	// disinguish default values, therefore it always calls ComputedDefaults. To compensate, this code block avoids
 	// re-generating the auto-name if it is located in PriorState and reuses the old one; this avoids generating a
 	// fresh random value and causing a replace plan.
-	if defaultOptions.PriorState != nil && defaultOptions.PropertyPath != nil {
-		prior := resource.NewObjectProperty(defaultOptions.PriorState)
-		oldV, gotOldV := defaultOptions.PropertyPath.Get(prior)
-		if oldV.IsString() && gotOldV {
-			return oldV.StringValue(), nil
+	if defaultOptions.PriorState != nil && defaultOptions.PriorValue.V != nil {
+		if defaultOptions.PriorValue.IsString() {
+			return defaultOptions.PriorValue.StringValue(), nil
 		}
 	}
 

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -824,7 +824,7 @@ func TestCheck(t *testing.T) {
 			config: shimv2.NewSchemaMap(testTFProviderV2.Schema),
 		}
 		computeStringDefault := func(_ context.Context, opts ComputeDefaultOptions) (interface{}, error) {
-			require.Equal(t, resource.PropertyPath{"stringPropertyValue"}, opts.PropertyPath)
+			require.Equal(t, resource.NewStringProperty("oldString"), opts.PriorValue)
 			if v, ok := opts.PriorState["stringPropertyValue"]; ok {
 				return v.StringValue() + "!", nil
 			}

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -824,8 +824,8 @@ func TestCheck(t *testing.T) {
 			config: shimv2.NewSchemaMap(testTFProviderV2.Schema),
 		}
 		computeStringDefault := func(_ context.Context, opts ComputeDefaultOptions) (interface{}, error) {
-			require.Equal(t, resource.NewStringProperty("oldString"), opts.PriorValue)
 			if v, ok := opts.PriorState["stringPropertyValue"]; ok {
+				require.Equal(t, resource.NewStringProperty("oldString"), opts.PriorValue)
 				return v.StringValue() + "!", nil
 			}
 			return nil, nil
@@ -877,7 +877,7 @@ func TestCheck(t *testing.T) {
 		    "urn": "urn:pulumi:dev::teststack::ExampleResource::exres",
 		    "randomSeed": "ZCiVOcvG/CT5jx4XriguWgj2iMpQEb8P3ZLqU/AS2yg=",
 		    "olds": {
-                      "__defaults": []
+		      "__defaults": []
 		    },
 		    "news": {
 		      "arrayPropertyValues": []
@@ -885,12 +885,12 @@ func TestCheck(t *testing.T) {
 		  },
 		  "response": {
 		    "inputs": {
-                      "__defaults": [],
+		      "__defaults": [],
 		      "arrayPropertyValues": []
 		    }
 		  }
 		}
-                `)
+		`)
 	})
 }
 

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -44,7 +44,7 @@ func makeTerraformInputs(olds, news resource.PropertyMap,
 	tfs shim.SchemaMap, ps map[string]*SchemaInfo) (map[string]interface{}, AssetTable, error) {
 
 	ctx := &conversionContext{Assets: AssetTable{}}
-	inputs, err := ctx.MakeTerraformInputs(olds, news, tfs, ps, false, resource.PropertyPath{})
+	inputs, err := ctx.MakeTerraformInputs(olds, news, tfs, ps, false)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -58,7 +58,7 @@ func makeTerraformInputsWithDefaults(olds, news resource.PropertyMap,
 		Assets:        AssetTable{},
 		ApplyDefaults: true,
 	}
-	inputs, err := ctx.MakeTerraformInputs(olds, news, tfs, ps, false, resource.PropertyPath{})
+	inputs, err := ctx.MakeTerraformInputs(olds, news, tfs, ps, false)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -67,8 +67,7 @@ func makeTerraformInputsWithDefaults(olds, news resource.PropertyMap,
 
 func makeTerraformInput(v resource.PropertyValue, tfs shim.Schema, ps *SchemaInfo) (interface{}, error) {
 	ctx := &conversionContext{}
-	return ctx.MakeTerraformInput("v", resource.PropertyValue{}, v, tfs, ps, false,
-		resource.PropertyPath{})
+	return ctx.MakeTerraformInput("v", resource.PropertyValue{}, v, tfs, ps, false)
 }
 
 // TestTerraformInputs verifies that we translate Pulumi inputs into Terraform inputs.


### PR DESCRIPTION
This is an alternative where we do not expose the Path to the changed value but expose the Value from prior state. This is perhaps more intuitive to the user and works just as well for the AutoName use case.