### PR TITLE
Fix #1370 - do not promote warnings to check failures

### DIFF
--- a/pf/tfbridge/detect_check_failures.go
+++ b/pf/tfbridge/detect_check_failures.go
@@ -38,6 +38,12 @@ func (p *provider) detectCheckFailure(
 	schemaInfos map[string]*tfbridge.SchemaInfo,
 	diag *tfprotov6.Diagnostic,
 ) *plugin.CheckFailure {
+	// For anything less critical than Error, refuse to treat it as a CheckFailure. Doing so
+	// would cause Pulumi program to fail-fast on a warning.
+	if diag.Severity > tfprotov6.DiagnosticSeverityError {
+		return nil
+	}
+
 	if diag.Attribute == nil || len(diag.Attribute.Steps()) < 1 {
 		return nil
 	}

--- a/pf/tfbridge/detect_check_failures_test.go
+++ b/pf/tfbridge/detect_check_failures_test.go
@@ -1,0 +1,58 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfbridge
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
+func TestDetectCheckFailures(t *testing.T) {
+	ctx := context.Background()
+	p := &provider{}
+	urn := resource.NewURN("stack", "project", "", "typ", "name")
+
+	t.Run("ignores warnings", func(t *testing.T) {
+		cf := p.detectCheckFailure(ctx, urn, false, nil, nil, &tfprotov6.Diagnostic{
+			Severity:  tfprotov6.DiagnosticSeverityWarning,
+			Attribute: tftypes.NewAttributePath().WithAttributeName("a"),
+		})
+		assert.Nil(t, cf)
+	})
+
+	t.Run("propagates errors", func(t *testing.T) {
+		cf := p.detectCheckFailure(ctx, urn, false, nil, nil, &tfprotov6.Diagnostic{
+			Severity:  tfprotov6.DiagnosticSeverityError,
+			Attribute: tftypes.NewAttributePath().WithAttributeName("a"),
+			Summary:   "Bad things happening",
+		})
+		assert.NotNil(t, cf)
+		assert.Equal(t, "Bad things happening. Examine values at 'name.a'.", cf.Reason)
+	})
+
+	t.Run("ignores errors not specific to an attribute", func(t *testing.T) {
+		cf := p.detectCheckFailure(ctx, urn, false, nil, nil, &tfprotov6.Diagnostic{
+			Severity: tfprotov6.DiagnosticSeverityError,
+			Summary:  "Bad things happening",
+		})
+		assert.Nil(t, cf)
+	})
+}


### PR DESCRIPTION
Fixes #1370 

TF Warnings are no longer translated to Pulumi CheckFailures in Check so that the program does not fail-fast.

Curiously these warnings are then dropped. 