### PR TITLE
Avoid NaN in JSON serialization

### DIFF
--- a/pkg/tfgen/examples_coverage_exporter.go
+++ b/pkg/tfgen/examples_coverage_exporter.go
@@ -182,10 +182,12 @@ func (ce *coverageExportUtil) exportByLanguage(outputDirectory string, fileName 
 	for _, language := range allLanguageStatistics {
 
 		// Calculating error percentages for all languages that were found
-		language.Successes.Pct = float64(language.Successes.Number) / float64(language.Total) * 100.0
-		language.Warnings.Pct = float64(language.Warnings.Number) / float64(language.Total) * 100.0
-		language.Failures.Pct = float64(language.Failures.Number) / float64(language.Total) * 100.0
-		language.Fatals.Pct = float64(language.Fatals.Number) / float64(language.Total) * 100.0
+		if language.Total > 0 {
+			language.Successes.Pct = float64(language.Successes.Number) / float64(language.Total) * 100.0
+			language.Warnings.Pct = float64(language.Warnings.Number) / float64(language.Total) * 100.0
+			language.Failures.Pct = float64(language.Failures.Number) / float64(language.Total) * 100.0
+			language.Fatals.Pct = float64(language.Fatals.Number) / float64(language.Total) * 100.0
+		}
 
 		// Appending and sorting conversion errors by their frequency
 		for reason, count := range language._errorHistogram {
@@ -269,14 +271,16 @@ func (ce *coverageExportUtil) exportOverall(outputDirectory string, fileName str
 	}
 
 	// Calculating overall error percentages
-	providerStatistic.Successes.Pct = float64(providerStatistic.Successes.Number) /
-		float64(providerStatistic.TotalConversions) * 100.0
-	providerStatistic.Warnings.Pct = float64(providerStatistic.Warnings.Number) /
-		float64(providerStatistic.TotalConversions) * 100.0
-	providerStatistic.Failures.Pct = float64(providerStatistic.Failures.Number) /
-		float64(providerStatistic.TotalConversions) * 100.0
-	providerStatistic.Fatals.Pct = float64(providerStatistic.Fatals.Number) /
-		float64(providerStatistic.TotalConversions) * 100.0
+	if providerStatistic.TotalConversions > 0 {
+		providerStatistic.Successes.Pct = float64(providerStatistic.Successes.Number) /
+			float64(providerStatistic.TotalConversions) * 100.0
+		providerStatistic.Warnings.Pct = float64(providerStatistic.Warnings.Number) /
+			float64(providerStatistic.TotalConversions) * 100.0
+		providerStatistic.Failures.Pct = float64(providerStatistic.Failures.Number) /
+			float64(providerStatistic.TotalConversions) * 100.0
+		providerStatistic.Fatals.Pct = float64(providerStatistic.Fatals.Number) /
+			float64(providerStatistic.TotalConversions) * 100.0
+	}
 
 	// Appending and sorting conversion errors by their frequency
 	for reason, count := range providerStatistic._errorHistogram {

--- a/pkg/tfgen/examples_coverage_test.go
+++ b/pkg/tfgen/examples_coverage_test.go
@@ -1,0 +1,28 @@
+// Copyright 2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfgen
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCoverageExport(t *testing.T) {
+	ce := &CoverageTracker{}
+	ct := newCoverageExportUtil(ce)
+	err := ct.tryExport(t.TempDir())
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
When there are no conversions, we would compute NaN and then try to serialize that to JSON which fails.

Fixes https://github.com/pulumi/pulumi-rke/issues/54.