### PR TITLE
Separate file acquisition from file parsing

### DIFF
--- a/pf/tests/internal/testprovider/random.go
+++ b/pf/tests/internal/testprovider/random.go
@@ -62,14 +62,15 @@ func RandomProvider() tfbridge.ProviderInfo {
 	}
 
 	return tfbridge.ProviderInfo{
-		Name:        "random",
-		P:           tfpf.ShimProvider(randomshim.NewProvider()),
-		Description: "A Pulumi package to safely use randomness in Pulumi programs.",
-		Keywords:    []string{"pulumi", "random"},
-		License:     "Apache-2.0",
-		Homepage:    "https://pulumi.io",
-		Repository:  "https://github.com/pulumi/pulumi-random",
-		Version:     "4.8.2",
+		Name:             "random",
+		P:                tfpf.ShimProvider(randomshim.NewProvider()),
+		Description:      "A Pulumi package to safely use randomness in Pulumi programs.",
+		Keywords:         []string{"pulumi", "random"},
+		License:          "Apache-2.0",
+		Homepage:         "https://pulumi.io",
+		Repository:       "https://github.com/pulumi/pulumi-random",
+		Version:          "4.8.2",
+		UpstreamRepoPath: ".",
 		Resources: map[string]*tfbridge.ResourceInfo{
 			"random_id":       {Tok: randomResource(randomMod, "RandomId")},
 			"random_password": {Tok: randomResource(randomMod, "RandomPassword")},
@@ -138,13 +139,15 @@ func MuxedRandomProvider() tfbridge.ProviderInfo {
 	pf := RandomProvider()
 
 	info := tfbridge.ProviderInfo{
-		Name:        "muxedrandom",
-		Description: "A Pulumi package to safely use randomness in Pulumi programs.",
-		Keywords:    []string{"pulumi", "random"},
-		License:     "Apache-2.0",
-		Homepage:    "https://pulumi.io",
-		Repository:  "https://github.com/pulumi/pulumi-random",
-		Version:     "4.8.2",
+		Name:             "muxedrandom",
+		Description:      "A Pulumi package to safely use randomness in Pulumi programs.",
+		Keywords:         []string{"pulumi", "random"},
+		License:          "Apache-2.0",
+		Homepage:         "https://pulumi.io",
+		Repository:       "https://github.com/pulumi/pulumi-random",
+		Version:          "4.8.2",
+		UpstreamRepoPath: ".",
+		ResourcePrefix:   "random",
 		P: tfpf.MuxShimWithPF(context.Background(),
 			sdkv2.NewProvider(sdkv2randomprovider.New()),
 			randomshim.NewProvider()),

--- a/pf/tests/internal/testprovider/testbridge.go
+++ b/pf/tests/internal/testprovider/testbridge.go
@@ -35,14 +35,15 @@ var testBridgeMetadata []byte
 // features of tfbridge and is the core of pulumi-resource-testbridge.
 func SyntheticTestBridgeProvider() tfbridge.ProviderInfo {
 	info := tfbridge.ProviderInfo{
-		Name:        "testbridge",
-		P:           tfpf.ShimProvider(&syntheticProvider{}),
-		Description: "A Pulumi package to test pulumi-terraform-bridge Plugin Framework support.",
-		Keywords:    []string{},
-		License:     "Apache-2.0",
-		Homepage:    "https://pulumi.io",
-		Repository:  "https://github.com/pulumi/pulumi-terraform-bridge",
-		Version:     "0.0.1",
+		Name:             "testbridge",
+		P:                tfpf.ShimProvider(&syntheticProvider{}),
+		Description:      "A Pulumi package to test pulumi-terraform-bridge Plugin Framework support.",
+		Keywords:         []string{},
+		License:          "Apache-2.0",
+		Homepage:         "https://pulumi.io",
+		Repository:       "https://github.com/pulumi/pulumi-terraform-bridge",
+		Version:          "0.0.1",
+		UpstreamRepoPath: ".",
 
 		Config: map[string]*tfbridge.SchemaInfo{
 			"string_defaultinfo_config_prop": {

--- a/pf/tests/internal/testprovider/tls.go
+++ b/pf/tests/internal/testprovider/tls.go
@@ -54,13 +54,14 @@ func TLSProvider() tfbridge.ProviderInfo {
 	}
 
 	return tfbridge.ProviderInfo{
-		Name:        "tls",
-		P:           tfpf.ShimProvider(tlsshim.NewProvider()),
-		Description: "A Pulumi package to create TLS resources in Pulumi programs.",
-		Keywords:    []string{"pulumi", "tls"},
-		License:     "Apache-2.0",
-		Homepage:    "https://pulumi.io",
-		Repository:  "https://github.com/pulumi/pulumi-tls",
+		Name:             "tls",
+		P:                tfpf.ShimProvider(tlsshim.NewProvider()),
+		Description:      "A Pulumi package to create TLS resources in Pulumi programs.",
+		Keywords:         []string{"pulumi", "tls"},
+		License:          "Apache-2.0",
+		Homepage:         "https://pulumi.io",
+		Repository:       "https://github.com/pulumi/pulumi-tls",
+		UpstreamRepoPath: ".",
 		Resources: map[string]*tfbridge.ResourceInfo{
 			"tls_cert_request":        {Tok: tlsResource(tlsMod, "CertRequest")},
 			"tls_locally_signed_cert": {Tok: tlsResource(tlsMod, "LocallySignedCert")},

--- a/pf/tests/provider_get_mapping_test.go
+++ b/pf/tests/provider_get_mapping_test.go
@@ -82,7 +82,7 @@ func TestMuxedGetMapping(t *testing.T) {
 		resp, err := server.GetMapping(req(key))
 		assert.NoError(t, err)
 
-		assert.Equal(t, "muxedrandom", resp.Provider)
+		assert.Equal(t, "random", resp.Provider)
 
 		var info tfbridge0.MarshallableProviderInfo
 		err = json.Unmarshal(resp.Data, &info)

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -432,20 +432,6 @@ func getDocsPath(repo string, kind DocKind) string {
 	return filepath.Join(repo, "docs", kindString)
 }
 
-// readMarkdown searches all possible locations for the markdown content
-func readMarkdown(repo string, kind DocKind, possibleLocations []string) ([]byte, string, bool) {
-	locationPrefix := getDocsPath(repo, kind)
-
-	for _, name := range possibleLocations {
-		location := filepath.Join(locationPrefix, name)
-		markdownBytes, err := os.ReadFile(location)
-		if err == nil {
-			return markdownBytes, name, true
-		}
-	}
-	return nil, "", false
-}
-
 //nolint:lll
 var (
 	// For example:

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -1205,9 +1205,8 @@ func (g *Generator) gatherResource(rawname string,
 	// Collect documentation information
 	var entityDocs entityDocs
 	if !isProvider {
-		pd, err := getDocsForResource(g, g.info.GetGitHubOrg(), g.info.Name,
-			g.info.GetResourcePrefix(), ResourceDocs, rawname, info, g.info.GetProviderModuleVersion(),
-			g.info.GetGitHubHost())
+		source := NewGitRepoDocsSource(g)
+		pd, err := getDocsForResource(g, source, ResourceDocs, rawname, info)
 		if err != nil {
 			return nil, err
 		}
@@ -1399,9 +1398,8 @@ func (g *Generator) gatherDataSource(rawname string,
 	g.renamesBuilder.registerDataSource(dataSourcePath)
 
 	// Collect documentation information for this data source.
-	entityDocs, err := getDocsForResource(g, g.info.GetGitHubOrg(), g.info.Name,
-		g.info.GetResourcePrefix(), DataSourceDocs, rawname, info, g.info.GetProviderModuleVersion(),
-		g.info.GetGitHubHost())
+	source := NewGitRepoDocsSource(g)
+	entityDocs, err := getDocsForResource(g, source, DataSourceDocs, rawname, info)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tfgen/generate_schema_test.go
+++ b/pkg/tfgen/generate_schema_test.go
@@ -47,8 +47,6 @@ func TestRegress611(t *testing.T) {
 	provider := testprovider.ProviderRegress611()
 	expectedFile := abs(t, "test_data/regress-611-schema.json")
 
-	enterProviderModule(t,
-		"github.com/hashicorp/terraform-provider-aws v1.0.0")
 	schema, err := GenerateSchema(provider, diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{
 		Color: colors.Never,
 	}))

--- a/pkg/tfgen/generate_schema_test.go
+++ b/pkg/tfgen/generate_schema_test.go
@@ -417,7 +417,7 @@ go 1.20
 %s
 `, strings.Join(deps, "\n"))
 	t.Logf("file: %q", goModBytes)
-	err := os.WriteFile(goMod, []byte(goModBytes), 0700)
+	err := os.WriteFile(goMod, []byte(goModBytes), 0600)
 	require.NoError(t, err)
 
 	changeDir(t, dir)

--- a/pkg/tfgen/generate_test.go
+++ b/pkg/tfgen/generate_test.go
@@ -98,6 +98,7 @@ func Test_ForceNew(t *testing.T) {
 	}
 
 	for _, test := range cases {
+		test := test
 		t.Run(test.Name, func(t *testing.T) {
 			v := &test.Var
 			actuallyForcesNew := v.forceNew()

--- a/pkg/tfgen/generate_test.go
+++ b/pkg/tfgen/generate_test.go
@@ -111,8 +111,7 @@ func Test_GenerateTestDataSchemas(t *testing.T) {
 	// mapping files in tf2pulumi/convert/testdata/mappings. Add in the use of PULUMI_ACCEPT and it means you
 	// don't have to manually write schemas, just mappings for tests.
 
-	testDir, err := filepath.Abs(filepath.Join("..", "tf2pulumi", "convert", "testdata"))
-	require.NoError(t, err)
+	testDir := abs(t, "..", "tf2pulumi", "convert", "testdata")
 	mappingsPath := filepath.Join(testDir, "mappings")
 	schemasPath := filepath.Join(testDir, "schemas")
 	mapper := &bridgetesting.TestFileMapper{Path: mappingsPath}
@@ -130,6 +129,7 @@ func Test_GenerateTestDataSchemas(t *testing.T) {
 			// Strip off the .json part to make the package name
 			pkg := strings.Replace(info.Name(), filepath.Ext(info.Name()), "", -1)
 			provInfo, err := providerInfoSource.GetProviderInfo("", "", pkg, "")
+			(*provInfo).UpstreamRepoPath = "."
 			require.NoError(t, err)
 
 			schema, err := GenerateSchema(*provInfo, nilSink)

--- a/pkg/tfgen/source.go
+++ b/pkg/tfgen/source.go
@@ -78,8 +78,9 @@ func (gh *gitRepoSource) getFile(
 		var err error
 		repoPath, err = getRepoPath(gh.githost, gh.org, gh.provider, gh.providerModuleVersion)
 		if err != nil {
-			return nil, fmt.Errorf("get file for %q (%q): %w",
-				rawname, kind, err)
+			fmt.Printf("Failed to get file for %q (%q): %s", rawname, kind, err.Error())
+			return nil, nil // fmt.Errorf("get file for %q (%q): %w",
+			// rawname, kind, err)
 		}
 	}
 

--- a/pkg/tfgen/source.go
+++ b/pkg/tfgen/source.go
@@ -44,6 +44,17 @@ func NewGitRepoDocsSource(g *Generator) DocsSource {
 	}
 }
 
+func NewNullSource() DocsSource { return nullSource{} }
+
+type nullSource struct{}
+
+func (nullSource) getResource(rawname string, info tfbridge.ResourceOrDataSourceInfo) (*DocFile, error) {
+	return nil, nil
+}
+func (nullSource) getDatasource(rawname string, info tfbridge.ResourceOrDataSourceInfo) (*DocFile, error) {
+	return nil, nil
+}
+
 type gitRepoSource struct {
 	docRules              *tfbridge.DocRuleInfo
 	upstreamRepoPath      string
@@ -78,9 +89,8 @@ func (gh *gitRepoSource) getFile(
 		var err error
 		repoPath, err = getRepoPath(gh.githost, gh.org, gh.provider, gh.providerModuleVersion)
 		if err != nil {
-			fmt.Printf("Failed to get file for %q (%q): %s", rawname, kind, err.Error())
-			return nil, nil // fmt.Errorf("get file for %q (%q): %w",
-			// rawname, kind, err)
+			return nil, fmt.Errorf("get file for %q (%q): %w",
+				rawname, kind, err)
 		}
 	}
 

--- a/pkg/tfgen/source.go
+++ b/pkg/tfgen/source.go
@@ -1,0 +1,96 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfgen
+
+import (
+	"fmt"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+)
+
+type DocsSource interface {
+	getResource(rawname string, info tfbridge.ResourceOrDataSourceInfo) (*DocFile, error)
+	getDatasource(rawname string, info tfbridge.ResourceOrDataSourceInfo) (*DocFile, error)
+}
+
+type DocFile struct {
+	Content  []byte
+	Filename string
+}
+
+func NewGitRepoDocsSource(g *Generator) DocsSource {
+	return &gitRepoSource{
+		docRules:              g.info.DocRules,
+		upstreamRepoPath:      g.info.UpstreamRepoPath,
+		org:                   g.info.GetGitHubOrg(),
+		provider:              g.info.Name,
+		resourcePrefix:        g.info.GetResourcePrefix(),
+		providerModuleVersion: g.info.GetProviderModuleVersion(),
+		githost:               g.info.GetGitHubHost(),
+	}
+}
+
+type gitRepoSource struct {
+	docRules              *tfbridge.DocRuleInfo
+	upstreamRepoPath      string
+	org                   string
+	provider              string // provider name?
+	resourcePrefix        string
+	providerModuleVersion string
+	githost               string
+}
+
+func (gh *gitRepoSource) getResource(rawname string, info tfbridge.ResourceOrDataSourceInfo) (*DocFile, error) {
+	return gh.getFile(rawname, info, ResourceDocs)
+}
+
+func (gh *gitRepoSource) getDatasource(rawname string, info tfbridge.ResourceOrDataSourceInfo) (*DocFile, error) {
+	return gh.getFile(rawname, info, DataSourceDocs)
+}
+
+func (gh *gitRepoSource) getFile(
+	rawname string, info tfbridge.ResourceOrDataSourceInfo, kind DocKind,
+) (*DocFile, error) {
+	var docinfo *tfbridge.DocInfo
+	if info != nil {
+		docinfo = info.GetDocs()
+	}
+	if docinfo != nil && len(docinfo.Markdown) != 0 {
+		return &DocFile{Content: docinfo.Markdown}, nil
+	}
+
+	repoPath := gh.upstreamRepoPath
+	if repoPath == "" {
+		var err error
+		repoPath, err = getRepoPath(gh.githost, gh.org, gh.provider, gh.providerModuleVersion)
+		if err != nil {
+			return nil, fmt.Errorf("get file for %q (%q): %w",
+				rawname, kind, err)
+		}
+	}
+
+	possibleMarkdownNames := getMarkdownNames(gh.resourcePrefix, rawname, gh.docRules)
+
+	if docinfo != nil && docinfo.Source != "" {
+		possibleMarkdownNames = append(possibleMarkdownNames, docinfo.Source)
+	}
+
+	markdownBytes, markdownFileName, found := readMarkdown(repoPath, kind, possibleMarkdownNames)
+	if !found {
+		return nil, nil
+	}
+
+	return &DocFile{markdownBytes, markdownFileName}, nil
+}

--- a/pkg/tfgen/test_data/regress-611-schema.json
+++ b/pkg/tfgen/test_data/regress-611-schema.json
@@ -65,7 +65,8 @@
     "aws:iam/RoleInlinePolicy:RoleInlinePolicy": {
       "properties": {
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "The name of the role.\n"
         },
         "policy": {
           "type": "string"
@@ -76,10 +77,12 @@
     "aws:iam/getGroupUser:getGroupUser": {
       "properties": {
         "arn": {
-          "type": "string"
+          "type": "string",
+          "description": "The Amazon Resource Name (ARN) specifying the group.\n"
         },
         "path": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the role.\n"
         },
         "userId": {
           "type": "string"
@@ -104,7 +107,8 @@
     "aws:index/getAvailabilityZoneFilter:getAvailabilityZoneFilter": {
       "properties": {
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "The full name of the availability zone to select.\n"
         },
         "values": {
           "type": "array",
@@ -161,49 +165,58 @@
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "description": "A list of actions that this statement either allows\nor denies. For example, ``[\"ec2:RunInstances\", \"s3:*\"]``.\n"
         },
         "conditions": {
           "type": "array",
           "items": {
             "$ref": "#/types/aws:x/iam/getPolicyDocumentStatementCondition:getPolicyDocumentStatementCondition"
-          }
+          },
+          "description": "A nested configuration block (described below)\nthat defines a further, possibly-service-specific condition that constrains\nwhether this statement applies.\n\nEach policy may have either zero or more `principals` blocks or zero or more\n`not_principals` blocks, both of which each accept the following arguments:\n"
         },
         "effect": {
-          "type": "string"
+          "type": "string",
+          "description": "Either \"Allow\" or \"Deny\", to specify whether this\nstatement allows or denies the given actions. The default is \"Allow\".\n"
         },
         "notActions": {
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "description": "A list of actions that this statement does *not*\napply to. Used to apply a policy statement to all actions *except* those\nlisted.\n"
         },
         "notPrincipals": {
           "type": "array",
           "items": {
             "$ref": "#/types/aws:x/iam/getPolicyDocumentStatementNotPrincipal:getPolicyDocumentStatementNotPrincipal"
-          }
+          },
+          "description": "Like `principals` except gives resources that\nthe statement does *not* apply to.\n"
         },
         "notResources": {
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "description": "A list of resource ARNs that this statement\ndoes *not* apply to. Used to apply a policy statement to all resources\n*except* those listed.\n"
         },
         "principals": {
           "type": "array",
           "items": {
             "$ref": "#/types/aws:x/iam/getPolicyDocumentStatementPrincipal:getPolicyDocumentStatementPrincipal"
-          }
+          },
+          "description": "A nested configuration block (described below)\nspecifying a resource (or resource pattern) to which this statement applies.\n"
         },
         "resources": {
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "description": "A list of resource ARNs that this statement applies\nto. This is required by AWS if used for an IAM policy.\n"
         },
         "sid": {
-          "type": "string"
+          "type": "string",
+          "description": "An ID for the policy statement.\n"
         }
       },
       "type": "object"
@@ -211,16 +224,19 @@
     "aws:x/iam/getPolicyDocumentStatementCondition:getPolicyDocumentStatementCondition": {
       "properties": {
         "test": {
-          "type": "string"
+          "type": "string",
+          "description": "The name of the\n[IAM condition type](http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html#AccessPolicyLanguage_ConditionType)\nto evaluate.\n"
         },
         "values": {
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "description": "The values to evaluate the condition against. If multiple\nvalues are provided, the condition matches if at least one of them applies.\n(That is, the tests are combined with the \"OR\" boolean operation.)\n\nWhen multiple `condition` blocks are provided, they must *all* evaluate to true\nfor the policy statement to apply. (In other words, the conditions are combined\nwith the \"AND\" boolean operation.)\n"
         },
         "variable": {
-          "type": "string"
+          "type": "string",
+          "description": "The name of a\n[Context Variable](http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html#AvailableKeys)\nto apply the condition to. Context variables may either be standard AWS\nvariables starting with `aws:`, or service-specific variables prefixed with\nthe service name.\n"
         }
       },
       "type": "object",
@@ -236,10 +252,12 @@
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "description": "List of identifiers for principals. When `type`\nis \"AWS\", these are IAM user or role ARNs.\n\nEach policy statement may have zero or more `condition` blocks, which each\naccept the following arguments:\n"
         },
         "type": {
-          "type": "string"
+          "type": "string",
+          "description": "The type of principal. For AWS accounts this is \"AWS\".\n"
         }
       },
       "type": "object",
@@ -254,10 +272,12 @@
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "description": "List of identifiers for principals. When `type`\nis \"AWS\", these are IAM user or role ARNs.\n\nEach policy statement may have zero or more `condition` blocks, which each\naccept the following arguments:\n"
         },
         "type": {
-          "type": "string"
+          "type": "string",
+          "description": "The type of principal. For AWS accounts this is \"AWS\".\n"
         }
       },
       "type": "object",
@@ -328,6 +348,7 @@
   },
   "resources": {
     "aws:iam/accessKey:AccessKey": {
+      "description": "Provides an IAM access key. This is a set of credentials that allow API requests to be made as an IAM user.\n\n## Example Usage\n\n```hcl\nresource \"aws_iam_access_key\" \"lb\" {\n  user    = \"${aws_iam_user.lb.name}\"\n  pgp_key = \"keybase:some_person_that_exists\"\n}\n\nresource \"aws_iam_user\" \"lb\" {\n  name = \"loadbalancer\"\n  path = \"/system/\"\n}\n\nresource \"aws_iam_user_policy\" \"lb_ro\" {\n  name = \"test\"\n  user = \"${aws_iam_user.lb.name}\"\n\n  policy = \u003c\u003cEOF\n{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"ec2:Describe*\"\n      ],\n      \"Effect\": \"Allow\",\n      \"Resource\": \"*\"\n    }\n  ]\n}\nEOF\n}\n\noutput \"secret\" {\n  value = \"${aws_iam_access_key.lb.encrypted_secret}\"\n}\n```\n",
       "properties": {
         "createDate": {
           "type": "string"
@@ -339,13 +360,16 @@
           "type": "string"
         },
         "keyFingerprint": {
-          "type": "string"
+          "type": "string",
+          "description": "The fingerprint of the PGP key used to encrypt\nthe secret\n"
         },
         "pgpKey": {
-          "type": "string"
+          "type": "string",
+          "description": "Either a base-64 encoded PGP public key, or a\nkeybase username in the form `keybase:some_person_that_exists`.\n"
         },
         "secret": {
           "type": "string",
+          "description": "The secret access key. Note that this will be written\nto the state file. Please supply a `pgp_key` instead, which will prevent the\nsecret from being stored in plain text\n",
           "secret": true
         },
         "sesSmtpPasswordV4": {
@@ -353,10 +377,12 @@
           "secret": true
         },
         "status": {
-          "type": "string"
+          "type": "string",
+          "description": "\"Active\" or \"Inactive\". Keys are initially active, but can be made\ninactive by other means.\n"
         },
         "user": {
-          "type": "string"
+          "type": "string",
+          "description": "The IAM user to associate with this access key.\n"
         }
       },
       "required": [
@@ -371,13 +397,16 @@
       "inputProperties": {
         "pgpKey": {
           "type": "string",
+          "description": "Either a base-64 encoded PGP public key, or a\nkeybase username in the form `keybase:some_person_that_exists`.\n",
           "willReplaceOnChanges": true
         },
         "status": {
-          "type": "string"
+          "type": "string",
+          "description": "\"Active\" or \"Inactive\". Keys are initially active, but can be made\ninactive by other means.\n"
         },
         "user": {
           "type": "string",
+          "description": "The IAM user to associate with this access key.\n",
           "willReplaceOnChanges": true
         }
       },
@@ -397,14 +426,17 @@
             "type": "string"
           },
           "keyFingerprint": {
-            "type": "string"
+            "type": "string",
+            "description": "The fingerprint of the PGP key used to encrypt\nthe secret\n"
           },
           "pgpKey": {
             "type": "string",
+            "description": "Either a base-64 encoded PGP public key, or a\nkeybase username in the form `keybase:some_person_that_exists`.\n",
             "willReplaceOnChanges": true
           },
           "secret": {
             "type": "string",
+            "description": "The secret access key. Note that this will be written\nto the state file. Please supply a `pgp_key` instead, which will prevent the\nsecret from being stored in plain text\n",
             "secret": true
           },
           "sesSmtpPasswordV4": {
@@ -412,10 +444,12 @@
             "secret": true
           },
           "status": {
-            "type": "string"
+            "type": "string",
+            "description": "\"Active\" or \"Inactive\". Keys are initially active, but can be made\ninactive by other means.\n"
           },
           "user": {
             "type": "string",
+            "description": "The IAM user to associate with this access key.\n",
             "willReplaceOnChanges": true
           }
         },
@@ -423,9 +457,11 @@
       }
     },
     "aws:iam/accountAlias:AccountAlias": {
+      "description": "\u003e **Note:** There is only a single account alias per AWS account.\n\nManages the account alias for the AWS Account.\n\n## Example Usage\n\n```hcl\nresource \"aws_iam_account_alias\" \"alias\" {\n  account_alias = \"my-account-alias\"\n}\n```\n\n## Import\n\nThe current Account Alias can be imported using the `account_alias`, e.g.\n\n```sh\u003cbreak\u003e\n$ pulumi import aws:iam/accountAlias:AccountAlias alias my-account-alias\n\u003cbreak\u003e```\u003cbreak\u003e\n",
       "properties": {
         "accountAlias": {
           "type": "string",
+          "description": "The account alias\n",
           "language": {
             "csharp": {
               "name": "Alias"
@@ -439,6 +475,7 @@
       "inputProperties": {
         "accountAlias": {
           "type": "string",
+          "description": "The account alias\n",
           "language": {
             "csharp": {
               "name": "Alias"
@@ -455,6 +492,7 @@
         "properties": {
           "accountAlias": {
             "type": "string",
+            "description": "The account alias\n",
             "language": {
               "csharp": {
                 "name": "Alias"
@@ -467,36 +505,47 @@
       }
     },
     "aws:iam/accountPasswordPolicy:AccountPasswordPolicy": {
+      "description": "\u003e **Note:** There is only a single policy allowed per AWS account. An existing policy will be lost when using this resource as an effect of this limitation.\n\nManages Password Policy for the AWS Account.\nSee more about [Account Password Policy](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_passwords_account-policy.html)\nin the official AWS docs.\n\n## Example Usage\n\n```hcl\nresource \"aws_iam_account_password_policy\" \"strict\" {\n  minimum_password_length        = 8\n  require_lowercase_characters   = true\n  require_numbers                = true\n  require_uppercase_characters   = true\n  require_symbols                = true\n  allow_users_to_change_password = true\n}\n```\n\n## Import\n\nIAM Account Password Policy can be imported using the word `iam-account-password-policy`, e.g.\n\n```sh\u003cbreak\u003e\n$ pulumi import aws:iam/accountPasswordPolicy:AccountPasswordPolicy strict iam-account-password-policy\n\u003cbreak\u003e```\u003cbreak\u003e\n",
       "properties": {
         "allowUsersToChangePassword": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether to allow users to change their own password\n"
         },
         "expirePasswords": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Indicates whether passwords in the account expire.\nReturns `true` if `max_password_age` contains a value greater than `0`.\nReturns `false` if it is `0` or _not present_.\n"
         },
         "hardExpiry": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether users are prevented from setting a new password after their password has expired\n(i.e. require administrator reset)\n"
         },
         "maxPasswordAge": {
-          "type": "integer"
+          "type": "integer",
+          "description": "The number of days that an user password is valid.\n"
         },
         "minimumPasswordLength": {
-          "type": "integer"
+          "type": "integer",
+          "description": "Minimum length to require for user passwords.\n"
         },
         "passwordReusePrevention": {
-          "type": "integer"
+          "type": "integer",
+          "description": "The number of previous passwords that users are prevented from reusing.\n"
         },
         "requireLowercaseCharacters": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether to require lowercase characters for user passwords.\n"
         },
         "requireNumbers": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether to require numbers for user passwords.\n"
         },
         "requireSymbols": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether to require symbols for user passwords.\n"
         },
         "requireUppercaseCharacters": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether to require uppercase characters for user passwords.\n"
         }
       },
       "required": [
@@ -511,83 +560,107 @@
       ],
       "inputProperties": {
         "allowUsersToChangePassword": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether to allow users to change their own password\n"
         },
         "hardExpiry": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether users are prevented from setting a new password after their password has expired\n(i.e. require administrator reset)\n"
         },
         "maxPasswordAge": {
-          "type": "integer"
+          "type": "integer",
+          "description": "The number of days that an user password is valid.\n"
         },
         "minimumPasswordLength": {
-          "type": "integer"
+          "type": "integer",
+          "description": "Minimum length to require for user passwords.\n"
         },
         "passwordReusePrevention": {
-          "type": "integer"
+          "type": "integer",
+          "description": "The number of previous passwords that users are prevented from reusing.\n"
         },
         "requireLowercaseCharacters": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether to require lowercase characters for user passwords.\n"
         },
         "requireNumbers": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether to require numbers for user passwords.\n"
         },
         "requireSymbols": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether to require symbols for user passwords.\n"
         },
         "requireUppercaseCharacters": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether to require uppercase characters for user passwords.\n"
         }
       },
       "stateInputs": {
         "description": "Input properties used for looking up and filtering AccountPasswordPolicy resources.\n",
         "properties": {
           "allowUsersToChangePassword": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether to allow users to change their own password\n"
           },
           "expirePasswords": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Indicates whether passwords in the account expire.\nReturns `true` if `max_password_age` contains a value greater than `0`.\nReturns `false` if it is `0` or _not present_.\n"
           },
           "hardExpiry": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether users are prevented from setting a new password after their password has expired\n(i.e. require administrator reset)\n"
           },
           "maxPasswordAge": {
-            "type": "integer"
+            "type": "integer",
+            "description": "The number of days that an user password is valid.\n"
           },
           "minimumPasswordLength": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Minimum length to require for user passwords.\n"
           },
           "passwordReusePrevention": {
-            "type": "integer"
+            "type": "integer",
+            "description": "The number of previous passwords that users are prevented from reusing.\n"
           },
           "requireLowercaseCharacters": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether to require lowercase characters for user passwords.\n"
           },
           "requireNumbers": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether to require numbers for user passwords.\n"
           },
           "requireSymbols": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether to require symbols for user passwords.\n"
           },
           "requireUppercaseCharacters": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether to require uppercase characters for user passwords.\n"
           }
         },
         "type": "object"
       }
     },
     "aws:iam/group:Group": {
+      "description": "Provides an IAM group.\n\n## Example Usage\n\n```hcl\nresource \"aws_iam_group\" \"developers\" {\n  name = \"developers\"\n  path = \"/users/\"\n}\n```\n\n## Import\n\nIAM Groups can be imported using the `name`, e.g.\n\n```sh\u003cbreak\u003e\n$ pulumi import aws:iam/group:Group developers developers\n\u003cbreak\u003e```\u003cbreak\u003e\n",
       "properties": {
         "arn": {
-          "type": "string"
+          "type": "string",
+          "description": "The ARN assigned by AWS for this group.\n"
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "The group's name. The name must consist of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: `=,.@-_.`. Group names are not distinguished by case. For example, you cannot create groups named both \"ADMINS\" and \"admins\".\n"
         },
         "path": {
-          "type": "string"
+          "type": "string",
+          "description": "Path in which to create the group.\n"
         },
         "uniqueId": {
-          "type": "string"
+          "type": "string",
+          "description": "The [unique ID][1] assigned by AWS.\n"
         }
       },
       "required": [
@@ -597,44 +670,54 @@
       ],
       "inputProperties": {
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "The group's name. The name must consist of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: `=,.@-_.`. Group names are not distinguished by case. For example, you cannot create groups named both \"ADMINS\" and \"admins\".\n"
         },
         "path": {
-          "type": "string"
+          "type": "string",
+          "description": "Path in which to create the group.\n"
         }
       },
       "stateInputs": {
         "description": "Input properties used for looking up and filtering Group resources.\n",
         "properties": {
           "arn": {
-            "type": "string"
+            "type": "string",
+            "description": "The ARN assigned by AWS for this group.\n"
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "The group's name. The name must consist of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: `=,.@-_.`. Group names are not distinguished by case. For example, you cannot create groups named both \"ADMINS\" and \"admins\".\n"
           },
           "path": {
-            "type": "string"
+            "type": "string",
+            "description": "Path in which to create the group.\n"
           },
           "uniqueId": {
-            "type": "string"
+            "type": "string",
+            "description": "The [unique ID][1] assigned by AWS.\n"
           }
         },
         "type": "object"
       }
     },
     "aws:iam/groupMembership:GroupMembership": {
+      "description": "Provides a top level resource to manage IAM Group membership for IAM Users. For\nmore information on managing IAM Groups or IAM Users, see [IAM Groups](https://www.terraform.io/docs/providers/aws/r/iam_group.html) or\n[IAM Users](https://www.terraform.io/docs/providers/aws/r/iam_user.html)\n\n## Example Usage\n\n```hcl\nresource \"aws_iam_group_membership\" \"team\" {\n  name = \"tf-testing-group-membership\"\n\n  users = [\n    \"${aws_iam_user.user_one.name}\",\n    \"${aws_iam_user.user_two.name}\",\n  ]\n\n  group = \"${aws_iam_group.group.name}\"\n}\n\nresource \"aws_iam_group\" \"group\" {\n  name = \"test-group\"\n}\n\nresource \"aws_iam_user\" \"user_one\" {\n  name = \"test-user\"\n}\n\nresource \"aws_iam_user\" \"user_two\" {\n  name = \"test-user-two\"\n}\n```\n",
       "properties": {
         "group": {
-          "type": "string"
+          "type": "string",
+          "description": "The IAM Group name to attach the list of `users` to\n"
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "The name to identify the Group Membership\n"
         },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "description": "A list of IAM User names to associate with the Group\n"
         }
       },
       "required": [
@@ -645,17 +728,20 @@
       "inputProperties": {
         "group": {
           "type": "string",
+          "description": "The IAM Group name to attach the list of `users` to\n",
           "willReplaceOnChanges": true
         },
         "name": {
           "type": "string",
+          "description": "The name to identify the Group Membership\n",
           "willReplaceOnChanges": true
         },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "description": "A list of IAM User names to associate with the Group\n"
         }
       },
       "requiredInputs": [
@@ -667,35 +753,43 @@
         "properties": {
           "group": {
             "type": "string",
+            "description": "The IAM Group name to attach the list of `users` to\n",
             "willReplaceOnChanges": true
           },
           "name": {
             "type": "string",
+            "description": "The name to identify the Group Membership\n",
             "willReplaceOnChanges": true
           },
           "users": {
             "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "description": "A list of IAM User names to associate with the Group\n"
           }
         },
         "type": "object"
       }
     },
     "aws:iam/groupPolicy:GroupPolicy": {
+      "description": "Provides an IAM policy attached to a group.\n\n## Example Usage\n\n```hcl\nresource \"aws_iam_group_policy\" \"my_developer_policy\" {\n  name  = \"my_developer_policy\"\n  group = \"${aws_iam_group.my_developers.id}\"\n\n  policy = \u003c\u003cEOF\n{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"ec2:Describe*\"\n      ],\n      \"Effect\": \"Allow\",\n      \"Resource\": \"*\"\n    }\n  ]\n}\nEOF\n}\n\nresource \"aws_iam_group\" \"my_developers\" {\n  name = \"developers\"\n  path = \"/users/\"\n}\n```\n",
       "properties": {
         "group": {
-          "type": "string"
+          "type": "string",
+          "description": "The IAM group to attach to the policy.\n"
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "The name of the policy.\n"
         },
         "namePrefix": {
-          "type": "string"
+          "type": "string",
+          "description": "Creates a unique name beginning with the specified\nprefix. Conflicts with `name`.\n"
         },
         "policy": {
-          "type": "string"
+          "type": "string",
+          "description": "The policy document. This is a JSON formatted string.\nThe heredoc syntax or `file` function is helpful here.\n"
         }
       },
       "required": [
@@ -706,14 +800,17 @@
       "inputProperties": {
         "group": {
           "type": "string",
+          "description": "The IAM group to attach to the policy.\n",
           "willReplaceOnChanges": true
         },
         "name": {
           "type": "string",
+          "description": "The name of the policy.\n",
           "willReplaceOnChanges": true
         },
         "namePrefix": {
           "type": "string",
+          "description": "Creates a unique name beginning with the specified\nprefix. Conflicts with `name`.\n",
           "willReplaceOnChanges": true
         },
         "policy": {
@@ -726,7 +823,8 @@
               "type": "string",
               "$ref": "#/types/aws:iam/documents:PolicyDocument"
             }
-          ]
+          ],
+          "description": "The policy document. This is a JSON formatted string.\nThe heredoc syntax or `file` function is helpful here.\n"
         }
       },
       "requiredInputs": [
@@ -738,14 +836,17 @@
         "properties": {
           "group": {
             "type": "string",
+            "description": "The IAM group to attach to the policy.\n",
             "willReplaceOnChanges": true
           },
           "name": {
             "type": "string",
+            "description": "The name of the policy.\n",
             "willReplaceOnChanges": true
           },
           "namePrefix": {
             "type": "string",
+            "description": "Creates a unique name beginning with the specified\nprefix. Conflicts with `name`.\n",
             "willReplaceOnChanges": true
           },
           "policy": {
@@ -758,20 +859,24 @@
                 "type": "string",
                 "$ref": "#/types/aws:iam/documents:PolicyDocument"
               }
-            ]
+            ],
+            "description": "The policy document. This is a JSON formatted string.\nThe heredoc syntax or `file` function is helpful here.\n"
           }
         },
         "type": "object"
       }
     },
     "aws:iam/groupPolicyAttachment:GroupPolicyAttachment": {
+      "description": "Attaches a Managed IAM Policy to an IAM group\n\n```hcl\nresource \"aws_iam_group\" \"group\" {\n  name = \"test-group\"\n}\n\nresource \"aws_iam_policy\" \"policy\" {\n  name        = \"test-policy\"\n  description = \"A test policy\"\n  policy      = # omitted\n}\n\nresource \"aws_iam_group_policy_attachment\" \"test-attach\" {\n  group      = \"${aws_iam_group.group.name}\"\n  policy_arn = \"${aws_iam_policy.policy.arn}\"\n}\n```\n",
       "properties": {
         "group": {
-          "type": "string"
+          "type": "string",
+          "description": "The group the policy should be applied to\n"
         },
         "policyArn": {
           "type": "string",
-          "$ref": "#/types/aws:index/aRN:ARN"
+          "$ref": "#/types/aws:index/aRN:ARN",
+          "description": "The ARN of the policy you want to apply\n"
         }
       },
       "required": [
@@ -790,11 +895,13 @@
               "$ref": "#/types/aws:iam/group:Group"
             }
           ],
+          "description": "The group the policy should be applied to\n",
           "willReplaceOnChanges": true
         },
         "policyArn": {
           "type": "string",
           "$ref": "#/types/aws:index/aRN:ARN",
+          "description": "The ARN of the policy you want to apply\n",
           "willReplaceOnChanges": true
         }
       },
@@ -816,11 +923,13 @@
                 "$ref": "#/types/aws:iam/group:Group"
               }
             ],
+            "description": "The group the policy should be applied to\n",
             "willReplaceOnChanges": true
           },
           "policyArn": {
             "type": "string",
             "$ref": "#/types/aws:index/aRN:ARN",
+            "description": "The ARN of the policy you want to apply\n",
             "willReplaceOnChanges": true
           }
         },
@@ -828,24 +937,31 @@
       }
     },
     "aws:iam/instanceProfile:InstanceProfile": {
+      "description": "Provides an IAM instance profile.\n\n\u003e **NOTE:** Either `role` or `roles` (**deprecated**) must be specified.\n\n## Example Usage\n\n```hcl\nresource \"aws_iam_instance_profile\" \"test_profile\" {\n  name  = \"test_profile\"\n  role = \"${aws_iam_role.role.name}\"\n}\n\nresource \"aws_iam_role\" \"role\" {\n  name = \"test_role\"\n  path = \"/\"\n\n  assume_role_policy = \u003c\u003cEOF\n{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Action\": \"sts:AssumeRole\",\n            \"Principal\": {\n               \"Service\": \"ec2.amazonaws.com\"\n            },\n            \"Effect\": \"Allow\",\n            \"Sid\": \"\"\n        }\n    ]\n}\nEOF\n}\n```\n\n## Import\n\nInstance Profiles can be imported using the `name`, e.g.\n\n```sh\u003cbreak\u003e\n$ pulumi import aws:iam/instanceProfile:InstanceProfile test_profile app-instance-profile-1\n\u003cbreak\u003e```\u003cbreak\u003e\n",
       "properties": {
         "arn": {
-          "type": "string"
+          "type": "string",
+          "description": "The ARN assigned by AWS to the instance profile.\n"
         },
         "createDate": {
-          "type": "string"
+          "type": "string",
+          "description": "The creation timestamp of the instance profile.\n"
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "The instance profile's name.\n"
         },
         "namePrefix": {
-          "type": "string"
+          "type": "string",
+          "description": "Creates a unique name beginning with the specified prefix. Conflicts with `name`.\n"
         },
         "path": {
-          "type": "string"
+          "type": "string",
+          "description": "Path in which to create the profile.\n"
         },
         "role": {
-          "type": "string"
+          "type": "string",
+          "description": "The role name to include in the profile.\n"
         },
         "tags": {
           "type": "object",
@@ -860,7 +976,8 @@
           }
         },
         "uniqueId": {
-          "type": "string"
+          "type": "string",
+          "description": "The [unique ID][1] assigned by AWS.\n"
         }
       },
       "required": [
@@ -873,14 +990,17 @@
       "inputProperties": {
         "name": {
           "type": "string",
+          "description": "The instance profile's name.\n",
           "willReplaceOnChanges": true
         },
         "namePrefix": {
           "type": "string",
+          "description": "Creates a unique name beginning with the specified prefix. Conflicts with `name`.\n",
           "willReplaceOnChanges": true
         },
         "path": {
           "type": "string",
+          "description": "Path in which to create the profile.\n",
           "willReplaceOnChanges": true
         },
         "role": {
@@ -893,7 +1013,8 @@
               "type": "string",
               "$ref": "#/types/aws:iam/role:Role"
             }
-          ]
+          ],
+          "description": "The role name to include in the profile.\n"
         },
         "tags": {
           "type": "object",
@@ -906,21 +1027,26 @@
         "description": "Input properties used for looking up and filtering InstanceProfile resources.\n",
         "properties": {
           "arn": {
-            "type": "string"
+            "type": "string",
+            "description": "The ARN assigned by AWS to the instance profile.\n"
           },
           "createDate": {
-            "type": "string"
+            "type": "string",
+            "description": "The creation timestamp of the instance profile.\n"
           },
           "name": {
             "type": "string",
+            "description": "The instance profile's name.\n",
             "willReplaceOnChanges": true
           },
           "namePrefix": {
             "type": "string",
+            "description": "Creates a unique name beginning with the specified prefix. Conflicts with `name`.\n",
             "willReplaceOnChanges": true
           },
           "path": {
             "type": "string",
+            "description": "Path in which to create the profile.\n",
             "willReplaceOnChanges": true
           },
           "role": {
@@ -933,7 +1059,8 @@
                 "type": "string",
                 "$ref": "#/types/aws:iam/role:Role"
               }
-            ]
+            ],
+            "description": "The role name to include in the profile.\n"
           },
           "tags": {
             "type": "object",
@@ -948,22 +1075,26 @@
             }
           },
           "uniqueId": {
-            "type": "string"
+            "type": "string",
+            "description": "The [unique ID][1] assigned by AWS.\n"
           }
         },
         "type": "object"
       }
     },
     "aws:iam/openIdConnectProvider:OpenIdConnectProvider": {
+      "description": "Provides an IAM OpenID Connect provider.\n\n## Example Usage\n\n```hcl\nresource \"aws_iam_openid_connect_provider\" \"default\" {\n    url = \"https://accounts.google.com\"\n    client_id_list = [\n     \"266362248691-342342xasdasdasda-apps.googleusercontent.com\"\n    ]\n    thumbprint_list = []\n}\n```\n\n## Import\n\nIAM OpenID Connect Providers can be imported using the `arn`, e.g.\n\n```sh\u003cbreak\u003e\n$ pulumi import aws:iam/openIdConnectProvider:OpenIdConnectProvider default arn:aws:iam::123456789012:oidc-provider/accounts.google.com\n\u003cbreak\u003e```\u003cbreak\u003e\n",
       "properties": {
         "arn": {
-          "type": "string"
+          "type": "string",
+          "description": "The ARN assigned by AWS for this provider.\n"
         },
         "clientIdLists": {
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "description": "A list of client IDs (also known as audiences). When a mobile or web app registers with an OpenID Connect provider, they establish a value that identifies the application. (This is the value that's sent as the client_id parameter on OAuth requests.)\n"
         },
         "tags": {
           "type": "object",
@@ -981,10 +1112,12 @@
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "description": "A list of server certificate thumbprints for the OpenID Connect (OIDC) identity provider's server certificate(s).\n"
         },
         "url": {
-          "type": "string"
+          "type": "string",
+          "description": "The URL of the identity provider. Corresponds to the _iss_ claim.\n"
         }
       },
       "required": [
@@ -1000,6 +1133,7 @@
           "items": {
             "type": "string"
           },
+          "description": "A list of client IDs (also known as audiences). When a mobile or web app registers with an OpenID Connect provider, they establish a value that identifies the application. (This is the value that's sent as the client_id parameter on OAuth requests.)\n",
           "willReplaceOnChanges": true
         },
         "tags": {
@@ -1012,10 +1146,12 @@
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "description": "A list of server certificate thumbprints for the OpenID Connect (OIDC) identity provider's server certificate(s).\n"
         },
         "url": {
           "type": "string",
+          "description": "The URL of the identity provider. Corresponds to the _iss_ claim.\n",
           "willReplaceOnChanges": true
         }
       },
@@ -1028,13 +1164,15 @@
         "description": "Input properties used for looking up and filtering OpenIdConnectProvider resources.\n",
         "properties": {
           "arn": {
-            "type": "string"
+            "type": "string",
+            "description": "The ARN assigned by AWS for this provider.\n"
           },
           "clientIdLists": {
             "type": "array",
             "items": {
               "type": "string"
             },
+            "description": "A list of client IDs (also known as audiences). When a mobile or web app registers with an OpenID Connect provider, they establish a value that identifies the application. (This is the value that's sent as the client_id parameter on OAuth requests.)\n",
             "willReplaceOnChanges": true
           },
           "tags": {
@@ -1053,10 +1191,12 @@
             "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "description": "A list of server certificate thumbprints for the OpenID Connect (OIDC) identity provider's server certificate(s).\n"
           },
           "url": {
             "type": "string",
+            "description": "The URL of the identity provider. Corresponds to the _iss_ claim.\n",
             "willReplaceOnChanges": true
           }
         },
@@ -1064,24 +1204,31 @@
       }
     },
     "aws:iam/policy:Policy": {
+      "description": "Provides an IAM policy.\n\n```hcl\nresource \"aws_iam_policy\" \"policy\" {\n  name        = \"test_policy\"\n  path        = \"/\"\n  description = \"My test policy\"\n\n  policy = \u003c\u003cEOF\n{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"ec2:Describe*\"\n      ],\n      \"Effect\": \"Allow\",\n      \"Resource\": \"*\"\n    }\n  ]\n}\nEOF\n}\n```\n\n## Import\n\nIAM Policies can be imported using the `arn`, e.g.\n\n```sh\u003cbreak\u003e\n$ pulumi import aws:iam/policy:Policy administrator arn:aws:iam::123456789012:policy/UsersManageOwnCredentials\n\u003cbreak\u003e```\u003cbreak\u003e\n",
       "properties": {
         "arn": {
-          "type": "string"
+          "type": "string",
+          "description": "The ARN assigned by AWS to this policy.\n"
         },
         "description": {
-          "type": "string"
+          "type": "string",
+          "description": "Description of the IAM policy.\n"
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "The name of the policy.\n"
         },
         "namePrefix": {
-          "type": "string"
+          "type": "string",
+          "description": "Creates a unique name beginning with the specified prefix. Conflicts with `name`.\n"
         },
         "path": {
-          "type": "string"
+          "type": "string",
+          "description": "Path in which to create the policy.\nSee [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html) for more information.\n"
         },
         "policy": {
           "type": "string",
+          "description": "The policy document. This is a JSON formatted string.\nThe heredoc syntax, `file` function, or the [`aws.x/iam.getPolicyDocument` data\nsource](https://www.terraform.io/docs/providers/aws/d/iam_policy_document.html)\nare all helpful here.\n",
           "language": {
             "csharp": {
               "name": "PolicyDocument"
@@ -1114,18 +1261,22 @@
       "inputProperties": {
         "description": {
           "type": "string",
+          "description": "Description of the IAM policy.\n",
           "willReplaceOnChanges": true
         },
         "name": {
           "type": "string",
+          "description": "The name of the policy.\n",
           "willReplaceOnChanges": true
         },
         "namePrefix": {
           "type": "string",
+          "description": "Creates a unique name beginning with the specified prefix. Conflicts with `name`.\n",
           "willReplaceOnChanges": true
         },
         "path": {
           "type": "string",
+          "description": "Path in which to create the policy.\nSee [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html) for more information.\n",
           "willReplaceOnChanges": true
         },
         "policy": {
@@ -1139,6 +1290,7 @@
               "$ref": "#/types/aws:iam/documents:PolicyDocument"
             }
           ],
+          "description": "The policy document. This is a JSON formatted string.\nThe heredoc syntax, `file` function, or the [`aws.x/iam.getPolicyDocument` data\nsource](https://www.terraform.io/docs/providers/aws/d/iam_policy_document.html)\nare all helpful here.\n",
           "language": {
             "csharp": {
               "name": "PolicyDocument"
@@ -1159,22 +1311,27 @@
         "description": "Input properties used for looking up and filtering Policy resources.\n",
         "properties": {
           "arn": {
-            "type": "string"
+            "type": "string",
+            "description": "The ARN assigned by AWS to this policy.\n"
           },
           "description": {
             "type": "string",
+            "description": "Description of the IAM policy.\n",
             "willReplaceOnChanges": true
           },
           "name": {
             "type": "string",
+            "description": "The name of the policy.\n",
             "willReplaceOnChanges": true
           },
           "namePrefix": {
             "type": "string",
+            "description": "Creates a unique name beginning with the specified prefix. Conflicts with `name`.\n",
             "willReplaceOnChanges": true
           },
           "path": {
             "type": "string",
+            "description": "Path in which to create the policy.\nSee [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html) for more information.\n",
             "willReplaceOnChanges": true
           },
           "policy": {
@@ -1188,6 +1345,7 @@
                 "$ref": "#/types/aws:iam/documents:PolicyDocument"
               }
             ],
+            "description": "The policy document. This is a JSON formatted string.\nThe heredoc syntax, `file` function, or the [`aws.x/iam.getPolicyDocument` data\nsource](https://www.terraform.io/docs/providers/aws/d/iam_policy_document.html)\nare all helpful here.\n",
             "language": {
               "csharp": {
                 "name": "PolicyDocument"
@@ -1219,26 +1377,31 @@
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "description": "The group(s) the policy should be applied to\n"
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "The name of the policy. This cannot be an empty string.\n"
         },
         "policyArn": {
           "type": "string",
-          "$ref": "#/types/aws:index/aRN:ARN"
+          "$ref": "#/types/aws:index/aRN:ARN",
+          "description": "The ARN of the policy you want to apply\n"
         },
         "roles": {
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "description": "The role(s) the policy should be applied to\n"
         },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "description": "The user(s) the policy should be applied to\n"
         }
       },
       "required": [
@@ -1259,15 +1422,18 @@
                 "$ref": "#/types/aws:iam/group:Group"
               }
             ]
-          }
+          },
+          "description": "The group(s) the policy should be applied to\n"
         },
         "name": {
           "type": "string",
+          "description": "The name of the policy. This cannot be an empty string.\n",
           "willReplaceOnChanges": true
         },
         "policyArn": {
           "type": "string",
           "$ref": "#/types/aws:index/aRN:ARN",
+          "description": "The ARN of the policy you want to apply\n",
           "willReplaceOnChanges": true
         },
         "roles": {
@@ -1283,7 +1449,8 @@
                 "$ref": "#/types/aws:iam/role:Role"
               }
             ]
-          }
+          },
+          "description": "The role(s) the policy should be applied to\n"
         },
         "users": {
           "type": "array",
@@ -1298,7 +1465,8 @@
                 "$ref": "#/types/aws:iam/user:User"
               }
             ]
-          }
+          },
+          "description": "The user(s) the policy should be applied to\n"
         }
       },
       "requiredInputs": [
@@ -1320,15 +1488,18 @@
                   "$ref": "#/types/aws:iam/group:Group"
                 }
               ]
-            }
+            },
+            "description": "The group(s) the policy should be applied to\n"
           },
           "name": {
             "type": "string",
+            "description": "The name of the policy. This cannot be an empty string.\n",
             "willReplaceOnChanges": true
           },
           "policyArn": {
             "type": "string",
             "$ref": "#/types/aws:index/aRN:ARN",
+            "description": "The ARN of the policy you want to apply\n",
             "willReplaceOnChanges": true
           },
           "roles": {
@@ -1344,7 +1515,8 @@
                   "$ref": "#/types/aws:iam/role:Role"
                 }
               ]
-            }
+            },
+            "description": "The role(s) the policy should be applied to\n"
           },
           "users": {
             "type": "array",
@@ -1359,28 +1531,35 @@
                   "$ref": "#/types/aws:iam/user:User"
                 }
               ]
-            }
+            },
+            "description": "The user(s) the policy should be applied to\n"
           }
         },
         "type": "object"
       }
     },
     "aws:iam/role:Role": {
+      "description": "Provides an IAM role.\n\n## Example Usage\n\n```hcl\nresource \"aws_iam_role\" \"test_role\" {\n  name = \"test_role\"\n\n  assume_role_policy = \u003c\u003cEOF\n{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"ec2.amazonaws.com\"\n      },\n      \"Effect\": \"Allow\",\n      \"Sid\": \"\"\n    }\n  ]\n}\nEOF\n}\n```\n\n## Example of Using Data Source for Assume Role Policy\n\n```hcl\ndata \"aws_iam_policy_document\" \"instance-assume-role-policy\" {\n  statement {\n    actions = [\"sts:AssumeRole\"]\n\n    principals {\n      type        = \"Service\"\n      identifiers = [\"ec2.amazonaws.com\"]\n    }\n  }\n}\n\nresource \"aws_iam_role\" \"instance\" {\n  name               = \"instance_role\"\n  path               = \"/system/\"\n  assume_role_policy = \"${data.aws_iam_policy_document.instance-assume-role-policy.json}\"\n}\n```\n\n## Import\n\nIAM Roles can be imported using the `name`, e.g.\n\n```sh\u003cbreak\u003e\n$ pulumi import aws:iam/role:Role developer developer_name\n\u003cbreak\u003e```\u003cbreak\u003e\n",
       "properties": {
         "arn": {
-          "type": "string"
+          "type": "string",
+          "description": "The Amazon Resource Name (ARN) specifying the role.\n"
         },
         "assumeRolePolicy": {
-          "type": "string"
+          "type": "string",
+          "description": "The policy that grants an entity permission to assume the role.\n\n\u003e **NOTE:** This `assume_role_policy` is very similar but slightly different than just a standard IAM policy and cannot use an `aws.iam.Policy` resource.  It _can_ however, use an `aws.x/iam.getPolicyDocument` data source, see example below for how this could work.\n"
         },
         "createDate": {
-          "type": "string"
+          "type": "string",
+          "description": "The creation date of the IAM role.\n"
         },
         "description": {
-          "type": "string"
+          "type": "string",
+          "description": "The description of the role.\n"
         },
         "forceDetachPolicies": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Specifies to force detaching any policies the role has before destroying it. Defaults to `false`.\n"
         },
         "inlinePolicies": {
           "type": "array",
@@ -1398,13 +1577,16 @@
           "type": "integer"
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "The name of the role.\n"
         },
         "namePrefix": {
-          "type": "string"
+          "type": "string",
+          "description": "Creates a unique name beginning with the specified prefix. Conflicts with `name`.\n"
         },
         "path": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the role.\nSee [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html) for more information.\n"
         },
         "permissionsBoundary": {
           "type": "string"
@@ -1422,7 +1604,8 @@
           }
         },
         "uniqueId": {
-          "type": "string"
+          "type": "string",
+          "description": "The stable and unique string identifying the role.\n"
         }
       },
       "required": [
@@ -1447,13 +1630,16 @@
               "type": "string",
               "$ref": "#/types/aws:iam/documents:PolicyDocument"
             }
-          ]
+          ],
+          "description": "The policy that grants an entity permission to assume the role.\n\n\u003e **NOTE:** This `assume_role_policy` is very similar but slightly different than just a standard IAM policy and cannot use an `aws.iam.Policy` resource.  It _can_ however, use an `aws.x/iam.getPolicyDocument` data source, see example below for how this could work.\n"
         },
         "description": {
-          "type": "string"
+          "type": "string",
+          "description": "The description of the role.\n"
         },
         "forceDetachPolicies": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Specifies to force detaching any policies the role has before destroying it. Defaults to `false`.\n"
         },
         "inlinePolicies": {
           "type": "array",
@@ -1472,14 +1658,17 @@
         },
         "name": {
           "type": "string",
+          "description": "The name of the role.\n",
           "willReplaceOnChanges": true
         },
         "namePrefix": {
           "type": "string",
+          "description": "Creates a unique name beginning with the specified prefix. Conflicts with `name`.\n",
           "willReplaceOnChanges": true
         },
         "path": {
           "type": "string",
+          "description": "The path to the role.\nSee [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html) for more information.\n",
           "willReplaceOnChanges": true
         },
         "permissionsBoundary": {
@@ -1499,7 +1688,8 @@
         "description": "Input properties used for looking up and filtering Role resources.\n",
         "properties": {
           "arn": {
-            "type": "string"
+            "type": "string",
+            "description": "The Amazon Resource Name (ARN) specifying the role.\n"
           },
           "assumeRolePolicy": {
             "type": "string",
@@ -1511,16 +1701,20 @@
                 "type": "string",
                 "$ref": "#/types/aws:iam/documents:PolicyDocument"
               }
-            ]
+            ],
+            "description": "The policy that grants an entity permission to assume the role.\n\n\u003e **NOTE:** This `assume_role_policy` is very similar but slightly different than just a standard IAM policy and cannot use an `aws.iam.Policy` resource.  It _can_ however, use an `aws.x/iam.getPolicyDocument` data source, see example below for how this could work.\n"
           },
           "createDate": {
-            "type": "string"
+            "type": "string",
+            "description": "The creation date of the IAM role.\n"
           },
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "The description of the role.\n"
           },
           "forceDetachPolicies": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Specifies to force detaching any policies the role has before destroying it. Defaults to `false`.\n"
           },
           "inlinePolicies": {
             "type": "array",
@@ -1539,14 +1733,17 @@
           },
           "name": {
             "type": "string",
+            "description": "The name of the role.\n",
             "willReplaceOnChanges": true
           },
           "namePrefix": {
             "type": "string",
+            "description": "Creates a unique name beginning with the specified prefix. Conflicts with `name`.\n",
             "willReplaceOnChanges": true
           },
           "path": {
             "type": "string",
+            "description": "The path to the role.\nSee [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html) for more information.\n",
             "willReplaceOnChanges": true
           },
           "permissionsBoundary": {
@@ -1565,25 +1762,31 @@
             }
           },
           "uniqueId": {
-            "type": "string"
+            "type": "string",
+            "description": "The stable and unique string identifying the role.\n"
           }
         },
         "type": "object"
       }
     },
     "aws:iam/rolePolicy:RolePolicy": {
+      "description": "Provides an IAM role policy.\n\n## Example Usage\n\n```hcl\nresource \"aws_iam_role_policy\" \"test_policy\" {\n  name = \"test_policy\"\n  role = \"${aws_iam_role.test_role.id}\"\n\n  policy = \u003c\u003cEOF\n{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"ec2:Describe*\"\n      ],\n      \"Effect\": \"Allow\",\n      \"Resource\": \"*\"\n    }\n  ]\n}\nEOF\n}\n\nresource \"aws_iam_role\" \"test_role\" {\n  name = \"test_role\"\n\n  assume_role_policy = \u003c\u003cEOF\n{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"ec2.amazonaws.com\"\n      },\n      \"Effect\": \"Allow\",\n      \"Sid\": \"\"\n    }\n  ]\n}\nEOF\n}\n```\n\n## Import\n\nIAM Role Policies can be imported using the `role_name:role_policy_name`, e.g.\n\n```sh\u003cbreak\u003e\n$ pulumi import aws:iam/rolePolicy:RolePolicy mypolicy role_of_mypolicy_name:mypolicy_name\n\u003cbreak\u003e```\u003cbreak\u003e\n",
       "properties": {
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "The name of the policy.\n"
         },
         "namePrefix": {
-          "type": "string"
+          "type": "string",
+          "description": "Creates a unique name beginning with the specified\nprefix. Conflicts with `name`.\n"
         },
         "policy": {
-          "type": "string"
+          "type": "string",
+          "description": "The policy document. This is a JSON formatted string.\nThe heredoc syntax or `file` function is helpful here.\n"
         },
         "role": {
-          "type": "string"
+          "type": "string",
+          "description": "The IAM role to attach to the policy.\n"
         }
       },
       "required": [
@@ -1594,10 +1797,12 @@
       "inputProperties": {
         "name": {
           "type": "string",
+          "description": "The name of the policy.\n",
           "willReplaceOnChanges": true
         },
         "namePrefix": {
           "type": "string",
+          "description": "Creates a unique name beginning with the specified\nprefix. Conflicts with `name`.\n",
           "willReplaceOnChanges": true
         },
         "policy": {
@@ -1610,7 +1815,8 @@
               "type": "string",
               "$ref": "#/types/aws:iam/documents:PolicyDocument"
             }
-          ]
+          ],
+          "description": "The policy document. This is a JSON formatted string.\nThe heredoc syntax or `file` function is helpful here.\n"
         },
         "role": {
           "type": "string",
@@ -1623,6 +1829,7 @@
               "$ref": "#/types/aws:iam/role:Role"
             }
           ],
+          "description": "The IAM role to attach to the policy.\n",
           "willReplaceOnChanges": true
         }
       },
@@ -1635,10 +1842,12 @@
         "properties": {
           "name": {
             "type": "string",
+            "description": "The name of the policy.\n",
             "willReplaceOnChanges": true
           },
           "namePrefix": {
             "type": "string",
+            "description": "Creates a unique name beginning with the specified\nprefix. Conflicts with `name`.\n",
             "willReplaceOnChanges": true
           },
           "policy": {
@@ -1651,7 +1860,8 @@
                 "type": "string",
                 "$ref": "#/types/aws:iam/documents:PolicyDocument"
               }
-            ]
+            ],
+            "description": "The policy document. This is a JSON formatted string.\nThe heredoc syntax or `file` function is helpful here.\n"
           },
           "role": {
             "type": "string",
@@ -1664,6 +1874,7 @@
                 "$ref": "#/types/aws:iam/role:Role"
               }
             ],
+            "description": "The IAM role to attach to the policy.\n",
             "willReplaceOnChanges": true
           }
         },
@@ -1671,13 +1882,16 @@
       }
     },
     "aws:iam/rolePolicyAttachment:RolePolicyAttachment": {
+      "description": "Attaches a Managed IAM Policy to an IAM role\n\n```hcl\nresource \"aws_iam_role\" \"role\" {\n    name = \"test-role\"\n    assume_role_policy = \u003c\u003cEOF\n    {\n      \"Version\": \"2012-10-17\",\n      \"Statement\": [\n        {\n          \"Action\": \"sts:AssumeRole\",\n          \"Principal\": {\n            \"Service\": \"ec2.amazonaws.com\"\n          },\n          \"Effect\": \"Allow\",\n          \"Sid\": \"\"\n        }\n      ]\n    }\nEOF\n}\n\nresource \"aws_iam_policy\" \"policy\" {\n    name        = \"test-policy\"\n    description = \"A test policy\"\n    policy = \u003c\u003cEOF\n{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"ec2:Describe*\"\n      ],\n      \"Effect\": \"Allow\",\n      \"Resource\": \"*\"\n    }\n  ]\n}\nEOF\n}\n\nresource \"aws_iam_role_policy_attachment\" \"test-attach\" {\n    role       = \"${aws_iam_role.role.name}\"\n    policy_arn = \"${aws_iam_policy.policy.arn}\"\n}\n```\n",
       "properties": {
         "policyArn": {
           "type": "string",
-          "$ref": "#/types/aws:index/aRN:ARN"
+          "$ref": "#/types/aws:index/aRN:ARN",
+          "description": "The ARN of the policy you want to apply\n"
         },
         "role": {
-          "type": "string"
+          "type": "string",
+          "description": "The role the policy should be applied to\n"
         }
       },
       "required": [
@@ -1688,6 +1902,7 @@
         "policyArn": {
           "type": "string",
           "$ref": "#/types/aws:index/aRN:ARN",
+          "description": "The ARN of the policy you want to apply\n",
           "willReplaceOnChanges": true
         },
         "role": {
@@ -1701,6 +1916,7 @@
               "$ref": "#/types/aws:iam/role:Role"
             }
           ],
+          "description": "The role the policy should be applied to\n",
           "willReplaceOnChanges": true
         }
       },
@@ -1714,6 +1930,7 @@
           "policyArn": {
             "type": "string",
             "$ref": "#/types/aws:index/aRN:ARN",
+            "description": "The ARN of the policy you want to apply\n",
             "willReplaceOnChanges": true
           },
           "role": {
@@ -1727,6 +1944,7 @@
                 "$ref": "#/types/aws:iam/role:Role"
               }
             ],
+            "description": "The role the policy should be applied to\n",
             "willReplaceOnChanges": true
           }
         },
@@ -1734,15 +1952,19 @@
       }
     },
     "aws:iam/samlProvider:SamlProvider": {
+      "description": "Provides an IAM SAML provider.\n\n## Example Usage\n\n```hcl\nresource \"aws_iam_saml_provider\" \"default\" {\n  name                   = \"myprovider\"\n  saml_metadata_document = \"${file(\"saml-metadata.xml\")}\"\n}\n```\n\n## Import\n\nIAM SAML Providers can be imported using the `arn`, e.g.\n\n```sh\u003cbreak\u003e\n$ pulumi import aws:iam/samlProvider:SamlProvider default arn:aws:iam::123456789012:saml-provider/SAMLADFS\n\u003cbreak\u003e```\u003cbreak\u003e\n",
       "properties": {
         "arn": {
-          "type": "string"
+          "type": "string",
+          "description": "The ARN assigned by AWS for this provider.\n"
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "The name of the provider to create.\n"
         },
         "samlMetadataDocument": {
-          "type": "string"
+          "type": "string",
+          "description": "An XML document generated by an identity provider that supports SAML 2.0.\n"
         },
         "tags": {
           "type": "object",
@@ -1757,7 +1979,8 @@
           }
         },
         "validUntil": {
-          "type": "string"
+          "type": "string",
+          "description": "The expiration date and time for the SAML provider in RFC1123 format, e.g. `Mon, 02 Jan 2006 15:04:05 MST`.\n"
         }
       },
       "required": [
@@ -1770,10 +1993,12 @@
       "inputProperties": {
         "name": {
           "type": "string",
+          "description": "The name of the provider to create.\n",
           "willReplaceOnChanges": true
         },
         "samlMetadataDocument": {
-          "type": "string"
+          "type": "string",
+          "description": "An XML document generated by an identity provider that supports SAML 2.0.\n"
         },
         "tags": {
           "type": "object",
@@ -1789,14 +2014,17 @@
         "description": "Input properties used for looking up and filtering SamlProvider resources.\n",
         "properties": {
           "arn": {
-            "type": "string"
+            "type": "string",
+            "description": "The ARN assigned by AWS for this provider.\n"
           },
           "name": {
             "type": "string",
+            "description": "The name of the provider to create.\n",
             "willReplaceOnChanges": true
           },
           "samlMetadataDocument": {
-            "type": "string"
+            "type": "string",
+            "description": "An XML document generated by an identity provider that supports SAML 2.0.\n"
           },
           "tags": {
             "type": "object",
@@ -1811,37 +2039,45 @@
             }
           },
           "validUntil": {
-            "type": "string"
+            "type": "string",
+            "description": "The expiration date and time for the SAML provider in RFC1123 format, e.g. `Mon, 02 Jan 2006 15:04:05 MST`.\n"
           }
         },
         "type": "object"
       }
     },
     "aws:iam/serverCertificate:ServerCertificate": {
+      "description": "\n\n## Import\n\nIAM Server Certificates can be imported using the `name`, e.g.\n\n```sh\u003cbreak\u003e\n$ pulumi import aws:iam/serverCertificate:ServerCertificate certificate example.com-certificate-until-2018\n\u003cbreak\u003e```\u003cbreak\u003e\n",
       "properties": {
         "arn": {
-          "type": "string"
+          "type": "string",
+          "description": "The Amazon Resource Name (ARN) specifying the server certificate.\n"
         },
         "certificateBody": {
-          "type": "string"
+          "type": "string",
+          "description": "(Required) The contents of the public key certificate in\nPEM-encoded format.\n"
         },
         "certificateChain": {
-          "type": "string"
+          "type": "string",
+          "description": "(Optional) The contents of the certificate chain.\nThis is typically a concatenation of the PEM-encoded public key certificates\nof the chain.\n"
         },
         "expiration": {
           "type": "string"
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "The name of the Server Certificate\n"
         },
         "namePrefix": {
-          "type": "string"
+          "type": "string",
+          "description": "Creates a unique name beginning with the specified\nprefix. Conflicts with `name`.\n"
         },
         "path": {
           "type": "string"
         },
         "privateKey": {
           "type": "string",
+          "description": "(Required) The contents of the private key in PEM-encoded format.\n",
           "secret": true
         },
         "tags": {
@@ -1872,18 +2108,22 @@
       "inputProperties": {
         "certificateBody": {
           "type": "string",
+          "description": "(Required) The contents of the public key certificate in\nPEM-encoded format.\n",
           "willReplaceOnChanges": true
         },
         "certificateChain": {
           "type": "string",
+          "description": "(Optional) The contents of the certificate chain.\nThis is typically a concatenation of the PEM-encoded public key certificates\nof the chain.\n",
           "willReplaceOnChanges": true
         },
         "name": {
           "type": "string",
+          "description": "The name of the Server Certificate\n",
           "willReplaceOnChanges": true
         },
         "namePrefix": {
           "type": "string",
+          "description": "Creates a unique name beginning with the specified\nprefix. Conflicts with `name`.\n",
           "willReplaceOnChanges": true
         },
         "path": {
@@ -1892,6 +2132,7 @@
         },
         "privateKey": {
           "type": "string",
+          "description": "(Required) The contents of the private key in PEM-encoded format.\n",
           "secret": true,
           "willReplaceOnChanges": true
         },
@@ -1910,14 +2151,17 @@
         "description": "Input properties used for looking up and filtering ServerCertificate resources.\n",
         "properties": {
           "arn": {
-            "type": "string"
+            "type": "string",
+            "description": "The Amazon Resource Name (ARN) specifying the server certificate.\n"
           },
           "certificateBody": {
             "type": "string",
+            "description": "(Required) The contents of the public key certificate in\nPEM-encoded format.\n",
             "willReplaceOnChanges": true
           },
           "certificateChain": {
             "type": "string",
+            "description": "(Optional) The contents of the certificate chain.\nThis is typically a concatenation of the PEM-encoded public key certificates\nof the chain.\n",
             "willReplaceOnChanges": true
           },
           "expiration": {
@@ -1925,10 +2169,12 @@
           },
           "name": {
             "type": "string",
+            "description": "The name of the Server Certificate\n",
             "willReplaceOnChanges": true
           },
           "namePrefix": {
             "type": "string",
+            "description": "Creates a unique name beginning with the specified\nprefix. Conflicts with `name`.\n",
             "willReplaceOnChanges": true
           },
           "path": {
@@ -1937,6 +2183,7 @@
           },
           "privateKey": {
             "type": "string",
+            "description": "(Required) The contents of the private key in PEM-encoded format.\n",
             "secret": true,
             "willReplaceOnChanges": true
           },
@@ -2207,24 +2454,31 @@
       }
     },
     "aws:iam/sshKey:SshKey": {
+      "description": "Uploads an SSH public key and associates it with the specified IAM user.\n\n## Example Usage\n\n```hcl\nresource \"aws_iam_user\" \"user\" {\n  name = \"test-user\"\n  path = \"/\"\n}\n\nresource \"aws_iam_user_ssh_key\" \"user\" {\n  username   = \"${aws_iam_user.user.name}\"\n  encoding   = \"PEM\"\n  public_key = \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 mytest@mydomain.com\"\n}\n```\n",
       "properties": {
         "encoding": {
-          "type": "string"
+          "type": "string",
+          "description": "Specifies the public key encoding format to use in the response. To retrieve the public key in ssh-rsa format, use SSH . To retrieve the public key in PEM format, use PEM .\n"
         },
         "fingerprint": {
-          "type": "string"
+          "type": "string",
+          "description": "The MD5 message digest of the SSH public key.\n"
         },
         "publicKey": {
-          "type": "string"
+          "type": "string",
+          "description": "The SSH public key. The public key must be encoded in ssh-rsa format or PEM format.\n"
         },
         "sshPublicKeyId": {
-          "type": "string"
+          "type": "string",
+          "description": "The unique identifier for the SSH public key.\n"
         },
         "status": {
-          "type": "string"
+          "type": "string",
+          "description": "The status to assign to the SSH public key. Active means the key can be used for authentication with an AWS CodeCommit repository. Inactive means the key cannot be used. Default is `active`.\n"
         },
         "username": {
-          "type": "string"
+          "type": "string",
+          "description": "The name of the IAM user to associate the SSH public key with.\n"
         }
       },
       "required": [
@@ -2238,17 +2492,21 @@
       "inputProperties": {
         "encoding": {
           "type": "string",
+          "description": "Specifies the public key encoding format to use in the response. To retrieve the public key in ssh-rsa format, use SSH . To retrieve the public key in PEM format, use PEM .\n",
           "willReplaceOnChanges": true
         },
         "publicKey": {
           "type": "string",
+          "description": "The SSH public key. The public key must be encoded in ssh-rsa format or PEM format.\n",
           "willReplaceOnChanges": true
         },
         "status": {
-          "type": "string"
+          "type": "string",
+          "description": "The status to assign to the SSH public key. Active means the key can be used for authentication with an AWS CodeCommit repository. Inactive means the key cannot be used. Default is `active`.\n"
         },
         "username": {
           "type": "string",
+          "description": "The name of the IAM user to associate the SSH public key with.\n",
           "willReplaceOnChanges": true
         }
       },
@@ -2262,23 +2520,29 @@
         "properties": {
           "encoding": {
             "type": "string",
+            "description": "Specifies the public key encoding format to use in the response. To retrieve the public key in ssh-rsa format, use SSH . To retrieve the public key in PEM format, use PEM .\n",
             "willReplaceOnChanges": true
           },
           "fingerprint": {
-            "type": "string"
+            "type": "string",
+            "description": "The MD5 message digest of the SSH public key.\n"
           },
           "publicKey": {
             "type": "string",
+            "description": "The SSH public key. The public key must be encoded in ssh-rsa format or PEM format.\n",
             "willReplaceOnChanges": true
           },
           "sshPublicKeyId": {
-            "type": "string"
+            "type": "string",
+            "description": "The unique identifier for the SSH public key.\n"
           },
           "status": {
-            "type": "string"
+            "type": "string",
+            "description": "The status to assign to the SSH public key. Active means the key can be used for authentication with an AWS CodeCommit repository. Inactive means the key cannot be used. Default is `active`.\n"
           },
           "username": {
             "type": "string",
+            "description": "The name of the IAM user to associate the SSH public key with.\n",
             "willReplaceOnChanges": true
           }
         },
@@ -2286,19 +2550,23 @@
       }
     },
     "aws:iam/user:User": {
+      "description": "Provides an IAM user.\n\n## Example Usage\n\n```hcl\nresource \"aws_iam_user\" \"lb\" {\n  name = \"loadbalancer\"\n  path = \"/system/\"\n}\n\nresource \"aws_iam_access_key\" \"lb\" {\n  user = \"${aws_iam_user.lb.name}\"\n}\n\nresource \"aws_iam_user_policy\" \"lb_ro\" {\n  name = \"test\"\n  user = \"${aws_iam_user.lb.name}\"\n\n  policy = \u003c\u003cEOF\n{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"ec2:Describe*\"\n      ],\n      \"Effect\": \"Allow\",\n      \"Resource\": \"*\"\n    }\n  ]\n}\nEOF\n}\n```\n\n## Import\n\nIAM Users can be imported using the `name`, e.g.\n\n```sh\u003cbreak\u003e\n$ pulumi import aws:iam/user:User lb loadbalancer\n\u003cbreak\u003e```\u003cbreak\u003e\n",
       "properties": {
         "arn": {
-          "type": "string"
+          "type": "string",
+          "description": "The ARN assigned by AWS for this user.\n"
         },
         "forceDestroy": {
           "type": "boolean",
           "description": "Delete user even if it has non-Terraform-managed IAM access keys, login profile or MFA devices\n"
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "The user's name. The name must consist of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: `=,.@-_.`. User names are not distinguished by case. For example, you cannot create users named both \"TESTUSER\" and \"testuser\".\n"
         },
         "path": {
-          "type": "string"
+          "type": "string",
+          "description": "Path in which to create the user.\n"
         },
         "permissionsBoundary": {
           "type": "string"
@@ -2316,7 +2584,8 @@
           }
         },
         "uniqueId": {
-          "type": "string"
+          "type": "string",
+          "description": "The [unique ID][1] assigned by AWS.\n"
         }
       },
       "required": [
@@ -2331,10 +2600,12 @@
           "description": "Delete user even if it has non-Terraform-managed IAM access keys, login profile or MFA devices\n"
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "The user's name. The name must consist of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: `=,.@-_.`. User names are not distinguished by case. For example, you cannot create users named both \"TESTUSER\" and \"testuser\".\n"
         },
         "path": {
-          "type": "string"
+          "type": "string",
+          "description": "Path in which to create the user.\n"
         },
         "permissionsBoundary": {
           "type": "string"
@@ -2350,17 +2621,20 @@
         "description": "Input properties used for looking up and filtering User resources.\n",
         "properties": {
           "arn": {
-            "type": "string"
+            "type": "string",
+            "description": "The ARN assigned by AWS for this user.\n"
           },
           "forceDestroy": {
             "type": "boolean",
             "description": "Delete user even if it has non-Terraform-managed IAM access keys, login profile or MFA devices\n"
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "The user's name. The name must consist of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: `=,.@-_.`. User names are not distinguished by case. For example, you cannot create users named both \"TESTUSER\" and \"testuser\".\n"
           },
           "path": {
-            "type": "string"
+            "type": "string",
+            "description": "Path in which to create the user.\n"
           },
           "permissionsBoundary": {
             "type": "string"
@@ -2378,7 +2652,8 @@
             }
           },
           "uniqueId": {
-            "type": "string"
+            "type": "string",
+            "description": "The [unique ID][1] assigned by AWS.\n"
           }
         },
         "type": "object"
@@ -2434,27 +2709,34 @@
       }
     },
     "aws:iam/userLoginProfile:UserLoginProfile": {
+      "description": "Provides one-time creation of a IAM user login profile, and uses PGP to\nencrypt the password for safe transport to the user. PGP keys can be\nobtained from Keybase.\n\n## Example Usage\n\n```hcl\nresource \"aws_iam_user\" \"u\" {\n  name          = \"auser\"\n  path          = \"/\"\n  force_destroy = true\n}\n\nresource \"aws_iam_user_login_profile\" \"u\" {\n  user    = \"${aws_iam_user.u.name}\"\n  pgp_key = \"keybase:some_person_that_exists\"\n}\n\noutput \"password\" {\n  value = \"${aws_iam_user_login_profile.u.encrypted_password}\"\n}\n```\n\n## Import\n\nIAM Login Profiles may not be imported.\n",
       "properties": {
         "encryptedPassword": {
-          "type": "string"
+          "type": "string",
+          "description": "The encrypted password, base64 encoded.\n"
         },
         "keyFingerprint": {
-          "type": "string"
+          "type": "string",
+          "description": "The fingerprint of the PGP key used to encrypt\nthe password\n"
         },
         "password": {
           "type": "string"
         },
         "passwordLength": {
-          "type": "integer"
+          "type": "integer",
+          "description": "The length of the generated\npassword.\n"
         },
         "passwordResetRequired": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether the\nuser should be forced to reset the generated password on first login.\n"
         },
         "pgpKey": {
-          "type": "string"
+          "type": "string",
+          "description": "Either a base-64 encoded PGP public key, or a\nkeybase username in the form `keybase:username`.\n"
         },
         "user": {
-          "type": "string"
+          "type": "string",
+          "description": "The IAM user's name.\n"
         }
       },
       "required": [
@@ -2467,18 +2749,22 @@
       "inputProperties": {
         "passwordLength": {
           "type": "integer",
+          "description": "The length of the generated\npassword.\n",
           "willReplaceOnChanges": true
         },
         "passwordResetRequired": {
           "type": "boolean",
+          "description": "Whether the\nuser should be forced to reset the generated password on first login.\n",
           "willReplaceOnChanges": true
         },
         "pgpKey": {
           "type": "string",
+          "description": "Either a base-64 encoded PGP public key, or a\nkeybase username in the form `keybase:username`.\n",
           "willReplaceOnChanges": true
         },
         "user": {
           "type": "string",
+          "description": "The IAM user's name.\n",
           "willReplaceOnChanges": true
         }
       },
@@ -2489,28 +2775,34 @@
         "description": "Input properties used for looking up and filtering UserLoginProfile resources.\n",
         "properties": {
           "encryptedPassword": {
-            "type": "string"
+            "type": "string",
+            "description": "The encrypted password, base64 encoded.\n"
           },
           "keyFingerprint": {
-            "type": "string"
+            "type": "string",
+            "description": "The fingerprint of the PGP key used to encrypt\nthe password\n"
           },
           "password": {
             "type": "string"
           },
           "passwordLength": {
             "type": "integer",
+            "description": "The length of the generated\npassword.\n",
             "willReplaceOnChanges": true
           },
           "passwordResetRequired": {
             "type": "boolean",
+            "description": "Whether the\nuser should be forced to reset the generated password on first login.\n",
             "willReplaceOnChanges": true
           },
           "pgpKey": {
             "type": "string",
+            "description": "Either a base-64 encoded PGP public key, or a\nkeybase username in the form `keybase:username`.\n",
             "willReplaceOnChanges": true
           },
           "user": {
             "type": "string",
+            "description": "The IAM user's name.\n",
             "willReplaceOnChanges": true
           }
         },
@@ -2518,18 +2810,22 @@
       }
     },
     "aws:iam/userPolicy:UserPolicy": {
+      "description": "Provides an IAM policy attached to a user.\n\n## Example Usage\n\n```hcl\nresource \"aws_iam_user_policy\" \"lb_ro\" {\n  name = \"test\"\n  user = \"${aws_iam_user.lb.name}\"\n\n  policy = \u003c\u003cEOF\n{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"ec2:Describe*\"\n      ],\n      \"Effect\": \"Allow\",\n      \"Resource\": \"*\"\n    }\n  ]\n}\nEOF\n}\n\nresource \"aws_iam_user\" \"lb\" {\n  name = \"loadbalancer\"\n  path = \"/system/\"\n}\n\nresource \"aws_iam_access_key\" \"lb\" {\n  user = \"${aws_iam_user.lb.name}\"\n}\n```\n",
       "properties": {
         "name": {
           "type": "string"
         },
         "namePrefix": {
-          "type": "string"
+          "type": "string",
+          "description": "Creates a unique name beginning with the specified prefix. Conflicts with `name`.\n"
         },
         "policy": {
-          "type": "string"
+          "type": "string",
+          "description": "The policy document. This is a JSON formatted string.\nThe heredoc syntax or `file` function is helpful here.\n"
         },
         "user": {
-          "type": "string"
+          "type": "string",
+          "description": "IAM user to which to attach this policy.\n"
         }
       },
       "required": [
@@ -2544,6 +2840,7 @@
         },
         "namePrefix": {
           "type": "string",
+          "description": "Creates a unique name beginning with the specified prefix. Conflicts with `name`.\n",
           "willReplaceOnChanges": true
         },
         "policy": {
@@ -2556,10 +2853,12 @@
               "type": "string",
               "$ref": "#/types/aws:iam/documents:PolicyDocument"
             }
-          ]
+          ],
+          "description": "The policy document. This is a JSON formatted string.\nThe heredoc syntax or `file` function is helpful here.\n"
         },
         "user": {
           "type": "string",
+          "description": "IAM user to which to attach this policy.\n",
           "willReplaceOnChanges": true
         }
       },
@@ -2576,6 +2875,7 @@
           },
           "namePrefix": {
             "type": "string",
+            "description": "Creates a unique name beginning with the specified prefix. Conflicts with `name`.\n",
             "willReplaceOnChanges": true
           },
           "policy": {
@@ -2588,10 +2888,12 @@
                 "type": "string",
                 "$ref": "#/types/aws:iam/documents:PolicyDocument"
               }
-            ]
+            ],
+            "description": "The policy document. This is a JSON formatted string.\nThe heredoc syntax or `file` function is helpful here.\n"
           },
           "user": {
             "type": "string",
+            "description": "IAM user to which to attach this policy.\n",
             "willReplaceOnChanges": true
           }
         },
@@ -2599,13 +2901,16 @@
       }
     },
     "aws:iam/userPolicyAttachment:UserPolicyAttachment": {
+      "description": "Attaches a Managed IAM Policy to an IAM user\n\n```hcl\nresource \"aws_iam_user\" \"user\" {\n    name = \"test-user\"\n}\n\nresource \"aws_iam_policy\" \"policy\" {\n    name        = \"test-policy\"\n    description = \"A test policy\"\n    policy      = # omitted\n}\n\nresource \"aws_iam_user_policy_attachment\" \"test-attach\" {\n    user       = \"${aws_iam_user.user.name}\"\n    policy_arn = \"${aws_iam_policy.policy.arn}\"\n}\n```\n",
       "properties": {
         "policyArn": {
           "type": "string",
-          "$ref": "#/types/aws:index/aRN:ARN"
+          "$ref": "#/types/aws:index/aRN:ARN",
+          "description": "The ARN of the policy you want to apply\n"
         },
         "user": {
-          "type": "string"
+          "type": "string",
+          "description": "The user the policy should be applied to\n"
         }
       },
       "required": [
@@ -2616,6 +2921,7 @@
         "policyArn": {
           "type": "string",
           "$ref": "#/types/aws:index/aRN:ARN",
+          "description": "The ARN of the policy you want to apply\n",
           "willReplaceOnChanges": true
         },
         "user": {
@@ -2629,6 +2935,7 @@
               "$ref": "#/types/aws:iam/user:User"
             }
           ],
+          "description": "The user the policy should be applied to\n",
           "willReplaceOnChanges": true
         }
       },
@@ -2642,6 +2949,7 @@
           "policyArn": {
             "type": "string",
             "$ref": "#/types/aws:index/aRN:ARN",
+            "description": "The ARN of the policy you want to apply\n",
             "willReplaceOnChanges": true
           },
           "user": {
@@ -2655,6 +2963,7 @@
                 "$ref": "#/types/aws:iam/user:User"
               }
             ],
+            "description": "The user the policy should be applied to\n",
             "willReplaceOnChanges": true
           }
         },
@@ -2756,11 +3065,13 @@
   },
   "functions": {
     "aws:iam/getAccountAlias:getAccountAlias": {
+      "description": "## Example Usage\n\n```hcl\ndata \"aws_iam_account_alias\" \"current\" {}\n\noutput \"account_id\" {\n  value = \"${data.aws_iam_account_alias.current.account_alias}\"\n}\n```\n",
       "outputs": {
         "description": "A collection of values returned by getAccountAlias.\n",
         "properties": {
           "accountAlias": {
-            "type": "string"
+            "type": "string",
+            "description": "The alias associated with the AWS account.\n"
           },
           "id": {
             "type": "string",
@@ -2775,11 +3086,13 @@
       }
     },
     "aws:iam/getGroup:getGroup": {
+      "description": "This data source can be used to fetch information about a specific\nIAM group. By using this data source, you can reference IAM group\nproperties without having to hard code ARNs as input.\n\n## Example Usage\n\n```hcl\ndata \"aws_iam_group\" \"example\" {\n  group_name = \"an_example_group_name\"\n}\n```\n",
       "inputs": {
         "description": "A collection of arguments for invoking getGroup.\n",
         "properties": {
           "groupName": {
-            "type": "string"
+            "type": "string",
+            "description": "The friendly IAM group name to match.\n"
           }
         },
         "type": "object",
@@ -2791,10 +3104,12 @@
         "description": "A collection of values returned by getGroup.\n",
         "properties": {
           "arn": {
-            "type": "string"
+            "type": "string",
+            "description": "The Amazon Resource Name (ARN) specifying the group.\n"
           },
           "groupId": {
-            "type": "string"
+            "type": "string",
+            "description": "The stable and unique string identifying the group.\n"
           },
           "groupName": {
             "type": "string"
@@ -2804,7 +3119,8 @@
             "description": "The provider-assigned unique ID for this managed resource.\n"
           },
           "path": {
-            "type": "string"
+            "type": "string",
+            "description": "The path to the role.\n"
           },
           "users": {
             "type": "array",
@@ -2825,11 +3141,13 @@
       }
     },
     "aws:iam/getInstanceProfile:getInstanceProfile": {
+      "description": "This data source can be used to fetch information about a specific\nIAM instance profile. By using this data source, you can reference IAM \ninstance profile properties without having to hard code ARNs as input.\n\n## Example Usage\n\n```hcl\ndata \"aws_iam_instance_profile\" \"example\" {\n  name = \"an_example_instance_profile_name\"\n}\n```\n",
       "inputs": {
         "description": "A collection of arguments for invoking getInstanceProfile.\n",
         "properties": {
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "The friendly IAM instance profile name to match.\n"
           }
         },
         "type": "object",
@@ -2841,10 +3159,12 @@
         "description": "A collection of values returned by getInstanceProfile.\n",
         "properties": {
           "arn": {
-            "type": "string"
+            "type": "string",
+            "description": "The Amazon Resource Name (ARN) specifying the instance profile.\n"
           },
           "createDate": {
-            "type": "string"
+            "type": "string",
+            "description": "The string representation of the date the instance profile\nwas created.\n"
           },
           "id": {
             "type": "string",
@@ -2854,13 +3174,15 @@
             "type": "string"
           },
           "path": {
-            "type": "string"
+            "type": "string",
+            "description": "The path to the instance profile.\n"
           },
           "roleArn": {
             "type": "string"
           },
           "roleId": {
-            "type": "string"
+            "type": "string",
+            "description": "The role id associated with this instance profile.\n"
           },
           "roleName": {
             "type": "string"
@@ -3064,11 +3386,13 @@
       }
     },
     "aws:iam/getRole:getRole": {
+      "description": "This data source can be used to fetch information about a specific\nIAM role. By using this data source, you can reference IAM role\nproperties without having to hard code ARNs as input.\n\n## Example Usage\n\n```hcl\ndata \"aws_iam_role\" \"example\" {\n  name = \"an_example_role_name\"\n}\n```\n",
       "inputs": {
         "description": "A collection of arguments for invoking getRole.\n",
         "properties": {
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "The friendly IAM role name to match.\n"
           },
           "tags": {
             "type": "object",
@@ -3086,10 +3410,12 @@
         "description": "A collection of values returned by getRole.\n",
         "properties": {
           "arn": {
-            "type": "string"
+            "type": "string",
+            "description": "The Amazon Resource Name (ARN) specifying the role.\n"
           },
           "assumeRolePolicy": {
-            "type": "string"
+            "type": "string",
+            "description": "The policy document associated with the role.\n"
           },
           "createDate": {
             "type": "string"
@@ -3108,7 +3434,8 @@
             "type": "string"
           },
           "path": {
-            "type": "string"
+            "type": "string",
+            "description": "The path to the role.\n"
           },
           "permissionsBoundary": {
             "type": "string"
@@ -3120,7 +3447,8 @@
             }
           },
           "uniqueId": {
-            "type": "string"
+            "type": "string",
+            "description": "The stable and unique string identifying the role.\n"
           }
         },
         "type": "object",
@@ -3251,13 +3579,16 @@
         "description": "A collection of arguments for invoking getServerCertificate.\n",
         "properties": {
           "latest": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "sort results by expiration date. returns the certificate with expiration date in furthest in the future.\n"
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "exact name of the cert to lookup\n"
           },
           "namePrefix": {
-            "type": "string"
+            "type": "string",
+            "description": "prefix of cert to filter by\n"
           },
           "pathPrefix": {
             "type": "string"
@@ -3581,6 +3912,7 @@
       }
     },
     "aws:index/getAvailabilityZone:getAvailabilityZone": {
+      "description": "`aws.getAvailabilityZone` provides details about a specific availability zone (AZ)\nin the current region.\n\nThis can be used both to validate an availability zone given in a variable\nand to split the AZ name into its component parts of an AWS region and an\nAZ identifier letter. The latter may be useful e.g. for implementing a\nconsistent subnet numbering scheme across several regions by mapping both\nthe region and the subnet letter to network numbers.\n\nThis is different from the `aws.getAvailabilityZones` (plural) data source,\nwhich provides a list of the available zones.\n\n## Example Usage\n\nThe following example shows how this data source might be used to derive\nVPC and subnet CIDR prefixes systematically for an availability zone.\n\n```hcl\nvariable \"region_number\" {\n  # Arbitrary mapping of region name to number to use in\n  # a VPC's CIDR prefix.\n  default = {\n    us-east-1      = 1\n    us-west-1      = 2\n    us-west-2      = 3\n    eu-central-1   = 4\n    ap-northeast-1 = 5\n  }\n}\n\nvariable \"az_number\" {\n  # Assign a number to each AZ letter used in our configuration\n  default = {\n    a = 1\n    b = 2\n    c = 3\n    d = 4\n    e = 5\n    f = 6\n  }\n}\n\n# Retrieve the AZ where we want to create network resources\n# This must be in the region selected on the AWS provider.\ndata \"aws_availability_zone\" \"example\" {\n  name = \"eu-central-1a\"\n}\n\n# Create a VPC for the region associated with the AZ\nresource \"aws_vpc\" \"example\" {\n  cidr_block = \"${cidrsubnet(\"10.0.0.0/8\", 4, var.region_number[data.aws_availability_zone.example.region])}\"\n}\n\n# Create a subnet for the AZ within the regional VPC\nresource \"aws_subnet\" \"example\" {\n  vpc_id     = \"${aws_vpc.example.id}\"\n  cidr_block = \"${cidrsubnet(aws_vpc.example.cidr_block, 4, var.az_number[data.aws_availability_zone.example.name_suffix])}\"\n}\n```\n",
       "inputs": {
         "description": "A collection of arguments for invoking getAvailabilityZone.\n",
         "properties": {
@@ -3594,10 +3926,12 @@
             }
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "The full name of the availability zone to select.\n"
           },
           "state": {
-            "type": "string"
+            "type": "string",
+            "description": "A specific availability zone state to require. May\nbe any of `\"available\"`, `\"information\"`, `\"impaired\"` or `\"available\"`.\n\nAll reasonable uses of this data source will specify `name`, since `state`\nalone would match a single AZ only in a region that itself has only one AZ.\n"
           },
           "zoneId": {
             "type": "string"
@@ -3625,10 +3959,12 @@
             "description": "The provider-assigned unique ID for this managed resource.\n"
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "The name of the selected availability zone.\n"
           },
           "nameSuffix": {
-            "type": "string"
+            "type": "string",
+            "description": "The part of the AZ name that appears after the region name,\nuniquely identifying the AZ within its region.\n"
           },
           "networkBorderGroup": {
             "type": "string"
@@ -3643,10 +3979,12 @@
             "type": "string"
           },
           "region": {
-            "type": "string"
+            "type": "string",
+            "description": "The region where the selected availability zone resides.\nThis is always the region selected on the provider, since this data source\nsearches only within that region.\n"
           },
           "state": {
-            "type": "string"
+            "type": "string",
+            "description": "The current state of the AZ.\n"
           },
           "zoneId": {
             "type": "string"
@@ -3673,6 +4011,7 @@
       }
     },
     "aws:index/getAvailabilityZones:getAvailabilityZones": {
+      "description": "The Availability Zones data source allows access to the list of AWS\nAvailability Zones which can be accessed by an AWS account within the region\nconfigured in the provider.\n\nThis is different from the `aws.getAvailabilityZone` (singular) data source,\nwhich provides some details about a specific availability zone.\n\n## Example Usage\n\n```hcl\n# Declare the data source\ndata \"aws_availability_zones\" \"available\" {}\n\n# e.g. Create subnets in the first two available availability zones\n\nresource \"aws_subnet\" \"primary\" {\n  availability_zone = \"${data.aws_availability_zones.available.names[0]}\"\n\n  # ...\n}\n\nresource \"aws_subnet\" \"secondary\" {\n  availability_zone = \"${data.aws_availability_zones.available.names[1]}\"\n\n  # ...\n}\n```\n",
       "inputs": {
         "description": "A collection of arguments for invoking getAvailabilityZones.\n",
         "properties": {
@@ -3698,7 +4037,8 @@
             }
           },
           "state": {
-            "type": "string"
+            "type": "string",
+            "description": "Allows to filter list of Availability Zones based on their\ncurrent state. Can be either `\"available\"`, `\"information\"`, `\"impaired\"` or\n`\"unavailable\"`. By default the list includes a complete set of Availability Zones\nto which the underlying AWS account has access, regardless of their state.\n"
           }
         },
         "type": "object"
@@ -3741,7 +4081,8 @@
             "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "description": "A list of the Availability Zone names available to the account.\n"
           },
           "state": {
             "type": "string"
@@ -3763,11 +4104,13 @@
       }
     },
     "aws:index/getBillingServiceAccount:getBillingServiceAccount": {
+      "description": "Use this data source to get the Account ID of the [AWS Billing and Cost Management Service Account](http://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/billing-getting-started.html#step-2) for the purpose of whitelisting in S3 bucket policy.\n\n## Example Usage\n\n```hcl\ndata \"aws_billing_service_account\" \"main\" {}\n\nresource \"aws_s3_bucket\" \"billing_logs\" {\n  bucket = \"my-billing-tf-test-bucket\"\n  acl    = \"private\"\n\n  policy = \u003c\u003cPOLICY\n{\n  \"Id\": \"Policy\",\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"s3:GetBucketAcl\", \"s3:GetBucketPolicy\"\n      ],\n      \"Effect\": \"Allow\",\n      \"Resource\": \"arn:aws:s3:::my-billing-tf-test-bucket\",\n      \"Principal\": {\n        \"AWS\": [\n          \"${data.aws_billing_service_account.main.id}\"\n        ]\n      }\n    },\n    {\n      \"Action\": [\n        \"s3:PutObject\"\n      ],\n      \"Effect\": \"Allow\",\n      \"Resource\": \"arn:aws:s3:::my-billing-tf-test-bucket/AWSLogs/*\",\n      \"Principal\": {\n        \"AWS\": [\n          \"${data.aws_billing_service_account.main.id}\"\n        ]\n      }\n    }\n  ]\n}\nPOLICY\n}\n```\n",
       "outputs": {
         "description": "A collection of values returned by getBillingServiceAccount.\n",
         "properties": {
           "arn": {
-            "type": "string"
+            "type": "string",
+            "description": "The ARN of the AWS billing service account.\n"
           },
           "id": {
             "type": "string",
@@ -3782,21 +4125,25 @@
       }
     },
     "aws:index/getCallerIdentity:getCallerIdentity": {
+      "description": "## Example Usage\n\n```hcl\ndata \"aws_caller_identity\" \"current\" {}\n\noutput \"account_id\" {\n  value = \"${data.aws_caller_identity.current.account_id}\"\n}\n\noutput \"caller_arn\" {\n  value = \"${data.aws_caller_identity.current.arn}\"\n}\n\noutput \"caller_user\" {\n  value = \"${data.aws_caller_identity.current.user_id}\"\n}\n```\n",
       "outputs": {
         "description": "A collection of values returned by getCallerIdentity.\n",
         "properties": {
           "accountId": {
-            "type": "string"
+            "type": "string",
+            "description": "The AWS Account ID number of the account that owns or contains the calling entity.\n"
           },
           "arn": {
-            "type": "string"
+            "type": "string",
+            "description": "The AWS ARN associated with the calling entity.\n"
           },
           "id": {
             "type": "string",
             "description": "The provider-assigned unique ID for this managed resource.\n"
           },
           "userId": {
-            "type": "string"
+            "type": "string",
+            "description": "The unique identifier of the calling entity.\n"
           }
         },
         "type": "object",
@@ -3843,6 +4190,7 @@
       }
     },
     "aws:index/getIpRanges:getIpRanges": {
+      "description": "Use this data source to get the [IP ranges](http://docs.aws.amazon.com/general/latest/gr/aws-ip-ranges.html) of various AWS products and services.\n\n## Example Usage\n\n```hcl\ndata \"aws_ip_ranges\" \"european_ec2\" {\n  regions  = [\"eu-west-1\", \"eu-central-1\"]\n  services = [\"ec2\"]\n}\n\nresource \"aws_security_group\" \"from_europe\" {\n  name = \"from_europe\"\n\n  ingress {\n    from_port   = \"443\"\n    to_port     = \"443\"\n    protocol    = \"tcp\"\n    cidr_blocks = [\"${data.aws_ip_ranges.european_ec2.cidr_blocks}\"]\n  }\n\n  tags {\n    CreateDate = \"${data.aws_ip_ranges.european_ec2.create_date}\"\n    SyncToken  = \"${data.aws_ip_ranges.european_ec2.sync_token}\"\n  }\n}\n```\n",
       "inputs": {
         "description": "A collection of arguments for invoking getIpRanges.\n",
         "properties": {
@@ -3850,7 +4198,8 @@
             "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "description": "Filter IP ranges by regions (or include all regions, if\nomitted). Valid items are `global` (for `cloudfront`) as well as all AWS regions\n(e.g. `eu-central-1`)\n"
           },
           "services": {
             "type": "array",
@@ -3874,10 +4223,12 @@
             "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "description": "The lexically ordered list of CIDR blocks.\n"
           },
           "createDate": {
-            "type": "string"
+            "type": "string",
+            "description": "The publication time of the IP ranges (e.g. `2016-08-03-23-46-05`).\n"
           },
           "id": {
             "type": "string",
@@ -3902,7 +4253,8 @@
             }
           },
           "syncToken": {
-            "type": "integer"
+            "type": "integer",
+            "description": "The publication time of the IP ranges, in Unix epoch time format\n(e.g. `1470267965`).\n"
           },
           "url": {
             "type": "string"
@@ -3920,6 +4272,7 @@
       }
     },
     "aws:index/getPartition:getPartition": {
+      "description": "## Example Usage\n\n```hcl\ndata \"aws_partition\" \"current\" {}\n\ndata \"aws_iam_policy_document\" \"s3_policy\" {\n  statement {\n    sid = \"1\"\n\n    actions = [\n      \"s3:ListBucket\",\n    ]\n\n    resources = [\n      \"arn:${data.aws_partition.current.partition}:s3:::my-bucket\",\n    ]\n  }\n}\n```\n",
       "outputs": {
         "description": "A collection of values returned by getPartition.\n",
         "properties": {
@@ -3947,14 +4300,17 @@
       }
     },
     "aws:index/getRegion:getRegion": {
+      "description": "`aws.getRegion` provides details about a specific AWS region.\n\nAs well as validating a given region name (and optionally obtaining its\nendpoint) this resource can be used to discover the name of the region\nconfigured within the provider. The latter can be useful in a child module\nwhich is inheriting an AWS provider configuration from its parent module.\n\n## Example Usage\n\nThe following example shows how the resource might be used to obtain\nthe name of the AWS region configured on the provider.\n\n```hcl\ndata \"aws_region\" \"current\" {\n  current = true\n}\n```\n",
       "inputs": {
         "description": "A collection of arguments for invoking getRegion.\n",
         "properties": {
           "endpoint": {
-            "type": "string"
+            "type": "string",
+            "description": "The endpoint of the region to select.\n\nAt least one of the above attributes should be provided to ensure that only\none region is matched.\n"
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "The full name of the region to select.\n"
           }
         },
         "type": "object"
@@ -3966,14 +4322,16 @@
             "type": "string"
           },
           "endpoint": {
-            "type": "string"
+            "type": "string",
+            "description": "The endpoint for the selected region.\n"
           },
           "id": {
             "type": "string",
             "description": "The provider-assigned unique ID for this managed resource.\n"
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "The name of the selected region.\n"
           }
         },
         "type": "object",
@@ -4110,7 +4468,8 @@
             }
           },
           "policyId": {
-            "type": "string"
+            "type": "string",
+            "description": "An ID for the policy document.\n"
           },
           "sourceJson": {
             "type": "string",
@@ -4126,7 +4485,8 @@
             "type": "array",
             "items": {
               "$ref": "#/types/aws:x/iam/getPolicyDocumentStatement:getPolicyDocumentStatement"
-            }
+            },
+            "description": "A nested configuration block (described below)\nconfiguring one *statement* to be included in the policy document.\n\nEach document configuration must have one or more `statement` blocks, which\neach accept the following arguments:\n"
           },
           "version": {
             "type": "string"
@@ -4142,7 +4502,8 @@
             "description": "The provider-assigned unique ID for this managed resource.\n"
           },
           "json": {
-            "type": "string"
+            "type": "string",
+            "description": "The above arguments serialized as a standard JSON policy document.\n"
           },
           "overrideJson": {
             "type": "string",

--- a/pkg/tfgen/test_data/regress-611-schema.json
+++ b/pkg/tfgen/test_data/regress-611-schema.json
@@ -65,8 +65,7 @@
     "aws:iam/RoleInlinePolicy:RoleInlinePolicy": {
       "properties": {
         "name": {
-          "type": "string",
-          "description": "The name of the role.\n"
+          "type": "string"
         },
         "policy": {
           "type": "string"
@@ -77,12 +76,10 @@
     "aws:iam/getGroupUser:getGroupUser": {
       "properties": {
         "arn": {
-          "type": "string",
-          "description": "The Amazon Resource Name (ARN) specifying the group.\n"
+          "type": "string"
         },
         "path": {
-          "type": "string",
-          "description": "The path to the role.\n"
+          "type": "string"
         },
         "userId": {
           "type": "string"
@@ -107,8 +104,7 @@
     "aws:index/getAvailabilityZoneFilter:getAvailabilityZoneFilter": {
       "properties": {
         "name": {
-          "type": "string",
-          "description": "The full name of the availability zone to select.\n"
+          "type": "string"
         },
         "values": {
           "type": "array",
@@ -165,58 +161,49 @@
           "type": "array",
           "items": {
             "type": "string"
-          },
-          "description": "A list of actions that this statement either allows\nor denies. For example, ``[\"ec2:RunInstances\", \"s3:*\"]``.\n"
+          }
         },
         "conditions": {
           "type": "array",
           "items": {
             "$ref": "#/types/aws:x/iam/getPolicyDocumentStatementCondition:getPolicyDocumentStatementCondition"
-          },
-          "description": "A nested configuration block (described below)\nthat defines a further, possibly-service-specific condition that constrains\nwhether this statement applies.\n\nEach policy may have either zero or more `principals` blocks or zero or more\n`not_principals` blocks, both of which each accept the following arguments:\n"
+          }
         },
         "effect": {
-          "type": "string",
-          "description": "Either \"Allow\" or \"Deny\", to specify whether this\nstatement allows or denies the given actions. The default is \"Allow\".\n"
+          "type": "string"
         },
         "notActions": {
           "type": "array",
           "items": {
             "type": "string"
-          },
-          "description": "A list of actions that this statement does *not*\napply to. Used to apply a policy statement to all actions *except* those\nlisted.\n"
+          }
         },
         "notPrincipals": {
           "type": "array",
           "items": {
             "$ref": "#/types/aws:x/iam/getPolicyDocumentStatementNotPrincipal:getPolicyDocumentStatementNotPrincipal"
-          },
-          "description": "Like `principals` except gives resources that\nthe statement does *not* apply to.\n"
+          }
         },
         "notResources": {
           "type": "array",
           "items": {
             "type": "string"
-          },
-          "description": "A list of resource ARNs that this statement\ndoes *not* apply to. Used to apply a policy statement to all resources\n*except* those listed.\n"
+          }
         },
         "principals": {
           "type": "array",
           "items": {
             "$ref": "#/types/aws:x/iam/getPolicyDocumentStatementPrincipal:getPolicyDocumentStatementPrincipal"
-          },
-          "description": "A nested configuration block (described below)\nspecifying a resource (or resource pattern) to which this statement applies.\n"
+          }
         },
         "resources": {
           "type": "array",
           "items": {
             "type": "string"
-          },
-          "description": "A list of resource ARNs that this statement applies\nto. This is required by AWS if used for an IAM policy.\n"
+          }
         },
         "sid": {
-          "type": "string",
-          "description": "An ID for the policy statement.\n"
+          "type": "string"
         }
       },
       "type": "object"
@@ -224,19 +211,16 @@
     "aws:x/iam/getPolicyDocumentStatementCondition:getPolicyDocumentStatementCondition": {
       "properties": {
         "test": {
-          "type": "string",
-          "description": "The name of the\n[IAM condition type](http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html#AccessPolicyLanguage_ConditionType)\nto evaluate.\n"
+          "type": "string"
         },
         "values": {
           "type": "array",
           "items": {
             "type": "string"
-          },
-          "description": "The values to evaluate the condition against. If multiple\nvalues are provided, the condition matches if at least one of them applies.\n(That is, the tests are combined with the \"OR\" boolean operation.)\n\nWhen multiple `condition` blocks are provided, they must *all* evaluate to true\nfor the policy statement to apply. (In other words, the conditions are combined\nwith the \"AND\" boolean operation.)\n"
+          }
         },
         "variable": {
-          "type": "string",
-          "description": "The name of a\n[Context Variable](http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html#AvailableKeys)\nto apply the condition to. Context variables may either be standard AWS\nvariables starting with `aws:`, or service-specific variables prefixed with\nthe service name.\n"
+          "type": "string"
         }
       },
       "type": "object",
@@ -252,12 +236,10 @@
           "type": "array",
           "items": {
             "type": "string"
-          },
-          "description": "List of identifiers for principals. When `type`\nis \"AWS\", these are IAM user or role ARNs.\n\nEach policy statement may have zero or more `condition` blocks, which each\naccept the following arguments:\n"
+          }
         },
         "type": {
-          "type": "string",
-          "description": "The type of principal. For AWS accounts this is \"AWS\".\n"
+          "type": "string"
         }
       },
       "type": "object",
@@ -272,12 +254,10 @@
           "type": "array",
           "items": {
             "type": "string"
-          },
-          "description": "List of identifiers for principals. When `type`\nis \"AWS\", these are IAM user or role ARNs.\n\nEach policy statement may have zero or more `condition` blocks, which each\naccept the following arguments:\n"
+          }
         },
         "type": {
-          "type": "string",
-          "description": "The type of principal. For AWS accounts this is \"AWS\".\n"
+          "type": "string"
         }
       },
       "type": "object",
@@ -348,7 +328,6 @@
   },
   "resources": {
     "aws:iam/accessKey:AccessKey": {
-      "description": "Provides an IAM access key. This is a set of credentials that allow API requests to be made as an IAM user.\n\n## Example Usage\n\n```hcl\nresource \"aws_iam_access_key\" \"lb\" {\n  user    = \"${aws_iam_user.lb.name}\"\n  pgp_key = \"keybase:some_person_that_exists\"\n}\n\nresource \"aws_iam_user\" \"lb\" {\n  name = \"loadbalancer\"\n  path = \"/system/\"\n}\n\nresource \"aws_iam_user_policy\" \"lb_ro\" {\n  name = \"test\"\n  user = \"${aws_iam_user.lb.name}\"\n\n  policy = \u003c\u003cEOF\n{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"ec2:Describe*\"\n      ],\n      \"Effect\": \"Allow\",\n      \"Resource\": \"*\"\n    }\n  ]\n}\nEOF\n}\n\noutput \"secret\" {\n  value = \"${aws_iam_access_key.lb.encrypted_secret}\"\n}\n```\n",
       "properties": {
         "createDate": {
           "type": "string"
@@ -360,16 +339,13 @@
           "type": "string"
         },
         "keyFingerprint": {
-          "type": "string",
-          "description": "The fingerprint of the PGP key used to encrypt\nthe secret\n"
+          "type": "string"
         },
         "pgpKey": {
-          "type": "string",
-          "description": "Either a base-64 encoded PGP public key, or a\nkeybase username in the form `keybase:some_person_that_exists`.\n"
+          "type": "string"
         },
         "secret": {
           "type": "string",
-          "description": "The secret access key. Note that this will be written\nto the state file. Please supply a `pgp_key` instead, which will prevent the\nsecret from being stored in plain text\n",
           "secret": true
         },
         "sesSmtpPasswordV4": {
@@ -377,12 +353,10 @@
           "secret": true
         },
         "status": {
-          "type": "string",
-          "description": "\"Active\" or \"Inactive\". Keys are initially active, but can be made\ninactive by other means.\n"
+          "type": "string"
         },
         "user": {
-          "type": "string",
-          "description": "The IAM user to associate with this access key.\n"
+          "type": "string"
         }
       },
       "required": [
@@ -397,16 +371,13 @@
       "inputProperties": {
         "pgpKey": {
           "type": "string",
-          "description": "Either a base-64 encoded PGP public key, or a\nkeybase username in the form `keybase:some_person_that_exists`.\n",
           "willReplaceOnChanges": true
         },
         "status": {
-          "type": "string",
-          "description": "\"Active\" or \"Inactive\". Keys are initially active, but can be made\ninactive by other means.\n"
+          "type": "string"
         },
         "user": {
           "type": "string",
-          "description": "The IAM user to associate with this access key.\n",
           "willReplaceOnChanges": true
         }
       },
@@ -426,17 +397,14 @@
             "type": "string"
           },
           "keyFingerprint": {
-            "type": "string",
-            "description": "The fingerprint of the PGP key used to encrypt\nthe secret\n"
+            "type": "string"
           },
           "pgpKey": {
             "type": "string",
-            "description": "Either a base-64 encoded PGP public key, or a\nkeybase username in the form `keybase:some_person_that_exists`.\n",
             "willReplaceOnChanges": true
           },
           "secret": {
             "type": "string",
-            "description": "The secret access key. Note that this will be written\nto the state file. Please supply a `pgp_key` instead, which will prevent the\nsecret from being stored in plain text\n",
             "secret": true
           },
           "sesSmtpPasswordV4": {
@@ -444,12 +412,10 @@
             "secret": true
           },
           "status": {
-            "type": "string",
-            "description": "\"Active\" or \"Inactive\". Keys are initially active, but can be made\ninactive by other means.\n"
+            "type": "string"
           },
           "user": {
             "type": "string",
-            "description": "The IAM user to associate with this access key.\n",
             "willReplaceOnChanges": true
           }
         },
@@ -457,11 +423,9 @@
       }
     },
     "aws:iam/accountAlias:AccountAlias": {
-      "description": "\u003e **Note:** There is only a single account alias per AWS account.\n\nManages the account alias for the AWS Account.\n\n## Example Usage\n\n```hcl\nresource \"aws_iam_account_alias\" \"alias\" {\n  account_alias = \"my-account-alias\"\n}\n```\n\n## Import\n\nThe current Account Alias can be imported using the `account_alias`, e.g.\n\n```sh\u003cbreak\u003e\n$ pulumi import aws:iam/accountAlias:AccountAlias alias my-account-alias\n\u003cbreak\u003e```\u003cbreak\u003e\n",
       "properties": {
         "accountAlias": {
           "type": "string",
-          "description": "The account alias\n",
           "language": {
             "csharp": {
               "name": "Alias"
@@ -475,7 +439,6 @@
       "inputProperties": {
         "accountAlias": {
           "type": "string",
-          "description": "The account alias\n",
           "language": {
             "csharp": {
               "name": "Alias"
@@ -492,7 +455,6 @@
         "properties": {
           "accountAlias": {
             "type": "string",
-            "description": "The account alias\n",
             "language": {
               "csharp": {
                 "name": "Alias"
@@ -505,47 +467,36 @@
       }
     },
     "aws:iam/accountPasswordPolicy:AccountPasswordPolicy": {
-      "description": "\u003e **Note:** There is only a single policy allowed per AWS account. An existing policy will be lost when using this resource as an effect of this limitation.\n\nManages Password Policy for the AWS Account.\nSee more about [Account Password Policy](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_passwords_account-policy.html)\nin the official AWS docs.\n\n## Example Usage\n\n```hcl\nresource \"aws_iam_account_password_policy\" \"strict\" {\n  minimum_password_length        = 8\n  require_lowercase_characters   = true\n  require_numbers                = true\n  require_uppercase_characters   = true\n  require_symbols                = true\n  allow_users_to_change_password = true\n}\n```\n\n## Import\n\nIAM Account Password Policy can be imported using the word `iam-account-password-policy`, e.g.\n\n```sh\u003cbreak\u003e\n$ pulumi import aws:iam/accountPasswordPolicy:AccountPasswordPolicy strict iam-account-password-policy\n\u003cbreak\u003e```\u003cbreak\u003e\n",
       "properties": {
         "allowUsersToChangePassword": {
-          "type": "boolean",
-          "description": "Whether to allow users to change their own password\n"
+          "type": "boolean"
         },
         "expirePasswords": {
-          "type": "boolean",
-          "description": "Indicates whether passwords in the account expire.\nReturns `true` if `max_password_age` contains a value greater than `0`.\nReturns `false` if it is `0` or _not present_.\n"
+          "type": "boolean"
         },
         "hardExpiry": {
-          "type": "boolean",
-          "description": "Whether users are prevented from setting a new password after their password has expired\n(i.e. require administrator reset)\n"
+          "type": "boolean"
         },
         "maxPasswordAge": {
-          "type": "integer",
-          "description": "The number of days that an user password is valid.\n"
+          "type": "integer"
         },
         "minimumPasswordLength": {
-          "type": "integer",
-          "description": "Minimum length to require for user passwords.\n"
+          "type": "integer"
         },
         "passwordReusePrevention": {
-          "type": "integer",
-          "description": "The number of previous passwords that users are prevented from reusing.\n"
+          "type": "integer"
         },
         "requireLowercaseCharacters": {
-          "type": "boolean",
-          "description": "Whether to require lowercase characters for user passwords.\n"
+          "type": "boolean"
         },
         "requireNumbers": {
-          "type": "boolean",
-          "description": "Whether to require numbers for user passwords.\n"
+          "type": "boolean"
         },
         "requireSymbols": {
-          "type": "boolean",
-          "description": "Whether to require symbols for user passwords.\n"
+          "type": "boolean"
         },
         "requireUppercaseCharacters": {
-          "type": "boolean",
-          "description": "Whether to require uppercase characters for user passwords.\n"
+          "type": "boolean"
         }
       },
       "required": [
@@ -560,107 +511,83 @@
       ],
       "inputProperties": {
         "allowUsersToChangePassword": {
-          "type": "boolean",
-          "description": "Whether to allow users to change their own password\n"
+          "type": "boolean"
         },
         "hardExpiry": {
-          "type": "boolean",
-          "description": "Whether users are prevented from setting a new password after their password has expired\n(i.e. require administrator reset)\n"
+          "type": "boolean"
         },
         "maxPasswordAge": {
-          "type": "integer",
-          "description": "The number of days that an user password is valid.\n"
+          "type": "integer"
         },
         "minimumPasswordLength": {
-          "type": "integer",
-          "description": "Minimum length to require for user passwords.\n"
+          "type": "integer"
         },
         "passwordReusePrevention": {
-          "type": "integer",
-          "description": "The number of previous passwords that users are prevented from reusing.\n"
+          "type": "integer"
         },
         "requireLowercaseCharacters": {
-          "type": "boolean",
-          "description": "Whether to require lowercase characters for user passwords.\n"
+          "type": "boolean"
         },
         "requireNumbers": {
-          "type": "boolean",
-          "description": "Whether to require numbers for user passwords.\n"
+          "type": "boolean"
         },
         "requireSymbols": {
-          "type": "boolean",
-          "description": "Whether to require symbols for user passwords.\n"
+          "type": "boolean"
         },
         "requireUppercaseCharacters": {
-          "type": "boolean",
-          "description": "Whether to require uppercase characters for user passwords.\n"
+          "type": "boolean"
         }
       },
       "stateInputs": {
         "description": "Input properties used for looking up and filtering AccountPasswordPolicy resources.\n",
         "properties": {
           "allowUsersToChangePassword": {
-            "type": "boolean",
-            "description": "Whether to allow users to change their own password\n"
+            "type": "boolean"
           },
           "expirePasswords": {
-            "type": "boolean",
-            "description": "Indicates whether passwords in the account expire.\nReturns `true` if `max_password_age` contains a value greater than `0`.\nReturns `false` if it is `0` or _not present_.\n"
+            "type": "boolean"
           },
           "hardExpiry": {
-            "type": "boolean",
-            "description": "Whether users are prevented from setting a new password after their password has expired\n(i.e. require administrator reset)\n"
+            "type": "boolean"
           },
           "maxPasswordAge": {
-            "type": "integer",
-            "description": "The number of days that an user password is valid.\n"
+            "type": "integer"
           },
           "minimumPasswordLength": {
-            "type": "integer",
-            "description": "Minimum length to require for user passwords.\n"
+            "type": "integer"
           },
           "passwordReusePrevention": {
-            "type": "integer",
-            "description": "The number of previous passwords that users are prevented from reusing.\n"
+            "type": "integer"
           },
           "requireLowercaseCharacters": {
-            "type": "boolean",
-            "description": "Whether to require lowercase characters for user passwords.\n"
+            "type": "boolean"
           },
           "requireNumbers": {
-            "type": "boolean",
-            "description": "Whether to require numbers for user passwords.\n"
+            "type": "boolean"
           },
           "requireSymbols": {
-            "type": "boolean",
-            "description": "Whether to require symbols for user passwords.\n"
+            "type": "boolean"
           },
           "requireUppercaseCharacters": {
-            "type": "boolean",
-            "description": "Whether to require uppercase characters for user passwords.\n"
+            "type": "boolean"
           }
         },
         "type": "object"
       }
     },
     "aws:iam/group:Group": {
-      "description": "Provides an IAM group.\n\n## Example Usage\n\n```hcl\nresource \"aws_iam_group\" \"developers\" {\n  name = \"developers\"\n  path = \"/users/\"\n}\n```\n\n## Import\n\nIAM Groups can be imported using the `name`, e.g.\n\n```sh\u003cbreak\u003e\n$ pulumi import aws:iam/group:Group developers developers\n\u003cbreak\u003e```\u003cbreak\u003e\n",
       "properties": {
         "arn": {
-          "type": "string",
-          "description": "The ARN assigned by AWS for this group.\n"
+          "type": "string"
         },
         "name": {
-          "type": "string",
-          "description": "The group's name. The name must consist of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: `=,.@-_.`. Group names are not distinguished by case. For example, you cannot create groups named both \"ADMINS\" and \"admins\".\n"
+          "type": "string"
         },
         "path": {
-          "type": "string",
-          "description": "Path in which to create the group.\n"
+          "type": "string"
         },
         "uniqueId": {
-          "type": "string",
-          "description": "The [unique ID][1] assigned by AWS.\n"
+          "type": "string"
         }
       },
       "required": [
@@ -670,54 +597,44 @@
       ],
       "inputProperties": {
         "name": {
-          "type": "string",
-          "description": "The group's name. The name must consist of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: `=,.@-_.`. Group names are not distinguished by case. For example, you cannot create groups named both \"ADMINS\" and \"admins\".\n"
+          "type": "string"
         },
         "path": {
-          "type": "string",
-          "description": "Path in which to create the group.\n"
+          "type": "string"
         }
       },
       "stateInputs": {
         "description": "Input properties used for looking up and filtering Group resources.\n",
         "properties": {
           "arn": {
-            "type": "string",
-            "description": "The ARN assigned by AWS for this group.\n"
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "description": "The group's name. The name must consist of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: `=,.@-_.`. Group names are not distinguished by case. For example, you cannot create groups named both \"ADMINS\" and \"admins\".\n"
+            "type": "string"
           },
           "path": {
-            "type": "string",
-            "description": "Path in which to create the group.\n"
+            "type": "string"
           },
           "uniqueId": {
-            "type": "string",
-            "description": "The [unique ID][1] assigned by AWS.\n"
+            "type": "string"
           }
         },
         "type": "object"
       }
     },
     "aws:iam/groupMembership:GroupMembership": {
-      "description": "Provides a top level resource to manage IAM Group membership for IAM Users. For\nmore information on managing IAM Groups or IAM Users, see [IAM Groups](https://www.terraform.io/docs/providers/aws/r/iam_group.html) or\n[IAM Users](https://www.terraform.io/docs/providers/aws/r/iam_user.html)\n\n## Example Usage\n\n```hcl\nresource \"aws_iam_group_membership\" \"team\" {\n  name = \"tf-testing-group-membership\"\n\n  users = [\n    \"${aws_iam_user.user_one.name}\",\n    \"${aws_iam_user.user_two.name}\",\n  ]\n\n  group = \"${aws_iam_group.group.name}\"\n}\n\nresource \"aws_iam_group\" \"group\" {\n  name = \"test-group\"\n}\n\nresource \"aws_iam_user\" \"user_one\" {\n  name = \"test-user\"\n}\n\nresource \"aws_iam_user\" \"user_two\" {\n  name = \"test-user-two\"\n}\n```\n",
       "properties": {
         "group": {
-          "type": "string",
-          "description": "The IAM Group name to attach the list of `users` to\n"
+          "type": "string"
         },
         "name": {
-          "type": "string",
-          "description": "The name to identify the Group Membership\n"
+          "type": "string"
         },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
-          },
-          "description": "A list of IAM User names to associate with the Group\n"
+          }
         }
       },
       "required": [
@@ -728,20 +645,17 @@
       "inputProperties": {
         "group": {
           "type": "string",
-          "description": "The IAM Group name to attach the list of `users` to\n",
           "willReplaceOnChanges": true
         },
         "name": {
           "type": "string",
-          "description": "The name to identify the Group Membership\n",
           "willReplaceOnChanges": true
         },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
-          },
-          "description": "A list of IAM User names to associate with the Group\n"
+          }
         }
       },
       "requiredInputs": [
@@ -753,43 +667,35 @@
         "properties": {
           "group": {
             "type": "string",
-            "description": "The IAM Group name to attach the list of `users` to\n",
             "willReplaceOnChanges": true
           },
           "name": {
             "type": "string",
-            "description": "The name to identify the Group Membership\n",
             "willReplaceOnChanges": true
           },
           "users": {
             "type": "array",
             "items": {
               "type": "string"
-            },
-            "description": "A list of IAM User names to associate with the Group\n"
+            }
           }
         },
         "type": "object"
       }
     },
     "aws:iam/groupPolicy:GroupPolicy": {
-      "description": "Provides an IAM policy attached to a group.\n\n## Example Usage\n\n```hcl\nresource \"aws_iam_group_policy\" \"my_developer_policy\" {\n  name  = \"my_developer_policy\"\n  group = \"${aws_iam_group.my_developers.id}\"\n\n  policy = \u003c\u003cEOF\n{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"ec2:Describe*\"\n      ],\n      \"Effect\": \"Allow\",\n      \"Resource\": \"*\"\n    }\n  ]\n}\nEOF\n}\n\nresource \"aws_iam_group\" \"my_developers\" {\n  name = \"developers\"\n  path = \"/users/\"\n}\n```\n",
       "properties": {
         "group": {
-          "type": "string",
-          "description": "The IAM group to attach to the policy.\n"
+          "type": "string"
         },
         "name": {
-          "type": "string",
-          "description": "The name of the policy.\n"
+          "type": "string"
         },
         "namePrefix": {
-          "type": "string",
-          "description": "Creates a unique name beginning with the specified\nprefix. Conflicts with `name`.\n"
+          "type": "string"
         },
         "policy": {
-          "type": "string",
-          "description": "The policy document. This is a JSON formatted string.\nThe heredoc syntax or `file` function is helpful here.\n"
+          "type": "string"
         }
       },
       "required": [
@@ -800,17 +706,14 @@
       "inputProperties": {
         "group": {
           "type": "string",
-          "description": "The IAM group to attach to the policy.\n",
           "willReplaceOnChanges": true
         },
         "name": {
           "type": "string",
-          "description": "The name of the policy.\n",
           "willReplaceOnChanges": true
         },
         "namePrefix": {
           "type": "string",
-          "description": "Creates a unique name beginning with the specified\nprefix. Conflicts with `name`.\n",
           "willReplaceOnChanges": true
         },
         "policy": {
@@ -823,8 +726,7 @@
               "type": "string",
               "$ref": "#/types/aws:iam/documents:PolicyDocument"
             }
-          ],
-          "description": "The policy document. This is a JSON formatted string.\nThe heredoc syntax or `file` function is helpful here.\n"
+          ]
         }
       },
       "requiredInputs": [
@@ -836,17 +738,14 @@
         "properties": {
           "group": {
             "type": "string",
-            "description": "The IAM group to attach to the policy.\n",
             "willReplaceOnChanges": true
           },
           "name": {
             "type": "string",
-            "description": "The name of the policy.\n",
             "willReplaceOnChanges": true
           },
           "namePrefix": {
             "type": "string",
-            "description": "Creates a unique name beginning with the specified\nprefix. Conflicts with `name`.\n",
             "willReplaceOnChanges": true
           },
           "policy": {
@@ -859,24 +758,20 @@
                 "type": "string",
                 "$ref": "#/types/aws:iam/documents:PolicyDocument"
               }
-            ],
-            "description": "The policy document. This is a JSON formatted string.\nThe heredoc syntax or `file` function is helpful here.\n"
+            ]
           }
         },
         "type": "object"
       }
     },
     "aws:iam/groupPolicyAttachment:GroupPolicyAttachment": {
-      "description": "Attaches a Managed IAM Policy to an IAM group\n\n```hcl\nresource \"aws_iam_group\" \"group\" {\n  name = \"test-group\"\n}\n\nresource \"aws_iam_policy\" \"policy\" {\n  name        = \"test-policy\"\n  description = \"A test policy\"\n  policy      = # omitted\n}\n\nresource \"aws_iam_group_policy_attachment\" \"test-attach\" {\n  group      = \"${aws_iam_group.group.name}\"\n  policy_arn = \"${aws_iam_policy.policy.arn}\"\n}\n```\n",
       "properties": {
         "group": {
-          "type": "string",
-          "description": "The group the policy should be applied to\n"
+          "type": "string"
         },
         "policyArn": {
           "type": "string",
-          "$ref": "#/types/aws:index/aRN:ARN",
-          "description": "The ARN of the policy you want to apply\n"
+          "$ref": "#/types/aws:index/aRN:ARN"
         }
       },
       "required": [
@@ -895,13 +790,11 @@
               "$ref": "#/types/aws:iam/group:Group"
             }
           ],
-          "description": "The group the policy should be applied to\n",
           "willReplaceOnChanges": true
         },
         "policyArn": {
           "type": "string",
           "$ref": "#/types/aws:index/aRN:ARN",
-          "description": "The ARN of the policy you want to apply\n",
           "willReplaceOnChanges": true
         }
       },
@@ -923,13 +816,11 @@
                 "$ref": "#/types/aws:iam/group:Group"
               }
             ],
-            "description": "The group the policy should be applied to\n",
             "willReplaceOnChanges": true
           },
           "policyArn": {
             "type": "string",
             "$ref": "#/types/aws:index/aRN:ARN",
-            "description": "The ARN of the policy you want to apply\n",
             "willReplaceOnChanges": true
           }
         },
@@ -937,31 +828,24 @@
       }
     },
     "aws:iam/instanceProfile:InstanceProfile": {
-      "description": "Provides an IAM instance profile.\n\n\u003e **NOTE:** Either `role` or `roles` (**deprecated**) must be specified.\n\n## Example Usage\n\n```hcl\nresource \"aws_iam_instance_profile\" \"test_profile\" {\n  name  = \"test_profile\"\n  role = \"${aws_iam_role.role.name}\"\n}\n\nresource \"aws_iam_role\" \"role\" {\n  name = \"test_role\"\n  path = \"/\"\n\n  assume_role_policy = \u003c\u003cEOF\n{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Action\": \"sts:AssumeRole\",\n            \"Principal\": {\n               \"Service\": \"ec2.amazonaws.com\"\n            },\n            \"Effect\": \"Allow\",\n            \"Sid\": \"\"\n        }\n    ]\n}\nEOF\n}\n```\n\n## Import\n\nInstance Profiles can be imported using the `name`, e.g.\n\n```sh\u003cbreak\u003e\n$ pulumi import aws:iam/instanceProfile:InstanceProfile test_profile app-instance-profile-1\n\u003cbreak\u003e```\u003cbreak\u003e\n",
       "properties": {
         "arn": {
-          "type": "string",
-          "description": "The ARN assigned by AWS to the instance profile.\n"
+          "type": "string"
         },
         "createDate": {
-          "type": "string",
-          "description": "The creation timestamp of the instance profile.\n"
+          "type": "string"
         },
         "name": {
-          "type": "string",
-          "description": "The instance profile's name.\n"
+          "type": "string"
         },
         "namePrefix": {
-          "type": "string",
-          "description": "Creates a unique name beginning with the specified prefix. Conflicts with `name`.\n"
+          "type": "string"
         },
         "path": {
-          "type": "string",
-          "description": "Path in which to create the profile.\n"
+          "type": "string"
         },
         "role": {
-          "type": "string",
-          "description": "The role name to include in the profile.\n"
+          "type": "string"
         },
         "tags": {
           "type": "object",
@@ -976,8 +860,7 @@
           }
         },
         "uniqueId": {
-          "type": "string",
-          "description": "The [unique ID][1] assigned by AWS.\n"
+          "type": "string"
         }
       },
       "required": [
@@ -990,17 +873,14 @@
       "inputProperties": {
         "name": {
           "type": "string",
-          "description": "The instance profile's name.\n",
           "willReplaceOnChanges": true
         },
         "namePrefix": {
           "type": "string",
-          "description": "Creates a unique name beginning with the specified prefix. Conflicts with `name`.\n",
           "willReplaceOnChanges": true
         },
         "path": {
           "type": "string",
-          "description": "Path in which to create the profile.\n",
           "willReplaceOnChanges": true
         },
         "role": {
@@ -1013,8 +893,7 @@
               "type": "string",
               "$ref": "#/types/aws:iam/role:Role"
             }
-          ],
-          "description": "The role name to include in the profile.\n"
+          ]
         },
         "tags": {
           "type": "object",
@@ -1027,26 +906,21 @@
         "description": "Input properties used for looking up and filtering InstanceProfile resources.\n",
         "properties": {
           "arn": {
-            "type": "string",
-            "description": "The ARN assigned by AWS to the instance profile.\n"
+            "type": "string"
           },
           "createDate": {
-            "type": "string",
-            "description": "The creation timestamp of the instance profile.\n"
+            "type": "string"
           },
           "name": {
             "type": "string",
-            "description": "The instance profile's name.\n",
             "willReplaceOnChanges": true
           },
           "namePrefix": {
             "type": "string",
-            "description": "Creates a unique name beginning with the specified prefix. Conflicts with `name`.\n",
             "willReplaceOnChanges": true
           },
           "path": {
             "type": "string",
-            "description": "Path in which to create the profile.\n",
             "willReplaceOnChanges": true
           },
           "role": {
@@ -1059,8 +933,7 @@
                 "type": "string",
                 "$ref": "#/types/aws:iam/role:Role"
               }
-            ],
-            "description": "The role name to include in the profile.\n"
+            ]
           },
           "tags": {
             "type": "object",
@@ -1075,26 +948,22 @@
             }
           },
           "uniqueId": {
-            "type": "string",
-            "description": "The [unique ID][1] assigned by AWS.\n"
+            "type": "string"
           }
         },
         "type": "object"
       }
     },
     "aws:iam/openIdConnectProvider:OpenIdConnectProvider": {
-      "description": "Provides an IAM OpenID Connect provider.\n\n## Example Usage\n\n```hcl\nresource \"aws_iam_openid_connect_provider\" \"default\" {\n    url = \"https://accounts.google.com\"\n    client_id_list = [\n     \"266362248691-342342xasdasdasda-apps.googleusercontent.com\"\n    ]\n    thumbprint_list = []\n}\n```\n\n## Import\n\nIAM OpenID Connect Providers can be imported using the `arn`, e.g.\n\n```sh\u003cbreak\u003e\n$ pulumi import aws:iam/openIdConnectProvider:OpenIdConnectProvider default arn:aws:iam::123456789012:oidc-provider/accounts.google.com\n\u003cbreak\u003e```\u003cbreak\u003e\n",
       "properties": {
         "arn": {
-          "type": "string",
-          "description": "The ARN assigned by AWS for this provider.\n"
+          "type": "string"
         },
         "clientIdLists": {
           "type": "array",
           "items": {
             "type": "string"
-          },
-          "description": "A list of client IDs (also known as audiences). When a mobile or web app registers with an OpenID Connect provider, they establish a value that identifies the application. (This is the value that's sent as the client_id parameter on OAuth requests.)\n"
+          }
         },
         "tags": {
           "type": "object",
@@ -1112,12 +981,10 @@
           "type": "array",
           "items": {
             "type": "string"
-          },
-          "description": "A list of server certificate thumbprints for the OpenID Connect (OIDC) identity provider's server certificate(s).\n"
+          }
         },
         "url": {
-          "type": "string",
-          "description": "The URL of the identity provider. Corresponds to the _iss_ claim.\n"
+          "type": "string"
         }
       },
       "required": [
@@ -1133,7 +1000,6 @@
           "items": {
             "type": "string"
           },
-          "description": "A list of client IDs (also known as audiences). When a mobile or web app registers with an OpenID Connect provider, they establish a value that identifies the application. (This is the value that's sent as the client_id parameter on OAuth requests.)\n",
           "willReplaceOnChanges": true
         },
         "tags": {
@@ -1146,12 +1012,10 @@
           "type": "array",
           "items": {
             "type": "string"
-          },
-          "description": "A list of server certificate thumbprints for the OpenID Connect (OIDC) identity provider's server certificate(s).\n"
+          }
         },
         "url": {
           "type": "string",
-          "description": "The URL of the identity provider. Corresponds to the _iss_ claim.\n",
           "willReplaceOnChanges": true
         }
       },
@@ -1164,15 +1028,13 @@
         "description": "Input properties used for looking up and filtering OpenIdConnectProvider resources.\n",
         "properties": {
           "arn": {
-            "type": "string",
-            "description": "The ARN assigned by AWS for this provider.\n"
+            "type": "string"
           },
           "clientIdLists": {
             "type": "array",
             "items": {
               "type": "string"
             },
-            "description": "A list of client IDs (also known as audiences). When a mobile or web app registers with an OpenID Connect provider, they establish a value that identifies the application. (This is the value that's sent as the client_id parameter on OAuth requests.)\n",
             "willReplaceOnChanges": true
           },
           "tags": {
@@ -1191,12 +1053,10 @@
             "type": "array",
             "items": {
               "type": "string"
-            },
-            "description": "A list of server certificate thumbprints for the OpenID Connect (OIDC) identity provider's server certificate(s).\n"
+            }
           },
           "url": {
             "type": "string",
-            "description": "The URL of the identity provider. Corresponds to the _iss_ claim.\n",
             "willReplaceOnChanges": true
           }
         },
@@ -1204,31 +1064,24 @@
       }
     },
     "aws:iam/policy:Policy": {
-      "description": "Provides an IAM policy.\n\n```hcl\nresource \"aws_iam_policy\" \"policy\" {\n  name        = \"test_policy\"\n  path        = \"/\"\n  description = \"My test policy\"\n\n  policy = \u003c\u003cEOF\n{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"ec2:Describe*\"\n      ],\n      \"Effect\": \"Allow\",\n      \"Resource\": \"*\"\n    }\n  ]\n}\nEOF\n}\n```\n\n## Import\n\nIAM Policies can be imported using the `arn`, e.g.\n\n```sh\u003cbreak\u003e\n$ pulumi import aws:iam/policy:Policy administrator arn:aws:iam::123456789012:policy/UsersManageOwnCredentials\n\u003cbreak\u003e```\u003cbreak\u003e\n",
       "properties": {
         "arn": {
-          "type": "string",
-          "description": "The ARN assigned by AWS to this policy.\n"
+          "type": "string"
         },
         "description": {
-          "type": "string",
-          "description": "Description of the IAM policy.\n"
+          "type": "string"
         },
         "name": {
-          "type": "string",
-          "description": "The name of the policy.\n"
+          "type": "string"
         },
         "namePrefix": {
-          "type": "string",
-          "description": "Creates a unique name beginning with the specified prefix. Conflicts with `name`.\n"
+          "type": "string"
         },
         "path": {
-          "type": "string",
-          "description": "Path in which to create the policy.\nSee [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html) for more information.\n"
+          "type": "string"
         },
         "policy": {
           "type": "string",
-          "description": "The policy document. This is a JSON formatted string.\nThe heredoc syntax, `file` function, or the [`aws.x/iam.getPolicyDocument` data\nsource](https://www.terraform.io/docs/providers/aws/d/iam_policy_document.html)\nare all helpful here.\n",
           "language": {
             "csharp": {
               "name": "PolicyDocument"
@@ -1261,22 +1114,18 @@
       "inputProperties": {
         "description": {
           "type": "string",
-          "description": "Description of the IAM policy.\n",
           "willReplaceOnChanges": true
         },
         "name": {
           "type": "string",
-          "description": "The name of the policy.\n",
           "willReplaceOnChanges": true
         },
         "namePrefix": {
           "type": "string",
-          "description": "Creates a unique name beginning with the specified prefix. Conflicts with `name`.\n",
           "willReplaceOnChanges": true
         },
         "path": {
           "type": "string",
-          "description": "Path in which to create the policy.\nSee [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html) for more information.\n",
           "willReplaceOnChanges": true
         },
         "policy": {
@@ -1290,7 +1139,6 @@
               "$ref": "#/types/aws:iam/documents:PolicyDocument"
             }
           ],
-          "description": "The policy document. This is a JSON formatted string.\nThe heredoc syntax, `file` function, or the [`aws.x/iam.getPolicyDocument` data\nsource](https://www.terraform.io/docs/providers/aws/d/iam_policy_document.html)\nare all helpful here.\n",
           "language": {
             "csharp": {
               "name": "PolicyDocument"
@@ -1311,27 +1159,22 @@
         "description": "Input properties used for looking up and filtering Policy resources.\n",
         "properties": {
           "arn": {
-            "type": "string",
-            "description": "The ARN assigned by AWS to this policy.\n"
+            "type": "string"
           },
           "description": {
             "type": "string",
-            "description": "Description of the IAM policy.\n",
             "willReplaceOnChanges": true
           },
           "name": {
             "type": "string",
-            "description": "The name of the policy.\n",
             "willReplaceOnChanges": true
           },
           "namePrefix": {
             "type": "string",
-            "description": "Creates a unique name beginning with the specified prefix. Conflicts with `name`.\n",
             "willReplaceOnChanges": true
           },
           "path": {
             "type": "string",
-            "description": "Path in which to create the policy.\nSee [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html) for more information.\n",
             "willReplaceOnChanges": true
           },
           "policy": {
@@ -1345,7 +1188,6 @@
                 "$ref": "#/types/aws:iam/documents:PolicyDocument"
               }
             ],
-            "description": "The policy document. This is a JSON formatted string.\nThe heredoc syntax, `file` function, or the [`aws.x/iam.getPolicyDocument` data\nsource](https://www.terraform.io/docs/providers/aws/d/iam_policy_document.html)\nare all helpful here.\n",
             "language": {
               "csharp": {
                 "name": "PolicyDocument"
@@ -1377,31 +1219,26 @@
           "type": "array",
           "items": {
             "type": "string"
-          },
-          "description": "The group(s) the policy should be applied to\n"
+          }
         },
         "name": {
-          "type": "string",
-          "description": "The name of the policy. This cannot be an empty string.\n"
+          "type": "string"
         },
         "policyArn": {
           "type": "string",
-          "$ref": "#/types/aws:index/aRN:ARN",
-          "description": "The ARN of the policy you want to apply\n"
+          "$ref": "#/types/aws:index/aRN:ARN"
         },
         "roles": {
           "type": "array",
           "items": {
             "type": "string"
-          },
-          "description": "The role(s) the policy should be applied to\n"
+          }
         },
         "users": {
           "type": "array",
           "items": {
             "type": "string"
-          },
-          "description": "The user(s) the policy should be applied to\n"
+          }
         }
       },
       "required": [
@@ -1422,18 +1259,15 @@
                 "$ref": "#/types/aws:iam/group:Group"
               }
             ]
-          },
-          "description": "The group(s) the policy should be applied to\n"
+          }
         },
         "name": {
           "type": "string",
-          "description": "The name of the policy. This cannot be an empty string.\n",
           "willReplaceOnChanges": true
         },
         "policyArn": {
           "type": "string",
           "$ref": "#/types/aws:index/aRN:ARN",
-          "description": "The ARN of the policy you want to apply\n",
           "willReplaceOnChanges": true
         },
         "roles": {
@@ -1449,8 +1283,7 @@
                 "$ref": "#/types/aws:iam/role:Role"
               }
             ]
-          },
-          "description": "The role(s) the policy should be applied to\n"
+          }
         },
         "users": {
           "type": "array",
@@ -1465,8 +1298,7 @@
                 "$ref": "#/types/aws:iam/user:User"
               }
             ]
-          },
-          "description": "The user(s) the policy should be applied to\n"
+          }
         }
       },
       "requiredInputs": [
@@ -1488,18 +1320,15 @@
                   "$ref": "#/types/aws:iam/group:Group"
                 }
               ]
-            },
-            "description": "The group(s) the policy should be applied to\n"
+            }
           },
           "name": {
             "type": "string",
-            "description": "The name of the policy. This cannot be an empty string.\n",
             "willReplaceOnChanges": true
           },
           "policyArn": {
             "type": "string",
             "$ref": "#/types/aws:index/aRN:ARN",
-            "description": "The ARN of the policy you want to apply\n",
             "willReplaceOnChanges": true
           },
           "roles": {
@@ -1515,8 +1344,7 @@
                   "$ref": "#/types/aws:iam/role:Role"
                 }
               ]
-            },
-            "description": "The role(s) the policy should be applied to\n"
+            }
           },
           "users": {
             "type": "array",
@@ -1531,35 +1359,28 @@
                   "$ref": "#/types/aws:iam/user:User"
                 }
               ]
-            },
-            "description": "The user(s) the policy should be applied to\n"
+            }
           }
         },
         "type": "object"
       }
     },
     "aws:iam/role:Role": {
-      "description": "Provides an IAM role.\n\n## Example Usage\n\n```hcl\nresource \"aws_iam_role\" \"test_role\" {\n  name = \"test_role\"\n\n  assume_role_policy = \u003c\u003cEOF\n{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"ec2.amazonaws.com\"\n      },\n      \"Effect\": \"Allow\",\n      \"Sid\": \"\"\n    }\n  ]\n}\nEOF\n}\n```\n\n## Example of Using Data Source for Assume Role Policy\n\n```hcl\ndata \"aws_iam_policy_document\" \"instance-assume-role-policy\" {\n  statement {\n    actions = [\"sts:AssumeRole\"]\n\n    principals {\n      type        = \"Service\"\n      identifiers = [\"ec2.amazonaws.com\"]\n    }\n  }\n}\n\nresource \"aws_iam_role\" \"instance\" {\n  name               = \"instance_role\"\n  path               = \"/system/\"\n  assume_role_policy = \"${data.aws_iam_policy_document.instance-assume-role-policy.json}\"\n}\n```\n\n## Import\n\nIAM Roles can be imported using the `name`, e.g.\n\n```sh\u003cbreak\u003e\n$ pulumi import aws:iam/role:Role developer developer_name\n\u003cbreak\u003e```\u003cbreak\u003e\n",
       "properties": {
         "arn": {
-          "type": "string",
-          "description": "The Amazon Resource Name (ARN) specifying the role.\n"
+          "type": "string"
         },
         "assumeRolePolicy": {
-          "type": "string",
-          "description": "The policy that grants an entity permission to assume the role.\n\n\u003e **NOTE:** This `assume_role_policy` is very similar but slightly different than just a standard IAM policy and cannot use an `aws.iam.Policy` resource.  It _can_ however, use an `aws.x/iam.getPolicyDocument` data source, see example below for how this could work.\n"
+          "type": "string"
         },
         "createDate": {
-          "type": "string",
-          "description": "The creation date of the IAM role.\n"
+          "type": "string"
         },
         "description": {
-          "type": "string",
-          "description": "The description of the role.\n"
+          "type": "string"
         },
         "forceDetachPolicies": {
-          "type": "boolean",
-          "description": "Specifies to force detaching any policies the role has before destroying it. Defaults to `false`.\n"
+          "type": "boolean"
         },
         "inlinePolicies": {
           "type": "array",
@@ -1577,16 +1398,13 @@
           "type": "integer"
         },
         "name": {
-          "type": "string",
-          "description": "The name of the role.\n"
+          "type": "string"
         },
         "namePrefix": {
-          "type": "string",
-          "description": "Creates a unique name beginning with the specified prefix. Conflicts with `name`.\n"
+          "type": "string"
         },
         "path": {
-          "type": "string",
-          "description": "The path to the role.\nSee [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html) for more information.\n"
+          "type": "string"
         },
         "permissionsBoundary": {
           "type": "string"
@@ -1604,8 +1422,7 @@
           }
         },
         "uniqueId": {
-          "type": "string",
-          "description": "The stable and unique string identifying the role.\n"
+          "type": "string"
         }
       },
       "required": [
@@ -1630,16 +1447,13 @@
               "type": "string",
               "$ref": "#/types/aws:iam/documents:PolicyDocument"
             }
-          ],
-          "description": "The policy that grants an entity permission to assume the role.\n\n\u003e **NOTE:** This `assume_role_policy` is very similar but slightly different than just a standard IAM policy and cannot use an `aws.iam.Policy` resource.  It _can_ however, use an `aws.x/iam.getPolicyDocument` data source, see example below for how this could work.\n"
+          ]
         },
         "description": {
-          "type": "string",
-          "description": "The description of the role.\n"
+          "type": "string"
         },
         "forceDetachPolicies": {
-          "type": "boolean",
-          "description": "Specifies to force detaching any policies the role has before destroying it. Defaults to `false`.\n"
+          "type": "boolean"
         },
         "inlinePolicies": {
           "type": "array",
@@ -1658,17 +1472,14 @@
         },
         "name": {
           "type": "string",
-          "description": "The name of the role.\n",
           "willReplaceOnChanges": true
         },
         "namePrefix": {
           "type": "string",
-          "description": "Creates a unique name beginning with the specified prefix. Conflicts with `name`.\n",
           "willReplaceOnChanges": true
         },
         "path": {
           "type": "string",
-          "description": "The path to the role.\nSee [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html) for more information.\n",
           "willReplaceOnChanges": true
         },
         "permissionsBoundary": {
@@ -1688,8 +1499,7 @@
         "description": "Input properties used for looking up and filtering Role resources.\n",
         "properties": {
           "arn": {
-            "type": "string",
-            "description": "The Amazon Resource Name (ARN) specifying the role.\n"
+            "type": "string"
           },
           "assumeRolePolicy": {
             "type": "string",
@@ -1701,20 +1511,16 @@
                 "type": "string",
                 "$ref": "#/types/aws:iam/documents:PolicyDocument"
               }
-            ],
-            "description": "The policy that grants an entity permission to assume the role.\n\n\u003e **NOTE:** This `assume_role_policy` is very similar but slightly different than just a standard IAM policy and cannot use an `aws.iam.Policy` resource.  It _can_ however, use an `aws.x/iam.getPolicyDocument` data source, see example below for how this could work.\n"
+            ]
           },
           "createDate": {
-            "type": "string",
-            "description": "The creation date of the IAM role.\n"
+            "type": "string"
           },
           "description": {
-            "type": "string",
-            "description": "The description of the role.\n"
+            "type": "string"
           },
           "forceDetachPolicies": {
-            "type": "boolean",
-            "description": "Specifies to force detaching any policies the role has before destroying it. Defaults to `false`.\n"
+            "type": "boolean"
           },
           "inlinePolicies": {
             "type": "array",
@@ -1733,17 +1539,14 @@
           },
           "name": {
             "type": "string",
-            "description": "The name of the role.\n",
             "willReplaceOnChanges": true
           },
           "namePrefix": {
             "type": "string",
-            "description": "Creates a unique name beginning with the specified prefix. Conflicts with `name`.\n",
             "willReplaceOnChanges": true
           },
           "path": {
             "type": "string",
-            "description": "The path to the role.\nSee [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html) for more information.\n",
             "willReplaceOnChanges": true
           },
           "permissionsBoundary": {
@@ -1762,31 +1565,25 @@
             }
           },
           "uniqueId": {
-            "type": "string",
-            "description": "The stable and unique string identifying the role.\n"
+            "type": "string"
           }
         },
         "type": "object"
       }
     },
     "aws:iam/rolePolicy:RolePolicy": {
-      "description": "Provides an IAM role policy.\n\n## Example Usage\n\n```hcl\nresource \"aws_iam_role_policy\" \"test_policy\" {\n  name = \"test_policy\"\n  role = \"${aws_iam_role.test_role.id}\"\n\n  policy = \u003c\u003cEOF\n{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"ec2:Describe*\"\n      ],\n      \"Effect\": \"Allow\",\n      \"Resource\": \"*\"\n    }\n  ]\n}\nEOF\n}\n\nresource \"aws_iam_role\" \"test_role\" {\n  name = \"test_role\"\n\n  assume_role_policy = \u003c\u003cEOF\n{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"ec2.amazonaws.com\"\n      },\n      \"Effect\": \"Allow\",\n      \"Sid\": \"\"\n    }\n  ]\n}\nEOF\n}\n```\n\n## Import\n\nIAM Role Policies can be imported using the `role_name:role_policy_name`, e.g.\n\n```sh\u003cbreak\u003e\n$ pulumi import aws:iam/rolePolicy:RolePolicy mypolicy role_of_mypolicy_name:mypolicy_name\n\u003cbreak\u003e```\u003cbreak\u003e\n",
       "properties": {
         "name": {
-          "type": "string",
-          "description": "The name of the policy.\n"
+          "type": "string"
         },
         "namePrefix": {
-          "type": "string",
-          "description": "Creates a unique name beginning with the specified\nprefix. Conflicts with `name`.\n"
+          "type": "string"
         },
         "policy": {
-          "type": "string",
-          "description": "The policy document. This is a JSON formatted string.\nThe heredoc syntax or `file` function is helpful here.\n"
+          "type": "string"
         },
         "role": {
-          "type": "string",
-          "description": "The IAM role to attach to the policy.\n"
+          "type": "string"
         }
       },
       "required": [
@@ -1797,12 +1594,10 @@
       "inputProperties": {
         "name": {
           "type": "string",
-          "description": "The name of the policy.\n",
           "willReplaceOnChanges": true
         },
         "namePrefix": {
           "type": "string",
-          "description": "Creates a unique name beginning with the specified\nprefix. Conflicts with `name`.\n",
           "willReplaceOnChanges": true
         },
         "policy": {
@@ -1815,8 +1610,7 @@
               "type": "string",
               "$ref": "#/types/aws:iam/documents:PolicyDocument"
             }
-          ],
-          "description": "The policy document. This is a JSON formatted string.\nThe heredoc syntax or `file` function is helpful here.\n"
+          ]
         },
         "role": {
           "type": "string",
@@ -1829,7 +1623,6 @@
               "$ref": "#/types/aws:iam/role:Role"
             }
           ],
-          "description": "The IAM role to attach to the policy.\n",
           "willReplaceOnChanges": true
         }
       },
@@ -1842,12 +1635,10 @@
         "properties": {
           "name": {
             "type": "string",
-            "description": "The name of the policy.\n",
             "willReplaceOnChanges": true
           },
           "namePrefix": {
             "type": "string",
-            "description": "Creates a unique name beginning with the specified\nprefix. Conflicts with `name`.\n",
             "willReplaceOnChanges": true
           },
           "policy": {
@@ -1860,8 +1651,7 @@
                 "type": "string",
                 "$ref": "#/types/aws:iam/documents:PolicyDocument"
               }
-            ],
-            "description": "The policy document. This is a JSON formatted string.\nThe heredoc syntax or `file` function is helpful here.\n"
+            ]
           },
           "role": {
             "type": "string",
@@ -1874,7 +1664,6 @@
                 "$ref": "#/types/aws:iam/role:Role"
               }
             ],
-            "description": "The IAM role to attach to the policy.\n",
             "willReplaceOnChanges": true
           }
         },
@@ -1882,16 +1671,13 @@
       }
     },
     "aws:iam/rolePolicyAttachment:RolePolicyAttachment": {
-      "description": "Attaches a Managed IAM Policy to an IAM role\n\n```hcl\nresource \"aws_iam_role\" \"role\" {\n    name = \"test-role\"\n    assume_role_policy = \u003c\u003cEOF\n    {\n      \"Version\": \"2012-10-17\",\n      \"Statement\": [\n        {\n          \"Action\": \"sts:AssumeRole\",\n          \"Principal\": {\n            \"Service\": \"ec2.amazonaws.com\"\n          },\n          \"Effect\": \"Allow\",\n          \"Sid\": \"\"\n        }\n      ]\n    }\nEOF\n}\n\nresource \"aws_iam_policy\" \"policy\" {\n    name        = \"test-policy\"\n    description = \"A test policy\"\n    policy = \u003c\u003cEOF\n{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"ec2:Describe*\"\n      ],\n      \"Effect\": \"Allow\",\n      \"Resource\": \"*\"\n    }\n  ]\n}\nEOF\n}\n\nresource \"aws_iam_role_policy_attachment\" \"test-attach\" {\n    role       = \"${aws_iam_role.role.name}\"\n    policy_arn = \"${aws_iam_policy.policy.arn}\"\n}\n```\n",
       "properties": {
         "policyArn": {
           "type": "string",
-          "$ref": "#/types/aws:index/aRN:ARN",
-          "description": "The ARN of the policy you want to apply\n"
+          "$ref": "#/types/aws:index/aRN:ARN"
         },
         "role": {
-          "type": "string",
-          "description": "The role the policy should be applied to\n"
+          "type": "string"
         }
       },
       "required": [
@@ -1902,7 +1688,6 @@
         "policyArn": {
           "type": "string",
           "$ref": "#/types/aws:index/aRN:ARN",
-          "description": "The ARN of the policy you want to apply\n",
           "willReplaceOnChanges": true
         },
         "role": {
@@ -1916,7 +1701,6 @@
               "$ref": "#/types/aws:iam/role:Role"
             }
           ],
-          "description": "The role the policy should be applied to\n",
           "willReplaceOnChanges": true
         }
       },
@@ -1930,7 +1714,6 @@
           "policyArn": {
             "type": "string",
             "$ref": "#/types/aws:index/aRN:ARN",
-            "description": "The ARN of the policy you want to apply\n",
             "willReplaceOnChanges": true
           },
           "role": {
@@ -1944,7 +1727,6 @@
                 "$ref": "#/types/aws:iam/role:Role"
               }
             ],
-            "description": "The role the policy should be applied to\n",
             "willReplaceOnChanges": true
           }
         },
@@ -1952,19 +1734,15 @@
       }
     },
     "aws:iam/samlProvider:SamlProvider": {
-      "description": "Provides an IAM SAML provider.\n\n## Example Usage\n\n```hcl\nresource \"aws_iam_saml_provider\" \"default\" {\n  name                   = \"myprovider\"\n  saml_metadata_document = \"${file(\"saml-metadata.xml\")}\"\n}\n```\n\n## Import\n\nIAM SAML Providers can be imported using the `arn`, e.g.\n\n```sh\u003cbreak\u003e\n$ pulumi import aws:iam/samlProvider:SamlProvider default arn:aws:iam::123456789012:saml-provider/SAMLADFS\n\u003cbreak\u003e```\u003cbreak\u003e\n",
       "properties": {
         "arn": {
-          "type": "string",
-          "description": "The ARN assigned by AWS for this provider.\n"
+          "type": "string"
         },
         "name": {
-          "type": "string",
-          "description": "The name of the provider to create.\n"
+          "type": "string"
         },
         "samlMetadataDocument": {
-          "type": "string",
-          "description": "An XML document generated by an identity provider that supports SAML 2.0.\n"
+          "type": "string"
         },
         "tags": {
           "type": "object",
@@ -1979,8 +1757,7 @@
           }
         },
         "validUntil": {
-          "type": "string",
-          "description": "The expiration date and time for the SAML provider in RFC1123 format, e.g. `Mon, 02 Jan 2006 15:04:05 MST`.\n"
+          "type": "string"
         }
       },
       "required": [
@@ -1993,12 +1770,10 @@
       "inputProperties": {
         "name": {
           "type": "string",
-          "description": "The name of the provider to create.\n",
           "willReplaceOnChanges": true
         },
         "samlMetadataDocument": {
-          "type": "string",
-          "description": "An XML document generated by an identity provider that supports SAML 2.0.\n"
+          "type": "string"
         },
         "tags": {
           "type": "object",
@@ -2014,17 +1789,14 @@
         "description": "Input properties used for looking up and filtering SamlProvider resources.\n",
         "properties": {
           "arn": {
-            "type": "string",
-            "description": "The ARN assigned by AWS for this provider.\n"
+            "type": "string"
           },
           "name": {
             "type": "string",
-            "description": "The name of the provider to create.\n",
             "willReplaceOnChanges": true
           },
           "samlMetadataDocument": {
-            "type": "string",
-            "description": "An XML document generated by an identity provider that supports SAML 2.0.\n"
+            "type": "string"
           },
           "tags": {
             "type": "object",
@@ -2039,45 +1811,37 @@
             }
           },
           "validUntil": {
-            "type": "string",
-            "description": "The expiration date and time for the SAML provider in RFC1123 format, e.g. `Mon, 02 Jan 2006 15:04:05 MST`.\n"
+            "type": "string"
           }
         },
         "type": "object"
       }
     },
     "aws:iam/serverCertificate:ServerCertificate": {
-      "description": "\n\n## Import\n\nIAM Server Certificates can be imported using the `name`, e.g.\n\n```sh\u003cbreak\u003e\n$ pulumi import aws:iam/serverCertificate:ServerCertificate certificate example.com-certificate-until-2018\n\u003cbreak\u003e```\u003cbreak\u003e\n",
       "properties": {
         "arn": {
-          "type": "string",
-          "description": "The Amazon Resource Name (ARN) specifying the server certificate.\n"
+          "type": "string"
         },
         "certificateBody": {
-          "type": "string",
-          "description": "(Required) The contents of the public key certificate in\nPEM-encoded format.\n"
+          "type": "string"
         },
         "certificateChain": {
-          "type": "string",
-          "description": "(Optional) The contents of the certificate chain.\nThis is typically a concatenation of the PEM-encoded public key certificates\nof the chain.\n"
+          "type": "string"
         },
         "expiration": {
           "type": "string"
         },
         "name": {
-          "type": "string",
-          "description": "The name of the Server Certificate\n"
+          "type": "string"
         },
         "namePrefix": {
-          "type": "string",
-          "description": "Creates a unique name beginning with the specified\nprefix. Conflicts with `name`.\n"
+          "type": "string"
         },
         "path": {
           "type": "string"
         },
         "privateKey": {
           "type": "string",
-          "description": "(Required) The contents of the private key in PEM-encoded format.\n",
           "secret": true
         },
         "tags": {
@@ -2108,22 +1872,18 @@
       "inputProperties": {
         "certificateBody": {
           "type": "string",
-          "description": "(Required) The contents of the public key certificate in\nPEM-encoded format.\n",
           "willReplaceOnChanges": true
         },
         "certificateChain": {
           "type": "string",
-          "description": "(Optional) The contents of the certificate chain.\nThis is typically a concatenation of the PEM-encoded public key certificates\nof the chain.\n",
           "willReplaceOnChanges": true
         },
         "name": {
           "type": "string",
-          "description": "The name of the Server Certificate\n",
           "willReplaceOnChanges": true
         },
         "namePrefix": {
           "type": "string",
-          "description": "Creates a unique name beginning with the specified\nprefix. Conflicts with `name`.\n",
           "willReplaceOnChanges": true
         },
         "path": {
@@ -2132,7 +1892,6 @@
         },
         "privateKey": {
           "type": "string",
-          "description": "(Required) The contents of the private key in PEM-encoded format.\n",
           "secret": true,
           "willReplaceOnChanges": true
         },
@@ -2151,17 +1910,14 @@
         "description": "Input properties used for looking up and filtering ServerCertificate resources.\n",
         "properties": {
           "arn": {
-            "type": "string",
-            "description": "The Amazon Resource Name (ARN) specifying the server certificate.\n"
+            "type": "string"
           },
           "certificateBody": {
             "type": "string",
-            "description": "(Required) The contents of the public key certificate in\nPEM-encoded format.\n",
             "willReplaceOnChanges": true
           },
           "certificateChain": {
             "type": "string",
-            "description": "(Optional) The contents of the certificate chain.\nThis is typically a concatenation of the PEM-encoded public key certificates\nof the chain.\n",
             "willReplaceOnChanges": true
           },
           "expiration": {
@@ -2169,12 +1925,10 @@
           },
           "name": {
             "type": "string",
-            "description": "The name of the Server Certificate\n",
             "willReplaceOnChanges": true
           },
           "namePrefix": {
             "type": "string",
-            "description": "Creates a unique name beginning with the specified\nprefix. Conflicts with `name`.\n",
             "willReplaceOnChanges": true
           },
           "path": {
@@ -2183,7 +1937,6 @@
           },
           "privateKey": {
             "type": "string",
-            "description": "(Required) The contents of the private key in PEM-encoded format.\n",
             "secret": true,
             "willReplaceOnChanges": true
           },
@@ -2454,31 +2207,24 @@
       }
     },
     "aws:iam/sshKey:SshKey": {
-      "description": "Uploads an SSH public key and associates it with the specified IAM user.\n\n## Example Usage\n\n```hcl\nresource \"aws_iam_user\" \"user\" {\n  name = \"test-user\"\n  path = \"/\"\n}\n\nresource \"aws_iam_user_ssh_key\" \"user\" {\n  username   = \"${aws_iam_user.user.name}\"\n  encoding   = \"PEM\"\n  public_key = \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 mytest@mydomain.com\"\n}\n```\n",
       "properties": {
         "encoding": {
-          "type": "string",
-          "description": "Specifies the public key encoding format to use in the response. To retrieve the public key in ssh-rsa format, use SSH . To retrieve the public key in PEM format, use PEM .\n"
+          "type": "string"
         },
         "fingerprint": {
-          "type": "string",
-          "description": "The MD5 message digest of the SSH public key.\n"
+          "type": "string"
         },
         "publicKey": {
-          "type": "string",
-          "description": "The SSH public key. The public key must be encoded in ssh-rsa format or PEM format.\n"
+          "type": "string"
         },
         "sshPublicKeyId": {
-          "type": "string",
-          "description": "The unique identifier for the SSH public key.\n"
+          "type": "string"
         },
         "status": {
-          "type": "string",
-          "description": "The status to assign to the SSH public key. Active means the key can be used for authentication with an AWS CodeCommit repository. Inactive means the key cannot be used. Default is `active`.\n"
+          "type": "string"
         },
         "username": {
-          "type": "string",
-          "description": "The name of the IAM user to associate the SSH public key with.\n"
+          "type": "string"
         }
       },
       "required": [
@@ -2492,21 +2238,17 @@
       "inputProperties": {
         "encoding": {
           "type": "string",
-          "description": "Specifies the public key encoding format to use in the response. To retrieve the public key in ssh-rsa format, use SSH . To retrieve the public key in PEM format, use PEM .\n",
           "willReplaceOnChanges": true
         },
         "publicKey": {
           "type": "string",
-          "description": "The SSH public key. The public key must be encoded in ssh-rsa format or PEM format.\n",
           "willReplaceOnChanges": true
         },
         "status": {
-          "type": "string",
-          "description": "The status to assign to the SSH public key. Active means the key can be used for authentication with an AWS CodeCommit repository. Inactive means the key cannot be used. Default is `active`.\n"
+          "type": "string"
         },
         "username": {
           "type": "string",
-          "description": "The name of the IAM user to associate the SSH public key with.\n",
           "willReplaceOnChanges": true
         }
       },
@@ -2520,29 +2262,23 @@
         "properties": {
           "encoding": {
             "type": "string",
-            "description": "Specifies the public key encoding format to use in the response. To retrieve the public key in ssh-rsa format, use SSH . To retrieve the public key in PEM format, use PEM .\n",
             "willReplaceOnChanges": true
           },
           "fingerprint": {
-            "type": "string",
-            "description": "The MD5 message digest of the SSH public key.\n"
+            "type": "string"
           },
           "publicKey": {
             "type": "string",
-            "description": "The SSH public key. The public key must be encoded in ssh-rsa format or PEM format.\n",
             "willReplaceOnChanges": true
           },
           "sshPublicKeyId": {
-            "type": "string",
-            "description": "The unique identifier for the SSH public key.\n"
+            "type": "string"
           },
           "status": {
-            "type": "string",
-            "description": "The status to assign to the SSH public key. Active means the key can be used for authentication with an AWS CodeCommit repository. Inactive means the key cannot be used. Default is `active`.\n"
+            "type": "string"
           },
           "username": {
             "type": "string",
-            "description": "The name of the IAM user to associate the SSH public key with.\n",
             "willReplaceOnChanges": true
           }
         },
@@ -2550,23 +2286,19 @@
       }
     },
     "aws:iam/user:User": {
-      "description": "Provides an IAM user.\n\n## Example Usage\n\n```hcl\nresource \"aws_iam_user\" \"lb\" {\n  name = \"loadbalancer\"\n  path = \"/system/\"\n}\n\nresource \"aws_iam_access_key\" \"lb\" {\n  user = \"${aws_iam_user.lb.name}\"\n}\n\nresource \"aws_iam_user_policy\" \"lb_ro\" {\n  name = \"test\"\n  user = \"${aws_iam_user.lb.name}\"\n\n  policy = \u003c\u003cEOF\n{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"ec2:Describe*\"\n      ],\n      \"Effect\": \"Allow\",\n      \"Resource\": \"*\"\n    }\n  ]\n}\nEOF\n}\n```\n\n## Import\n\nIAM Users can be imported using the `name`, e.g.\n\n```sh\u003cbreak\u003e\n$ pulumi import aws:iam/user:User lb loadbalancer\n\u003cbreak\u003e```\u003cbreak\u003e\n",
       "properties": {
         "arn": {
-          "type": "string",
-          "description": "The ARN assigned by AWS for this user.\n"
+          "type": "string"
         },
         "forceDestroy": {
           "type": "boolean",
           "description": "Delete user even if it has non-Terraform-managed IAM access keys, login profile or MFA devices\n"
         },
         "name": {
-          "type": "string",
-          "description": "The user's name. The name must consist of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: `=,.@-_.`. User names are not distinguished by case. For example, you cannot create users named both \"TESTUSER\" and \"testuser\".\n"
+          "type": "string"
         },
         "path": {
-          "type": "string",
-          "description": "Path in which to create the user.\n"
+          "type": "string"
         },
         "permissionsBoundary": {
           "type": "string"
@@ -2584,8 +2316,7 @@
           }
         },
         "uniqueId": {
-          "type": "string",
-          "description": "The [unique ID][1] assigned by AWS.\n"
+          "type": "string"
         }
       },
       "required": [
@@ -2600,12 +2331,10 @@
           "description": "Delete user even if it has non-Terraform-managed IAM access keys, login profile or MFA devices\n"
         },
         "name": {
-          "type": "string",
-          "description": "The user's name. The name must consist of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: `=,.@-_.`. User names are not distinguished by case. For example, you cannot create users named both \"TESTUSER\" and \"testuser\".\n"
+          "type": "string"
         },
         "path": {
-          "type": "string",
-          "description": "Path in which to create the user.\n"
+          "type": "string"
         },
         "permissionsBoundary": {
           "type": "string"
@@ -2621,20 +2350,17 @@
         "description": "Input properties used for looking up and filtering User resources.\n",
         "properties": {
           "arn": {
-            "type": "string",
-            "description": "The ARN assigned by AWS for this user.\n"
+            "type": "string"
           },
           "forceDestroy": {
             "type": "boolean",
             "description": "Delete user even if it has non-Terraform-managed IAM access keys, login profile or MFA devices\n"
           },
           "name": {
-            "type": "string",
-            "description": "The user's name. The name must consist of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: `=,.@-_.`. User names are not distinguished by case. For example, you cannot create users named both \"TESTUSER\" and \"testuser\".\n"
+            "type": "string"
           },
           "path": {
-            "type": "string",
-            "description": "Path in which to create the user.\n"
+            "type": "string"
           },
           "permissionsBoundary": {
             "type": "string"
@@ -2652,8 +2378,7 @@
             }
           },
           "uniqueId": {
-            "type": "string",
-            "description": "The [unique ID][1] assigned by AWS.\n"
+            "type": "string"
           }
         },
         "type": "object"
@@ -2709,34 +2434,27 @@
       }
     },
     "aws:iam/userLoginProfile:UserLoginProfile": {
-      "description": "Provides one-time creation of a IAM user login profile, and uses PGP to\nencrypt the password for safe transport to the user. PGP keys can be\nobtained from Keybase.\n\n## Example Usage\n\n```hcl\nresource \"aws_iam_user\" \"u\" {\n  name          = \"auser\"\n  path          = \"/\"\n  force_destroy = true\n}\n\nresource \"aws_iam_user_login_profile\" \"u\" {\n  user    = \"${aws_iam_user.u.name}\"\n  pgp_key = \"keybase:some_person_that_exists\"\n}\n\noutput \"password\" {\n  value = \"${aws_iam_user_login_profile.u.encrypted_password}\"\n}\n```\n\n## Import\n\nIAM Login Profiles may not be imported.\n",
       "properties": {
         "encryptedPassword": {
-          "type": "string",
-          "description": "The encrypted password, base64 encoded.\n"
+          "type": "string"
         },
         "keyFingerprint": {
-          "type": "string",
-          "description": "The fingerprint of the PGP key used to encrypt\nthe password\n"
+          "type": "string"
         },
         "password": {
           "type": "string"
         },
         "passwordLength": {
-          "type": "integer",
-          "description": "The length of the generated\npassword.\n"
+          "type": "integer"
         },
         "passwordResetRequired": {
-          "type": "boolean",
-          "description": "Whether the\nuser should be forced to reset the generated password on first login.\n"
+          "type": "boolean"
         },
         "pgpKey": {
-          "type": "string",
-          "description": "Either a base-64 encoded PGP public key, or a\nkeybase username in the form `keybase:username`.\n"
+          "type": "string"
         },
         "user": {
-          "type": "string",
-          "description": "The IAM user's name.\n"
+          "type": "string"
         }
       },
       "required": [
@@ -2749,22 +2467,18 @@
       "inputProperties": {
         "passwordLength": {
           "type": "integer",
-          "description": "The length of the generated\npassword.\n",
           "willReplaceOnChanges": true
         },
         "passwordResetRequired": {
           "type": "boolean",
-          "description": "Whether the\nuser should be forced to reset the generated password on first login.\n",
           "willReplaceOnChanges": true
         },
         "pgpKey": {
           "type": "string",
-          "description": "Either a base-64 encoded PGP public key, or a\nkeybase username in the form `keybase:username`.\n",
           "willReplaceOnChanges": true
         },
         "user": {
           "type": "string",
-          "description": "The IAM user's name.\n",
           "willReplaceOnChanges": true
         }
       },
@@ -2775,34 +2489,28 @@
         "description": "Input properties used for looking up and filtering UserLoginProfile resources.\n",
         "properties": {
           "encryptedPassword": {
-            "type": "string",
-            "description": "The encrypted password, base64 encoded.\n"
+            "type": "string"
           },
           "keyFingerprint": {
-            "type": "string",
-            "description": "The fingerprint of the PGP key used to encrypt\nthe password\n"
+            "type": "string"
           },
           "password": {
             "type": "string"
           },
           "passwordLength": {
             "type": "integer",
-            "description": "The length of the generated\npassword.\n",
             "willReplaceOnChanges": true
           },
           "passwordResetRequired": {
             "type": "boolean",
-            "description": "Whether the\nuser should be forced to reset the generated password on first login.\n",
             "willReplaceOnChanges": true
           },
           "pgpKey": {
             "type": "string",
-            "description": "Either a base-64 encoded PGP public key, or a\nkeybase username in the form `keybase:username`.\n",
             "willReplaceOnChanges": true
           },
           "user": {
             "type": "string",
-            "description": "The IAM user's name.\n",
             "willReplaceOnChanges": true
           }
         },
@@ -2810,22 +2518,18 @@
       }
     },
     "aws:iam/userPolicy:UserPolicy": {
-      "description": "Provides an IAM policy attached to a user.\n\n## Example Usage\n\n```hcl\nresource \"aws_iam_user_policy\" \"lb_ro\" {\n  name = \"test\"\n  user = \"${aws_iam_user.lb.name}\"\n\n  policy = \u003c\u003cEOF\n{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"ec2:Describe*\"\n      ],\n      \"Effect\": \"Allow\",\n      \"Resource\": \"*\"\n    }\n  ]\n}\nEOF\n}\n\nresource \"aws_iam_user\" \"lb\" {\n  name = \"loadbalancer\"\n  path = \"/system/\"\n}\n\nresource \"aws_iam_access_key\" \"lb\" {\n  user = \"${aws_iam_user.lb.name}\"\n}\n```\n",
       "properties": {
         "name": {
           "type": "string"
         },
         "namePrefix": {
-          "type": "string",
-          "description": "Creates a unique name beginning with the specified prefix. Conflicts with `name`.\n"
+          "type": "string"
         },
         "policy": {
-          "type": "string",
-          "description": "The policy document. This is a JSON formatted string.\nThe heredoc syntax or `file` function is helpful here.\n"
+          "type": "string"
         },
         "user": {
-          "type": "string",
-          "description": "IAM user to which to attach this policy.\n"
+          "type": "string"
         }
       },
       "required": [
@@ -2840,7 +2544,6 @@
         },
         "namePrefix": {
           "type": "string",
-          "description": "Creates a unique name beginning with the specified prefix. Conflicts with `name`.\n",
           "willReplaceOnChanges": true
         },
         "policy": {
@@ -2853,12 +2556,10 @@
               "type": "string",
               "$ref": "#/types/aws:iam/documents:PolicyDocument"
             }
-          ],
-          "description": "The policy document. This is a JSON formatted string.\nThe heredoc syntax or `file` function is helpful here.\n"
+          ]
         },
         "user": {
           "type": "string",
-          "description": "IAM user to which to attach this policy.\n",
           "willReplaceOnChanges": true
         }
       },
@@ -2875,7 +2576,6 @@
           },
           "namePrefix": {
             "type": "string",
-            "description": "Creates a unique name beginning with the specified prefix. Conflicts with `name`.\n",
             "willReplaceOnChanges": true
           },
           "policy": {
@@ -2888,12 +2588,10 @@
                 "type": "string",
                 "$ref": "#/types/aws:iam/documents:PolicyDocument"
               }
-            ],
-            "description": "The policy document. This is a JSON formatted string.\nThe heredoc syntax or `file` function is helpful here.\n"
+            ]
           },
           "user": {
             "type": "string",
-            "description": "IAM user to which to attach this policy.\n",
             "willReplaceOnChanges": true
           }
         },
@@ -2901,16 +2599,13 @@
       }
     },
     "aws:iam/userPolicyAttachment:UserPolicyAttachment": {
-      "description": "Attaches a Managed IAM Policy to an IAM user\n\n```hcl\nresource \"aws_iam_user\" \"user\" {\n    name = \"test-user\"\n}\n\nresource \"aws_iam_policy\" \"policy\" {\n    name        = \"test-policy\"\n    description = \"A test policy\"\n    policy      = # omitted\n}\n\nresource \"aws_iam_user_policy_attachment\" \"test-attach\" {\n    user       = \"${aws_iam_user.user.name}\"\n    policy_arn = \"${aws_iam_policy.policy.arn}\"\n}\n```\n",
       "properties": {
         "policyArn": {
           "type": "string",
-          "$ref": "#/types/aws:index/aRN:ARN",
-          "description": "The ARN of the policy you want to apply\n"
+          "$ref": "#/types/aws:index/aRN:ARN"
         },
         "user": {
-          "type": "string",
-          "description": "The user the policy should be applied to\n"
+          "type": "string"
         }
       },
       "required": [
@@ -2921,7 +2616,6 @@
         "policyArn": {
           "type": "string",
           "$ref": "#/types/aws:index/aRN:ARN",
-          "description": "The ARN of the policy you want to apply\n",
           "willReplaceOnChanges": true
         },
         "user": {
@@ -2935,7 +2629,6 @@
               "$ref": "#/types/aws:iam/user:User"
             }
           ],
-          "description": "The user the policy should be applied to\n",
           "willReplaceOnChanges": true
         }
       },
@@ -2949,7 +2642,6 @@
           "policyArn": {
             "type": "string",
             "$ref": "#/types/aws:index/aRN:ARN",
-            "description": "The ARN of the policy you want to apply\n",
             "willReplaceOnChanges": true
           },
           "user": {
@@ -2963,7 +2655,6 @@
                 "$ref": "#/types/aws:iam/user:User"
               }
             ],
-            "description": "The user the policy should be applied to\n",
             "willReplaceOnChanges": true
           }
         },
@@ -3065,13 +2756,11 @@
   },
   "functions": {
     "aws:iam/getAccountAlias:getAccountAlias": {
-      "description": "## Example Usage\n\n```hcl\ndata \"aws_iam_account_alias\" \"current\" {}\n\noutput \"account_id\" {\n  value = \"${data.aws_iam_account_alias.current.account_alias}\"\n}\n```\n",
       "outputs": {
         "description": "A collection of values returned by getAccountAlias.\n",
         "properties": {
           "accountAlias": {
-            "type": "string",
-            "description": "The alias associated with the AWS account.\n"
+            "type": "string"
           },
           "id": {
             "type": "string",
@@ -3086,13 +2775,11 @@
       }
     },
     "aws:iam/getGroup:getGroup": {
-      "description": "This data source can be used to fetch information about a specific\nIAM group. By using this data source, you can reference IAM group\nproperties without having to hard code ARNs as input.\n\n## Example Usage\n\n```hcl\ndata \"aws_iam_group\" \"example\" {\n  group_name = \"an_example_group_name\"\n}\n```\n",
       "inputs": {
         "description": "A collection of arguments for invoking getGroup.\n",
         "properties": {
           "groupName": {
-            "type": "string",
-            "description": "The friendly IAM group name to match.\n"
+            "type": "string"
           }
         },
         "type": "object",
@@ -3104,12 +2791,10 @@
         "description": "A collection of values returned by getGroup.\n",
         "properties": {
           "arn": {
-            "type": "string",
-            "description": "The Amazon Resource Name (ARN) specifying the group.\n"
+            "type": "string"
           },
           "groupId": {
-            "type": "string",
-            "description": "The stable and unique string identifying the group.\n"
+            "type": "string"
           },
           "groupName": {
             "type": "string"
@@ -3119,8 +2804,7 @@
             "description": "The provider-assigned unique ID for this managed resource.\n"
           },
           "path": {
-            "type": "string",
-            "description": "The path to the role.\n"
+            "type": "string"
           },
           "users": {
             "type": "array",
@@ -3141,13 +2825,11 @@
       }
     },
     "aws:iam/getInstanceProfile:getInstanceProfile": {
-      "description": "This data source can be used to fetch information about a specific\nIAM instance profile. By using this data source, you can reference IAM \ninstance profile properties without having to hard code ARNs as input.\n\n## Example Usage\n\n```hcl\ndata \"aws_iam_instance_profile\" \"example\" {\n  name = \"an_example_instance_profile_name\"\n}\n```\n",
       "inputs": {
         "description": "A collection of arguments for invoking getInstanceProfile.\n",
         "properties": {
           "name": {
-            "type": "string",
-            "description": "The friendly IAM instance profile name to match.\n"
+            "type": "string"
           }
         },
         "type": "object",
@@ -3159,12 +2841,10 @@
         "description": "A collection of values returned by getInstanceProfile.\n",
         "properties": {
           "arn": {
-            "type": "string",
-            "description": "The Amazon Resource Name (ARN) specifying the instance profile.\n"
+            "type": "string"
           },
           "createDate": {
-            "type": "string",
-            "description": "The string representation of the date the instance profile\nwas created.\n"
+            "type": "string"
           },
           "id": {
             "type": "string",
@@ -3174,15 +2854,13 @@
             "type": "string"
           },
           "path": {
-            "type": "string",
-            "description": "The path to the instance profile.\n"
+            "type": "string"
           },
           "roleArn": {
             "type": "string"
           },
           "roleId": {
-            "type": "string",
-            "description": "The role id associated with this instance profile.\n"
+            "type": "string"
           },
           "roleName": {
             "type": "string"
@@ -3386,13 +3064,11 @@
       }
     },
     "aws:iam/getRole:getRole": {
-      "description": "This data source can be used to fetch information about a specific\nIAM role. By using this data source, you can reference IAM role\nproperties without having to hard code ARNs as input.\n\n## Example Usage\n\n```hcl\ndata \"aws_iam_role\" \"example\" {\n  name = \"an_example_role_name\"\n}\n```\n",
       "inputs": {
         "description": "A collection of arguments for invoking getRole.\n",
         "properties": {
           "name": {
-            "type": "string",
-            "description": "The friendly IAM role name to match.\n"
+            "type": "string"
           },
           "tags": {
             "type": "object",
@@ -3410,12 +3086,10 @@
         "description": "A collection of values returned by getRole.\n",
         "properties": {
           "arn": {
-            "type": "string",
-            "description": "The Amazon Resource Name (ARN) specifying the role.\n"
+            "type": "string"
           },
           "assumeRolePolicy": {
-            "type": "string",
-            "description": "The policy document associated with the role.\n"
+            "type": "string"
           },
           "createDate": {
             "type": "string"
@@ -3434,8 +3108,7 @@
             "type": "string"
           },
           "path": {
-            "type": "string",
-            "description": "The path to the role.\n"
+            "type": "string"
           },
           "permissionsBoundary": {
             "type": "string"
@@ -3447,8 +3120,7 @@
             }
           },
           "uniqueId": {
-            "type": "string",
-            "description": "The stable and unique string identifying the role.\n"
+            "type": "string"
           }
         },
         "type": "object",
@@ -3579,16 +3251,13 @@
         "description": "A collection of arguments for invoking getServerCertificate.\n",
         "properties": {
           "latest": {
-            "type": "boolean",
-            "description": "sort results by expiration date. returns the certificate with expiration date in furthest in the future.\n"
+            "type": "boolean"
           },
           "name": {
-            "type": "string",
-            "description": "exact name of the cert to lookup\n"
+            "type": "string"
           },
           "namePrefix": {
-            "type": "string",
-            "description": "prefix of cert to filter by\n"
+            "type": "string"
           },
           "pathPrefix": {
             "type": "string"
@@ -3912,7 +3581,6 @@
       }
     },
     "aws:index/getAvailabilityZone:getAvailabilityZone": {
-      "description": "`aws.getAvailabilityZone` provides details about a specific availability zone (AZ)\nin the current region.\n\nThis can be used both to validate an availability zone given in a variable\nand to split the AZ name into its component parts of an AWS region and an\nAZ identifier letter. The latter may be useful e.g. for implementing a\nconsistent subnet numbering scheme across several regions by mapping both\nthe region and the subnet letter to network numbers.\n\nThis is different from the `aws.getAvailabilityZones` (plural) data source,\nwhich provides a list of the available zones.\n\n## Example Usage\n\nThe following example shows how this data source might be used to derive\nVPC and subnet CIDR prefixes systematically for an availability zone.\n\n```hcl\nvariable \"region_number\" {\n  # Arbitrary mapping of region name to number to use in\n  # a VPC's CIDR prefix.\n  default = {\n    us-east-1      = 1\n    us-west-1      = 2\n    us-west-2      = 3\n    eu-central-1   = 4\n    ap-northeast-1 = 5\n  }\n}\n\nvariable \"az_number\" {\n  # Assign a number to each AZ letter used in our configuration\n  default = {\n    a = 1\n    b = 2\n    c = 3\n    d = 4\n    e = 5\n    f = 6\n  }\n}\n\n# Retrieve the AZ where we want to create network resources\n# This must be in the region selected on the AWS provider.\ndata \"aws_availability_zone\" \"example\" {\n  name = \"eu-central-1a\"\n}\n\n# Create a VPC for the region associated with the AZ\nresource \"aws_vpc\" \"example\" {\n  cidr_block = \"${cidrsubnet(\"10.0.0.0/8\", 4, var.region_number[data.aws_availability_zone.example.region])}\"\n}\n\n# Create a subnet for the AZ within the regional VPC\nresource \"aws_subnet\" \"example\" {\n  vpc_id     = \"${aws_vpc.example.id}\"\n  cidr_block = \"${cidrsubnet(aws_vpc.example.cidr_block, 4, var.az_number[data.aws_availability_zone.example.name_suffix])}\"\n}\n```\n",
       "inputs": {
         "description": "A collection of arguments for invoking getAvailabilityZone.\n",
         "properties": {
@@ -3926,12 +3594,10 @@
             }
           },
           "name": {
-            "type": "string",
-            "description": "The full name of the availability zone to select.\n"
+            "type": "string"
           },
           "state": {
-            "type": "string",
-            "description": "A specific availability zone state to require. May\nbe any of `\"available\"`, `\"information\"`, `\"impaired\"` or `\"available\"`.\n\nAll reasonable uses of this data source will specify `name`, since `state`\nalone would match a single AZ only in a region that itself has only one AZ.\n"
+            "type": "string"
           },
           "zoneId": {
             "type": "string"
@@ -3959,12 +3625,10 @@
             "description": "The provider-assigned unique ID for this managed resource.\n"
           },
           "name": {
-            "type": "string",
-            "description": "The name of the selected availability zone.\n"
+            "type": "string"
           },
           "nameSuffix": {
-            "type": "string",
-            "description": "The part of the AZ name that appears after the region name,\nuniquely identifying the AZ within its region.\n"
+            "type": "string"
           },
           "networkBorderGroup": {
             "type": "string"
@@ -3979,12 +3643,10 @@
             "type": "string"
           },
           "region": {
-            "type": "string",
-            "description": "The region where the selected availability zone resides.\nThis is always the region selected on the provider, since this data source\nsearches only within that region.\n"
+            "type": "string"
           },
           "state": {
-            "type": "string",
-            "description": "The current state of the AZ.\n"
+            "type": "string"
           },
           "zoneId": {
             "type": "string"
@@ -4011,7 +3673,6 @@
       }
     },
     "aws:index/getAvailabilityZones:getAvailabilityZones": {
-      "description": "The Availability Zones data source allows access to the list of AWS\nAvailability Zones which can be accessed by an AWS account within the region\nconfigured in the provider.\n\nThis is different from the `aws.getAvailabilityZone` (singular) data source,\nwhich provides some details about a specific availability zone.\n\n## Example Usage\n\n```hcl\n# Declare the data source\ndata \"aws_availability_zones\" \"available\" {}\n\n# e.g. Create subnets in the first two available availability zones\n\nresource \"aws_subnet\" \"primary\" {\n  availability_zone = \"${data.aws_availability_zones.available.names[0]}\"\n\n  # ...\n}\n\nresource \"aws_subnet\" \"secondary\" {\n  availability_zone = \"${data.aws_availability_zones.available.names[1]}\"\n\n  # ...\n}\n```\n",
       "inputs": {
         "description": "A collection of arguments for invoking getAvailabilityZones.\n",
         "properties": {
@@ -4037,8 +3698,7 @@
             }
           },
           "state": {
-            "type": "string",
-            "description": "Allows to filter list of Availability Zones based on their\ncurrent state. Can be either `\"available\"`, `\"information\"`, `\"impaired\"` or\n`\"unavailable\"`. By default the list includes a complete set of Availability Zones\nto which the underlying AWS account has access, regardless of their state.\n"
+            "type": "string"
           }
         },
         "type": "object"
@@ -4081,8 +3741,7 @@
             "type": "array",
             "items": {
               "type": "string"
-            },
-            "description": "A list of the Availability Zone names available to the account.\n"
+            }
           },
           "state": {
             "type": "string"
@@ -4104,13 +3763,11 @@
       }
     },
     "aws:index/getBillingServiceAccount:getBillingServiceAccount": {
-      "description": "Use this data source to get the Account ID of the [AWS Billing and Cost Management Service Account](http://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/billing-getting-started.html#step-2) for the purpose of whitelisting in S3 bucket policy.\n\n## Example Usage\n\n```hcl\ndata \"aws_billing_service_account\" \"main\" {}\n\nresource \"aws_s3_bucket\" \"billing_logs\" {\n  bucket = \"my-billing-tf-test-bucket\"\n  acl    = \"private\"\n\n  policy = \u003c\u003cPOLICY\n{\n  \"Id\": \"Policy\",\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": [\n        \"s3:GetBucketAcl\", \"s3:GetBucketPolicy\"\n      ],\n      \"Effect\": \"Allow\",\n      \"Resource\": \"arn:aws:s3:::my-billing-tf-test-bucket\",\n      \"Principal\": {\n        \"AWS\": [\n          \"${data.aws_billing_service_account.main.id}\"\n        ]\n      }\n    },\n    {\n      \"Action\": [\n        \"s3:PutObject\"\n      ],\n      \"Effect\": \"Allow\",\n      \"Resource\": \"arn:aws:s3:::my-billing-tf-test-bucket/AWSLogs/*\",\n      \"Principal\": {\n        \"AWS\": [\n          \"${data.aws_billing_service_account.main.id}\"\n        ]\n      }\n    }\n  ]\n}\nPOLICY\n}\n```\n",
       "outputs": {
         "description": "A collection of values returned by getBillingServiceAccount.\n",
         "properties": {
           "arn": {
-            "type": "string",
-            "description": "The ARN of the AWS billing service account.\n"
+            "type": "string"
           },
           "id": {
             "type": "string",
@@ -4125,25 +3782,21 @@
       }
     },
     "aws:index/getCallerIdentity:getCallerIdentity": {
-      "description": "## Example Usage\n\n```hcl\ndata \"aws_caller_identity\" \"current\" {}\n\noutput \"account_id\" {\n  value = \"${data.aws_caller_identity.current.account_id}\"\n}\n\noutput \"caller_arn\" {\n  value = \"${data.aws_caller_identity.current.arn}\"\n}\n\noutput \"caller_user\" {\n  value = \"${data.aws_caller_identity.current.user_id}\"\n}\n```\n",
       "outputs": {
         "description": "A collection of values returned by getCallerIdentity.\n",
         "properties": {
           "accountId": {
-            "type": "string",
-            "description": "The AWS Account ID number of the account that owns or contains the calling entity.\n"
+            "type": "string"
           },
           "arn": {
-            "type": "string",
-            "description": "The AWS ARN associated with the calling entity.\n"
+            "type": "string"
           },
           "id": {
             "type": "string",
             "description": "The provider-assigned unique ID for this managed resource.\n"
           },
           "userId": {
-            "type": "string",
-            "description": "The unique identifier of the calling entity.\n"
+            "type": "string"
           }
         },
         "type": "object",
@@ -4190,7 +3843,6 @@
       }
     },
     "aws:index/getIpRanges:getIpRanges": {
-      "description": "Use this data source to get the [IP ranges](http://docs.aws.amazon.com/general/latest/gr/aws-ip-ranges.html) of various AWS products and services.\n\n## Example Usage\n\n```hcl\ndata \"aws_ip_ranges\" \"european_ec2\" {\n  regions  = [\"eu-west-1\", \"eu-central-1\"]\n  services = [\"ec2\"]\n}\n\nresource \"aws_security_group\" \"from_europe\" {\n  name = \"from_europe\"\n\n  ingress {\n    from_port   = \"443\"\n    to_port     = \"443\"\n    protocol    = \"tcp\"\n    cidr_blocks = [\"${data.aws_ip_ranges.european_ec2.cidr_blocks}\"]\n  }\n\n  tags {\n    CreateDate = \"${data.aws_ip_ranges.european_ec2.create_date}\"\n    SyncToken  = \"${data.aws_ip_ranges.european_ec2.sync_token}\"\n  }\n}\n```\n",
       "inputs": {
         "description": "A collection of arguments for invoking getIpRanges.\n",
         "properties": {
@@ -4198,8 +3850,7 @@
             "type": "array",
             "items": {
               "type": "string"
-            },
-            "description": "Filter IP ranges by regions (or include all regions, if\nomitted). Valid items are `global` (for `cloudfront`) as well as all AWS regions\n(e.g. `eu-central-1`)\n"
+            }
           },
           "services": {
             "type": "array",
@@ -4223,12 +3874,10 @@
             "type": "array",
             "items": {
               "type": "string"
-            },
-            "description": "The lexically ordered list of CIDR blocks.\n"
+            }
           },
           "createDate": {
-            "type": "string",
-            "description": "The publication time of the IP ranges (e.g. `2016-08-03-23-46-05`).\n"
+            "type": "string"
           },
           "id": {
             "type": "string",
@@ -4253,8 +3902,7 @@
             }
           },
           "syncToken": {
-            "type": "integer",
-            "description": "The publication time of the IP ranges, in Unix epoch time format\n(e.g. `1470267965`).\n"
+            "type": "integer"
           },
           "url": {
             "type": "string"
@@ -4272,7 +3920,6 @@
       }
     },
     "aws:index/getPartition:getPartition": {
-      "description": "## Example Usage\n\n```hcl\ndata \"aws_partition\" \"current\" {}\n\ndata \"aws_iam_policy_document\" \"s3_policy\" {\n  statement {\n    sid = \"1\"\n\n    actions = [\n      \"s3:ListBucket\",\n    ]\n\n    resources = [\n      \"arn:${data.aws_partition.current.partition}:s3:::my-bucket\",\n    ]\n  }\n}\n```\n",
       "outputs": {
         "description": "A collection of values returned by getPartition.\n",
         "properties": {
@@ -4300,17 +3947,14 @@
       }
     },
     "aws:index/getRegion:getRegion": {
-      "description": "`aws.getRegion` provides details about a specific AWS region.\n\nAs well as validating a given region name (and optionally obtaining its\nendpoint) this resource can be used to discover the name of the region\nconfigured within the provider. The latter can be useful in a child module\nwhich is inheriting an AWS provider configuration from its parent module.\n\n## Example Usage\n\nThe following example shows how the resource might be used to obtain\nthe name of the AWS region configured on the provider.\n\n```hcl\ndata \"aws_region\" \"current\" {\n  current = true\n}\n```\n",
       "inputs": {
         "description": "A collection of arguments for invoking getRegion.\n",
         "properties": {
           "endpoint": {
-            "type": "string",
-            "description": "The endpoint of the region to select.\n\nAt least one of the above attributes should be provided to ensure that only\none region is matched.\n"
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "description": "The full name of the region to select.\n"
+            "type": "string"
           }
         },
         "type": "object"
@@ -4322,16 +3966,14 @@
             "type": "string"
           },
           "endpoint": {
-            "type": "string",
-            "description": "The endpoint for the selected region.\n"
+            "type": "string"
           },
           "id": {
             "type": "string",
             "description": "The provider-assigned unique ID for this managed resource.\n"
           },
           "name": {
-            "type": "string",
-            "description": "The name of the selected region.\n"
+            "type": "string"
           }
         },
         "type": "object",
@@ -4468,8 +4110,7 @@
             }
           },
           "policyId": {
-            "type": "string",
-            "description": "An ID for the policy document.\n"
+            "type": "string"
           },
           "sourceJson": {
             "type": "string",
@@ -4485,8 +4126,7 @@
             "type": "array",
             "items": {
               "$ref": "#/types/aws:x/iam/getPolicyDocumentStatement:getPolicyDocumentStatement"
-            },
-            "description": "A nested configuration block (described below)\nconfiguring one *statement* to be included in the policy document.\n\nEach document configuration must have one or more `statement` blocks, which\neach accept the following arguments:\n"
+            }
           },
           "version": {
             "type": "string"
@@ -4502,8 +4142,7 @@
             "description": "The provider-assigned unique ID for this managed resource.\n"
           },
           "json": {
-            "type": "string",
-            "description": "The above arguments serialized as a standard JSON policy document.\n"
+            "type": "string"
           },
           "overrideJson": {
             "type": "string",


### PR DESCRIPTION
For a given resource, the bridge:
1. Finds the file associated with the resource.
2. Parses the file into `entityDocs`

Currently, steps (1) and (2) are tied together in one function: `getDocsForResource`. This PR encapsulates (1) behind an interface (`DocsSource`) which is then passed to `getDocsForResource`. This makes testing much easier, and also simplifies our code.

---

The only user observable change in functionality is a much more obvious and useful error message when unable to find the upstream repository. The new warning looks like this:

```
warning: Unable to find the upstream provider's documentation:

The upstream repository is expected to be at "github.com/vancluever/terraform-provider-acme".

If the expected path is not correct, you should check the values of these fields (current values shown):

tfbridge.ProviderInfo{
        GitHubHost:              "github.com",
        GitHubOrg:               "vancluever",
        Name:                    "acme",
        TFProviderModuleVersion: "",
}

The original error is: error running 'go mod download -json github.com/vancluever/terraform-provider-acme' in "/Users/ianwahbe/go/src/github.com/pulumiverse/pulumi-acme/provider" dir for module: exit status 1

Output: {
        "Path": "github.com/vancluever/terraform-provider-acme",
        "Error": "module github.com/vancluever/terraform-provider-acme: not a known dependency"
}
```

Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/1365