### PR TITLE
Fixes #1021

### DIFF
--- a/pkg/tfbridge/diff_test.go
+++ b/pkg/tfbridge/diff_test.go
@@ -145,7 +145,7 @@ func TestCustomizeDiff(t *testing.T) {
 		assert.Equal(t, expectedDiff, diff)
 	})
 
-	t.Run("CustomDiffDoesNotPanicOnGetRawState", func(t *testing.T) {
+	t.Run("CustomDiffDoesNotPanicOnGetRawStateOrRawConfig", func(t *testing.T) {
 		for _, diffStrat := range []shimv2.DiffStrategy{shimv2.PlanState, shimv2.ClassicDiff} {
 			diffStrat := diffStrat
 			t.Run(fmt.Sprintf("%v", diffStrat), func(t *testing.T) {
@@ -155,6 +155,10 @@ func TestCustomizeDiff(t *testing.T) {
 						rawStateType := diff.GetRawState().Type()
 						if !rawStateType.HasAttribute("outp") {
 							return fmt.Errorf("Expected rawState type to have attribute: outp")
+						}
+						rawConfigType := diff.GetRawConfig().Type()
+						if !rawConfigType.HasAttribute("outp") {
+							return fmt.Errorf("Expected rawConfig type to have attribute: outp")
 						}
 						return nil
 					},

--- a/pkg/tfshim/sdk-v2/provider_diff.go
+++ b/pkg/tfshim/sdk-v2/provider_diff.go
@@ -94,6 +94,10 @@ func (p v2Provider) simpleDiff(
 			}
 			state.RawState = priorStateVal
 		}
+		if state.RawConfig.IsNull() {
+			// Same trick as above.
+			state.RawConfig = rawConfigVal
+		}
 		return res.SimpleDiff(ctx, state, c, meta)
 	case PlanState:
 		return simpleDiffViaPlanState(ctx, res, s, rawConfigVal, meta)
@@ -157,6 +161,9 @@ func simpleDiffViaPlanState(
 	state.RawPlan = proposedNewStateVal
 	if state.RawState.IsNull() {
 		state.RawState = priorStateVal
+	}
+	if state.RawConfig.IsNull() {
+		state.RawConfig = rawConfigVal
 	}
 	return res.SimpleDiff(ctx, state, planned, meta)
 }


### PR DESCRIPTION
Fixes #1021 

Currently accessing RawConfig may panic on seeing a nil, and this breaks providers that start using GetRawConfig() in diff customizers, which is a common idiom in TF. The fix is along the same lines as https://github.com/pulumi/pulumi-terraform-bridge/pull/1314 - we propagate the current notion of rawConfigVal to populate the structure in question. This should be much better than panic in these situations but there's more work remaining in the future to make sure the rawConfigVal is similar to what TF would pass in the same situation to avoid logical discrepancies.

