### PR TITLE
Fix withoutPackageName

### DIFF
--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -1652,7 +1652,7 @@ func withoutPackageName(pkg string, rawname string) string {
 	// but every rule has an exception! In HTTP provider the "http" datasource intentionally
 	// does not do that, as noted in:
 	//
-	// https://github.com/hashicorp/terraform-provider-http/blob/0eeb9818e8114631a3c7dc61e750f11180ca987b/internal/provider/data_source_http.go#L47
+	// https://github.com/hashicorp/terraform-provider-http/blob/master/internal/provider/data_source_http.go#L47
 	//
 	// Therefore the code trims the prefix if it finds it, but leaves as-is otherwise.
 	return strings.TrimPrefix(rawname, pkg+"_")

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -1652,7 +1652,8 @@ func withoutPackageName(pkg string, rawname string) string {
 	// but every rule has an exception! In HTTP provider the "http" datasource intentionally
 	// does not do that, as noted in:
 	//
-	// https://github.com/hashicorp/terraform-provider-http/blob/master/internal/provider/data_source_http.go#L47
+	///nolint:lll
+	// https://github.com/hashicorp/terraform-provider-http/blob/0eeb9818e8114631a3c7dc61e750f11180ca987b/internal/provider/data_source_http.go#L47
 	//
 	// Therefore the code trims the prefix if it finds it, but leaves as-is otherwise.
 	return strings.TrimPrefix(rawname, pkg+"_")

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -1648,9 +1648,14 @@ func resourceName(provider string, rawname string,
 
 // withoutPackageName strips off the package prefix from a raw name.
 func withoutPackageName(pkg string, rawname string) string {
-	contract.Assertf(strings.HasPrefix(rawname, pkg+"_"), `strings.HasPrefix(rawname, pkg+"_")`)
-	name := rawname[len(pkg)+1:] // strip off the pkg prefix.
-	return name
+	// Providers almost always have function and resource names prefixed with the package name,
+	// but every rule has an exception! In HTTP provider the "http" datasource intentionally
+	// does not do that, as noted in:
+	//
+	// https://github.com/hashicorp/terraform-provider-http/blob/0eeb9818e8114631a3c7dc61e750f11180ca987b/internal/provider/data_source_http.go#L47
+	//
+	// Therefore the code trims the prefix if it finds it, but leaves as-is otherwise.
+	return strings.TrimPrefix(rawname, pkg+"_")
 }
 
 func stableResources(resources shim.ResourceMap) []string {

--- a/pkg/tfgen/generate_test.go
+++ b/pkg/tfgen/generate_test.go
@@ -365,3 +365,8 @@ func TestModulePlacementForType(t *testing.T) {
 	}
 
 }
+
+func TestWithoutPackageName(t *testing.T) {
+	assert.Equal(t, "http", withoutPackageName("http", "http"))
+	assert.Equal(t, "s3_bucket", withoutPackageName("aws", "aws_s3_bucket"))
+}


### PR DESCRIPTION
Fixes #1379 

HTTP provider is special that it does not follow the TF convention of "${pkg_name}.${resource_name}". This caused a panic in the bridge at generation time. This is now corrected as we no longer assume that convention.