### PR TITLE
Provider init benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
             **/go.sum
       - name: Build
         run: make build
+      - name: Build PF
+        run: cd pf && make build
       - name: Install golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/pf/tests/internal/testprovider/aws.go
+++ b/pf/tests/internal/testprovider/aws.go
@@ -1,0 +1,22 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testprovider
+
+import (
+	_ "embed"
+)
+
+//go:embed cmd/pulumi-resource-aws/bridge-metadata.json
+var BigMetadata []byte

--- a/pf/tests/internal/testprovider/random.go
+++ b/pf/tests/internal/testprovider/random.go
@@ -27,6 +27,8 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/pf/tests/internal/testprovider/sdkv2randomprovider"
 	"github.com/terraform-providers/terraform-provider-random/randomshim"
 
+	sdk2schema "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	tfpf "github.com/pulumi/pulumi-terraform-bridge/pf/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	sdkv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
@@ -115,6 +117,10 @@ func RandomProvider() tfbridge.ProviderInfo {
 }
 
 func MuxedRandomProvider() tfbridge.ProviderInfo {
+	return MuxedRandomProviderWithSdkProvider(sdkv2randomprovider.New())
+}
+
+func MuxedRandomProviderWithSdkProvider(sdk2provider *sdk2schema.Provider) tfbridge.ProviderInfo {
 	randomPkg := "muxedrandom"
 	randomMod := "index"
 
@@ -146,7 +152,7 @@ func MuxedRandomProvider() tfbridge.ProviderInfo {
 		Repository:  "https://github.com/pulumi/pulumi-random",
 		Version:     "4.8.2",
 		P: tfpf.MuxShimWithPF(context.Background(),
-			sdkv2.NewProvider(sdkv2randomprovider.New()),
+			sdkv2.NewProvider(sdk2provider),
 			randomshim.NewProvider()),
 		Resources: map[string]*tfbridge.ResourceInfo{
 			// "random_human_number": {Tok: randomResource("RandomHumanNumber")},

--- a/pf/tests/internal/testprovider/sdkv2randomprovider/provider.go
+++ b/pf/tests/internal/testprovider/sdkv2randomprovider/provider.go
@@ -17,6 +17,7 @@ package sdkv2randomprovider
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -28,6 +29,18 @@ func New() *schema.Provider {
 			"random_human_number": humanNumber(),
 		},
 	}
+
+	p.ConfigureContextFunc = configure("1.2.3", p)
+
+	return p
+}
+
+func Sized(count int) *schema.Provider {
+	m := make(map[string]*schema.Resource, count)
+	for i := 0; i < count; i++ {
+		m[fmt.Sprintf("random_human_number_%d", i)] = humanNumber()
+	}
+	p := &schema.Provider{ResourcesMap: m}
 
 	p.ConfigureContextFunc = configure("1.2.3", p)
 

--- a/pf/tests/provider_init_benchmark_test.go
+++ b/pf/tests/provider_init_benchmark_test.go
@@ -1,0 +1,62 @@
+package tfbridgetests
+
+import (
+	"fmt"
+	"github.com/pulumi/pulumi-terraform-bridge/pf/tests/internal/testprovider"
+	"github.com/pulumi/pulumi-terraform-bridge/pf/tests/internal/testprovider/sdkv2randomprovider"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"testing"
+)
+
+// Benchmark tests based on init of an example large provider
+
+func BenchmarkRandomProviderInit(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		testprovider.RandomProvider()
+	}
+}
+
+func BenchmarkMuxedRandomProviderInit(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		testprovider.MuxedRandomProvider()
+	}
+}
+
+func BenchmarkSizedMuxedRandomProviderInit(b *testing.B) {
+	for _, size := range []int{100, 10000} {
+		b.Run(fmt.Sprintf("resources_size_%d", size), func(b *testing.B) {
+			prov := sdkv2randomprovider.Sized(size)
+			b.ResetTimer()
+			for n := 0; n < b.N; n++ {
+				testprovider.MuxedRandomProviderWithSdkProvider(prov)
+			}
+		})
+	}
+}
+
+func BenchmarkMuxedRandomProviderMustApplyAutoAliases(b *testing.B) {
+	p := testprovider.MuxedRandomProvider()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		p.MustApplyAutoAliases()
+	}
+}
+
+func BenchmarkSizedMuxedRandomProviderMustApplyAutoAliases(b *testing.B) {
+	for _, size := range []int{100, 10000} {
+		b.Run(fmt.Sprintf("resources_size_%d", size), func(b *testing.B) {
+			prov := sdkv2randomprovider.Sized(size)
+			p := testprovider.MuxedRandomProviderWithSdkProvider(prov)
+			b.ResetTimer()
+			for n := 0; n < b.N; n++ {
+				p.MustApplyAutoAliases()
+			}
+		})
+	}
+}
+
+func BenchmarkLoadMetadata(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		tfbridge.NewProviderMetadata(testprovider.BigMetadata)
+	}
+}


### PR DESCRIPTION
Adding some benchmarks so we can observe changes in provider init time in the future. I broke out some metrics for loading a large metadata file as well as some around `MustApplyAutoAliases` based on the significance in our current investigations. I also find it interesting that initializing a Muxed provider is so much slower than initiating a vanilla PF provider. 

Sample before Anton's jsoniter change:
```
❯ go test -run="^$" -bench=. -benchtime=10s
goos: darwin
goarch: arm64
pkg: github.com/pulumi/pulumi-terraform-bridge/pf/tests
BenchmarkRandomProviderInit-12                              			 1000000	     11075 ns/op
BenchmarkMuxedRandomProviderInit-12                         			  209493	     57241 ns/op
BenchmarkSizedMuxedRandomProviderInit/resources_size_100-12 			  165622	     72675 ns/op
BenchmarkSizedMuxedRandomProviderInit/resources_size_10000-12       	  	   10000	   1158911 ns/op
BenchmarkMuxedRandomProviderMustApplyAutoAliases-12                	   	  286514	     42117 ns/op
BenchmarkSizedMuxedRandomProviderMustApplyAutoAliases/resources_size_100-12    	  299841	     40039 ns/op
BenchmarkSizedMuxedRandomProviderMustApplyAutoAliases/resources_size_10000-12 	  321598	     37014 ns/op
BenchmarkLoadMetadata-12                                                 	     178	  66922526 ns/op
```

After jsoniter:
```
❯ go test -run="^$" -bench=. -benchtime=10s
goos: darwin
goarch: arm64
pkg: github.com/pulumi/pulumi-terraform-bridge/pf/tests
BenchmarkRandomProviderInit-12                              			 2512153	      4779 ns/op
BenchmarkMuxedRandomProviderInit-12                         			  293250	     40511 ns/op
BenchmarkSizedMuxedRandomProviderInit/resources_size_100-12 			  218238	     56443 ns/op
BenchmarkSizedMuxedRandomProviderInit/resources_size_10000-12         		   10000	   1177436 ns/op
BenchmarkMuxedRandomProviderMustApplyAutoAliases-12                   		  316081	     38707 ns/op
BenchmarkSizedMuxedRandomProviderMustApplyAutoAliases/resources_size_100-12	  328318	     36714 ns/op
BenchmarkSizedMuxedRandomProviderMustApplyAutoAliases/resources_size_10000-12 	  350518	     34213 ns/op
BenchmarkLoadMetadata-12                                                 	     751	  16085014 ns/op
```
