### PR TITLE
Add logging context to `PreConfigureCallback` and `PreCheckCallback`

### DIFF
--- a/pf/internal/logging/logging.go
+++ b/pf/internal/logging/logging.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/logging"
 )
 
@@ -56,7 +57,11 @@ func InitLogging(ctx context.Context, opts LogOptions) context.Context {
 		ctx = tflog.SetField(ctx, "provider", p)
 	}
 
-	return ctx
+	return context.WithValue(ctx, logging.CtxKey,
+		logging.NewHost(ctx, opts.LogSink, opts.URN,
+			func(l *logging.Host[tfbridge.Log]) tfbridge.Log {
+				return l
+			}))
 }
 
 // See InitLogging.

--- a/pf/internal/logging/logging.go
+++ b/pf/internal/logging/logging.go
@@ -24,10 +24,13 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	rprovider "github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/logging"
 )
+
+type LogSink = logging.Sink
 
 // Sets up Context-scoped loggers to route Terraform logs to the Pulumi CLI process so they are visible to the user.
 //
@@ -63,14 +66,6 @@ type LogOptions struct {
 	ProviderVersion string
 	URN             resource.URN
 }
-
-// Abstracts the logging interface to HostClient. This is the interface providers use to report logging information back
-// to the Pulumi CLI over gRPC.
-type LogSink interface {
-	Log(context context.Context, sev diag.Severity, urn resource.URN, msg string) error
-}
-
-var _ LogSink = (*rprovider.HostClient)(nil)
 
 // Directs any logs written using the tflog API in the given Context to the given output.
 func setupRootLoggers(ctx context.Context, output io.Writer) context.Context {

--- a/pf/internal/logging/logging_test.go
+++ b/pf/internal/logging/logging_test.go
@@ -26,6 +26,8 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 )
 
 func TestLogging(t *testing.T) {
@@ -82,6 +84,29 @@ func TestLogging(t *testing.T) {
 			},
 			logs: []log{{sev: diag.Warning, msg: `provider\=random@4.12.0`}},
 		},
+		{
+			name: "User Logging",
+			opts: LogOptions{URN: urn},
+			emit: func(ctx context.Context) {
+				log := tfbridge.GetLogger(ctx)
+				log.Warn("warn")
+				log.Status().Info("info - status")
+
+			},
+			logs: []log{
+				{
+					urn: urn,
+					msg: "warn",
+					sev: diag.Warning,
+				},
+				{
+					urn:       urn,
+					msg:       "info - status",
+					sev:       diag.Info,
+					ephemeral: true,
+				},
+			},
+		},
 	}
 
 	for _, c := range cases {
@@ -100,6 +125,7 @@ func TestLogging(t *testing.T) {
 			for i := range c.logs {
 				assert.Equal(t, c.logs[i].sev, s.logs[i].sev)
 				assert.Equal(t, c.logs[i].urn, s.logs[i].urn)
+				assert.Equal(t, c.logs[i].ephemeral, s.logs[i].ephemeral)
 				assert.Regexp(t, c.logs[i].msg, s.logs[i].msg)
 			}
 		})

--- a/pf/internal/logging/logging_test.go
+++ b/pf/internal/logging/logging_test.go
@@ -142,9 +142,10 @@ func TestParseUrnFromRawString(t *testing.T) {
 }
 
 type log struct {
-	sev diag.Severity
-	urn resource.URN
-	msg string
+	sev       diag.Severity
+	urn       resource.URN
+	msg       string
+	ephemeral bool
 }
 
 type testLogSink struct {
@@ -158,6 +159,16 @@ func (sink *testLogSink) Log(context context.Context, sev diag.Severity, urn res
 		sev: sev,
 		urn: urn,
 		msg: msg,
+	})
+	return nil
+}
+
+func (sink *testLogSink) LogStatus(context context.Context, sev diag.Severity, urn resource.URN, msg string) error {
+	sink.logs = append(sink.logs, log{
+		sev:       sev,
+		urn:       urn,
+		msg:       msg,
+		ephemeral: true,
 	})
 	return nil
 }

--- a/pf/tests/testdata/basicprogram/Pulumi.yaml
+++ b/pf/tests/testdata/basicprogram/Pulumi.yaml
@@ -127,7 +127,12 @@ outputs:
   testComputedNull__actual: |-
     null
 
-  # fn::toJSON: ${minimalRes.optionalInputStringCopy}
+  # TODO: https://github.com/pulumi/pulumi-yaml/issues/492
+  # The `null` above should be this:
+  #
+  #     fn::toJSON: ${minimalRes.optionalInputStringCopy}
+  #
+  # We should re-enable the test when pulumi-yaml#492 is closed.
 
   testComputedNull__expect: |-
     null

--- a/pkg/tests/regress_940_test.go
+++ b/pkg/tests/regress_940_test.go
@@ -15,6 +15,7 @@
 package tests
 
 import (
+	"context"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -41,7 +42,8 @@ func TestRegress940(t *testing.T) {
 		}),
 	}
 
-	result, _, err := tfbridge.MakeTerraformInputs(instance, config, olds, news, shimmedR.Schema(), map[string]*tfbridge.SchemaInfo{})
+	ctx := context.Background()
+	result, _, err := tfbridge.MakeTerraformInputs(ctx, instance, config, olds, news, shimmedR.Schema(), map[string]*tfbridge.SchemaInfo{})
 
 	t.Run("no error with empty keys", func(t *testing.T) {
 		assert.NoError(t, err)

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -141,11 +141,6 @@ type Log interface {
 }
 
 // Get access to the [Logger] associated with this context.
-//
-// If called on a context that does not have an associated [Logger], GetLogger will panic.
-//
-// Currently, only the context from [ResourceInfo.PreCheckCallback] and
-// [ProviderInfo.PreConfigureCallback] have an associated [Logger].
 func GetLogger(ctx context.Context) Logger {
 	logger, ok := ctx.Value(logging.CtxKey).(Logger)
 	if !ok {

--- a/pkg/tfbridge/log.go
+++ b/pkg/tfbridge/log.go
@@ -21,7 +21,10 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/logging"
 )
 
 // LogRedirector creates a new redirection writer that takes as input plugin stderr output, and routes it to the
@@ -113,4 +116,14 @@ func (lr *LogRedirector) Write(p []byte) (n int, err error) {
 	}
 
 	return written, nil
+}
+
+func ctxWithHostLogger(
+	ctx context.Context, host *provider.HostClient, urn resource.URN,
+) context.Context {
+	return context.WithValue(ctx, logging.CtxKey,
+		logging.NewHost(ctx, host, urn,
+			func(l *logging.Host[Log]) Log {
+				return l
+			}))
 }

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -592,8 +592,11 @@ func TestCheckCallback(t *testing.T) {
 	}
 
 	callback := func(
-		_ context.Context, config, meta resource.PropertyMap,
+		ctx context.Context, config, meta resource.PropertyMap,
 	) (resource.PropertyMap, error) {
+		// We test that we have access to the logger in this callback.
+		GetLogger(ctx).Status().Info("Did not panic")
+
 		config["arrayPropertyValues"] = resource.NewArrayProperty(
 			[]resource.PropertyValue{meta["prop"]},
 		)
@@ -824,7 +827,10 @@ func TestCheck(t *testing.T) {
 			tf:     shimv2.NewProvider(testTFProviderV2),
 			config: shimv2.NewSchemaMap(testTFProviderV2.Schema),
 		}
-		computeStringDefault := func(_ context.Context, opts ComputeDefaultOptions) (interface{}, error) {
+		computeStringDefault := func(ctx context.Context, opts ComputeDefaultOptions) (interface{}, error) {
+			// We check that we have access to the logger when computing a default value.
+			GetLogger(ctx).Status().Info("Did not panic")
+
 			if v, ok := opts.PriorState["stringPropertyValue"]; ok {
 				require.Equal(t, resource.NewStringProperty("oldString"), opts.PriorValue)
 				return v.StringValue() + "!", nil
@@ -1522,6 +1528,9 @@ func TestPreConfigureCallback(t *testing.T) {
 					vars resource.PropertyMap,
 					config shim.ResourceConfig,
 				) error {
+					// We check that we have access to the logger in this callback.
+					GetLogger(ctx).Status().Info("Did not panic")
+
 					if cv, ok := vars["configValue"]; ok {
 						// This used to panic when cv is a resource.Computed.
 						cv.StringValue()

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -213,7 +213,8 @@ func TestBuildConfig(t *testing.T) {
 		"configValue": resource.NewStringProperty("foo"),
 		"version":     resource.NewStringProperty("0.0.1"),
 	}
-	configOut, err := buildTerraformConfig(provider, configIn)
+	ctx := context.Background()
+	configOut, err := buildTerraformConfig(ctx, provider, configIn)
 	assert.NoError(t, err)
 
 	expected := provider.tf.NewResourceConfig(map[string]interface{}{

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -636,6 +636,7 @@ func TestMetaProperties(t *testing.T) {
 	for _, f := range factories {
 		t.Run(f.SDKVersion(), func(t *testing.T) {
 			prov := f.NewTestProvider()
+			ctx := context.Background()
 
 			const resName = "example_resource"
 			res := prov.ResourcesMap().Get(resName)
@@ -649,7 +650,7 @@ func TestMetaProperties(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotNil(t, props)
 
-			state, err = MakeTerraformState(Resource{TF: res, Schema: &ResourceInfo{}}, state.ID(), props)
+			state, err = MakeTerraformState(ctx, Resource{TF: res, Schema: &ResourceInfo{}}, state.ID(), props)
 			assert.NoError(t, err)
 			assert.NotNil(t, state)
 
@@ -663,7 +664,7 @@ func TestMetaProperties(t *testing.T) {
 			// Delete the resource's meta-property and ensure that we re-populate its schema version.
 			delete(props, metaKey)
 
-			state, err = MakeTerraformState(Resource{TF: res, Schema: &ResourceInfo{}}, state.ID(), props)
+			state, err = MakeTerraformState(ctx, Resource{TF: res, Schema: &ResourceInfo{}}, state.ID(), props)
 			assert.NoError(t, err)
 			assert.NotNil(t, state)
 
@@ -698,7 +699,7 @@ func TestMetaProperties(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotNil(t, props)
 
-			state, err = MakeTerraformState(Resource{TF: res, Schema: &ResourceInfo{}}, state.ID(), props)
+			state, err = MakeTerraformState(ctx, Resource{TF: res, Schema: &ResourceInfo{}}, state.ID(), props)
 			assert.NoError(t, err)
 			assert.NotNil(t, state)
 
@@ -711,6 +712,7 @@ func TestInjectingCustomTimeouts(t *testing.T) {
 	for _, f := range factories {
 		t.Run(f.SDKVersion(), func(t *testing.T) {
 			prov := f.NewTestProvider()
+			ctx := context.Background()
 
 			const resName = "second_resource"
 			res := prov.ResourcesMap().Get(resName)
@@ -724,7 +726,7 @@ func TestInjectingCustomTimeouts(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotNil(t, props)
 
-			state, err = MakeTerraformState(Resource{TF: res, Schema: &ResourceInfo{}}, state.ID(), props)
+			state, err = MakeTerraformState(ctx, Resource{TF: res, Schema: &ResourceInfo{}}, state.ID(), props)
 			assert.NoError(t, err)
 			assert.NotNil(t, state)
 
@@ -738,7 +740,7 @@ func TestInjectingCustomTimeouts(t *testing.T) {
 			// Delete the resource's meta-property and ensure that we re-populate its schema version.
 			delete(props, metaKey)
 
-			state, err = MakeTerraformState(Resource{TF: res, Schema: &ResourceInfo{}}, state.ID(), props)
+			state, err = MakeTerraformState(ctx, Resource{TF: res, Schema: &ResourceInfo{}}, state.ID(), props)
 			assert.NoError(t, err)
 			assert.NotNil(t, state)
 
@@ -775,7 +777,7 @@ func TestInjectingCustomTimeouts(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotNil(t, props)
 
-			state, err = MakeTerraformState(Resource{TF: res, Schema: &ResourceInfo{}}, state.ID(), props)
+			state, err = MakeTerraformState(ctx, Resource{TF: res, Schema: &ResourceInfo{}}, state.ID(), props)
 			assert.NoError(t, err)
 			assert.NotNil(t, state)
 
@@ -816,6 +818,7 @@ func TestResultAttributesRoundTrip(t *testing.T) {
 	for _, f := range factories {
 		t.Run(f.SDKVersion(), func(t *testing.T) {
 			prov := f.NewTestProvider()
+			ctx := context.Background()
 
 			const resName = "example_resource"
 			res := prov.ResourcesMap().Get("example_resource")
@@ -829,7 +832,7 @@ func TestResultAttributesRoundTrip(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotNil(t, props)
 
-			state, err = MakeTerraformState(Resource{TF: res, Schema: &ResourceInfo{}}, state.ID(), props)
+			state, err = MakeTerraformState(ctx, Resource{TF: res, Schema: &ResourceInfo{}}, state.ID(), props)
 			assert.NoError(t, err)
 			assert.NotNil(t, state)
 
@@ -1187,7 +1190,9 @@ func TestOverridingTFSchema(t *testing.T) {
 		assert.Equal(t, tfOutputs, result)
 	})
 	t.Run("MakeTerraformInputs", func(t *testing.T) {
+		ctx := context.Background()
 		result, _, err := MakeTerraformInputs(
+			ctx,
 			nil,
 			nil,
 			nil,

--- a/unstable/logging/logging.go
+++ b/unstable/logging/logging.go
@@ -1,0 +1,118 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logging
+
+import (
+	"fmt"
+)
+
+import (
+	"context"
+
+	"github.com/golang/glog"
+	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
+type ctxKey struct{}
+
+// The key used to retrieve tfbridge.Logger from a context.
+var CtxKey = ctxKey{}
+
+// Abstracts the logging interface to HostClient. This is the interface providers use to report logging information back
+// to the Pulumi CLI over gRPC.
+type Sink interface {
+	Log(context context.Context, sev diag.Severity, urn resource.URN, msg string) error
+	LogStatus(context context.Context, sev diag.Severity, urn resource.URN, msg string) error
+}
+
+var _ Sink = (*provider.HostClient)(nil)
+
+// A user friendly interface to log against, shared by SDKv2 and PF providers.
+//
+// Host[tfbridge.Log] implements [tfbridge.Logger].
+//
+// Because [tfbridge.Logger] has a dependent type: [tfbridge.Log] and because we are
+// unable to name either type here, we need to parameterize [Host] with `L`, where `L` is
+// always [tfbridge.Log]. This allows us to return `L` from Host[tfbridge.Log].Status()
+// and satisfy the [tfbridge.Logger] interface.
+type Host[L any] struct {
+	ctx  context.Context
+	sink Sink
+	urn  resource.URN
+
+	// If we are logging ephemerally.
+	status bool
+
+	// This is the identity function, but must be defined at the call-site because we
+	// cannot name [tfbridge.Log].
+	mkStatus func(*Host[L]) L
+}
+
+func NewHost[L any](ctx context.Context,
+	sink Sink,
+	urn resource.URN,
+	mkStatus func(*Host[L]) L,
+) *Host[L] {
+	// This nil check catches half-nil fat pointers from casting
+	// `*provider.HostClient` to `Sink`.
+	if host, ok := sink.(*provider.HostClient); ok && host == nil {
+		sink = nil
+	}
+	return &Host[L]{ctx, sink, urn, false /*status*/, mkStatus}
+}
+
+func (l *Host[L]) f(severity diag.Severity, msg string) {
+	if l.sink != nil {
+		f := l.sink.Log
+		if l.status {
+			f = l.sink.LogStatus
+		}
+		err := f(l.ctx, severity, l.urn, msg)
+		if err == nil {
+			// We successfully wrote out our value, so we're done.
+			return
+		}
+	}
+
+	// We failed to write out a clean error message, so lets write to glog.
+	var sev string
+	switch severity {
+	case diag.Debug:
+		sev = "Debug"
+	case diag.Info:
+		sev = "Info"
+	case diag.Warning:
+		sev = "Warning"
+	case diag.Error:
+		sev = "Error"
+	default:
+		sev = fmt.Sprintf("%#v", severity)
+	}
+
+	glog.V(9).Infof("[%s]: %q", sev, msg)
+}
+
+func (l *Host[L]) Status() L {
+	copy := *l
+	copy.status = true
+	return l.mkStatus(&copy)
+}
+
+func (l *Host[L]) Debug(msg string) { l.f(diag.Debug, msg) }
+func (l *Host[L]) Info(msg string)  { l.f(diag.Info, msg) }
+func (l *Host[L]) Warn(msg string)  { l.f(diag.Warning, msg) }
+func (l *Host[L]) Error(msg string) { l.f(diag.Error, msg) }


### PR DESCRIPTION
Add the ability to return structured logs from `Pre*Callback` methods.


---

Side note:

We should deprecate `PreConfigureCallbackWithLogger` for `PreConfigureCallbackWithCtx` with an attached logger. This will fix the interface (not directly exposing callers to `*provider.Host`) and allow us to attach additional context data in a consistent way.

---

This PR contains **BREAKING CHANGES** to the following functions. All three functions now take a `context.Context` as their first argument. None of the functions are used outside of the bridge, according to a GH code search:
- `tfbridge.MakeTerraformInputs`: https://github.com/search?q=%2FMakeTerraformInputs%2F+-is%3Afork&type=code
- `tfbridge.MakeTerraformState`: https://github.com/search?q=%2FMakeTerraformState%2F+-is%3Afork&type=code
- `tfbridge.MakeTerraformConfig`: https://github.com/search?q=%2FMakeTerraformConfig%2F+-is%3Afork&type=code

Given the unique context where these functions make sense, I believe they are unlikely to be used outside the bridge.