### PR TITLE
Update the go version of downstream tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           cache-dependency-path: |
             **/go.sum
       # Required to pin Gradle < 8.0 until downstram tests upgrade to compatible pulumi-java release.


### PR DESCRIPTION
Fixes downstream tests in light of https://github.com/pulumi/ci-mgmt/pull/537.