### PR TITLE
Introduce a hook for editing state (outputs)

### DIFF
--- a/pf/tests/internal/testprovider/testbridge_resource_testcompres.go
+++ b/pf/tests/internal/testprovider/testbridge_resource_testcompres.go
@@ -30,6 +30,8 @@ type testCompRes struct{}
 
 var _ resource.Resource = &testCompRes{}
 
+var _ resource.ResourceWithImportState = &testCompRes{}
+
 func newTestCompRes() resource.Resource {
 	return &testCompRes{}
 }
@@ -89,9 +91,14 @@ func (e *testCompRes) Read(ctx context.Context, req resource.ReadRequest, resp *
 }
 
 func (e *testCompRes) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	panic("TODO Update")
+	resp.State.Raw = req.Plan.Raw.Copy()
 }
 
 func (e *testCompRes) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	panic("TODO Delete")
+}
+
+func (e *testCompRes) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resp.State.SetAttribute(ctx, path.Root("id"), "someID")
+	resp.State.SetAttribute(ctx, path.Root("ecdsacurve"), "P384")
 }

--- a/pf/tests/provider_transform_outputs_test.go
+++ b/pf/tests/provider_transform_outputs_test.go
@@ -1,0 +1,143 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfbridgetests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pulumi/pulumi-terraform-bridge/pf/tests/internal/testprovider"
+	testutils "github.com/pulumi/pulumi-terraform-bridge/testing/x"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
+func TestTransformOutputs(t *testing.T) {
+	p := testprovider.SyntheticTestBridgeProvider()
+
+	p.Resources["testbridge_testcompres"].TransformOutputs = func(
+		_ context.Context,
+		pm resource.PropertyMap,
+	) (resource.PropertyMap, error) {
+		c := pm.Copy()
+		c["ecdsacurve"] = resource.NewStringProperty("TRANSFORMED")
+		return c, nil
+	}
+	provider := newProviderServer(t, p)
+
+	t.Run("Create preview", func(t *testing.T) {
+		testutils.Replay(t, provider, `
+		{
+		  "method": "/pulumirpc.ResourceProvider/Create",
+		  "request": {
+		    "urn": "urn:pulumi:dev::teststack::testbridge:index/testres:Testcompres::exres",
+		    "properties": {},
+		    "preview": true
+		  },
+		  "response": {
+		    "properties": {
+		      "id": "*",
+		      "ecdsacurve": "TRANSFORMED"
+		    }
+		  }
+		}`)
+	})
+
+	t.Run("Create", func(t *testing.T) {
+		testutils.Replay(t, provider, `
+		{
+		  "method": "/pulumirpc.ResourceProvider/Create",
+		  "request": {
+		    "urn": "urn:pulumi:dev::teststack::testbridge:index/testres:Testcompres::exres",
+		    "properties": {
+                      "ecdsacurve": "P384"
+                    }
+		  },
+		  "response": {
+                    "id": "*",
+		    "properties": {
+		      "id": "*",
+		      "ecdsacurve": "TRANSFORMED"
+		    }
+		  }
+		}`)
+	})
+
+	t.Run("Update preview", func(t *testing.T) {
+		testutils.Replay(t, provider, `
+		{
+		  "method": "/pulumirpc.ResourceProvider/Update",
+		  "request": {
+		    "id": "0",
+		    "urn": "urn:pulumi:dev::teststack::testbridge:index/testres:Testcompres::exres",
+		    "olds": {
+                      "ecdsacurve": "P384"
+		    },
+		    "news": {
+                      "ecdsacurve": "P385"
+		    },
+	            "preview": true
+		  },
+		  "response": {
+		    "properties": {
+		      "id": "*",
+	              "ecdsacurve": "TRANSFORMED"
+		    }
+		  }
+		}`)
+	})
+
+	t.Run("Update", func(t *testing.T) {
+		testutils.Replay(t, provider, `
+		{
+		  "method": "/pulumirpc.ResourceProvider/Update",
+		  "request": {
+		    "id": "0",
+		    "urn": "urn:pulumi:dev::teststack::testbridge:index/testres:Testcompres::exres",
+		    "olds": {
+                      "ecdsacurve": "P384"
+		    },
+		    "news": {
+                      "ecdsacurve": "P385"
+		    }
+		  },
+		  "response": {
+		    "properties": {
+		      "id": "*",
+	              "ecdsacurve": "TRANSFORMED"
+		    }
+		  }
+		}`)
+	})
+
+	t.Run("Read to import", func(t *testing.T) {
+		testutils.Replay(t, provider, `
+		{
+		  "method": "/pulumirpc.ResourceProvider/Read",
+		  "request": {
+		    "id": "0",
+		    "urn": "urn:pulumi:dev::teststack::testbridge:index/testres:Testcompres::exres",
+	            "properties": {}
+		  },
+		  "response": {
+	            "id": "*",
+	            "inputs": "*",
+		    "properties": {
+			"id": "*",
+                        "ecdsacurve": "TRANSFORMED"
+		    }
+		  }
+		}`)
+	})
+}

--- a/pf/tfbridge/provider_create.go
+++ b/pf/tfbridge/provider_create.go
@@ -66,6 +66,16 @@ func (p *provider) CreateWithContext(
 		if err != nil {
 			return "", nil, 0, err
 		}
+
+		if rh.pulumiResourceInfo.TransformOutputs != nil {
+			var err error
+			plannedStatePropertyMap, err = rh.pulumiResourceInfo.TransformOutputs(ctx,
+				plannedStatePropertyMap)
+			if err != nil {
+				return "", nil, 0, err
+			}
+		}
+
 		return "", plannedStatePropertyMap, resource.StatusOK, nil
 	}
 
@@ -102,6 +112,14 @@ func (p *provider) CreateWithContext(
 	createdStateMap, err := createdState.ToPropertyMap(&rh)
 	if err != nil {
 		return "", nil, 0, err
+	}
+
+	if rh.pulumiResourceInfo.TransformOutputs != nil {
+		var err error
+		createdStateMap, err = rh.pulumiResourceInfo.TransformOutputs(ctx, createdStateMap)
+		if err != nil {
+			return "", nil, 0, err
+		}
 	}
 
 	createdID, err := createdState.ExtractID(&rh)

--- a/pf/tfbridge/provider_read.go
+++ b/pf/tfbridge/provider_read.go
@@ -65,7 +65,7 @@ func (p *provider) ReadWithContext(
 		return result, ignoredStatus, err
 	}
 
-	if result.Outputs != nil {
+	if result.Outputs != nil && rh.pulumiResourceInfo.TransformOutputs != nil {
 		var err error
 		result.Outputs, err = rh.pulumiResourceInfo.TransformOutputs(ctx, result.Outputs)
 		if err != nil {

--- a/pf/tfbridge/provider_read.go
+++ b/pf/tfbridge/provider_read.go
@@ -66,6 +66,14 @@ func (p *provider) ReadWithContext(
 	}
 
 	if result.Outputs != nil {
+		var err error
+		result.Outputs, err = rh.pulumiResourceInfo.TransformOutputs(ctx, result.Outputs)
+		if err != nil {
+			return result, ignoredStatus, err
+		}
+	}
+
+	if result.Outputs != nil {
 		result.Inputs, err = tfbridge.ExtractInputsFromOutputs(
 			oldInputs,
 			result.Outputs,

--- a/pf/tfbridge/provider_update.go
+++ b/pf/tfbridge/provider_update.go
@@ -77,6 +77,16 @@ func (p *provider) UpdateWithContext(
 		if err != nil {
 			return nil, 0, err
 		}
+
+		if rh.pulumiResourceInfo.TransformOutputs != nil {
+			var err error
+			plannedStatePropertyMap, err = rh.pulumiResourceInfo.TransformOutputs(ctx,
+				plannedStatePropertyMap)
+			if err != nil {
+				return nil, 0, err
+			}
+		}
+
 		return plannedStatePropertyMap, resource.StatusOK, nil
 	}
 
@@ -110,6 +120,14 @@ func (p *provider) UpdateWithContext(
 	updatedStateMap, err := updatedState.ToPropertyMap(&rh)
 	if err != nil {
 		return nil, 0, err
+	}
+
+	if rh.pulumiResourceInfo.TransformOutputs != nil {
+		var err error
+		updatedStateMap, err = rh.pulumiResourceInfo.TransformOutputs(ctx, updatedStateMap)
+		if err != nil {
+			return nil, 0, err
+		}
 	}
 
 	return updatedStateMap, resource.StatusOK, nil

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -323,6 +323,13 @@ type ResourceInfo struct {
 
 	// An experimental way to augment the Check function in the Pulumi life cycle.
 	PreCheckCallback PreCheckCallback
+
+	// Resource operations such as Create, Read, and Update return the resource outputs to be
+	// recored in Pulumi statefile. TransformOutputs provides the last chance to edit these
+	// outputs before they are stored. In particular, it can be used as a last resort hook to
+	// make corrections in the default translation of the resource state from TF to Pulumi.
+	// Should be used sparingly.
+	TransformOutputs func(ctx context.Context, outputs resource.PropertyMap) (resource.PropertyMap, error)
 }
 
 type PreCheckCallback = func(


### PR DESCRIPTION
When working on https://github.com/pulumi/pulumi-aws/issues/2778 I would like to be able to remove "tagsAll" from Pulumi state file before it gets persisted, although the underlying TF provider keeps populating this output property. Unfortunately it's really non-trivial to do this in the provider itself without changes to the bridge. The proposed change here introduces a hook for editing the state right before it gets sent to the engine which includes these gRPC methods:

- Create
- Update
- Read

In particular the hook edits the `outputs` bits of the state. The `inputs` bits can be normally modified in PreCheckCallback, although there is no mechanism yet to modify them in the Read scenario (pulumi refresh or import). It's left for future work as not really required by the scenario being addressed here. 

