### PR TITLE
Avoid spurious diffs caused by schema.NormalizeObjectFromLegacySDK

### DIFF
--- a/pkg/tests/go.mod
+++ b/pkg/tests/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/armon/go-metrics v0.4.0 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
-	github.com/aws/aws-sdk-go v1.44.122 // indirect
+	github.com/aws/aws-sdk-go v1.44.122
 	github.com/aws/aws-sdk-go-v2 v1.17.3 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.3 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.15.15 // indirect

--- a/pkg/tests/internal/webaclschema/schemas.go
+++ b/pkg/tests/internal/webaclschema/schemas.go
@@ -1,0 +1,1239 @@
+// Copied from https://github.com/pulumi/terraform-provider-aws/blob/9106d49534199fa6d12d33c27c6cbd4ff777102c/internal/service/wafv2/schemas.go
+//
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package wafv2
+
+import (
+	"math"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/service/wafv2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	// "github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+var listOfEmptyObjectSchema *schema.Schema = &schema.Schema{
+	Type:     schema.TypeList,
+	Optional: true,
+	MaxItems: 1,
+	Elem: &schema.Resource{
+		Schema: map[string]*schema.Schema{},
+	},
+}
+
+func emptySchema() *schema.Schema {
+	return listOfEmptyObjectSchema
+}
+
+func ruleLabelsSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeSet,
+		Optional: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"name": {
+					Type:     schema.TypeString,
+					Required: true,
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(1, 1024),
+						validation.StringMatch(regexp.MustCompile(`^[0-9A-Za-z_\-:]+$`), "must contain only alphanumeric, underscore, hyphen, and colon characters"),
+					),
+				},
+			},
+		},
+	}
+}
+
+func ruleGroupRootStatementSchema(level int) *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Required: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"and_statement":                         statementSchema(level - 1),
+				"byte_match_statement":                  byteMatchStatementSchema(),
+				"geo_match_statement":                   geoMatchStatementSchema(),
+				"ip_set_reference_statement":            ipSetReferenceStatementSchema(),
+				"label_match_statement":                 labelMatchStatementSchema(),
+				"not_statement":                         statementSchema(level - 1),
+				"or_statement":                          statementSchema(level - 1),
+				"rate_based_statement":                  rateBasedStatementSchema(level - 1),
+				"regex_match_statement":                 regexMatchStatementSchema(),
+				"regex_pattern_set_reference_statement": regexPatternSetReferenceStatementSchema(),
+				"size_constraint_statement":             sizeConstraintSchema(),
+				"sqli_match_statement":                  sqliMatchStatementSchema(),
+				"xss_match_statement":                   xssMatchStatementSchema(),
+			},
+		},
+	}
+}
+
+func statementSchema(level int) *schema.Schema {
+	if level > 1 {
+		return &schema.Schema{
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"statement": {
+						Type:     schema.TypeList,
+						Required: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"and_statement":                         statementSchema(level - 1),
+								"byte_match_statement":                  byteMatchStatementSchema(),
+								"geo_match_statement":                   geoMatchStatementSchema(),
+								"ip_set_reference_statement":            ipSetReferenceStatementSchema(),
+								"label_match_statement":                 labelMatchStatementSchema(),
+								"not_statement":                         statementSchema(level - 1),
+								"or_statement":                          statementSchema(level - 1),
+								"regex_match_statement":                 regexMatchStatementSchema(),
+								"regex_pattern_set_reference_statement": regexPatternSetReferenceStatementSchema(),
+								"size_constraint_statement":             sizeConstraintSchema(),
+								"sqli_match_statement":                  sqliMatchStatementSchema(),
+								"xss_match_statement":                   xssMatchStatementSchema(),
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"statement": {
+					Type:     schema.TypeList,
+					Required: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"byte_match_statement":                  byteMatchStatementSchema(),
+							"geo_match_statement":                   geoMatchStatementSchema(),
+							"ip_set_reference_statement":            ipSetReferenceStatementSchema(),
+							"label_match_statement":                 labelMatchStatementSchema(),
+							"regex_match_statement":                 regexMatchStatementSchema(),
+							"regex_pattern_set_reference_statement": regexPatternSetReferenceStatementSchema(),
+							"size_constraint_statement":             sizeConstraintSchema(),
+							"sqli_match_statement":                  sqliMatchStatementSchema(),
+							"xss_match_statement":                   xssMatchStatementSchema(),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func byteMatchStatementSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"field_to_match": fieldToMatchSchema(),
+				"positional_constraint": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringInSlice(wafv2.PositionalConstraint_Values(), false),
+				},
+				"search_string": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringLenBetween(1, 200),
+				},
+				"text_transformation": textTransformationSchema(),
+			},
+		},
+	}
+}
+
+func geoMatchStatementSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"country_codes": {
+					Type:     schema.TypeList,
+					Required: true,
+					MinItems: 1,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"forwarded_ip_config": forwardedIPConfigSchema(),
+			},
+		},
+	}
+}
+
+func ipSetReferenceStatementSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"arn": {
+					Type:     schema.TypeString,
+					Required: true,
+					//ValidateFunc: verify.ValidARN,
+				},
+				"ip_set_forwarded_ip_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"fallback_behavior": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringInSlice(wafv2.FallbackBehavior_Values(), false),
+							},
+							"header_name": {
+								Type:     schema.TypeString,
+								Required: true,
+								ValidateFunc: validation.All(
+									validation.StringLenBetween(1, 255),
+									validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9-]+$`), "must contain only alphanumeric and hyphen characters"),
+								),
+							},
+							"position": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringInSlice(wafv2.ForwardedIPPosition_Values(), false),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func labelMatchStatementSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"key": {
+					Type:     schema.TypeString,
+					Required: true,
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(1, 1024),
+						validation.StringMatch(regexp.MustCompile(`^[0-9A-Za-z_\-:]+$`), "must contain only alphanumeric, underscore, hyphen, and colon characters"),
+					),
+				},
+				"scope": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringInSlice(wafv2.LabelMatchScope_Values(), false),
+				},
+			},
+		},
+	}
+}
+
+func regexMatchStatementSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"regex_string": {
+					Type:     schema.TypeString,
+					Required: true,
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(1, 512),
+						validation.StringIsValidRegExp,
+					),
+				},
+				"field_to_match":      fieldToMatchSchema(),
+				"text_transformation": textTransformationSchema(),
+			},
+		},
+	}
+}
+
+func regexPatternSetReferenceStatementSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"arn": {
+					Type:     schema.TypeString,
+					Required: true,
+					// ValidateFunc: verify.ValidARN,
+				},
+				"field_to_match":      fieldToMatchSchema(),
+				"text_transformation": textTransformationSchema(),
+			},
+		},
+	}
+}
+
+func sizeConstraintSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"comparison_operator": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringInSlice(wafv2.ComparisonOperator_Values(), false),
+				},
+				"field_to_match": fieldToMatchSchema(),
+				"size": {
+					Type:         schema.TypeInt,
+					Required:     true,
+					ValidateFunc: validation.IntBetween(0, math.MaxInt32),
+				},
+				"text_transformation": textTransformationSchema(),
+			},
+		},
+	}
+}
+
+func sqliMatchStatementSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"field_to_match":      fieldToMatchSchema(),
+				"text_transformation": textTransformationSchema(),
+			},
+		},
+	}
+}
+
+func xssMatchStatementSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"field_to_match":      fieldToMatchSchema(),
+				"text_transformation": textTransformationSchema(),
+			},
+		},
+	}
+}
+
+func fieldToMatchBaseSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"all_query_arguments": emptySchema(),
+			"body":                bodySchema(),
+			"cookies":             cookiesSchema(),
+			"headers":             headersSchema(),
+			"json_body":           jsonBodySchema(),
+			"method":              emptySchema(),
+			"query_string":        emptySchema(),
+			"single_header": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.All(
+								validation.StringLenBetween(1, 40),
+								// The value is returned in lower case by the API.
+								// Trying to solve it with StateFunc and/or DiffSuppressFunc resulted in hash problem of the rule field or didn't work.
+								validation.StringMatch(regexp.MustCompile(`^[a-z0-9-_]+$`), "must contain only lowercase alphanumeric characters, underscores, and hyphens"),
+							),
+						},
+					},
+				},
+			},
+			"single_query_argument": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.All(
+								validation.StringLenBetween(1, 30),
+								// The value is returned in lower case by the API.
+								// Trying to solve it with StateFunc and/or DiffSuppressFunc resulted in hash problem of the rule field or didn't work.
+								validation.StringMatch(regexp.MustCompile(`^[a-z0-9-_]+$`), "must contain only lowercase alphanumeric characters, underscores, and hyphens"),
+							),
+						},
+					},
+				},
+			},
+			"uri_path": emptySchema(),
+		},
+	}
+}
+
+func fieldToMatchSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem:     fieldToMatchBaseSchema(),
+	}
+}
+
+func jsonBodySchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"invalid_fallback_behavior": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringInSlice(wafv2.BodyParsingFallbackBehavior_Values(), false),
+				},
+				"match_pattern": jsonBodyMatchPatternSchema(),
+				"match_scope": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringInSlice(wafv2.JsonMatchScope_Values(), false),
+				},
+				"oversize_handling": oversizeHandlingOptionalSchema(wafv2.OversizeHandlingContinue),
+			},
+		},
+	}
+}
+
+func jsonBodyMatchPatternSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Required: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"all": emptySchema(),
+				"included_paths": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MinItems: 1,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+						ValidateFunc: validation.All(
+							validation.StringLenBetween(1, 512),
+							validation.StringMatch(regexp.MustCompile(`(/)|(/(([^~])|(~[01]))+)`), "must be a valid JSON pointer")),
+					},
+				},
+			},
+		},
+	}
+}
+
+func forwardedIPConfigSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"fallback_behavior": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringInSlice(wafv2.FallbackBehavior_Values(), false),
+				},
+				"header_name": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			},
+		},
+	}
+}
+
+func textTransformationSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeSet,
+		Required: true,
+		MinItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"priority": {
+					Type:     schema.TypeInt,
+					Required: true,
+				},
+				"type": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringInSlice(wafv2.TextTransformationType_Values(), false),
+				},
+			},
+		},
+	}
+}
+
+func visibilityConfigSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Required: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"cloudwatch_metrics_enabled": {
+					Type:     schema.TypeBool,
+					Required: true,
+				},
+				"metric_name": {
+					Type:     schema.TypeString,
+					Required: true,
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(1, 128),
+						validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9-_]+$`), "must contain only alphanumeric hyphen and underscore characters"),
+					),
+				},
+				"sampled_requests_enabled": {
+					Type:     schema.TypeBool,
+					Required: true,
+				},
+			},
+		},
+	}
+}
+
+func allowConfigSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"custom_request_handling": customRequestHandlingSchema(),
+			},
+		},
+	}
+}
+
+func captchaConfigSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"custom_request_handling": customRequestHandlingSchema(),
+			},
+		},
+	}
+}
+
+func outerCaptchaConfigSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"immunity_time_property": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"immunity_time": {
+								Type:     schema.TypeInt,
+								Optional: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func challengeConfigSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"custom_request_handling": customRequestHandlingSchema(),
+			},
+		},
+	}
+}
+
+func countConfigSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"custom_request_handling": customRequestHandlingSchema(),
+			},
+		},
+	}
+}
+
+func blockConfigSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"custom_response": customResponseSchema(),
+			},
+		},
+	}
+}
+
+func customRequestHandlingSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"insert_header": {
+					Type:     schema.TypeSet,
+					Required: true,
+					MinItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"name": {
+								Type:     schema.TypeString,
+								Required: true,
+								ValidateFunc: validation.All(
+									validation.StringLenBetween(1, 64),
+									validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9._$-]+$`), "must contain only alphanumeric, hyphen, underscore, dot and $ characters"),
+								),
+							},
+							"value": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringLenBetween(1, 255),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func customResponseSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"custom_response_body_key": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(1, 128),
+						validation.StringMatch(regexp.MustCompile(`^[\w\-]+$`), "must contain only alphanumeric, hyphen, and underscore characters"),
+					),
+				},
+				"response_code": {
+					Type:         schema.TypeInt,
+					Required:     true,
+					ValidateFunc: validation.IntBetween(200, 600),
+				},
+				"response_header": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"name": {
+								Type:     schema.TypeString,
+								Required: true,
+								ValidateFunc: validation.All(
+									validation.StringLenBetween(1, 64),
+									validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9._$-]+$`), "must contain only alphanumeric, hyphen, underscore, dot and $ characters"),
+								),
+							},
+							"value": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringLenBetween(1, 255),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func customResponseBodySchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeSet,
+		Optional: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"key": {
+					Type:     schema.TypeString,
+					Required: true,
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(1, 128),
+						validation.StringMatch(regexp.MustCompile(`^[\w\-]+$`), "must contain only alphanumeric, hyphen, and underscore characters"),
+					),
+				},
+				"content": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringLenBetween(1, 10240),
+				},
+				"content_type": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringInSlice(wafv2.ResponseContentType_Values(), false),
+				},
+			},
+		},
+	}
+}
+
+func cookiesSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"match_scope":       matchScopeSchema(),
+				"oversize_handling": oversizeHandlingRequiredSchema(),
+				"match_pattern":     cookiesMatchPatternSchema(),
+			},
+		},
+	}
+}
+
+func cookiesMatchPatternSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Required: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"all": emptySchema(),
+				"excluded_cookies": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"included_cookies": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+			},
+		},
+	}
+}
+
+func bodySchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"oversize_handling": oversizeHandlingOptionalSchema(wafv2.OversizeHandlingContinue),
+			},
+		},
+	}
+}
+
+func oversizeHandlingOptionalSchema(defaultValue string) *schema.Schema {
+	return &schema.Schema{
+		Type:         schema.TypeString,
+		Optional:     true,
+		Default:      defaultValue,
+		ValidateFunc: validation.StringInSlice(wafv2.OversizeHandling_Values(), false),
+	}
+}
+
+func oversizeHandlingRequiredSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:         schema.TypeString,
+		Required:     true,
+		ValidateFunc: validation.StringInSlice(wafv2.OversizeHandling_Values(), false),
+	}
+}
+
+func matchScopeSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:         schema.TypeString,
+		Required:     true,
+		ValidateFunc: validation.StringInSlice(wafv2.MapMatchScope_Values(), false),
+	}
+}
+
+func headersSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"match_pattern": {
+					Type:     schema.TypeList,
+					Required: true,
+					MaxItems: 1,
+					MinItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"all":              emptySchema(),
+							"excluded_headers": headersMatchPatternBaseSchema(),
+							"included_headers": headersMatchPatternBaseSchema(),
+						},
+					},
+				},
+				"match_scope":       matchScopeSchema(),
+				"oversize_handling": oversizeHandlingRequiredSchema(),
+			},
+		},
+	}
+}
+
+func headersMatchPatternBaseSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MinItems: 1,
+		MaxItems: 199,
+		Elem: &schema.Schema{
+			Type: schema.TypeString,
+			ValidateFunc: validation.All(
+				validation.StringLenBetween(1, 64),
+				validation.StringMatch(regexp.MustCompile(`.*\S.*`), ""),
+			),
+		},
+	}
+}
+
+func webACLRootStatementSchema(level int) *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Required: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"and_statement":                         statementSchema(level),
+				"byte_match_statement":                  byteMatchStatementSchema(),
+				"geo_match_statement":                   geoMatchStatementSchema(),
+				"ip_set_reference_statement":            ipSetReferenceStatementSchema(),
+				"label_match_statement":                 labelMatchStatementSchema(),
+				"managed_rule_group_statement":          managedRuleGroupStatementSchema(level),
+				"not_statement":                         statementSchema(level),
+				"or_statement":                          statementSchema(level),
+				"rate_based_statement":                  rateBasedStatementSchema(level),
+				"regex_match_statement":                 regexMatchStatementSchema(),
+				"regex_pattern_set_reference_statement": regexPatternSetReferenceStatementSchema(),
+				"rule_group_reference_statement":        ruleGroupReferenceStatementSchema(),
+				"size_constraint_statement":             sizeConstraintSchema(),
+				"sqli_match_statement":                  sqliMatchStatementSchema(),
+				"xss_match_statement":                   xssMatchStatementSchema(),
+			},
+		},
+	}
+}
+
+func managedRuleGroupStatementSchema(level int) *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"managed_rule_group_configs": managedRuleGroupConfigSchema(),
+				"name": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringLenBetween(1, 128),
+				},
+				"rule_action_override": ruleActionOverrideSchema(),
+				"scope_down_statement": scopeDownStatementSchema(level - 1),
+				"vendor_name": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringLenBetween(1, 128),
+				},
+				"version": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringLenBetween(1, 128),
+				},
+			},
+		},
+	}
+}
+
+func rateBasedStatementSchema(level int) *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"aggregate_key_type": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Default:      wafv2.RateBasedStatementAggregateKeyTypeIp,
+					ValidateFunc: validation.StringInSlice(wafv2.RateBasedStatementAggregateKeyType_Values(), false),
+				},
+				"forwarded_ip_config": forwardedIPConfigSchema(),
+				"limit": {
+					Type:         schema.TypeInt,
+					Required:     true,
+					ValidateFunc: validation.IntBetween(100, 2000000000),
+				},
+				"scope_down_statement": scopeDownStatementSchema(level - 1),
+			},
+		},
+	}
+}
+
+func scopeDownStatementSchema(level int) *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"and_statement":                         statementSchema(level),
+				"byte_match_statement":                  byteMatchStatementSchema(),
+				"geo_match_statement":                   geoMatchStatementSchema(),
+				"label_match_statement":                 labelMatchStatementSchema(),
+				"ip_set_reference_statement":            ipSetReferenceStatementSchema(),
+				"not_statement":                         statementSchema(level),
+				"or_statement":                          statementSchema(level),
+				"regex_match_statement":                 regexMatchStatementSchema(),
+				"regex_pattern_set_reference_statement": regexPatternSetReferenceStatementSchema(),
+				"size_constraint_statement":             sizeConstraintSchema(),
+				"sqli_match_statement":                  sqliMatchStatementSchema(),
+				"xss_match_statement":                   xssMatchStatementSchema(),
+			},
+		},
+	}
+}
+
+func ruleActionOverrideSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 100,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"action_to_use": actionToUseSchema(),
+				"name": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringLenBetween(1, 128),
+				},
+			},
+		},
+	}
+}
+
+func managedRuleGroupConfigSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"aws_managed_rules_bot_control_rule_set": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"inspection_level": {
+								Type:     schema.TypeString,
+								Required: true,
+								// ValidateFunc: validation.StringInSlice(wafv2.InspectionLevel_Values(), false),
+							},
+						},
+					},
+				},
+				"aws_managed_rules_atp_rule_set": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"login_path": {
+								Type:     schema.TypeString,
+								Required: true,
+								ValidateFunc: validation.All(
+									validation.StringLenBetween(1, 256),
+									validation.StringMatch(regexp.MustCompile(`.*\S.*`), `must conform to pattern .*\S.* `),
+								),
+							},
+							"request_inspection":  managedRuleGroupConfigATPRequestInspectionSchema(),
+							"response_inspection": managedRuleGroupConfigATPResponseInspectionSchema(),
+						},
+					},
+				},
+				"login_path": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(1, 256),
+						validation.StringMatch(regexp.MustCompile(`.*\S.*`), `must conform to pattern .*\S.* `),
+					),
+				},
+				"password_field": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"identifier": {
+								Type:     schema.TypeString,
+								Required: true,
+								ValidateFunc: validation.All(
+									validation.StringLenBetween(1, 512),
+									validation.StringMatch(regexp.MustCompile(`.*\S.*`), `must conform to pattern .*\S.* `),
+								),
+							},
+						},
+					},
+				},
+				"payload_type": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringInSlice(wafv2.PayloadType_Values(), false),
+				},
+				"username_field": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"identifier": {
+								Type:     schema.TypeString,
+								Required: true,
+								ValidateFunc: validation.All(
+									validation.StringLenBetween(1, 512),
+									validation.StringMatch(regexp.MustCompile(`.*\S.*`), `must conform to pattern .*\S.* `),
+								),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func actionToUseSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Required: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"allow":   allowConfigSchema(),
+				"block":   blockConfigSchema(),
+				"captcha": captchaConfigSchema(),
+				"count":   countConfigSchema(),
+			},
+		},
+	}
+}
+
+func ruleGroupReferenceStatementSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"arn": {
+					Type:     schema.TypeString,
+					Required: true,
+					//ValidateFunc: verify.ValidARN,
+				},
+				"rule_action_override": ruleActionOverrideSchema(),
+			},
+		},
+	}
+}
+
+func managedRuleGroupConfigATPRequestInspectionSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"password_field": {
+					Type:     schema.TypeList,
+					Required: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"identifier": {
+								Type:     schema.TypeString,
+								Required: true,
+								ValidateFunc: validation.All(
+									validation.StringLenBetween(1, 512),
+									validation.StringMatch(regexp.MustCompile(`.*\S.*`), `must conform to pattern .*\S.* `),
+								),
+							},
+						},
+					},
+				},
+				"payload_type": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringInSlice(wafv2.PayloadType_Values(), false),
+				},
+				"username_field": {
+					Type:     schema.TypeList,
+					Required: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"identifier": {
+								Type:     schema.TypeString,
+								Required: true,
+								ValidateFunc: validation.All(
+									validation.StringLenBetween(1, 512),
+									validation.StringMatch(regexp.MustCompile(`.*\S.*`), `must conform to pattern .*\S.* `),
+								),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func managedRuleGroupConfigATPResponseInspectionSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"body_contains": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"failure_strings": {
+								Type:     schema.TypeSet,
+								Required: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							"success_strings": {
+								Type:     schema.TypeSet,
+								Required: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+						},
+					},
+				},
+				"header": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"failure_values": {
+								Type:     schema.TypeSet,
+								Required: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+								// TODO: ValidateFunc: length > 0
+							},
+							"name": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringLenBetween(1, 256),
+							},
+							"success_values": {
+								Type:     schema.TypeSet,
+								Required: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+								// TODO: ValidateFunc: length > 0
+							},
+						},
+					},
+				},
+				"json": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"failure_values": {
+								Type:     schema.TypeSet,
+								Required: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+								// TODO: ValidateFunc: length > 0
+							},
+							"identifier": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringLenBetween(1, 256),
+							},
+							"success_values": {
+								Type:     schema.TypeSet,
+								Required: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+								// TODO: ValidateFunc: length > 0
+							},
+						},
+					},
+				},
+				"status_code": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"failure_codes": {
+								Type:     schema.TypeSet,
+								Required: true,
+								Elem:     &schema.Schema{Type: schema.TypeInt},
+								// TODO: ValidateFunc: length > 0
+							},
+							"success_codes": {
+								Type:     schema.TypeSet,
+								Required: true,
+								Elem:     &schema.Schema{Type: schema.TypeInt},
+								// TODO: ValidateFunc: length > 0
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/tests/internal/webaclschema/schemas.go
+++ b/pkg/tests/internal/webaclschema/schemas.go
@@ -47,31 +47,6 @@ func ruleLabelsSchema() *schema.Schema {
 	}
 }
 
-func ruleGroupRootStatementSchema(level int) *schema.Schema {
-	return &schema.Schema{
-		Type:     schema.TypeList,
-		Required: true,
-		MaxItems: 1,
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"and_statement":                         statementSchema(level - 1),
-				"byte_match_statement":                  byteMatchStatementSchema(),
-				"geo_match_statement":                   geoMatchStatementSchema(),
-				"ip_set_reference_statement":            ipSetReferenceStatementSchema(),
-				"label_match_statement":                 labelMatchStatementSchema(),
-				"not_statement":                         statementSchema(level - 1),
-				"or_statement":                          statementSchema(level - 1),
-				"rate_based_statement":                  rateBasedStatementSchema(level - 1),
-				"regex_match_statement":                 regexMatchStatementSchema(),
-				"regex_pattern_set_reference_statement": regexPatternSetReferenceStatementSchema(),
-				"size_constraint_statement":             sizeConstraintSchema(),
-				"sqli_match_statement":                  sqliMatchStatementSchema(),
-				"xss_match_statement":                   xssMatchStatementSchema(),
-			},
-		},
-	}
-}
-
 func statementSchema(level int) *schema.Schema {
 	if level > 1 {
 		return &schema.Schema{

--- a/pkg/tests/internal/webaclschema/webacl.go
+++ b/pkg/tests/internal/webaclschema/webacl.go
@@ -83,8 +83,14 @@ func ResourceWebACL() *schema.Resource {
 				name := idParts[1]
 				scope := idParts[2]
 				d.SetId(id)
-				d.Set("name", name)
-				d.Set("scope", scope)
+				err := d.Set("name", name)
+				if err != nil {
+					return nil, err
+				}
+				err = d.Set("scope", scope)
+				if err != nil {
+					return nil, err
+				}
 				return []*schema.ResourceData{d}, nil
 			},
 		},

--- a/pkg/tests/internal/webaclschema/webacl.go
+++ b/pkg/tests/internal/webaclschema/webacl.go
@@ -1,0 +1,195 @@
+// Copied from https://github.com/pulumi/terraform-provider-aws/blob/9106d49534199fa6d12d33c27c6cbd4ff777102c/internal/service/wafv2/web_acl.go
+//
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package wafv2
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"hash/crc32"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func ResourceWebACL() *schema.Resource {
+	hashcodeString := func(s string) int {
+		v := int(crc32.ChecksumIEEE([]byte(s)))
+		if v >= 0 {
+			return v
+		}
+		if -v >= 0 {
+			return -v
+		}
+		// v == MinInt
+		return 0
+	}
+
+	ruleElement := &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"action": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"allow":     allowConfigSchema(),
+						"block":     blockConfigSchema(),
+						"captcha":   captchaConfigSchema(),
+						"challenge": challengeConfigSchema(),
+						"count":     countConfigSchema(),
+					},
+				},
+			},
+			"captcha_config": outerCaptchaConfigSchema(),
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(1, 128),
+			},
+			"override_action": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"count": emptySchema(),
+						"none":  emptySchema(),
+					},
+				},
+			},
+			"priority": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"rule_label":        ruleLabelsSchema(),
+			"statement":         webACLRootStatementSchema(3),
+			"visibility_config": visibilityConfigSchema(),
+		},
+	}
+	return &schema.Resource{
+		Importer: &schema.ResourceImporter{
+			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				idParts := strings.Split(d.Id(), "/")
+				if len(idParts) != 3 || idParts[0] == "" || idParts[1] == "" || idParts[2] == "" {
+					return nil, fmt.Errorf("Unexpected format of ID (%q), expected ID/NAME/SCOPE", d.Id())
+				}
+				id := idParts[0]
+				name := idParts[1]
+				scope := idParts[2]
+				d.SetId(id)
+				d.Set("name", name)
+				d.Set("scope", scope)
+				return []*schema.ResourceData{d}, nil
+			},
+		},
+
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"arn": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"capacity": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"captcha_config":       outerCaptchaConfigSchema(),
+				"custom_response_body": customResponseBodySchema(),
+				"default_action": {
+					Type:     schema.TypeList,
+					Required: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"allow": allowConfigSchema(),
+							"block": blockConfigSchema(),
+						},
+					},
+				},
+				"description": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringLenBetween(1, 256),
+				},
+				"lock_token": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"name": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(1, 128),
+						validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9-_]+$`), "must contain only alphanumeric hyphen and underscore characters"),
+					),
+				},
+				"rule": {
+					Type: schema.TypeSet,
+					Set: func(v interface{}) int {
+						var buf bytes.Buffer
+						schema.SerializeResourceForHash(&buf, v, ruleElement)
+						// before := "action:(<allow:(<custom_request_handling:();>;);"
+						// after := "action:(<allow:(<>;);"
+						s := buf.String()
+						//s = strings.ReplaceAll(s, before, after)
+						n := hashcodeString(s)
+						if 1+2 == 18 {
+							fmt.Printf("PRE-HASH:\n%s\n\n", s)
+							fmt.Printf("HASHED: %d\n", n)
+						}
+						return n
+					},
+					Optional: true,
+					Elem:     ruleElement,
+				},
+				"scope": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+					//ValidateFunc: validation.StringInSlice(wafv2.Scope_Values(), false),
+				},
+				// names.AttrTags:    tftags.TagsSchema(),
+				// names.AttrTagsAll: tftags.TagsSchemaTrulyComputed(),
+				"token_domains": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+						ValidateFunc: validation.All(
+							validation.StringLenBetween(1, 253),
+							validation.StringMatch(regexp.MustCompile(`^[\w\.\-/]+$`), "must contain only alphanumeric, hyphen, dot, underscore and forward-slash characters"),
+						),
+					},
+				},
+				"visibility_config": visibilityConfigSchema(),
+				"tags":              TagsSchema(),
+				"tags_all":          TagsSchemaTrulyComputed(),
+			}
+		},
+
+		//CustomizeDiff: verify.SetTagsDiff,
+	}
+}
+
+func TagsSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeMap,
+		Optional: true,
+		Elem:     &schema.Schema{Type: schema.TypeString},
+	}
+}
+
+func TagsSchemaTrulyComputed() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeMap,
+		Computed: true,
+		Elem:     &schema.Schema{Type: schema.TypeString},
+	}
+}

--- a/pkg/tests/regress_aws_1423_test.go
+++ b/pkg/tests/regress_aws_1423_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	testutils "github.com/pulumi/pulumi-terraform-bridge/testing/x"
+	webaclschema "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/internal/webaclschema"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
 )
@@ -28,52 +29,7 @@ import (
 func TestRegressAws1423(t *testing.T) {
 	ctx := context.Background()
 
-	emptySchema := func() *schema.Schema {
-		return &schema.Schema{
-			Type:     schema.TypeList,
-			Optional: true,
-			MaxItems: 1,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{},
-			},
-		}
-	}
-
-	resource := &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"rule": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"name": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"override": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"count": emptySchema(),
-									"none":  emptySchema(),
-								},
-							},
-						},
-						"priority": {
-							Type:     schema.TypeInt,
-							Required: true,
-						},
-					},
-				},
-			},
-		},
-	}
+	resource := webaclschema.ResourceWebACL()
 
 	tfProvider := &schema.Provider{
 		Schema: map[string]*schema.Schema{},
@@ -82,7 +38,7 @@ func TestRegressAws1423(t *testing.T) {
 		},
 	}
 
-	p := shimv2.NewProvider(tfProvider) // , shimv2.WithDiffStrategy(shimv2.PlanState))
+	p := shimv2.NewProvider(tfProvider, shimv2.WithDiffStrategy(shimv2.PlanState))
 
 	info := tfbridge.ProviderInfo{
 		P:           p,
@@ -109,7 +65,7 @@ func TestRegressAws1423(t *testing.T) {
 
 	shimv2.SetInstanceStateStrategy(p.ResourcesMap().Get("aws_wafv2_web_acl"), shimv2.CtyInstanceState)
 
-	testCase := `
+	testCase1 := `
 	{
 	  "method": "/pulumirpc.ResourceProvider/Create",
 	  "request": {
@@ -123,8 +79,10 @@ func TestRegressAws1423(t *testing.T) {
 		{
 		  "__defaults": [],
 		  "name": "rule-1",
-                  "priority": 0,
-		  "override": {
+		  "action": null,
+		  "captchaConfig": null,
+		  "priority": 0,
+		  "overrideAction": {
 		    "__defaults": [],
 		    "count": {
 		      "__defaults": []
@@ -137,12 +95,29 @@ func TestRegressAws1423(t *testing.T) {
 	  },
 	  "response": {
 	    "properties": {
+              "tags": null,
+              "tagsAll": "*",
+	      "arn": "*",
+	      "capacity": "*",
+	      "captchaConfig": "*",
+	      "customResponseBodies": [],
+	      "defaultAction": null,
+	      "description": null,
+	      "lockToken": "*",
 	      "id": "*",
-              "name": "aclw-a956aa7",
+	      "name": "aclw-a956aa7",
+	      "scope": "",
+	      "tokenDomains": null,
+	      "visibilityConfig": null,
 	      "rules": [
 		{
+		  "action": null,
+		  "captchaConfig": null,
+		  "ruleLabels": [],
+		  "statement": null,
+		  "visibilityConfig": null,
 		  "name": "rule-1",
-		  "override": {
+		  "overrideAction": {
 		    "count": {},
 		    "none": null
 		  },
@@ -152,5 +127,316 @@ func TestRegressAws1423(t *testing.T) {
 	    }
 	  }
 	}`
-	testutils.Replay(t, server, testCase)
+	t.Run("testCase1", func(t *testing.T) {
+		testutils.Replay(t, server, testCase1)
+	})
+
+	testCase2CreatePreview := `
+	{
+	  "method": "/pulumirpc.ResourceProvider/Create",
+	  "request": {
+	    "urn": "urn:pulumi:dev::aws-2264::aws:wafv2/webAcl:WebAcl::my-web-acl",
+	    "properties": {
+	      "__defaults": [],
+	      "defaultAction": {
+		"__defaults": [],
+		"block": {
+		  "__defaults": []
+		}
+	      },
+	      "name": "my-web-acl",
+	      "rules": [
+		{
+		  "__defaults": [],
+		  "action": {
+		    "__defaults": [],
+		    "allow": {
+		      "__defaults": []
+		    }
+		  },
+		  "name": "US-access-only",
+		  "priority": 0,
+		  "statement": {
+		    "__defaults": [],
+		    "geoMatchStatement": {
+		      "__defaults": [],
+		      "countryCodes": [
+			"US"
+		      ]
+		    }
+		  },
+		  "visibilityConfig": {
+		    "__defaults": [],
+		    "cloudwatchMetricsEnabled": true,
+		    "metricName": "US-access-only",
+		    "sampledRequestsEnabled": true
+		  }
+		}
+	      ],
+	      "scope": "REGIONAL",
+	      "visibilityConfig": {
+		"__defaults": [],
+		"cloudwatchMetricsEnabled": true,
+		"metricName": "my-web-acl",
+		"sampledRequestsEnabled": true
+	      }
+	    },
+	    "preview": true
+	  },
+	  "response": {
+	    "properties": {
+              "tokenDomains": null,
+              "description": null, "tags": null, "tagsAll": "*",
+	      "arn": "04da6b54-80e4-46f7-96ec-b56ff0331ba9",
+	      "capacity": "04da6b54-80e4-46f7-96ec-b56ff0331ba9",
+	      "captchaConfig": null,
+	      "customResponseBodies": [],
+	      "defaultAction": {
+		"allow": null,
+		"block": {"customResponse": null}
+	      },
+	      "id": "04da6b54-80e4-46f7-96ec-b56ff0331ba9",
+	      "lockToken": "04da6b54-80e4-46f7-96ec-b56ff0331ba9",
+	      "name": "my-web-acl",
+	      "rules": [
+		{
+		  "action": {
+		    "allow": {
+		      "customRequestHandling": null
+		    },
+		    "block": null,
+		    "captcha": null,
+		    "challenge": null,
+		    "count": null
+		  },
+		  "captchaConfig": null,
+		  "name": "US-access-only",
+		  "overrideAction": null,
+		  "priority": 0,
+		  "ruleLabels": [],
+		  "statement": {
+		    "andStatement": null,
+		    "byteMatchStatement": null,
+		    "geoMatchStatement": {
+		      "countryCodes": [
+			"US"
+		      ],
+		      "forwardedIpConfig": null
+		    },
+		    "ipSetReferenceStatement": null,
+		    "labelMatchStatement": null,
+		    "managedRuleGroupStatement": null,
+		    "notStatement": null,
+		    "orStatement": null,
+		    "rateBasedStatement": null,
+		    "regexMatchStatement": null,
+		    "regexPatternSetReferenceStatement": null,
+		    "ruleGroupReferenceStatement": null,
+		    "sizeConstraintStatement": null,
+		    "sqliMatchStatement": null,
+		    "xssMatchStatement": null
+		  },
+		  "visibilityConfig": {
+		    "cloudwatchMetricsEnabled": true,
+		    "metricName": "US-access-only",
+		    "sampledRequestsEnabled": true
+		  }
+		}
+	      ],
+	      "scope": "REGIONAL",
+	      "visibilityConfig": {
+		"cloudwatchMetricsEnabled": true,
+		"metricName": "my-web-acl",
+		"sampledRequestsEnabled": true
+	      }
+	    }
+	  }
+	}
+        `
+
+	testCase2 := `
+	{
+	  "method": "/pulumirpc.ResourceProvider/Diff",
+	  "request": {
+	    "id": "6ff5298f-7bcd-4e73-ba75-8784c2c77bcb",
+	    "urn": "urn:pulumi:dev::aws-2264::aws:wafv2/webAcl:WebAcl::my-web-acl-2",
+	    "olds": {
+	      "arn": "arn:aws:wafv2:us-east-1:616138583583:regional/webacl/my-web-acl-2/6ff5298f-7bcd-4e73-ba75-8784c2c77bcb",
+	      "associationConfig": null,
+	      "capacity": 1,
+	      "captchaConfig": null,
+	      "customResponseBodies": [],
+	      "defaultAction": {
+		"allow": null,
+		"block": {
+		  "customResponse": null
+		}
+	      },
+	      "description": "",
+	      "id": "6ff5298f-7bcd-4e73-ba75-8784c2c77bcb",
+	      "lockToken": "a58a7783-ac87-4ba9-8801-324ae5c63a07",
+	      "name": "my-web-acl-2",
+	      "rules": [
+		{
+		  "action": {
+		    "allow": {
+		      "customRequestHandling": null
+		    },
+		    "block": null,
+		    "captcha": null,
+		    "challenge": null,
+		    "count": null
+		  },
+		  "captchaConfig": null,
+		  "name": "US-access-only",
+		  "overrideAction": null,
+		  "priority": 0,
+		  "ruleLabels": [],
+		  "statement": {
+		    "andStatement": null,
+		    "byteMatchStatement": null,
+		    "geoMatchStatement": {
+		      "countryCodes": [
+			"US"
+		      ],
+		      "forwardedIpConfig": null
+		    },
+		    "ipSetReferenceStatement": null,
+		    "labelMatchStatement": null,
+		    "managedRuleGroupStatement": null,
+		    "notStatement": null,
+		    "orStatement": null,
+		    "rateBasedStatement": null,
+		    "regexMatchStatement": null,
+		    "regexPatternSetReferenceStatement": null,
+		    "ruleGroupReferenceStatement": null,
+		    "sizeConstraintStatement": null,
+		    "sqliMatchStatement": null,
+		    "xssMatchStatement": null
+		  },
+		  "visibilityConfig": {
+		    "cloudwatchMetricsEnabled": true,
+		    "metricName": "US-access-only",
+		    "sampledRequestsEnabled": true
+		  }
+		}
+	      ],
+	      "scope": "REGIONAL",
+	      "tags": {},
+	      "tagsAll": {},
+	      "tokenDomains": [],
+	      "visibilityConfig": {
+		"cloudwatchMetricsEnabled": true,
+		"metricName": "my-web-acl-2",
+		"sampledRequestsEnabled": true
+	      }
+	    },
+	    "news": {
+	      "__defaults": [],
+	      "defaultAction": {
+		"__defaults": [],
+		"block": {
+		  "__defaults": []
+		}
+	      },
+	      "name": "my-web-acl-2",
+	      "rules": [
+		{
+		  "__defaults": [],
+		  "action": {
+		    "__defaults": [],
+		    "allow": {
+		      "__defaults": []
+		    }
+		  },
+		  "name": "US-access-only",
+		  "priority": 0,
+		  "statement": {
+		    "__defaults": [],
+		    "geoMatchStatement": {
+		      "__defaults": [],
+		      "countryCodes": [
+			"US"
+		      ]
+		    }
+		  },
+		  "visibilityConfig": {
+		    "__defaults": [],
+		    "cloudwatchMetricsEnabled": true,
+		    "metricName": "US-access-only",
+		    "sampledRequestsEnabled": true
+		  }
+		}
+	      ],
+	      "scope": "REGIONAL",
+	      "visibilityConfig": {
+		"__defaults": [],
+		"cloudwatchMetricsEnabled": true,
+		"metricName": "my-web-acl-2",
+		"sampledRequestsEnabled": true
+	      }
+	    },
+	    "oldInputs": {
+	      "__defaults": [],
+	      "defaultAction": {
+		"__defaults": [],
+		"block": {
+		  "__defaults": []
+		}
+	      },
+	      "name": "my-web-acl-2",
+	      "rules": [
+		{
+		  "__defaults": [],
+		  "action": {
+		    "__defaults": [],
+		    "allow": {
+		      "__defaults": []
+		    }
+		  },
+		  "name": "US-access-only",
+		  "priority": 0,
+		  "statement": {
+		    "__defaults": [],
+		    "geoMatchStatement": {
+		      "__defaults": [],
+		      "countryCodes": [
+			"US"
+		      ]
+		    }
+		  },
+		  "visibilityConfig": {
+		    "__defaults": [],
+		    "cloudwatchMetricsEnabled": true,
+		    "metricName": "US-access-only",
+		    "sampledRequestsEnabled": true
+		  }
+		}
+	      ],
+	      "scope": "REGIONAL",
+	      "visibilityConfig": {
+		"__defaults": [],
+		"cloudwatchMetricsEnabled": true,
+		"metricName": "my-web-acl-2",
+		"sampledRequestsEnabled": true
+	      }
+	    }
+	  },
+	  "response": {
+	    "stables": "*",
+	    "changes": "DIFF_NONE",
+	    "hasDetailedDiff": true
+	  }
+	}`
+
+	t.Run("testCase2/createPreview", func(t *testing.T) {
+		// This is wrong; this test case is from a preview after an up wihtout edits, it should not detect
+		// diffs.
+		testutils.Replay(t, server, testCase2CreatePreview)
+	})
+	t.Run("testCase2/diff", func(t *testing.T) {
+		// This is wrong; this test case is from a preview after an up wihtout edits, it should not detect
+		// diffs.
+		testutils.Replay(t, server, testCase2)
+	})
 }

--- a/pkg/tfshim/sdk-v2/provider_diff.go
+++ b/pkg/tfshim/sdk-v2/provider_diff.go
@@ -94,7 +94,6 @@ func (p v2Provider) simpleDiff(
 			}
 			state.RawState = priorStateVal
 		}
-
 		if state.RawConfig.IsNull() {
 			// Same trick as above.
 			state.RawConfig = rawConfigVal
@@ -166,7 +165,6 @@ func simpleDiffViaPlanState(
 	if state.RawConfig.IsNull() {
 		state.RawConfig = rawConfigVal
 	}
-
 	return res.SimpleDiff(ctx, state, planned, meta)
 }
 

--- a/pkg/tfshim/sdk-v2/provider_diff.go
+++ b/pkg/tfshim/sdk-v2/provider_diff.go
@@ -94,6 +94,7 @@ func (p v2Provider) simpleDiff(
 			}
 			state.RawState = priorStateVal
 		}
+
 		if state.RawConfig.IsNull() {
 			// Same trick as above.
 			state.RawConfig = rawConfigVal
@@ -165,6 +166,7 @@ func simpleDiffViaPlanState(
 	if state.RawConfig.IsNull() {
 		state.RawConfig = rawConfigVal
 	}
+
 	return res.SimpleDiff(ctx, state, planned, meta)
 }
 


### PR DESCRIPTION
This change is currently under CtyInstanceState flag and so it can start rolling out targeting just one affected resource in AWS, WAFv2 WebACL.

There is a deeper problem captured here in the test, the way we use the TF primitives conflicts.

- schema.NormalizeObjectFromLegacySDK substitutes nil with empty lists.
- NewResourceConfigShimmed substitutes in the other direction

Comparing their results with Diff may cause the same data to appear to cause the diff.

In pulumi/pulumi-aws#2664 the exact issue is with `.rule[0].action.allow.customRequestHandler` field. It is truly absent from the user program, but schema.NormalizeObjectFromLegacySDK injects it back valued as an empty list. Once it's injected in the state, set element hashing gets confused about the hash of `.rule[0]`, so we get different hash for the rule in the state from the rule in config, causing a replace plan.

Avoiding the normalization pass seems like the simplest fix in terms of LOC changed, but this warrants future work to ensure inconsistent normalization does not affect us further.

