### PR TITLE
Replace /pf in downstream tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,4 +93,4 @@ jobs:
           pulumi-bot-token: ${{ secrets.PULUMI_BOT_TOKEN }}
           github-actions-token: ${{ secrets.GITHUB_TOKEN }}
           use-provider-dir: true
-          replacements: github.com/pulumi/pulumi-terraform-bridge/v3=pulumi-terraform-bridge,github.com/pulumi/pulumi-terraform-bridge/x/muxer=pulumi-terraform-bridge/x/muxer
+          replacements: github.com/pulumi/pulumi-terraform-bridge/v3=pulumi-terraform-bridge,github.com/pulumi/pulumi-terraform-bridge/x/muxer=pulumi-terraform-bridge/x/muxer,github.com/pulumi/pulumi-terraform-bridge/pf=pulumi-terraform-bridge/pf


### PR DESCRIPTION
Fixup our downstream tests (now just pulumi-random) to use the in-repo version of /pf as well as the muxer and the bridge. This is necessary as we require upgrades to happen in lock-step and make changes that would otherwise be breaking, similar to pulumi/{pkg,sdk}.