### PR TITLE
stringEncoder fromPropertyValue will now format numbers

### DIFF
--- a/pf/internal/convert/string.go
+++ b/pf/internal/convert/string.go
@@ -37,20 +37,52 @@ func (*stringEncoder) fromPropertyValue(p resource.PropertyValue) (tftypes.Value
 	if propertyValueIsUnkonwn(p) {
 		return tftypes.NewValue(tftypes.String, tftypes.UnknownValue), nil
 	}
-	if p.IsNull() {
+
+	switch {
+	case p.IsNull():
 		return tftypes.NewValue(tftypes.String, nil), nil
-	}
 
-	// Special-case to tolerate booleans.
-	if p.IsBool() {
+	// Special-case values that can be converted into strings for backward
+	// comparability with SDKv{1,2} based resources.
+	//
+	// Unfortunately, it is not possible to round trip values that are not string
+	// typed with full fidelity. For example, consider this simple YAML program:
+	//
+	//	resources:
+	//	  r:
+	//	    type: some:simple:Resource
+	//	    properties:
+	//	      stringType: 0x1234
+	//
+	// In YAML, 0x1234 is parsed as the number 4660, so our recourse will receive
+	// `4660` as its output. This problem appears even for simple numbers:
+	//
+	//
+	//	resources:
+	//	  r:
+	//	    type: some:simple:Resource
+	//	    properties:
+	//	      s1: 1
+	//	      s2: 1.0
+	//
+	// Go formats float64(1) as "1", so we get the expected result. float64(1) is
+	// equal to float64(1.0), so we are unable to distinguish between s1 and s2.
+	//
+	// We have the same problems with bools: YAML parses "YES" as true, so we are
+	// unable to distinguish between the two.
+
+	case p.IsBool():
 		return tftypes.NewValue(tftypes.String, fmt.Sprintf("%v", p.BoolValue())), nil
-	}
+	case p.IsNumber():
+		return tftypes.NewValue(tftypes.String, fmt.Sprintf("%v", p.NumberValue())), nil
 
-	if !p.IsString() {
+	case p.IsString():
+		return tftypes.NewValue(tftypes.String, p.StringValue()), nil
+
+	default:
 		return tftypes.NewValue(tftypes.String, nil),
 			fmt.Errorf("Expected a string, got: %v", p)
 	}
-	return tftypes.NewValue(tftypes.String, p.StringValue()), nil
 }
 
 func (*stringDecoder) toPropertyValue(v tftypes.Value) (resource.PropertyValue, error) {

--- a/pkg/tfgen/generate_test.go
+++ b/pkg/tfgen/generate_test.go
@@ -98,6 +98,7 @@ func Test_ForceNew(t *testing.T) {
 	}
 
 	for _, test := range cases {
+		test := test
 		t.Run(test.Name, func(t *testing.T) {
 			v := &test.Var
 			actuallyForcesNew := v.forceNew()


### PR DESCRIPTION
This is necessary for backwards compatibility with SDKv{1,2} based provider. It is
dangerous; there are many ways to represent bools and numbers so we are unable to round trip.

This is the bridge side fix for https://github.com/pulumi/pulumi-aws/issues/2806.