### PR TITLE
Remove logic for unused PULUMI_REPO_PATHS

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,4 +103,3 @@ tfgen, the command that generates Pulumi schema/code for a bridged provider supp
 * `PULUMI_SKIP_MISSING_MAPPING_ERROR`: If truthy, tfgen will not fail if a data source or resource in the TF provider is not mapped to the Pulumi provider. Instead, a warning is printed. Default is `false`.
 * `PULUMI_SKIP_EXTRA_MAPPING_ERROR`: If truthy, tfgen will not fail if a mapped data source or resource does not exist in the TF provider. Instead, warning is printed. Default is `false`.
 * `PULUMI_MISSING_DOCS_ERROR`: If truthy, tfgen will fail if docs cannot be found for a data source or resource. Default is `false`.
-* `PULUMI_REPO_PATHS`: Override the paths to where to locate specific repos e.g. "github.com/foo/terraform-provider-bar=./terraform-provider-bar"

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -144,13 +144,6 @@ func getRepoPath(gitHost string, org string, provider string, version string) (s
 		moduleCoordinates = fmt.Sprintf("%s/%s", moduleCoordinates, version)
 	}
 
-	if repoPathsEnvVar, has := os.LookupEnv("PULUMI_REPO_PATHS"); has {
-		path := findRepoPath(repoPathsEnvVar, moduleCoordinates)
-		if path != "" {
-			return path, nil
-		}
-	}
-
 	if path, ok := repoPaths.Load(moduleCoordinates); ok {
 		return path.(string), nil
 	}
@@ -188,19 +181,6 @@ func getRepoPath(gitHost string, org string, provider string, version string) (s
 	repoPaths.Store(moduleCoordinates, target.Dir)
 
 	return target.Dir, nil
-}
-
-// findRepoPath returns the value associated first match of the module coordinates.
-// repoPathsEnvVar is in the format "github.com/foo/terraform-provider-bar=./terraform-provider-bar"
-func findRepoPath(repoPathsEnvVar string, moduleCoordinates string) string {
-	for _, provider := range strings.Split(repoPathsEnvVar, ",") {
-		parts := strings.SplitN(provider, "=", 2)
-
-		if parts[0] == moduleCoordinates {
-			return parts[1]
-		}
-	}
-	return ""
 }
 
 func getMarkdownNames(packagePrefix, rawName string, globalInfo *tfbridge.DocRuleInfo) []string {

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -900,14 +900,6 @@ func TestParseImports_WithOverride(t *testing.T) {
 
 	assert.Equal(t, "## Import\n\noverridden import details", parser.ret.Import)
 }
-
-func TestFindRepoPath(t *testing.T) {
-	env := "domain.test/foo/bar=./baz,github.com/foo/terraform-provider-bar=./terraform-provider-bar,"
-	actual := findRepoPath(env, "github.com/foo/terraform-provider-bar")
-
-	assert.Equal(t, "./terraform-provider-bar", actual)
-}
-
 func TestExampleGeneration(t *testing.T) {
 	info := testprovider.ProviderMiniRandom()
 


### PR DESCRIPTION
With the merge of https://github.com/pulumi/pulumi-aws/pull/2784, we are using the UpstreamRepoPath field on tfbridge,ProviderInfo everywhere.
Thus, we no longer need to discover PULUMI_REPO_PATHS and can remove this logic.

Org-wide search for this variable: https://github.com/search?q=org%3Apulumi+PULUMI_REPO_PATHS&type=code
