### PR TITLE
Faster metadata parsing

### DIFF
--- a/unstable/metadata/metadata.go
+++ b/unstable/metadata/metadata.go
@@ -16,7 +16,7 @@ package metadata
 
 import (
 	"encoding/json"
-
+	"github.com/json-iterator/go"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
@@ -26,7 +26,8 @@ type Data struct{ m map[string]*json.RawMessage }
 func New(data []byte) (*Data, error) {
 	m := map[string]*json.RawMessage{}
 	if len(data) > 0 {
-		err := json.Unmarshal(data, &m)
+		jsoni := jsoniter.ConfigCompatibleWithStandardLibrary
+		err := jsoni.Unmarshal(data, &m)
 		if err != nil {
 			return nil, err
 		}
@@ -38,7 +39,8 @@ func (d *Data) Marshal() []byte {
 	if d == nil {
 		d = &Data{m: make(map[string]*json.RawMessage)}
 	}
-	bytes, err := json.MarshalIndent(d.m, "", "    ")
+	jsoni := jsoniter.ConfigCompatibleWithStandardLibrary
+	bytes, err := jsoni.MarshalIndent(d.m, "", "    ")
 	// `d.m` is a `map[string]json.RawMessage`. `json.MarshalIndent` errors only when
 	// it is asked to serialize an unmarshalable type (complex, function or channel)
 	// or a cyclic data structure. Because `string` and `json.RawMessage` are
@@ -58,7 +60,8 @@ func Set(d *Data, key string, value any) error {
 		delete(d.m, key)
 		return nil
 	}
-	data, err := json.Marshal(value)
+	jsoni := jsoniter.ConfigCompatibleWithStandardLibrary
+	data, err := jsoni.Marshal(value)
 	if err != nil {
 		return err
 	}
@@ -73,7 +76,8 @@ func Get[T any](d *Data, key string) (T, bool, error) {
 	if !ok {
 		return t, false, nil
 	}
-	err := json.Unmarshal(*data, &t)
+	jsoni := jsoniter.ConfigCompatibleWithStandardLibrary
+	err := jsoni.Unmarshal(*data, &t)
 	return t, true, err
 }
 

--- a/unstable/metadata/metadata.go
+++ b/unstable/metadata/metadata.go
@@ -39,8 +39,7 @@ func (d *Data) Marshal() []byte {
 	if d == nil {
 		d = &Data{m: make(map[string]*json.RawMessage)}
 	}
-	jsoni := jsoniter.ConfigCompatibleWithStandardLibrary
-	bytes, err := jsoni.MarshalIndent(d.m, "", "    ")
+	bytes, err := json.MarshalIndent(d.m, "", "    ")
 	// `d.m` is a `map[string]json.RawMessage`. `json.MarshalIndent` errors only when
 	// it is asked to serialize an unmarshalable type (complex, function or channel)
 	// or a cyclic data structure. Because `string` and `json.RawMessage` are


### PR DESCRIPTION
Benchmarks here:

https://github.com/pulumi/pulumi-aws/pull/2819

Use json-iterator as a drop-in replacement for the stdlib. Should already be a Pulumi dependency.

It gives a quick speedup for the large AWS use case with very little effort.

Approximate saving is 300ms.