### PR TITLE
Fix #1381

### DIFF
--- a/pf/tests/provider_check_test.go
+++ b/pf/tests/provider_check_test.go
@@ -256,8 +256,9 @@ func TestCheck(t *testing.T) {
 				_ context.Context, config, meta resource.PropertyMap,
 			) (resource.PropertyMap, error) {
 				t.Logf("Meta: %#v", meta)
-				config["prop"] = meta["prop"]
-				return config, nil
+				result := config.Copy()
+				result["prop"] = meta["prop"]
+				return result, nil
 			},
 		},
 		{

--- a/pf/tfbridge/provider_check.go
+++ b/pf/tfbridge/provider_check.go
@@ -48,7 +48,8 @@ func (p *provider) CheckWithContext(
 
 	if info := rh.pulumiResourceInfo; info != nil {
 		if check := info.PreCheckCallback; check != nil {
-			checkedInputs, err := check(ctx, checkedInputs, p.lastKnownProviderConfig.Copy())
+			var err error
+			checkedInputs, err = check(ctx, checkedInputs, p.lastKnownProviderConfig.Copy())
 			if err != nil {
 				return checkedInputs, []plugin.CheckFailure{}, err
 			}


### PR DESCRIPTION
Fixes #1381  - with this change PreCheckCallback starts working the same way for Plugin Framework resources as normal resources, that is it can return a modify inputs map to be used in place of the original map. This arose in the context of investigating tags secrets leaks for pulumi-aws and in particular how tags/tagsAll behavior is different between normal and PF based resources in the currently released version.