### PR TITLE
Structured argument parsing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/spf13/afero v1.9.5
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.3
+	github.com/yuin/goldmark v1.4.13
 	github.com/zclconf/go-cty v1.13.2
 	golang.org/x/crypto v0.10.0
 	golang.org/x/mod v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -2376,6 +2376,7 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
+github.com/yuin/goldmark v1.4.13 h1:fVcFKWvrslecOb/tg+Cc05dkeYx540o0FuFt3nUVDoE=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43/go.mod h1:aX5oPXxHm3bOH+xeAttToC8pqch2ScQN/JoXYupl6xs=
 github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50/go.mod h1:NUSPSUX/bi6SeDMUh6brw0nXpxHnc96TguQh0+r/ssA=

--- a/pf/go.mod
+++ b/pf/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.3.5 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
+	github.com/yuin/goldmark v1.4.13 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20230706204954-ccb25ca9f130 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230706204954-ccb25ca9f130 // indirect
 )

--- a/pf/go.sum
+++ b/pf/go.sum
@@ -1852,6 +1852,7 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
+github.com/yuin/goldmark v1.4.13 h1:fVcFKWvrslecOb/tg+Cc05dkeYx540o0FuFt3nUVDoE=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43/go.mod h1:aX5oPXxHm3bOH+xeAttToC8pqch2ScQN/JoXYupl6xs=
 github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50/go.mod h1:NUSPSUX/bi6SeDMUh6brw0nXpxHnc96TguQh0+r/ssA=

--- a/pf/tests/go.mod
+++ b/pf/tests/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v5 v5.3.5 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
+	github.com/yuin/goldmark v1.4.13 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20230706204954-ccb25ca9f130 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230706204954-ccb25ca9f130 // indirect
 )

--- a/pf/tests/go.sum
+++ b/pf/tests/go.sum
@@ -2391,6 +2391,7 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
+github.com/yuin/goldmark v1.4.13 h1:fVcFKWvrslecOb/tg+Cc05dkeYx540o0FuFt3nUVDoE=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43/go.mod h1:aX5oPXxHm3bOH+xeAttToC8pqch2ScQN/JoXYupl6xs=
 github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50/go.mod h1:NUSPSUX/bi6SeDMUh6brw0nXpxHnc96TguQh0+r/ssA=

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -896,14 +896,8 @@ func parseArgReferenceSection(subsection []string, ret *entityDocs) {
 		name     string
 		listItem bool
 	}
-	var current []*namedNode
-	var latest []*namedNode
-	setLatest := func() {
-		latest = current[:0] // Zero out latest without re-allocation
-		for _, n := range current {
-			latest = append(latest, n)
-		}
-	}
+	var current, latest []*namedNode
+	setLatest := func() { latest = append(latest[:0], current...) }
 	keyOf := func(path []*namedNode) docsPath {
 		if len(path) == 0 {
 			return ""
@@ -995,14 +989,15 @@ func parseArgReferenceSection(subsection []string, ret *entityDocs) {
 			return ast.WalkContinue
 		}
 
-		var key docsPath
+		var stack []*namedNode
 		if len(latest) > len(current) {
-			key = keyOf(latest)
+			stack = latest
 		} else {
-			key = keyOf(current)
+			stack = current
 		}
 
-		if key == "" {
+		key := keyOf(stack)
+		if key == "" || !stack[len(stack)-1].listItem {
 			return ast.WalkContinue
 		}
 

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -894,10 +894,26 @@ func parseArgReferenceSection(subsection []string, ret *entityDocs) {
 	type namedNode struct {
 		node     ast.Node
 		name     string
-		writable bool
+		listItem bool
 	}
-	var parent, child, latest, latestParent *namedNode
-	setLatest := func() { latest, latestParent = child, parent }
+	var current []*namedNode
+	var latest []*namedNode
+	setLatest := func() {
+		latest = current[:0] // Zero out latest without re-allocation
+		for _, n := range current {
+			latest = append(latest, n)
+		}
+	}
+	keyOf := func(path []*namedNode) docsPath {
+		if len(path) == 0 {
+			return ""
+		}
+		key := docsPath(path[0].name)
+		for _, n := range path[1:] {
+			key = key.join(n.name)
+		}
+		return key
+	}
 
 	skipPrint := map[ast.Node]bool{}
 
@@ -918,16 +934,9 @@ func parseArgReferenceSection(subsection []string, ret *entityDocs) {
 			unbaked = map[docsPath]struct{}{}
 		case ast.KindListItem:
 			// We have entered a new item
-			if name := nodeItemName(src, node); name != "" && child == nil {
-				var key docsPath
-				if parent == nil {
-					child = nil
-					parent = &namedNode{node, name, true}
-					key = docsPath(name)
-				} else {
-					child = &namedNode{node, name, true}
-					key = docsPath(parent.name).join(name)
-				}
+			if name := nodeItemName(src, node); name != "" {
+				current = append(current, &namedNode{node, name, true})
+				key := keyOf(current)
 				setLatest()
 
 				_, isBaked := baked[key]
@@ -939,8 +948,8 @@ func parseArgReferenceSection(subsection []string, ret *entityDocs) {
 		case ast.KindHeading:
 			target := isHeadingTarget(src, node.(*ast.Heading))
 			if target != "" {
-				child = &namedNode{node, target, true}
-				parent = child
+				current = append(current[:0], &namedNode{node, target, false})
+				skipPrint[node] = true
 				setLatest()
 				return ast.WalkSkipChildren
 			}
@@ -958,17 +967,18 @@ func parseArgReferenceSection(subsection []string, ret *entityDocs) {
 					// Setting both child an parent effectively sets
 					// this until the list ends (and we reset).
 					p := node.Parent()
-					child = &namedNode{p, target, false}
-					parent = child
+					current = append(current[:0], &namedNode{p, target, false})
+					skipPrint[node.Parent()] = true
 					setLatest()
 					return ast.WalkSkipChildren
 				}
 			}
 		case ast.KindText:
 			if genericNestedRegexp.Match(node.Text(src)) {
-				if latestParent != nil {
-					latestParent.writable = false
-					parent = latestParent
+				if len(latest) > 0 {
+					parent := *latest[0]
+					parent.listItem = false
+					current = append(latest[:0], &parent)
 				}
 				skipPrint[node.Parent()] = true
 				return ast.WalkSkipChildren
@@ -986,22 +996,10 @@ func parseArgReferenceSection(subsection []string, ret *entityDocs) {
 		}
 
 		var key docsPath
-		if child != nil && parent != child {
-			if child.writable {
-				key = docsPath(parent.name).join(child.name)
-			}
-		} else if latest != nil && parent == nil {
-			if latest.writable {
-				key = docsPath(latestParent.name).join(latest.name)
-			}
-		} else if parent != nil {
-			if parent.writable {
-				key = docsPath(parent.name)
-			}
-		} else if latestParent != nil {
-			if latestParent.writable {
-				key = docsPath(latestParent.name)
-			}
+		if len(latest) > len(current) {
+			key = keyOf(latest)
+		} else {
+			key = keyOf(current)
 		}
 
 		if key == "" {
@@ -1028,25 +1026,21 @@ func parseArgReferenceSection(subsection []string, ret *entityDocs) {
 		if node.Kind() == ast.KindList {
 			// When we exit a list, clear our current state
 			if !entering {
-				parent = nil
-				child = nil
+				current = current[:0]
 			}
 			return ast.WalkContinue, nil
 		}
 
 		defer func() {
-			if child != nil && child.node == node {
-				child = nil
-			} else if parent != nil && parent.node == node {
-				parent = nil
+			if l := len(current); l > 0 && current[l-1].node == node && current[l-1].listItem {
+				current = current[:l-1]
 			}
 		}()
 
 		// Write the state on exit:
 
 		// There are several early exit conditions:
-		if (latest == nil && latestParent == nil) || // Don't have a node to write to
-			node == latestParent.node && latestParent == child ||
+		if len(latest) == 0 || // Don't have a node to write to
 			skipPrint[node] { // Is a marker node
 			return ast.WalkContinue, nil
 		}

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -30,6 +30,9 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/text"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
@@ -233,12 +236,11 @@ func TestArgumentRegex(t *testing.T) {
 				"action": {
 					description: "The action that CloudFront or AWS WAF takes when a web request matches the conditions in the rule. Not used if `type` is `GROUP`.",
 				},
+				"action.type": {description: "valid values are: `BLOCK`, `ALLOW`, or `COUNT`"},
 				"override_action": {
 					description: "Override the action that a group requests CloudFront or AWS WAF takes when a web request matches the conditions in the rule. Only used if `type` is `GROUP`.",
 				},
-				"type": {
-					description: "valid values are: `BLOCK`, `ALLOW`, or `COUNT`",
-				},
+				"override_action.type": {description: "valid values are: `BLOCK`, `ALLOW`, or `COUNT`"},
 			},
 		},
 		{
@@ -310,7 +312,7 @@ func TestArgumentRegex(t *testing.T) {
 					description: "Indicates how to allocate the target capacity across\nthe Spot pools specified by the Spot fleet request. The default is\n`lowestPrice`.",
 				},
 				"instance_pools_to_use_count": {
-					description: "\nThe number of Spot pools across which to allocate your target Spot capacity.\nValid only when `allocation_strategy` is set to `lowestPrice`. Spot Fleet selects\nthe cheapest Spot pools and evenly allocates your target Spot capacity across\nthe number of Spot pools that you specify.",
+					description: "The number of Spot pools across which to allocate your target Spot capacity.\nValid only when `allocation_strategy` is set to `lowestPrice`. Spot Fleet selects\nthe cheapest Spot pools and evenly allocates your target Spot capacity across\nthe number of Spot pools that you specify.",
 				},
 			},
 		},
@@ -331,9 +333,9 @@ func TestArgumentRegex(t *testing.T) {
 				"zone_id": {description: "The DNS zone ID to which the page rule should be added."},
 				"target":  {description: "The URL pattern to target with the page rule."},
 				"actions": {description: "The actions taken by the page rule, options given below."},
-				// Note: We parse this as an argument, but it is then discarded when assembling *argumetDocs
-				// because it doesn't correspond to a top level resource property.
-				"always_use_https": {description: "Boolean of whether this action is enabled. Default: false."},
+				"actions.always_use_https": {
+					description: "Boolean of whether this action is enabled. Default: false.",
+				},
 			},
 		},
 	}
@@ -713,27 +715,34 @@ func TestParseAttributesReferenceSection(t *testing.T) {
 }
 
 func TestGetNestedBlockName(t *testing.T) {
-	var tests = []struct {
-		input, expected string
-	}{
+	var tests = []struct{ input, expected string }{
 		{"", ""},
 		{"The `website` object supports the following:", "website"},
 		{"The optional `settings.location_preference` subblock supports:", "location_preference"},
 		{"The optional `settings.ip_configuration.authorized_networks[]` sublist supports:", "authorized_networks"},
+		// This is a common starting line of base arguments, so should result in zero value:
+		{"The following arguments are supported:", ""},
+		{"* `kms_key_id` - ...", ""},
+		{"## Import", ""},
+
+		// Heading arguments
 		{"#### result_configuration Argument Reference", "result_configuration"},
 		{"### advanced_security_options", "advanced_security_options"},
 		{"### `server_side_encryption`", "server_side_encryption"},
 		{"### Failover Routing Policy", "failover_routing_policy"},
 		{"##### `log_configuration`", "log_configuration"},
 		{"### data_format_conversion_configuration", "data_format_conversion_configuration"},
-		// This is a common starting line of base arguments, so should result in zero value:
-		{"The following arguments are supported:", ""},
-		{"* `kms_key_id` - ...", ""},
-		{"## Import", ""},
 	}
 
 	for _, tt := range tests {
-		assert.Equal(t, tt.expected, getNestedBlockName(tt.input))
+		if strings.HasPrefix(tt.input, "#") {
+			src := []byte(tt.input)
+			parsed := goldmark.New().Parser().Parse(
+				text.NewReader(src))
+			assert.Equal(t, tt.expected, isHeadingTarget(src, parsed.FirstChild().(*ast.Heading)))
+		} else {
+			assert.Equal(t, tt.expected, getNestedBlockName([]byte(tt.input)))
+		}
 	}
 }
 

--- a/pkg/tfgen/test_data/resources/bigtable_instance/docs.json
+++ b/pkg/tfgen/test_data/resources/bigtable_instance/docs.json
@@ -1,0 +1,48 @@
+{
+  "Description": "## +---\n\nsubcategory: \"Cloud Bigtable\"\ndescription: |-\n  Creates a Google Bigtable instance.\n---\n\n# google_bigtable_instance\n\nCreates a Google Bigtable instance. For more information see:\n\n* [API documentation](https://cloud.google.com/bigtable/docs/reference/admin/rest/v2/projects.instances.clusters)\n* How-to Guides\n    * [Official Documentation](https://cloud.google.com/bigtable/docs)\n\n## Example Usage\n\n### Simple Instance\n\n```hcl\nresource \"google_bigtable_instance\" \"production-instance\" {\n  name = \"tf-instance\"\n\n  cluster {\n    cluster_id   = \"tf-instance-cluster\"\n    num_nodes    = 1\n    storage_type = \"HDD\"\n  }\n\n  labels = {\n    my-label = \"prod-label\"\n  }\n}\n```\n\n### Replicated Instance\n\n```hcl\nresource \"google_bigtable_instance\" \"production-instance\" {\n  name = \"tf-instance\"\n\n  # A cluster with fixed number of nodes.\n  cluster {\n    cluster_id   = \"tf-instance-cluster1\"\n    num_nodes    = 1\n    storage_type = \"HDD\"\n    zone    = \"us-central1-c\"\n  }\n\n  # a cluster with auto scaling.\n  cluster {\n    cluster_id   = \"tf-instance-cluster2\"\n    storage_type = \"HDD\"\n    zone    = \"us-central1-b\"\n    autoscaling_config {\n      min_nodes = 1\n      max_nodes = 3\n      cpu_target = 50\n    }\n  }\n\n  labels = {\n    my-label = \"prod-label\"\n  }\n}\n```",
+  "Arguments": {
+    "cluster": {
+      "description": "A block of cluster configuration options. This can be specified at least once, and up \nto as many as possible within 8 cloud regions. Removing the field entirely from the config will cause the provider\nto default to the backend value. See structure below."
+    },
+    "cluster.autoscaling_config": {
+      "description": "[Autoscaling](https://cloud.google.com/bigtable/docs/autoscaling#parameters) config for the cluster, contains the following arguments:\n\n`min_nodes` - (Required) The minimum number of nodes for autoscaling.\n\n`max_nodes` - (Required) The maximum number of nodes for autoscaling.\n\n`cpu_target` - (Required) The target CPU utilization for autoscaling, in percentage. Must be between 10 and 80.\n\n`storage_target` - The target storage utilization for autoscaling, in GB, for each node in a cluster. This number is limited between 2560 (2.5TiB) and 5120 (5TiB) for a SSD cluster and between 8192 (8TiB) and 16384 (16 TiB) for an HDD cluster. If not set, whatever is already set for the cluster will not change, or if the cluster is just being created, it will use the default value of 2560 for SSD clusters and 8192 for HDD clusters.\n\n!\u003e **Warning**: Only one of `autoscaling_config` or `num_nodes` should be set for a cluster. If both are set, `num_nodes` is ignored. If none is set, autoscaling will be disabled and sized to the current node count."
+    },
+    "cluster.cluster_id": {
+      "description": "The ID of the Cloud Bigtable cluster. Must be 6-30 characters and must only contain hyphens, lowercase letters and numbers."
+    },
+    "cluster.num_nodes": {
+      "description": "The number of nodes in the cluster.\nIf no value is set, Cloud Bigtable automatically allocates nodes based on your data footprint and optimized for 50% storage utilization."
+    },
+    "cluster.zone": {
+      "description": "The zone to create the Cloud Bigtable cluster in. If it not\nspecified, the provider zone is used. Each cluster must have a different zone in the same region. Zones that support\nBigtable instances are noted on the [Cloud Bigtable locations page](https://cloud.google.com/bigtable/docs/locations)."
+    },
+    "deletion_protection": {
+      "description": "Whether or not to allow this provider to destroy the instance. Unless this field is set to false\nin the statefile, a `pulumi destroy` or `pulumi up` that would delete the instance will fail."
+    },
+    "display_name": {
+      "description": "The human-readable display name of the Bigtable instance. Defaults to the instance `name`."
+    },
+    "instance_type": {
+      "description": "The instance type to create. One of `\"DEVELOPMENT\"` or `\"PRODUCTION\"`. Defaults to `\"PRODUCTION\"`.\nIt is recommended to leave this field unspecified since the distinction between `\"DEVELOPMENT\"` and `\"PRODUCTION\"` instances is going away,\nand all instances will become `\"PRODUCTION\"` instances. This means that new and existing `\"DEVELOPMENT\"` instances will be converted to\n`\"PRODUCTION\"` instances. It is recommended for users to use `\"PRODUCTION\"` instances in any case, since a 1-node `\"PRODUCTION\"` instance\nis functionally identical to a `\"DEVELOPMENT\"` instance, but without the accompanying restrictions."
+    },
+    "kms_key_name": {
+      "description": "Describes the Cloud KMS encryption key that will be used to protect the destination Bigtable cluster. The requirements for this key are: 1) The Cloud Bigtable service account associated with the project that contains this cluster must be granted the `cloudkms.cryptoKeyEncrypterDecrypter` role on the CMEK key. 2) Only regional keys can be used and the region of the CMEK key must match the region of the cluster.\n\n\u003e **Note**: Removing the field entirely from the config will cause the provider to default to the backend value.\n\n!\u003e **Warning**: Modifying this field will cause the provider to delete/recreate the entire resource.\n\n!\u003e **Warning:** Modifying the `storage_type`, `zone` or `kms_key_name` of an existing cluster (by\n`cluster_id`) will cause the provider to delete/recreate the entire\n`google_bigtable_instance` resource. If these values are changing, use a new\n`cluster_id`."
+    },
+    "labels": {
+      "description": "A set of key/value label pairs to assign to the resource. Label keys must follow the requirements at https://cloud.google.com/resource-manager/docs/creating-managing-labels#requirements."
+    },
+    "name": {
+      "description": "The name (also called Instance Id in the Cloud Console) of the Cloud Bigtable instance. Must be 6-33 characters and must only contain hyphens, lowercase letters and numbers."
+    },
+    "project": {
+      "description": "The ID of the project in which the resource belongs. If it\nis not provided, the provider project is used."
+    },
+    "storage_type": {
+      "description": "The storage type to use. One of `\"SSD\"` or\n`\"HDD\"`. Defaults to `\"SSD\"`."
+    }
+  },
+  "Attributes": {
+    "id": "an identifier for the resource with format `projects/{{project}}/instances/{{name}}`"
+  },
+  "Import": "## Import\n\nBigtable Instances can be imported using any of these accepted formats: \u003cbreak\u003e\u003cbreak\u003e```sh\u003cbreak\u003e $ pulumi import MISSING_TOK default projects/{{project}}/instances/{{name}} \u003cbreak\u003e```\u003cbreak\u003e\u003cbreak\u003e \u003cbreak\u003e\u003cbreak\u003e```sh\u003cbreak\u003e $ pulumi import MISSING_TOK default {{project}}/{{name}} \u003cbreak\u003e```\u003cbreak\u003e\u003cbreak\u003e \u003cbreak\u003e\u003cbreak\u003e```sh\u003cbreak\u003e $ pulumi import MISSING_TOK default {{name}} \u003cbreak\u003e```\u003cbreak\u003e\u003cbreak\u003e"
+}

--- a/pkg/tfgen/test_data/resources/bigtable_instance/docs.json
+++ b/pkg/tfgen/test_data/resources/bigtable_instance/docs.json
@@ -5,7 +5,19 @@
       "description": "A block of cluster configuration options. This can be specified at least once, and up \nto as many as possible within 8 cloud regions. Removing the field entirely from the config will cause the provider\nto default to the backend value. See structure below."
     },
     "cluster.autoscaling_config": {
-      "description": "[Autoscaling](https://cloud.google.com/bigtable/docs/autoscaling#parameters) config for the cluster, contains the following arguments:\n\n`min_nodes` - (Required) The minimum number of nodes for autoscaling.\n\n`max_nodes` - (Required) The maximum number of nodes for autoscaling.\n\n`cpu_target` - (Required) The target CPU utilization for autoscaling, in percentage. Must be between 10 and 80.\n\n`storage_target` - The target storage utilization for autoscaling, in GB, for each node in a cluster. This number is limited between 2560 (2.5TiB) and 5120 (5TiB) for a SSD cluster and between 8192 (8TiB) and 16384 (16 TiB) for an HDD cluster. If not set, whatever is already set for the cluster will not change, or if the cluster is just being created, it will use the default value of 2560 for SSD clusters and 8192 for HDD clusters.\n\n!\u003e **Warning**: Only one of `autoscaling_config` or `num_nodes` should be set for a cluster. If both are set, `num_nodes` is ignored. If none is set, autoscaling will be disabled and sized to the current node count."
+      "description": "[Autoscaling](https://cloud.google.com/bigtable/docs/autoscaling#parameters) config for the cluster, contains the following arguments:"
+    },
+    "cluster.autoscaling_config.cpu_target": {
+      "description": "The target CPU utilization for autoscaling, in percentage. Must be between 10 and 80."
+    },
+    "cluster.autoscaling_config.max_nodes": {
+      "description": "The maximum number of nodes for autoscaling."
+    },
+    "cluster.autoscaling_config.min_nodes": {
+      "description": "The minimum number of nodes for autoscaling."
+    },
+    "cluster.autoscaling_config.storage_target": {
+      "description": "The target storage utilization for autoscaling, in GB, for each node in a cluster. This number is limited between 2560 (2.5TiB) and 5120 (5TiB) for a SSD cluster and between 8192 (8TiB) and 16384 (16 TiB) for an HDD cluster. If not set, whatever is already set for the cluster will not change, or if the cluster is just being created, it will use the default value of 2560 for SSD clusters and 8192 for HDD clusters.\n\n!\u003e **Warning**: Only one of `autoscaling_config` or `num_nodes` should be set for a cluster. If both are set, `num_nodes` is ignored. If none is set, autoscaling will be disabled and sized to the current node count."
     },
     "cluster.cluster_id": {
       "description": "The ID of the Cloud Bigtable cluster. Must be 6-30 characters and must only contain hyphens, lowercase letters and numbers."

--- a/pkg/tfgen/test_data/resources/bigtable_instance/upstream.md
+++ b/pkg/tfgen/test_data/resources/bigtable_instance/upstream.md
@@ -1,0 +1,156 @@
++---
+subcategory: "Cloud Bigtable"
+description: |-
+  Creates a Google Bigtable instance.
+---
+
+# google_bigtable_instance
+
+Creates a Google Bigtable instance. For more information see:
+
+* [API documentation](https://cloud.google.com/bigtable/docs/reference/admin/rest/v2/projects.instances.clusters)
+* How-to Guides
+    * [Official Documentation](https://cloud.google.com/bigtable/docs)
+
+## Example Usage - Simple Instance
+
+```hcl
+resource "google_bigtable_instance" "production-instance" {
+  name = "tf-instance"
+
+  cluster {
+    cluster_id   = "tf-instance-cluster"
+    num_nodes    = 1
+    storage_type = "HDD"
+  }
+
+  labels = {
+    my-label = "prod-label"
+  }
+}
+```
+
+## Example Usage - Replicated Instance
+
+```hcl
+resource "google_bigtable_instance" "production-instance" {
+  name = "tf-instance"
+
+  # A cluster with fixed number of nodes.
+  cluster {
+    cluster_id   = "tf-instance-cluster1"
+    num_nodes    = 1
+    storage_type = "HDD"
+    zone    = "us-central1-c"
+  }
+
+  # a cluster with auto scaling.
+  cluster {
+    cluster_id   = "tf-instance-cluster2"
+    storage_type = "HDD"
+    zone    = "us-central1-b"
+    autoscaling_config {
+      min_nodes = 1
+      max_nodes = 3
+      cpu_target = 50
+    }
+  }
+
+  labels = {
+    my-label = "prod-label"
+  }
+}
+```
+
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name (also called Instance Id in the Cloud Console) of the Cloud Bigtable instance. Must be 6-33 characters and must only contain hyphens, lowercase letters and numbers.
+
+* `cluster` - (Required) A block of cluster configuration options. This can be specified at least once, and up 
+to as many as possible within 8 cloud regions. Removing the field entirely from the config will cause the provider
+to default to the backend value. See [structure below](#nested_cluster).
+
+-----
+
+* `project` - (Optional) The ID of the project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
+* `instance_type` - (Optional, Deprecated) The instance type to create. One of `"DEVELOPMENT"` or `"PRODUCTION"`. Defaults to `"PRODUCTION"`.
+    It is recommended to leave this field unspecified since the distinction between `"DEVELOPMENT"` and `"PRODUCTION"` instances is going away,
+    and all instances will become `"PRODUCTION"` instances. This means that new and existing `"DEVELOPMENT"` instances will be converted to
+    `"PRODUCTION"` instances. It is recommended for users to use `"PRODUCTION"` instances in any case, since a 1-node `"PRODUCTION"` instance
+    is functionally identical to a `"DEVELOPMENT"` instance, but without the accompanying restrictions.
+
+* `display_name` - (Optional) The human-readable display name of the Bigtable instance. Defaults to the instance `name`.
+
+* `deletion_protection` - (Optional) Whether or not to allow this provider to destroy the instance. Unless this field is set to false
+in the statefile, a `pulumi destroy` or `pulumi up` that would delete the instance will fail.
+
+* `labels` - (Optional) A set of key/value label pairs to assign to the resource. Label keys must follow the requirements at https://cloud.google.com/resource-manager/docs/creating-managing-labels#requirements.
+
+
+-----
+
+<a name="nested_cluster"></a>The `cluster` block supports the following arguments:
+
+* `cluster_id` - (Required) The ID of the Cloud Bigtable cluster. Must be 6-30 characters and must only contain hyphens, lowercase letters and numbers.
+
+* `zone` - (Optional) The zone to create the Cloud Bigtable cluster in. If it not
+specified, the provider zone is used. Each cluster must have a different zone in the same region. Zones that support
+Bigtable instances are noted on the [Cloud Bigtable locations page](https://cloud.google.com/bigtable/docs/locations).
+
+* `num_nodes` - (Optional) The number of nodes in the cluster.
+If no value is set, Cloud Bigtable automatically allocates nodes based on your data footprint and optimized for 50% storage utilization.
+
+* `autoscaling_config` - (Optional) [Autoscaling](https://cloud.google.com/bigtable/docs/autoscaling#parameters) config for the cluster, contains the following arguments:
+
+  * `min_nodes` - (Required) The minimum number of nodes for autoscaling.
+  * `max_nodes` - (Required) The maximum number of nodes for autoscaling.
+  * `cpu_target` - (Required) The target CPU utilization for autoscaling, in percentage. Must be between 10 and 80.
+  * `storage_target` - The target storage utilization for autoscaling, in GB, for each node in a cluster. This number is limited between 2560 (2.5TiB) and 5120 (5TiB) for a SSD cluster and between 8192 (8TiB) and 16384 (16 TiB) for an HDD cluster. If not set, whatever is already set for the cluster will not change, or if the cluster is just being created, it will use the default value of 2560 for SSD clusters and 8192 for HDD clusters.
+
+!> **Warning**: Only one of `autoscaling_config` or `num_nodes` should be set for a cluster. If both are set, `num_nodes` is ignored. If none is set, autoscaling will be disabled and sized to the current node count.
+
+* `storage_type` - (Optional) The storage type to use. One of `"SSD"` or
+`"HDD"`. Defaults to `"SSD"`.
+
+* `kms_key_name` - (Optional) Describes the Cloud KMS encryption key that will be used to protect the destination Bigtable cluster. The requirements for this key are: 1) The Cloud Bigtable service account associated with the project that contains this cluster must be granted the `cloudkms.cryptoKeyEncrypterDecrypter` role on the CMEK key. 2) Only regional keys can be used and the region of the CMEK key must match the region of the cluster.
+
+-> **Note**: Removing the field entirely from the config will cause the provider to default to the backend value.
+
+!> **Warning**: Modifying this field will cause the provider to delete/recreate the entire resource.
+
+!> **Warning:** Modifying the `storage_type`, `zone` or `kms_key_name` of an existing cluster (by
+`cluster_id`) will cause the provider to delete/recreate the entire
+`google_bigtable_instance` resource. If these values are changing, use a new
+`cluster_id`.
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are exported:
+
+* `id` - an identifier for the resource with format `projects/{{project}}/instances/{{name}}`
+
+## Timeouts
+
+This resource provides the following
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options:
+
+- `create` - Default is 60 minutes.
+- `update` - Default is 60 minutes.
+- `read` - Default is 60 minutes.
+
+Adding clusters to existing instances can take a long time. Consider setting a higher value to timeouts if you plan on doing that.
+
+## Import
+
+Bigtable Instances can be imported using any of these accepted formats:
+
+```
+$ terraform import google_bigtable_instance.default projects/{{project}}/instances/{{name}}
+$ terraform import google_bigtable_instance.default {{project}}/{{name}}
+$ terraform import google_bigtable_instance.default {{name}}
+```

--- a/pkg/tfgen/test_data/resources/lb_listener_rule/docs.json
+++ b/pkg/tfgen/test_data/resources/lb_listener_rule/docs.json
@@ -89,7 +89,7 @@
       "description": "The value of query parameter"
     },
     "condition": {
-      "description": "A Condition block. Multiple condition blocks of different types can be set and all must be satisfied for the rule to match. Condition blocks are documented below.\n\nOne or more condition blocks can be set per rule. Most condition types can only be specified once per rule except for `http-header` and `query-string` which can be specified multiple times."
+      "description": "A Condition block. Multiple condition blocks of different types can be set and all must be satisfied for the rule to match. Condition blocks are documented below."
     },
     "condition.host_header": {
       "description": "Contains a single `values` item which is a list of host header patterns to match. The maximum size of each pattern is 128 characters. Comparison is case insensitive. Wildcard characters supported: * (matches 0 or more characters) and ? (matches exactly 1 character). Only one pattern needs to match for the condition to be satisfied."

--- a/pkg/tfgen/test_data/resources/lb_listener_rule/docs.json
+++ b/pkg/tfgen/test_data/resources/lb_listener_rule/docs.json
@@ -89,7 +89,7 @@
       "description": "The value of query parameter"
     },
     "condition": {
-      "description": "A Condition block. Multiple condition blocks of different types can be set and all must be satisfied for the rule to match. Condition blocks are documented below."
+      "description": "A Condition block. Multiple condition blocks of different types can be set and all must be satisfied for the rule to match. Condition blocks are documented below.\n\nOne or more condition blocks can be set per rule. Most condition types can only be specified once per rule except for `http-header` and `query-string` which can be specified multiple times."
     },
     "condition.host_header": {
       "description": "Contains a single `values` item which is a list of host header patterns to match. The maximum size of each pattern is 128 characters. Comparison is case insensitive. Wildcard characters supported: * (matches 0 or more characters) and ? (matches exactly 1 character). Only one pattern needs to match for the condition to be satisfied."
@@ -143,7 +143,7 @@
       "description": "Query string value pattern to match."
     },
     "query_string.values": {
-      "description": "Query string pairs or values to match. Query String Value blocks documented below. Multiple `values` blocks can be specified, see example above. Maximum size of each string is 128 characters. Comparison is case insensitive. Wildcard characters supported: * (matches 0 or more characters) and ? (matches exactly 1 character). To search for a literal '\\*' or '?' character in a query string, escape the character with a backslash (\\\\). Only one pair needs to match for the condition to be satisfied.\n\nQuery String Value Blocks (for `query_string.values`) support the following:"
+      "description": "Query string pairs or values to match. Query String Value blocks documented below. Multiple `values` blocks can be specified, see example above. Maximum size of each string is 128 characters. Comparison is case insensitive. Wildcard characters supported: * (matches 0 or more characters) and ? (matches exactly 1 character). To search for a literal '\\*' or '?' character in a query string, escape the character with a backslash (\\\\). Only one pair needs to match for the condition to be satisfied."
     },
     "redirect.host": {
       "description": "The hostname. This component is not percent-encoded. The hostname can contain `#{host}`. Defaults to `#{host}`."

--- a/pkg/tfgen/test_data/resources/lb_listener_rule/docs.json
+++ b/pkg/tfgen/test_data/resources/lb_listener_rule/docs.json
@@ -1,0 +1,188 @@
+{
+  "Description": "Provides a Load Balancer Listener Rule resource.\n\n\u003e **Note:** `aws_alb_listener_rule` is known as `aws_lb_listener_rule`. The functionality is identical.\n\n## Example Usage\n\n```terraform\nresource \"aws_lb\" \"front_end\" {\n  # ...\n}\n\nresource \"aws_lb_listener\" \"front_end\" {\n  # Other parameters\n}\n\nresource \"aws_lb_listener_rule\" \"static\" {\n  listener_arn = aws_lb_listener.front_end.arn\n  priority     = 100\n\n  action {\n    type             = \"forward\"\n    target_group_arn = aws_lb_target_group.static.arn\n  }\n\n  condition {\n    path_pattern {\n      values = [\"/static/*\"]\n    }\n  }\n\n  condition {\n    host_header {\n      values = [\"example.com\"]\n    }\n  }\n}\n\n# Forward action\n\nresource \"aws_lb_listener_rule\" \"host_based_weighted_routing\" {\n  listener_arn = aws_lb_listener.front_end.arn\n  priority     = 99\n\n  action {\n    type             = \"forward\"\n    target_group_arn = aws_lb_target_group.static.arn\n  }\n\n  condition {\n    host_header {\n      values = [\"my-service.*.mycompany.io\"]\n    }\n  }\n}\n\n# Weighted Forward action\n\nresource \"aws_lb_listener_rule\" \"host_based_routing\" {\n  listener_arn = aws_lb_listener.front_end.arn\n  priority     = 99\n\n  action {\n    type = \"forward\"\n    forward {\n      target_group {\n        arn    = aws_lb_target_group.main.arn\n        weight = 80\n      }\n\n      target_group {\n        arn    = aws_lb_target_group.canary.arn\n        weight = 20\n      }\n\n      stickiness {\n        enabled  = true\n        duration = 600\n      }\n    }\n  }\n\n  condition {\n    host_header {\n      values = [\"my-service.*.mycompany.io\"]\n    }\n  }\n}\n\n# Redirect action\n\nresource \"aws_lb_listener_rule\" \"redirect_http_to_https\" {\n  listener_arn = aws_lb_listener.front_end.arn\n\n  action {\n    type = \"redirect\"\n\n    redirect {\n      port        = \"443\"\n      protocol    = \"HTTPS\"\n      status_code = \"HTTP_301\"\n    }\n  }\n\n  condition {\n    http_header {\n      http_header_name = \"X-Forwarded-For\"\n      values           = [\"192.168.1.*\"]\n    }\n  }\n}\n\n# Fixed-response action\n\nresource \"aws_lb_listener_rule\" \"health_check\" {\n  listener_arn = aws_lb_listener.front_end.arn\n\n  action {\n    type = \"fixed-response\"\n\n    fixed_response {\n      content_type = \"text/plain\"\n      message_body = \"HEALTHY\"\n      status_code  = \"200\"\n    }\n  }\n\n  condition {\n    query_string {\n      key   = \"health\"\n      value = \"check\"\n    }\n\n    query_string {\n      value = \"bar\"\n    }\n  }\n}\n\n# Authenticate-cognito Action\n\nresource \"aws_cognito_user_pool\" \"pool\" {\n  # ...\n}\n\nresource \"aws_cognito_user_pool_client\" \"client\" {\n  # ...\n}\n\nresource \"aws_cognito_user_pool_domain\" \"domain\" {\n  # ...\n}\n\nresource \"aws_lb_listener_rule\" \"admin\" {\n  listener_arn = aws_lb_listener.front_end.arn\n\n  action {\n    type = \"authenticate-cognito\"\n\n    authenticate_cognito {\n      user_pool_arn       = aws_cognito_user_pool.pool.arn\n      user_pool_client_id = aws_cognito_user_pool_client.client.id\n      user_pool_domain    = aws_cognito_user_pool_domain.domain.domain\n    }\n  }\n\n  action {\n    type             = \"forward\"\n    target_group_arn = aws_lb_target_group.static.arn\n  }\n}\n\n# Authenticate-oidc Action\n\nresource \"aws_lb_listener_rule\" \"oidc\" {\n  listener_arn = aws_lb_listener.front_end.arn\n\n  action {\n    type = \"authenticate-oidc\"\n\n    authenticate_oidc {\n      authorization_endpoint = \"https://example.com/authorization_endpoint\"\n      client_id              = \"client_id\"\n      client_secret          = \"client_secret\"\n      issuer                 = \"https://example.com\"\n      token_endpoint         = \"https://example.com/token_endpoint\"\n      user_info_endpoint     = \"https://example.com/user_info_endpoint\"\n    }\n  }\n\n  action {\n    type             = \"forward\"\n    target_group_arn = aws_lb_target_group.static.arn\n  }\n}\n```",
+  "Arguments": {
+    "action": {
+      "description": "An Action block. Action blocks are documented below."
+    },
+    "action.authenticate_cognito": {
+      "description": "Information for creating an authenticate action using Cognito. Required if `type` is `authenticate-cognito`."
+    },
+    "action.authenticate_oidc": {
+      "description": "Information for creating an authenticate action using OIDC. Required if `type` is `authenticate-oidc`."
+    },
+    "action.fixed_response": {
+      "description": "Information for creating an action that returns a custom HTTP response. Required if `type` is `fixed-response`."
+    },
+    "action.forward": {
+      "description": "Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`."
+    },
+    "action.redirect": {
+      "description": "Information for creating a redirect action. Required if `type` is `redirect`."
+    },
+    "action.target_group_arn": {
+      "description": "The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead."
+    },
+    "action.type": {
+      "description": "The type of routing action. Valid values are `forward`, `redirect`, `fixed-response`, `authenticate-cognito` and `authenticate-oidc`."
+    },
+    "authenticate_cognito.authentication_request_extra_params": {
+      "description": "The query parameters to include in the redirect request to the authorization endpoint. Max: 10."
+    },
+    "authenticate_cognito.on_unauthenticated_request": {
+      "description": "The behavior if the user is not authenticated. Valid values: `deny`, `allow` and `authenticate`"
+    },
+    "authenticate_cognito.scope": {
+      "description": "The set of user claims to be requested from the IdP."
+    },
+    "authenticate_cognito.session_cookie_name": {
+      "description": "The name of the cookie used to maintain session information."
+    },
+    "authenticate_cognito.session_timeout": {
+      "description": "The maximum duration of the authentication session, in seconds."
+    },
+    "authenticate_cognito.user_pool_arn": {
+      "description": "The ARN of the Cognito user pool."
+    },
+    "authenticate_cognito.user_pool_client_id": {
+      "description": "The ID of the Cognito user pool client."
+    },
+    "authenticate_cognito.user_pool_domain": {
+      "description": "The domain prefix or fully-qualified domain name of the Cognito user pool."
+    },
+    "authenticate_oidc.authentication_request_extra_params": {
+      "description": "The query parameters to include in the redirect request to the authorization endpoint. Max: 10."
+    },
+    "authenticate_oidc.authorization_endpoint": {
+      "description": "The authorization endpoint of the IdP."
+    },
+    "authenticate_oidc.client_id": {
+      "description": "The OAuth 2.0 client identifier."
+    },
+    "authenticate_oidc.client_secret": {
+      "description": "The OAuth 2.0 client secret."
+    },
+    "authenticate_oidc.issuer": {
+      "description": "The OIDC issuer identifier of the IdP."
+    },
+    "authenticate_oidc.on_unauthenticated_request": {
+      "description": "The behavior if the user is not authenticated. Valid values: `deny`, `allow` and `authenticate`"
+    },
+    "authenticate_oidc.scope": {
+      "description": "The set of user claims to be requested from the IdP."
+    },
+    "authenticate_oidc.session_cookie_name": {
+      "description": "The name of the cookie used to maintain session information."
+    },
+    "authenticate_oidc.session_timeout": {
+      "description": "The maximum duration of the authentication session, in seconds."
+    },
+    "authenticate_oidc.token_endpoint": {
+      "description": "The token endpoint of the IdP."
+    },
+    "authenticate_oidc.user_info_endpoint": {
+      "description": "The user info endpoint of the IdP."
+    },
+    "authentication_request_extra_params.key": {
+      "description": "The key of query parameter"
+    },
+    "authentication_request_extra_params.value": {
+      "description": "The value of query parameter"
+    },
+    "condition": {
+      "description": "A Condition block. Multiple condition blocks of different types can be set and all must be satisfied for the rule to match. Condition blocks are documented below."
+    },
+    "condition.host_header": {
+      "description": "Contains a single `values` item which is a list of host header patterns to match. The maximum size of each pattern is 128 characters. Comparison is case insensitive. Wildcard characters supported: * (matches 0 or more characters) and ? (matches exactly 1 character). Only one pattern needs to match for the condition to be satisfied."
+    },
+    "condition.http_header": {
+      "description": "HTTP headers to match. HTTP Header block fields documented below."
+    },
+    "condition.http_request_method": {
+      "description": "Contains a single `values` item which is a list of HTTP request methods or verbs to match. Maximum size is 40 characters. Only allowed characters are A-Z, hyphen (-) and underscore (\\_). Comparison is case sensitive. Wildcards are not supported. Only one needs to match for the condition to be satisfied. AWS recommends that GET and HEAD requests are routed in the same way because the response to a HEAD request may be cached."
+    },
+    "condition.path_pattern": {
+      "description": "Contains a single `values` item which is a list of path patterns to match against the request URL. Maximum size of each pattern is 128 characters. Comparison is case sensitive. Wildcard characters supported: * (matches 0 or more characters) and ? (matches exactly 1 character). Only one pattern needs to match for the condition to be satisfied. Path pattern is compared only to the path of the URL, not to its query string. To compare against the query string, use a `query_string` condition."
+    },
+    "condition.query_string": {
+      "description": "Query strings to match. Query String block fields documented below."
+    },
+    "condition.source_ip": {
+      "description": "Contains a single `values` item which is a list of source IP CIDR notations to match. You can use both IPv4 and IPv6 addresses. Wildcards are not supported. Condition is satisfied if the source IP address of the request matches one of the CIDR blocks. Condition is not satisfied by the addresses in the `X-Forwarded-For` header, use `http_header` condition instead.\n\n\u003e **NOTE::** Exactly one of `host_header`, `http_header`, `http_request_method`, `path_pattern`, `query_string` or `source_ip` must be set per condition."
+    },
+    "fixed_response.content_type": {
+      "description": "The content type. Valid values are `text/plain`, `text/css`, `text/html`, `application/javascript` and `application/json`."
+    },
+    "fixed_response.message_body": {
+      "description": "The message body."
+    },
+    "fixed_response.status_code": {
+      "description": "The HTTP response code. Valid values are `2XX`, `4XX`, or `5XX`."
+    },
+    "forward.stickiness": {
+      "description": "The target group stickiness for the rule."
+    },
+    "forward.target_group": {
+      "description": "One or more target groups block."
+    },
+    "http_header.http_header_name": {
+      "description": "Name of HTTP header to search. The maximum size is 40 characters. Comparison is case insensitive. Only RFC7240 characters are supported. Wildcards are not supported. You cannot use HTTP header condition to specify the host header, use a `host-header` condition instead."
+    },
+    "http_header.values": {
+      "description": "List of header value patterns to match. Maximum size of each pattern is 128 characters. Comparison is case insensitive. Wildcard characters supported: * (matches 0 or more characters) and ? (matches exactly 1 character). If the same header appears multiple times in the request they will be searched in order until a match is found. Only one pattern needs to match for the condition to be satisfied. To require that all of the strings are a match, create one condition block per string."
+    },
+    "listener_arn": {
+      "description": "The ARN of the listener to which to attach the rule."
+    },
+    "priority": {
+      "description": "The priority for the rule between `1` and `50000`. Leaving it unset will automatically set the rule with next available priority after currently existing highest rule. A listener can't have multiple rules with the same priority."
+    },
+    "query_string.key": {
+      "description": "Query string key pattern to match."
+    },
+    "query_string.value": {
+      "description": "Query string value pattern to match."
+    },
+    "query_string.values": {
+      "description": "Query string pairs or values to match. Query String Value blocks documented below. Multiple `values` blocks can be specified, see example above. Maximum size of each string is 128 characters. Comparison is case insensitive. Wildcard characters supported: * (matches 0 or more characters) and ? (matches exactly 1 character). To search for a literal '\\*' or '?' character in a query string, escape the character with a backslash (\\\\). Only one pair needs to match for the condition to be satisfied.\n\nQuery String Value Blocks (for `query_string.values`) support the following:"
+    },
+    "redirect.host": {
+      "description": "The hostname. This component is not percent-encoded. The hostname can contain `#{host}`. Defaults to `#{host}`."
+    },
+    "redirect.path": {
+      "description": "The absolute path, starting with the leading \"/\". This component is not percent-encoded. The path can contain #{host}, #{path}, and #{port}. Defaults to `/#{path}`."
+    },
+    "redirect.port": {
+      "description": "The port. Specify a value from `1` to `65535` or `#{port}`. Defaults to `#{port}`."
+    },
+    "redirect.protocol": {
+      "description": "The protocol. Valid values are `HTTP`, `HTTPS`, or `#{protocol}`. Defaults to `#{protocol}`."
+    },
+    "redirect.query": {
+      "description": "The query parameters, URL-encoded when necessary, but not percent-encoded. Do not include the leading \"?\". Defaults to `#{query}`."
+    },
+    "redirect.status_code": {
+      "description": "The HTTP redirect code. The redirect is either permanent (`HTTP_301`) or temporary (`HTTP_302`)."
+    },
+    "stickiness.duration": {
+      "description": "The time period, in seconds, during which requests from a client should be routed to the same target group. The range is 1-604800 seconds (7 days)."
+    },
+    "stickiness.enabled": {
+      "description": "Indicates whether target group stickiness is enabled."
+    },
+    "tags": {
+      "description": "A map of tags to assign to the resource. .If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level."
+    },
+    "target_group.arn": {
+      "description": "The Amazon Resource Name (ARN) of the target group."
+    },
+    "target_group.weight": {
+      "description": "The weight. The range is 0 to 999."
+    }
+  },
+  "Attributes": {
+    "arn": "The ARN of the rule (matches `id`)",
+    "id": "The ARN of the rule (matches `arn`)",
+    "tags_all": "A map of tags assigned to the resource, including those inherited from the provider `default_tags` configuration block."
+  },
+  "Import": "## Import\n\nUsing `pulumi import`, import rules using their ARN. For example:\n\n```sh\u003cbreak\u003e\n$ pulumi import  front_end arn:aws:elasticloadbalancing:us-west-2:187416307283:listener-rule/app/test/8e4497da625e2d8a/9ab28ade35828f96/67b3d2d36dd7c26b\n\u003cbreak\u003e```\u003cbreak\u003e\n"
+}

--- a/pkg/tfgen/test_data/resources/lb_listener_rule/upstream.md
+++ b/pkg/tfgen/test_data/resources/lb_listener_rule/upstream.md
@@ -1,0 +1,347 @@
+---
+subcategory: "ELB (Elastic Load Balancing)"
+layout: "aws"
+page_title: "AWS: aws_lb_listener_rule"
+description: |-
+  Provides a Load Balancer Listener Rule resource.
+---
+
+# Resource: aws_lb_listener_rule
+
+Provides a Load Balancer Listener Rule resource.
+
+~> **Note:** `aws_alb_listener_rule` is known as `aws_lb_listener_rule`. The functionality is identical.
+
+## Example Usage
+
+```terraform
+resource "aws_lb" "front_end" {
+  # ...
+}
+
+resource "aws_lb_listener" "front_end" {
+  # Other parameters
+}
+
+resource "aws_lb_listener_rule" "static" {
+  listener_arn = aws_lb_listener.front_end.arn
+  priority     = 100
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.static.arn
+  }
+
+  condition {
+    path_pattern {
+      values = ["/static/*"]
+    }
+  }
+
+  condition {
+    host_header {
+      values = ["example.com"]
+    }
+  }
+}
+
+# Forward action
+
+resource "aws_lb_listener_rule" "host_based_weighted_routing" {
+  listener_arn = aws_lb_listener.front_end.arn
+  priority     = 99
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.static.arn
+  }
+
+  condition {
+    host_header {
+      values = ["my-service.*.mycompany.io"]
+    }
+  }
+}
+
+# Weighted Forward action
+
+resource "aws_lb_listener_rule" "host_based_routing" {
+  listener_arn = aws_lb_listener.front_end.arn
+  priority     = 99
+
+  action {
+    type = "forward"
+    forward {
+      target_group {
+        arn    = aws_lb_target_group.main.arn
+        weight = 80
+      }
+
+      target_group {
+        arn    = aws_lb_target_group.canary.arn
+        weight = 20
+      }
+
+      stickiness {
+        enabled  = true
+        duration = 600
+      }
+    }
+  }
+
+  condition {
+    host_header {
+      values = ["my-service.*.mycompany.io"]
+    }
+  }
+}
+
+# Redirect action
+
+resource "aws_lb_listener_rule" "redirect_http_to_https" {
+  listener_arn = aws_lb_listener.front_end.arn
+
+  action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+
+  condition {
+    http_header {
+      http_header_name = "X-Forwarded-For"
+      values           = ["192.168.1.*"]
+    }
+  }
+}
+
+# Fixed-response action
+
+resource "aws_lb_listener_rule" "health_check" {
+  listener_arn = aws_lb_listener.front_end.arn
+
+  action {
+    type = "fixed-response"
+
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "HEALTHY"
+      status_code  = "200"
+    }
+  }
+
+  condition {
+    query_string {
+      key   = "health"
+      value = "check"
+    }
+
+    query_string {
+      value = "bar"
+    }
+  }
+}
+
+# Authenticate-cognito Action
+
+resource "aws_cognito_user_pool" "pool" {
+  # ...
+}
+
+resource "aws_cognito_user_pool_client" "client" {
+  # ...
+}
+
+resource "aws_cognito_user_pool_domain" "domain" {
+  # ...
+}
+
+resource "aws_lb_listener_rule" "admin" {
+  listener_arn = aws_lb_listener.front_end.arn
+
+  action {
+    type = "authenticate-cognito"
+
+    authenticate_cognito {
+      user_pool_arn       = aws_cognito_user_pool.pool.arn
+      user_pool_client_id = aws_cognito_user_pool_client.client.id
+      user_pool_domain    = aws_cognito_user_pool_domain.domain.domain
+    }
+  }
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.static.arn
+  }
+}
+
+# Authenticate-oidc Action
+
+resource "aws_lb_listener_rule" "oidc" {
+  listener_arn = aws_lb_listener.front_end.arn
+
+  action {
+    type = "authenticate-oidc"
+
+    authenticate_oidc {
+      authorization_endpoint = "https://example.com/authorization_endpoint"
+      client_id              = "client_id"
+      client_secret          = "client_secret"
+      issuer                 = "https://example.com"
+      token_endpoint         = "https://example.com/token_endpoint"
+      user_info_endpoint     = "https://example.com/user_info_endpoint"
+    }
+  }
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.static.arn
+  }
+}
+```
+
+## Argument Reference
+
+This resource supports the following arguments:
+
+* `listener_arn` - (Required, Forces New Resource) The ARN of the listener to which to attach the rule.
+* `priority` - (Optional) The priority for the rule between `1` and `50000`. Leaving it unset will automatically set the rule with next available priority after currently existing highest rule. A listener can't have multiple rules with the same priority.
+* `action` - (Required) An Action block. Action blocks are documented below.
+* `condition` - (Required) A Condition block. Multiple condition blocks of different types can be set and all must be satisfied for the rule to match. Condition blocks are documented below.
+* `tags` - (Optional) A map of tags to assign to the resource. .If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+
+### Action Blocks
+
+Action Blocks (for `action`) support the following:
+
+* `type` - (Required) The type of routing action. Valid values are `forward`, `redirect`, `fixed-response`, `authenticate-cognito` and `authenticate-oidc`.
+* `target_group_arn` - (Optional) The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
+* `forward` - (Optional) Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`.
+* `redirect` - (Optional) Information for creating a redirect action. Required if `type` is `redirect`.
+* `fixed_response` - (Optional) Information for creating an action that returns a custom HTTP response. Required if `type` is `fixed-response`.
+* `authenticate_cognito` - (Optional) Information for creating an authenticate action using Cognito. Required if `type` is `authenticate-cognito`.
+* `authenticate_oidc` - (Optional) Information for creating an authenticate action using OIDC. Required if `type` is `authenticate-oidc`.
+
+Forward Blocks (for `forward`) support the following:
+
+* `target_group` - (Required) One or more target groups block.
+* `stickiness` - (Optional) The target group stickiness for the rule.
+
+Target Group Blocks (for `target_group`) supports the following:
+
+* `arn` - (Required) The Amazon Resource Name (ARN) of the target group.
+* `weight` - (Optional) The weight. The range is 0 to 999.
+
+Target Group Stickiness Config Blocks (for `stickiness`) supports the following:
+
+* `enabled` - (Required) Indicates whether target group stickiness is enabled.
+* `duration` - (Optional) The time period, in seconds, during which requests from a client should be routed to the same target group. The range is 1-604800 seconds (7 days).
+
+Redirect Blocks (for `redirect`) support the following:
+
+~> **NOTE::** You can reuse URI components using the following reserved keywords: `#{protocol}`, `#{host}`, `#{port}`, `#{path}` (the leading "/" is removed) and `#{query}`.
+
+* `host` - (Optional) The hostname. This component is not percent-encoded. The hostname can contain `#{host}`. Defaults to `#{host}`.
+* `path` - (Optional) The absolute path, starting with the leading "/". This component is not percent-encoded. The path can contain #{host}, #{path}, and #{port}. Defaults to `/#{path}`.
+* `port` - (Optional) The port. Specify a value from `1` to `65535` or `#{port}`. Defaults to `#{port}`.
+* `protocol` - (Optional) The protocol. Valid values are `HTTP`, `HTTPS`, or `#{protocol}`. Defaults to `#{protocol}`.
+* `query` - (Optional) The query parameters, URL-encoded when necessary, but not percent-encoded. Do not include the leading "?". Defaults to `#{query}`.
+* `status_code` - (Required) The HTTP redirect code. The redirect is either permanent (`HTTP_301`) or temporary (`HTTP_302`).
+
+Fixed-response Blocks (for `fixed_response`) support the following:
+
+* `content_type` - (Required) The content type. Valid values are `text/plain`, `text/css`, `text/html`, `application/javascript` and `application/json`.
+* `message_body` - (Optional) The message body.
+* `status_code` - (Optional) The HTTP response code. Valid values are `2XX`, `4XX`, or `5XX`.
+
+Authenticate Cognito Blocks (for `authenticate_cognito`) supports the following:
+
+* `authentication_request_extra_params` - (Optional) The query parameters to include in the redirect request to the authorization endpoint. Max: 10.
+* `on_unauthenticated_request` - (Optional) The behavior if the user is not authenticated. Valid values: `deny`, `allow` and `authenticate`
+* `scope` - (Optional) The set of user claims to be requested from the IdP.
+* `session_cookie_name` - (Optional) The name of the cookie used to maintain session information.
+* `session_timeout` - (Optional) The maximum duration of the authentication session, in seconds.
+* `user_pool_arn` - (Required) The ARN of the Cognito user pool.
+* `user_pool_client_id` - (Required) The ID of the Cognito user pool client.
+* `user_pool_domain` - (Required) The domain prefix or fully-qualified domain name of the Cognito user pool.
+
+Authenticate OIDC Blocks (for `authenticate_oidc`) supports the following:
+
+* `authentication_request_extra_params` - (Optional) The query parameters to include in the redirect request to the authorization endpoint. Max: 10.
+* `authorization_endpoint` - (Required) The authorization endpoint of the IdP.
+* `client_id` - (Required) The OAuth 2.0 client identifier.
+* `client_secret` - (Required) The OAuth 2.0 client secret.
+* `issuer` - (Required) The OIDC issuer identifier of the IdP.
+* `on_unauthenticated_request` - (Optional) The behavior if the user is not authenticated. Valid values: `deny`, `allow` and `authenticate`
+* `scope` - (Optional) The set of user claims to be requested from the IdP.
+* `session_cookie_name` - (Optional) The name of the cookie used to maintain session information.
+* `session_timeout` - (Optional) The maximum duration of the authentication session, in seconds.
+* `token_endpoint` - (Required) The token endpoint of the IdP.
+* `user_info_endpoint` - (Required) The user info endpoint of the IdP.
+
+Authentication Request Extra Params Blocks (for `authentication_request_extra_params`) supports the following:
+
+* `key` - (Required) The key of query parameter
+* `value` - (Required) The value of query parameter
+
+### Condition Blocks
+
+One or more condition blocks can be set per rule. Most condition types can only be specified once per rule except for `http-header` and `query-string` which can be specified multiple times.
+
+Condition Blocks (for `condition`) support the following:
+
+* `host_header` - (Optional) Contains a single `values` item which is a list of host header patterns to match. The maximum size of each pattern is 128 characters. Comparison is case insensitive. Wildcard characters supported: * (matches 0 or more characters) and ? (matches exactly 1 character). Only one pattern needs to match for the condition to be satisfied.
+* `http_header` - (Optional) HTTP headers to match. [HTTP Header block](#http-header-blocks) fields documented below.
+* `http_request_method` - (Optional) Contains a single `values` item which is a list of HTTP request methods or verbs to match. Maximum size is 40 characters. Only allowed characters are A-Z, hyphen (-) and underscore (\_). Comparison is case sensitive. Wildcards are not supported. Only one needs to match for the condition to be satisfied. AWS recommends that GET and HEAD requests are routed in the same way because the response to a HEAD request may be cached.
+* `path_pattern` - (Optional) Contains a single `values` item which is a list of path patterns to match against the request URL. Maximum size of each pattern is 128 characters. Comparison is case sensitive. Wildcard characters supported: * (matches 0 or more characters) and ? (matches exactly 1 character). Only one pattern needs to match for the condition to be satisfied. Path pattern is compared only to the path of the URL, not to its query string. To compare against the query string, use a `query_string` condition.
+* `query_string` - (Optional) Query strings to match. [Query String block](#query-string-blocks) fields documented below.
+* `source_ip` - (Optional) Contains a single `values` item which is a list of source IP CIDR notations to match. You can use both IPv4 and IPv6 addresses. Wildcards are not supported. Condition is satisfied if the source IP address of the request matches one of the CIDR blocks. Condition is not satisfied by the addresses in the `X-Forwarded-For` header, use `http_header` condition instead.
+
+~> **NOTE::** Exactly one of `host_header`, `http_header`, `http_request_method`, `path_pattern`, `query_string` or `source_ip` must be set per condition.
+
+#### HTTP Header Blocks
+
+HTTP Header Blocks (for `http_header`) support the following:
+
+* `http_header_name` - (Required) Name of HTTP header to search. The maximum size is 40 characters. Comparison is case insensitive. Only RFC7240 characters are supported. Wildcards are not supported. You cannot use HTTP header condition to specify the host header, use a `host-header` condition instead.
+* `values` - (Required) List of header value patterns to match. Maximum size of each pattern is 128 characters. Comparison is case insensitive. Wildcard characters supported: * (matches 0 or more characters) and ? (matches exactly 1 character). If the same header appears multiple times in the request they will be searched in order until a match is found. Only one pattern needs to match for the condition to be satisfied. To require that all of the strings are a match, create one condition block per string.
+
+#### Query String Blocks
+
+Query String Blocks (for `query_string`) support the following:
+
+* `values` - (Required) Query string pairs or values to match. Query String Value blocks documented below. Multiple `values` blocks can be specified, see example above. Maximum size of each string is 128 characters. Comparison is case insensitive. Wildcard characters supported: * (matches 0 or more characters) and ? (matches exactly 1 character). To search for a literal '\*' or '?' character in a query string, escape the character with a backslash (\\). Only one pair needs to match for the condition to be satisfied.
+
+Query String Value Blocks (for `query_string.values`) support the following:
+
+* `key` - (Optional) Query string key pattern to match.
+* `value` - (Required) Query string value pattern to match.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `id` - The ARN of the rule (matches `arn`)
+* `arn` - The ARN of the rule (matches `id`)
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider `default_tags` configuration block.
+
+## Import
+
+
+
+```terraform
+import {
+  to = aws_lb_listener_rule.front_end
+  id = "arn:aws:elasticloadbalancing:us-west-2:187416307283:listener-rule/app/test/8e4497da625e2d8a/9ab28ade35828f96/67b3d2d36dd7c26b"
+}
+```
+
+Using `pulumi import`, import rules using their ARN. For example:
+
+```console
+% pulumi import aws_lb_listener_rule.front_end arn:aws:elasticloadbalancing:us-west-2:187416307283:listener-rule/app/test/8e4497da625e2d8a/9ab28ade35828f96/67b3d2d36dd7c26b
+```

--- a/pkg/tfgen/test_data/resources/libvirt_network/docs.json
+++ b/pkg/tfgen/test_data/resources/libvirt_network/docs.json
@@ -4,9 +4,6 @@
     "addresses": {
       "description": "A list of (0 or 1) IPv4 and (0 or 1) IPv6 subnets in\nCIDR notation.  This defines the subnets associated to that network.\nThis argument is also used to define the address on the real host.\nIf `dhcp {  enabled = true }` addresses is also used to define the address range served by\nthe DHCP server.\nNo DHCP server will be started if `addresses` is omitted."
     },
-    "altering_libvirt": {
-      "description": "The optional `xml` block relates to the generated network XML.\n\nCurrently the following attributes are supported:"
-    },
     "altering_libvirt.xslt": {
       "description": ""
     },

--- a/pkg/tfgen/test_data/resources/libvirt_network/docs.json
+++ b/pkg/tfgen/test_data/resources/libvirt_network/docs.json
@@ -1,0 +1,75 @@
+{
+  "Description": "Manages a VM network resource within libvirt. For more information see\n[the official documentation](https://libvirt.org/formatnetwork.html).\n\n## Example Usage\n\n```hcl\nresource \"libvirt_network\" \"kube_network\" {\n  # the name used by libvirt\n  name = \"k8snet\"\n\n  # mode can be: \"nat\" (default), \"none\", \"route\", \"open\", \"bridge\"\n  mode = \"nat\"\n\n  #  the domain used by the DNS server in this network\n  domain = \"k8s.local\"\n\n  #  list of subnets the addresses allowed for domains connected\n  # also derived to define the host addresses\n  # also derived to define the addresses served by the DHCP server\n  addresses = [\"10.17.3.0/24\", \"2001:db8:ca2:2::1/64\"]\n\n  # (optional) the bridge device defines the name of a bridge device\n  # which will be used to construct the virtual network.\n  # (only necessary in \"bridge\" mode)\n  # bridge = \"br7\"\n\n  # (optional) the MTU for the network. If not supplied, the underlying device's\n  # default is used (usually 1500)\n  # mtu = 9000\n\n  # (Optional) DNS configuration\n  dns {\n    # (Optional, default false)\n    # Set to true, if no other option is specified and you still want to \n    # enable dns.\n    enabled = true\n    # (Optional, default false)\n    # true: DNS requests under this domain will only be resolved by the\n    # virtual network's own DNS server\n    # false: Unresolved requests will be forwarded to the host's\n    # upstream DNS server if the virtual network's DNS server does not\n    # have an answer.\n￼   local_only = true\n\n    # (Optional) one or more DNS forwarder entries.  One or both of\n    # \"address\" and \"domain\" must be specified.  The format is:\n    # forwarders {\n    #     address = \"my address\"\n    #     domain = \"my domain\"\n    #  } \n    # \n\n    # (Optional) one or more DNS host entries.  Both of\n    # \"ip\" and \"hostname\" must be specified.  The format is:\n    # hosts  {\n    #     hostname = \"my_hostname\"\n    #     ip = \"my.ip.address.1\"\n    #   }\n    # hosts {\n    #     hostname = \"my_hostname\"\n    #     ip = \"my.ip.address.2\"\n    #   }\n    # \n\n    # (Optional) one or more static routes.\n    # \"cidr\" and \"gateway\" must be specified. The format is:\n    # routes {\n    #     cidr = \"10.17.0.0/16\"\n    #     gateway = \"10.18.0.2\"\n    #   }\n  }\n\n  # (Optional) Dnsmasq options configuration\n  dnsmasq_options {\n    # (Optional) one or more option entries.\n    # \"option_name\" muast be specified while \"option_value\" is\n\t# optional to also support value-less options.  The format is:\n    # options  {\n    #     option_name = \"server\"\n    #     option_value = \"/base.domain/my.ip.address.1\"\n    #   }\n    # options  {\n    #     option_name = \"no-hosts\"\n    #   }\n    # options {\n    #     option_name = \"address\"\n    #     ip = \"/.api.base.domain/my.ip.address.2\"\n    #   }\n    #\n  }\n\n}\n```",
+  "Arguments": {
+    "addresses": {
+      "description": "A list of (0 or 1) IPv4 and (0 or 1) IPv6 subnets in\nCIDR notation.  This defines the subnets associated to that network.\nThis argument is also used to define the address on the real host.\nIf `dhcp {  enabled = true }` addresses is also used to define the address range served by\nthe DHCP server.\nNo DHCP server will be started if `addresses` is omitted."
+    },
+    "altering_libvirt.xslt": {
+      "description": ""
+    },
+    "autostart": {
+      "description": "Set to `true` to start the network on host boot up.\nIf not specified `false` is assumed."
+    },
+    "bridge": {
+      "description": "The bridge device defines the name of a bridge\ndevice which will be used to construct the virtual network (when not provided,\nit will be automatically obtained by libvirt in `none`, `nat`, `route` and `open` modes)."
+    },
+    "dns": {
+      "description": "configuration of DNS specific settings for the network"
+    },
+    "dns.dhcp": {
+      "description": "DHCP configuration. \nYou need to use it in conjuction with the adresses variable."
+    },
+    "dns.dnsmasq_options": {
+      "description": "configuration of Dnsmasq options for the network\nYou need to provide a list of option name and value pairs."
+    },
+    "dns.enabled": {
+      "description": "when false, disable the DHCP server\n```hcl\nresource \"libvirt_network\" \"test_net\" {\nname      = \"networktest\"\nmode      = \"nat\"\ndomain    = \"k8s.local\"\naddresses = [\"10.17.3.0/24\"]\ndhcp {\nenabled = true\n}\n```"
+    },
+    "dns.forwarders": {
+      "description": "Either `address`, `domain`, or both must be set"
+    },
+    "dns.hosts": {
+      "description": "a DNS host entry block. You can have one or more of these\nblocks in your DNS definition. You must specify both `ip` and `hostname`.\n\nAn advanced example of round-robin DNS (using DNS host templates) follows:\n\n```hcl\nresource \"libvirt_network\" \"my_network\" {\n...\ndns {\nhosts { flatten(data.libvirt_network_dns_host_template.hosts.*.rendered) }\n}\n...\n}\n\ndata \"libvirt_network_dns_host_template\" \"hosts\" {\ncount    = var.host_count\nip       = var.host_ips[count.index]\nhostname = \"my_host\"\n}\n```\n\nAn advanced example of setting up multiple SRV records using DNS SRV templates is:\n\n```hcl\ndata \"libvirt_network_dns_srv_template\" \"etcd_cluster\" {\ncount    = var.etcd_count\nservice  = \"etcd-server\"\nprotocol = \"tcp\"\ndomain   = var.discovery_domain\ntarget   = \"${var.cluster_name}-etcd-${count.index}.${discovery_domain}\"\n}\n\nresource \"libvirt_network\" \"k8snet\" {\n...\ndns {\nsrvs = [ flatten(data.libvirt_network_dns_srv_template.etcd_cluster.*.rendered) ]\n}\n...\n}\n```"
+    },
+    "dns.local_only": {
+      "description": "true/false: true means 'do not forward unresolved requests for this domain to the part DNS server"
+    },
+    "dns.options": {
+      "description": "a Dnsmasq option entry block. You can have one or more of these\nblocks in your definition. You must specify `option_name` while `option_value` is\noptional to support value-less options.\n\nAn example of setting Dnsmasq options (using Dnsmasq option templates) follows:\n\n```hcl\nresource \"libvirt_network\" \"my_network\" {\n...\ndnsmasq_options {\noptions { flatten(data.libvirt_network_dnsmasq_options_template.options.*.rendered) }\n}\n...\n}\n\ndata \"libvirt_network_dnsmasq_options_template\" \"options\" {\ncount = length(var.libvirt_dnsmasq_options)\noption_name = keys(var.libvirt_dnsmasq_options)[count.index]\noption_value = values(var.libvirt_dnsmasq_options)[count.index]\n}\n```"
+    },
+    "dns.srvs": {
+      "description": "a DNS SRV entry block. You can have one or more of these blocks\nin your DNS definition. You must specify `service` and `protocol`."
+    },
+    "domain": {
+      "description": "The domain used by the DNS server."
+    },
+    "mode": {
+      "description": "One of:"
+    },
+    "mtu": {
+      "description": "The MTU to set for the underlying network interfaces. When\nnot supplied, libvirt will use the default for the interface, usually 1500.\nLibvirt version 5.1 and greater will advertise this value to nodes via DHCP."
+    },
+    "name": {
+      "description": "A unique name for the resource, required by libvirt.\nChanging this forces a new resource to be created."
+    },
+    "nat": {
+      "description": "it is the default network mode. This is a configuration that\nallows guest OS to get outbound connectivity regardless of whether the host\nuses ethernet, wireless, dialup, or VPN networking without requiring any\nspecific admin configuration. In the absence of host networking, it at\nleast allows guests to talk directly to each other."
+    },
+    "none": {
+      "description": "the guests can talk to each other and the host OS, but cannot reach\nany other machines on the LAN."
+    },
+    "open": {
+      "description": "similar to `route`, but no firewall rules are added."
+    },
+    "route": {
+      "description": "this is a variant on the default network which routes traffic from\nthe virtual network to the LAN **without applying any NAT**. It requires that\nthe IP address range be pre-configured in the routing tables of the router\non the host network."
+    },
+    "routes": {
+      "description": "a list of static routes. A `cidr` and a `gateway` must\nbe provided. The `gateway` must be reachable via the bridge interface."
+    }
+  },
+  "Attributes": {
+    "id": "a unique identifier for the resource"
+  },
+  "Import": ""
+}

--- a/pkg/tfgen/test_data/resources/libvirt_network/docs.json
+++ b/pkg/tfgen/test_data/resources/libvirt_network/docs.json
@@ -4,6 +4,9 @@
     "addresses": {
       "description": "A list of (0 or 1) IPv4 and (0 or 1) IPv6 subnets in\nCIDR notation.  This defines the subnets associated to that network.\nThis argument is also used to define the address on the real host.\nIf `dhcp {  enabled = true }` addresses is also used to define the address range served by\nthe DHCP server.\nNo DHCP server will be started if `addresses` is omitted."
     },
+    "altering_libvirt": {
+      "description": "The optional `xml` block relates to the generated network XML.\n\nCurrently the following attributes are supported:"
+    },
     "altering_libvirt.xslt": {
       "description": ""
     },
@@ -13,32 +16,32 @@
     "bridge": {
       "description": "The bridge device defines the name of a bridge\ndevice which will be used to construct the virtual network (when not provided,\nit will be automatically obtained by libvirt in `none`, `nat`, `route` and `open` modes)."
     },
-    "dns": {
-      "description": "configuration of DNS specific settings for the network"
-    },
-    "dns.dhcp": {
+    "dhcp": {
       "description": "DHCP configuration. \nYou need to use it in conjuction with the adresses variable."
     },
-    "dns.dnsmasq_options": {
-      "description": "configuration of Dnsmasq options for the network\nYou need to provide a list of option name and value pairs."
+    "dhcp.enabled": {
+      "description": "when false, disable the DHCP server\n\n```hcl\n\t\t\t\tresource \"libvirt_network\" \"test_net\" {\n\t\t\t\t\tname      = \"networktest\"\n\t\t\t\t\tmode      = \"nat\"\n\t\t\t\t\tdomain    = \"k8s.local\"\n\t\t\t\t\taddresses = [\"10.17.3.0/24\"]\n\t\t\t\t\tdhcp {\n\t\t\t\t\t\tenabled = true\n\t\t\t\t\t}\n```"
     },
-    "dns.enabled": {
-      "description": "when false, disable the DHCP server\n```hcl\nresource \"libvirt_network\" \"test_net\" {\nname      = \"networktest\"\nmode      = \"nat\"\ndomain    = \"k8s.local\"\naddresses = [\"10.17.3.0/24\"]\ndhcp {\nenabled = true\n}\n```"
+    "dns": {
+      "description": "configuration of DNS specific settings for the network"
     },
     "dns.forwarders": {
       "description": "Either `address`, `domain`, or both must be set"
     },
     "dns.hosts": {
-      "description": "a DNS host entry block. You can have one or more of these\nblocks in your DNS definition. You must specify both `ip` and `hostname`.\n\nAn advanced example of round-robin DNS (using DNS host templates) follows:\n\n```hcl\nresource \"libvirt_network\" \"my_network\" {\n...\ndns {\nhosts { flatten(data.libvirt_network_dns_host_template.hosts.*.rendered) }\n}\n...\n}\n\ndata \"libvirt_network_dns_host_template\" \"hosts\" {\ncount    = var.host_count\nip       = var.host_ips[count.index]\nhostname = \"my_host\"\n}\n```\n\nAn advanced example of setting up multiple SRV records using DNS SRV templates is:\n\n```hcl\ndata \"libvirt_network_dns_srv_template\" \"etcd_cluster\" {\ncount    = var.etcd_count\nservice  = \"etcd-server\"\nprotocol = \"tcp\"\ndomain   = var.discovery_domain\ntarget   = \"${var.cluster_name}-etcd-${count.index}.${discovery_domain}\"\n}\n\nresource \"libvirt_network\" \"k8snet\" {\n...\ndns {\nsrvs = [ flatten(data.libvirt_network_dns_srv_template.etcd_cluster.*.rendered) ]\n}\n...\n}\n```"
+      "description": "a DNS host entry block. You can have one or more of these\nblocks in your DNS definition. You must specify both `ip` and `hostname`.\n\nAn advanced example of round-robin DNS (using DNS host templates) follows:\n\n```hcl\nresource \"libvirt_network\" \"my_network\" {\n  ...\n  dns {\n    hosts { flatten(data.libvirt_network_dns_host_template.hosts.*.rendered) }\n  }\n  ...\n}\n\ndata \"libvirt_network_dns_host_template\" \"hosts\" {\n  count    = var.host_count\n  ip       = var.host_ips[count.index]\n  hostname = \"my_host\"\n}\n```\n\nAn advanced example of setting up multiple SRV records using DNS SRV templates is:\n\n```hcl\ndata \"libvirt_network_dns_srv_template\" \"etcd_cluster\" {\n  count    = var.etcd_count\n  service  = \"etcd-server\"\n  protocol = \"tcp\"\n  domain   = var.discovery_domain\n  target   = \"${var.cluster_name}-etcd-${count.index}.${discovery_domain}\"\n}\n\nresource \"libvirt_network\" \"k8snet\" {\n  ...\n  dns {\n    srvs = [ flatten(data.libvirt_network_dns_srv_template.etcd_cluster.*.rendered) ]\n  }\n  ...\n}\n```"
     },
     "dns.local_only": {
       "description": "true/false: true means 'do not forward unresolved requests for this domain to the part DNS server"
     },
-    "dns.options": {
-      "description": "a Dnsmasq option entry block. You can have one or more of these\nblocks in your definition. You must specify `option_name` while `option_value` is\noptional to support value-less options.\n\nAn example of setting Dnsmasq options (using Dnsmasq option templates) follows:\n\n```hcl\nresource \"libvirt_network\" \"my_network\" {\n...\ndnsmasq_options {\noptions { flatten(data.libvirt_network_dnsmasq_options_template.options.*.rendered) }\n}\n...\n}\n\ndata \"libvirt_network_dnsmasq_options_template\" \"options\" {\ncount = length(var.libvirt_dnsmasq_options)\noption_name = keys(var.libvirt_dnsmasq_options)[count.index]\noption_value = values(var.libvirt_dnsmasq_options)[count.index]\n}\n```"
-    },
     "dns.srvs": {
       "description": "a DNS SRV entry block. You can have one or more of these blocks\nin your DNS definition. You must specify `service` and `protocol`."
+    },
+    "dnsmasq_options": {
+      "description": "configuration of Dnsmasq options for the network\nYou need to provide a list of option name and value pairs."
+    },
+    "dnsmasq_options.options": {
+      "description": "a Dnsmasq option entry block. You can have one or more of these\nblocks in your definition. You must specify `option_name` while `option_value` is\noptional to support value-less options.\n\nAn example of setting Dnsmasq options (using Dnsmasq option templates) follows:\n\n```hcl\n        resource \"libvirt_network\" \"my_network\" {\n          ...\n          dnsmasq_options {\n            options { flatten(data.libvirt_network_dnsmasq_options_template.options.*.rendered) }\n          }\n          ...\n        }\n\n        data \"libvirt_network_dnsmasq_options_template\" \"options\" {\n          count = length(var.libvirt_dnsmasq_options)\n          option_name = keys(var.libvirt_dnsmasq_options)[count.index]\n          option_value = values(var.libvirt_dnsmasq_options)[count.index]\n        }\n```"
     },
     "domain": {
       "description": "The domain used by the DNS server."
@@ -46,23 +49,26 @@
     "mode": {
       "description": "One of:"
     },
+    "mode.bridge": {
+      "description": "use a pre-existing host bridge. The guests will effectively be\ndirectly connected to the physical network (i.e. their IP addresses will\nall be on the subnet of the physical network, and there will be no\nrestrictions on inbound or outbound connections). The `bridge` network\nattribute is mandatory in this case."
+    },
+    "mode.nat": {
+      "description": "it is the default network mode. This is a configuration that\nallows guest OS to get outbound connectivity regardless of whether the host\nuses ethernet, wireless, dialup, or VPN networking without requiring any\nspecific admin configuration. In the absence of host networking, it at\nleast allows guests to talk directly to each other."
+    },
+    "mode.none": {
+      "description": "the guests can talk to each other and the host OS, but cannot reach\nany other machines on the LAN."
+    },
+    "mode.open": {
+      "description": "similar to `route`, but no firewall rules are added."
+    },
+    "mode.route": {
+      "description": "this is a variant on the default network which routes traffic from\nthe virtual network to the LAN **without applying any NAT**. It requires that\nthe IP address range be pre-configured in the routing tables of the router\non the host network."
+    },
     "mtu": {
       "description": "The MTU to set for the underlying network interfaces. When\nnot supplied, libvirt will use the default for the interface, usually 1500.\nLibvirt version 5.1 and greater will advertise this value to nodes via DHCP."
     },
     "name": {
       "description": "A unique name for the resource, required by libvirt.\nChanging this forces a new resource to be created."
-    },
-    "nat": {
-      "description": "it is the default network mode. This is a configuration that\nallows guest OS to get outbound connectivity regardless of whether the host\nuses ethernet, wireless, dialup, or VPN networking without requiring any\nspecific admin configuration. In the absence of host networking, it at\nleast allows guests to talk directly to each other."
-    },
-    "none": {
-      "description": "the guests can talk to each other and the host OS, but cannot reach\nany other machines on the LAN."
-    },
-    "open": {
-      "description": "similar to `route`, but no firewall rules are added."
-    },
-    "route": {
-      "description": "this is a variant on the default network which routes traffic from\nthe virtual network to the LAN **without applying any NAT**. It requires that\nthe IP address range be pre-configured in the routing tables of the router\non the host network."
     },
     "routes": {
       "description": "a list of static routes. A `cidr` and a `gateway` must\nbe provided. The `gateway` must be reachable via the bridge interface."

--- a/pkg/tfgen/test_data/resources/libvirt_network/upstream.md
+++ b/pkg/tfgen/test_data/resources/libvirt_network/upstream.md
@@ -1,0 +1,247 @@
+---
+layout: "libvirt"
+page_title: "Libvirt: libvirt_network"
+sidebar_current: "docs-libvirt-network"
+description: |-
+  Manages a virtual machine (network) in libvirt
+---
+
+# libvirt\_network
+
+Manages a VM network resource within libvirt. For more information see
+[the official documentation](https://libvirt.org/formatnetwork.html).
+
+## Example Usage
+
+```hcl
+resource "libvirt_network" "kube_network" {
+  # the name used by libvirt
+  name = "k8snet"
+
+  # mode can be: "nat" (default), "none", "route", "open", "bridge"
+  mode = "nat"
+
+  #  the domain used by the DNS server in this network
+  domain = "k8s.local"
+
+  #  list of subnets the addresses allowed for domains connected
+  # also derived to define the host addresses
+  # also derived to define the addresses served by the DHCP server
+  addresses = ["10.17.3.0/24", "2001:db8:ca2:2::1/64"]
+
+  # (optional) the bridge device defines the name of a bridge device
+  # which will be used to construct the virtual network.
+  # (only necessary in "bridge" mode)
+  # bridge = "br7"
+
+  # (optional) the MTU for the network. If not supplied, the underlying device's
+  # default is used (usually 1500)
+  # mtu = 9000
+
+  # (Optional) DNS configuration
+  dns {
+    # (Optional, default false)
+    # Set to true, if no other option is specified and you still want to 
+    # enable dns.
+    enabled = true
+    # (Optional, default false)
+    # true: DNS requests under this domain will only be resolved by the
+    # virtual network's own DNS server
+    # false: Unresolved requests will be forwarded to the host's
+    # upstream DNS server if the virtual network's DNS server does not
+    # have an answer.
+￼   local_only = true
+
+    # (Optional) one or more DNS forwarder entries.  One or both of
+    # "address" and "domain" must be specified.  The format is:
+    # forwarders {
+    #     address = "my address"
+    #     domain = "my domain"
+    #  } 
+    # 
+
+    # (Optional) one or more DNS host entries.  Both of
+    # "ip" and "hostname" must be specified.  The format is:
+    # hosts  {
+    #     hostname = "my_hostname"
+    #     ip = "my.ip.address.1"
+    #   }
+    # hosts {
+    #     hostname = "my_hostname"
+    #     ip = "my.ip.address.2"
+    #   }
+    # 
+
+    # (Optional) one or more static routes.
+    # "cidr" and "gateway" must be specified. The format is:
+    # routes {
+    #     cidr = "10.17.0.0/16"
+    #     gateway = "10.18.0.2"
+    #   }
+  }
+
+  # (Optional) Dnsmasq options configuration
+  dnsmasq_options {
+    # (Optional) one or more option entries.
+    # "option_name" muast be specified while "option_value" is
+	# optional to also support value-less options.  The format is:
+    # options  {
+    #     option_name = "server"
+    #     option_value = "/base.domain/my.ip.address.1"
+    #   }
+    # options  {
+    #     option_name = "no-hosts"
+    #   }
+    # options {
+    #     option_name = "address"
+    #     ip = "/.api.base.domain/my.ip.address.2"
+    #   }
+    #
+  }
+
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) A unique name for the resource, required by libvirt.
+  Changing this forces a new resource to be created.
+* `domain` - (Optional) The domain used by the DNS server.
+* `addresses` - (Optional) A list of (0 or 1) IPv4 and (0 or 1) IPv6 subnets in
+  CIDR notation.  This defines the subnets associated to that network.
+  This argument is also used to define the address on the real host.
+  If `dhcp {  enabled = true }` addresses is also used to define the address range served by
+  the DHCP server.
+  No DHCP server will be started if `addresses` is omitted.
+* `mode` -  One of:
+    - `none`: the guests can talk to each other and the host OS, but cannot reach
+    any other machines on the LAN.
+    - `nat`: it is the default network mode. This is a configuration that
+    allows guest OS to get outbound connectivity regardless of whether the host
+    uses ethernet, wireless, dialup, or VPN networking without requiring any
+    specific admin configuration. In the absence of host networking, it at
+    least allows guests to talk directly to each other.
+    - `route`: this is a variant on the default network which routes traffic from
+    the virtual network to the LAN **without applying any NAT**. It requires that
+    the IP address range be pre-configured in the routing tables of the router
+    on the host network.
+    - `open`: similar to `route`, but no firewall rules are added.
+    - `bridge`: use a pre-existing host bridge. The guests will effectively be
+    directly connected to the physical network (i.e. their IP addresses will
+    all be on the subnet of the physical network, and there will be no
+    restrictions on inbound or outbound connections). The `bridge` network
+    attribute is mandatory in this case.
+* `bridge` - (Optional) The bridge device defines the name of a bridge
+   device which will be used to construct the virtual network (when not provided,
+   it will be automatically obtained by libvirt in `none`, `nat`, `route` and `open` modes).
+* `mtu` - (Optional) The MTU to set for the underlying network interfaces. When
+   not supplied, libvirt will use the default for the interface, usually 1500.
+   Libvirt version 5.1 and greater will advertise this value to nodes via DHCP.
+* `autostart` - (Optional) Set to `true` to start the network on host boot up.
+  If not specified `false` is assumed.
+* `routes` - (Optional) a list of static routes. A `cidr` and a `gateway` must
+  be provided. The `gateway` must be reachable via the bridge interface.
+* `dns` - (Optional) configuration of DNS specific settings for the network
+
+Inside of `dns` section the following argument are supported:
+* `local_only` - (Optional) true/false: true means 'do not forward unresolved requests for this domain to the part DNS server
+* `forwarders` - (Optional) Either `address`, `domain`, or both must be set
+* `srvs` - (Optional) a DNS SRV entry block. You can have one or more of these blocks
+   in your DNS definition. You must specify `service` and `protocol`.
+* `hosts` - (Optional) a DNS host entry block. You can have one or more of these
+   blocks in your DNS definition. You must specify both `ip` and `hostname`.
+
+An advanced example of round-robin DNS (using DNS host templates) follows:
+
+```hcl
+resource "libvirt_network" "my_network" {
+  ...
+  dns {
+    hosts { flatten(data.libvirt_network_dns_host_template.hosts.*.rendered) }
+  }
+  ...
+}
+
+data "libvirt_network_dns_host_template" "hosts" {
+  count    = var.host_count
+  ip       = var.host_ips[count.index]
+  hostname = "my_host"
+}
+```
+
+An advanced example of setting up multiple SRV records using DNS SRV templates is:
+
+```hcl
+data "libvirt_network_dns_srv_template" "etcd_cluster" {
+  count    = var.etcd_count
+  service  = "etcd-server"
+  protocol = "tcp"
+  domain   = var.discovery_domain
+  target   = "${var.cluster_name}-etcd-${count.index}.${discovery_domain}"
+}
+
+resource "libvirt_network" "k8snet" {
+  ...
+  dns {
+    srvs = [ flatten(data.libvirt_network_dns_srv_template.etcd_cluster.*.rendered) ]
+  }
+  ...
+}
+```
+
+* `dhcp` - (Optional) DHCP configuration. 
+   You need to use it in conjuction with the adresses variable.
+  * `enabled` - (Optional) when false, disable the DHCP server
+```hcl
+				resource "libvirt_network" "test_net" {
+					name      = "networktest"
+					mode      = "nat"
+					domain    = "k8s.local"
+					addresses = ["10.17.3.0/24"]
+					dhcp {
+						enabled = true
+					}
+```
+
+* `dnsmasq_options` - (Optional) configuration of Dnsmasq options for the network
+  You need to provide a list of option name and value pairs.
+
+  * `options` - (Optional) a Dnsmasq option entry block. You can have one or more of these
+   blocks in your definition. You must specify `option_name` while `option_value` is
+   optional to support value-less options.
+
+  An example of setting Dnsmasq options (using Dnsmasq option templates) follows:
+
+```hcl
+        resource "libvirt_network" "my_network" {
+          ...
+          dnsmasq_options {
+            options { flatten(data.libvirt_network_dnsmasq_options_template.options.*.rendered) }
+          }
+          ...
+        }
+
+        data "libvirt_network_dnsmasq_options_template" "options" {
+          count = length(var.libvirt_dnsmasq_options)
+          option_name = keys(var.libvirt_dnsmasq_options)[count.index]
+          option_value = values(var.libvirt_dnsmasq_options)[count.index]
+        }
+```
+
+### Altering libvirt's generated network XML definition
+
+The optional `xml` block relates to the generated network XML.
+
+Currently the following attributes are supported:
+
+* `xslt`: specifies a XSLT stylesheet to transform the generated XML definition before creating the network.
+  This is used to support features the provider does not allow to set from the schema.
+  It is not recommended to alter properties and settings that are exposed to the schema, as terraform will insist in changing them back to the known state.
+
+See the domain option with the same name for more information and examples.
+
+## Attributes Reference
+
+* `id` - a unique identifier for the resource


### PR DESCRIPTION
This is part of the fix for #1358.

2620ecfe2b876116cb1776ce2b436a244ad246e6 adds the new tests on the old parser. This lets 00a1cdea96ccae2bf909f3d556b17bb9987f5f2d show the change in the parse. 

#1358 needs `mode.*` fields to be parsed as associated with `mode`. Currently, each `mode` option is parsed as a sub-field. A future PR will roll unexpected arguments into their parents (actually fixing #1358), but that requires the correct that this PR gives.

Comparison PRs against upstream are incoming.