### PR TITLE
Prevent panic on parseCheckError non-validation error

### DIFF
--- a/pkg/tfbridge/adapt_check_failures.go
+++ b/pkg/tfbridge/adapt_check_failures.go
@@ -77,8 +77,7 @@ func parseCheckError(
 		pp := NewCheckFailurePath(schemaMap, schemaInfos, name)
 		return &pp, MiscFailure, err.Error()
 	}
-	var d *diagnostics.ValidationError
-	if errors.As(err, &d) {
+	if d := (*diagnostics.ValidationError)(nil); errors.As(err, &d) {
 		failType := MiscFailure
 		if strings.Contains(d.Summary, "Invalid or unknown key") {
 			failType = InvalidKey

--- a/pkg/tfbridge/adapt_check_failures.go
+++ b/pkg/tfbridge/adapt_check_failures.go
@@ -91,7 +91,7 @@ func parseCheckError(
 		return pp, failType, s
 	}
 	// If there is no way to identify a propertyPath, still report a generic CheckFailure.
-	return nil, MiscFailure, d.Error()
+	return nil, MiscFailure, err.Error()
 }
 
 // Best effort path converter; may return nil.

--- a/pkg/tfbridge/adapt_check_failures_test.go
+++ b/pkg/tfbridge/adapt_check_failures_test.go
@@ -1,0 +1,36 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfbridge
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
+)
+
+func TestParseCheckErrorMiscFailure(t *testing.T) {
+	schemaMap := &schema.SchemaMap{}
+	schemaInfos := map[string]*SchemaInfo{}
+	err := errors.New("random unexpected error")
+
+	path, reason, errString := parseCheckError(schemaMap, schemaInfos, err)
+
+	assert.Nil(t, path)
+	assert.Equal(t, MiscFailure, reason)
+	assert.Equal(t, "random unexpected error", errString)
+}


### PR DESCRIPTION
Fix https://github.com/pulumi/pulumi-terraform-bridge/issues/1368 by not dereferencing `*diagnostics.ValidationError` when  `errors.As` failed.

I admit I haven't looked at the larger context of the problem, just hoping to avoid the panic in this specific case.
