### PR TITLE
Add `Generics` option to `GolangInfo`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,5 +48,6 @@ tidy::
 	cd pf/tests/testdatagen/genrandom && go mod tidy
 	cd pkg/tests && go mod tidy
 	cd x/muxer && go mod tidy
+	cd x/muxer/tests && go mod tidy
 	cd testing && go mod tidy
 	go mod tidy

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -680,6 +680,13 @@ type GolangInfo struct {
 	// InternalDependencies are blank imports that are emitted in the SDK so that `go mod tidy` does not remove the
 	// associated module dependencies from the SDK's go.mod.
 	InternalDependencies []string
+
+	// Specifies how to handle generating a variant of the SDK that uses generics.
+	// Allowed values are the following:
+	// - "none" (default): do not generate a generics variant of the SDK
+	// - "side-by-side": generate a side-by-side generics variant of the SDK under the x subdirectory
+	// - "only-generics": generate a generics variant of the SDK only
+	Generics string
 }
 
 // CSharpInfo contains optional overlay information for C# code-generation.

--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -422,6 +422,7 @@ func goLanguageExtensions(providerInfo *tfbridge.ProviderInfo) pschema.RawMessag
 		OmitExtraInputTypes:            g.OmitExtraInputTypes,
 		RespectSchemaVersion:           g.RespectSchemaVersion,
 		InternalDependencies:           g.InternalDependencies,
+		Generics:                       g.Generics,
 	}
 	return rawMessage(info)
 }


### PR DESCRIPTION
This is a new Go schema option in Pulumi v3.84.0 that should be exposed for bridged providers. Commits:
1. Update deps to v3.84.0
2. Expose the `Generics` option

Fixes #1391