### PR TITLE
Add ResourceInfo.TransformFromState

### DIFF
--- a/pf/tfbridge/provider_check.go
+++ b/pf/tfbridge/provider_check.go
@@ -46,6 +46,11 @@ func (p *provider) CheckWithContext(
 		return checkedInputs, []plugin.CheckFailure{}, err
 	}
 
+	priorState, err = transformFromState(ctx, rh, priorState)
+	if err != nil {
+		return checkedInputs, []plugin.CheckFailure{}, err
+	}
+
 	if info := rh.pulumiResourceInfo; info != nil {
 		if check := info.PreCheckCallback; check != nil {
 			var err error

--- a/pf/tfbridge/provider_delete.go
+++ b/pf/tfbridge/provider_delete.go
@@ -40,6 +40,11 @@ func (p *provider) DeleteWithContext(
 		return resource.StatusOK, err
 	}
 
+	props, err = transformFromState(ctx, rh, props)
+	if err != nil {
+		return resource.StatusOK, err
+	}
+
 	tfType := rh.schema.Type().TerraformType(ctx).(tftypes.Object)
 
 	priorState, err := convert.EncodePropertyMapToDynamic(rh.encoder, tfType, props)

--- a/pf/tfbridge/provider_diff.go
+++ b/pf/tfbridge/provider_diff.go
@@ -44,15 +44,19 @@ func (p *provider) DiffWithContext(
 	ignoreChanges []string,
 ) (plugin.DiffResult, error) {
 	ctx = p.initLogging(ctx, p.logSink, urn)
-
-	checkedInputs, err := applyIgnoreChanges(priorStateMap, checkedInputs, ignoreChanges)
-	if err != nil {
-		return plugin.DiffResult{}, fmt.Errorf("failed to apply ignore changes: %w", err)
-	}
-
 	rh, err := p.resourceHandle(ctx, urn)
 	if err != nil {
 		return plugin.DiffResult{}, err
+	}
+
+	priorStateMap, err = transformFromState(ctx, rh, priorStateMap)
+	if err != nil {
+		return plugin.DiffResult{}, err
+	}
+
+	checkedInputs, err = applyIgnoreChanges(priorStateMap, checkedInputs, ignoreChanges)
+	if err != nil {
+		return plugin.DiffResult{}, fmt.Errorf("failed to apply ignore changes: %w", err)
 	}
 
 	rawPriorState, err := parseResourceState(&rh, priorStateMap)

--- a/pf/tfbridge/provider_read.go
+++ b/pf/tfbridge/provider_read.go
@@ -57,6 +57,13 @@ func (p *provider) ReadWithContext(
 	var result plugin.ReadResult
 
 	if isRefresh {
+		// If we are in a refresh, then currentStateMap was read from the state
+		// and should be transformed.
+		currentStateMap, err = transformFromState(ctx, rh, currentStateMap)
+		if err != nil {
+			return plugin.ReadResult{}, 0, err
+		}
+
 		result, err = p.readViaReadResource(ctx, &rh, id, oldInputs, currentStateMap)
 	} else {
 		result, err = p.readViaImportResourceState(ctx, &rh, id)

--- a/pf/tfbridge/provider_resources.go
+++ b/pf/tfbridge/provider_resources.go
@@ -95,3 +95,20 @@ func (p *provider) resourceHandle(ctx context.Context, urn pulumiresource.URN) (
 	result.schemaOnlyShimResource, _ = p.schemaOnlyProvider.ResourcesMap().GetOk(typeName)
 	return result, nil
 }
+
+func transformFromState(
+	ctx context.Context, rh resourceHandle, state pulumiresource.PropertyMap,
+) (pulumiresource.PropertyMap, error) {
+	if rh.pulumiResourceInfo == nil {
+		return state, nil
+	}
+	f := rh.pulumiResourceInfo.TransformFromState
+	if f == nil {
+		return state, nil
+	}
+	o, err := f(ctx, state)
+	if err != nil {
+		return nil, fmt.Errorf("transforming from state: %w", err)
+	}
+	return o, err
+}

--- a/pf/tfbridge/provider_update.go
+++ b/pf/tfbridge/provider_update.go
@@ -39,14 +39,19 @@ func (p *provider) UpdateWithContext(
 ) (resource.PropertyMap, resource.Status, error) {
 	ctx = p.initLogging(ctx, p.logSink, urn)
 
-	checkedInputs, err := applyIgnoreChanges(priorStateMap, checkedInputs, ignoreChanges)
-	if err != nil {
-		return nil, 0, fmt.Errorf("failed to apply ignore changes: %w", err)
-	}
-
 	rh, err := p.resourceHandle(ctx, urn)
 	if err != nil {
 		return nil, 0, err
+	}
+
+	priorStateMap, err = transformFromState(ctx, rh, priorStateMap)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	checkedInputs, err = applyIgnoreChanges(priorStateMap, checkedInputs, ignoreChanges)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to apply ignore changes: %w", err)
 	}
 
 	tfType := rh.schema.Type().TerraformType(ctx).(tftypes.Object)

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -329,8 +329,16 @@ type ResourceInfo struct {
 	// outputs before they are stored. In particular, it can be used as a last resort hook to
 	// make corrections in the default translation of the resource state from TF to Pulumi.
 	// Should be used sparingly.
-	TransformOutputs func(ctx context.Context, outputs resource.PropertyMap) (resource.PropertyMap, error)
+	TransformOutputs PropertyTransform
+
+	// Check, Diff, Read, Update and Delete refer to old inputs sourced from the
+	// Pulumi statefile. TransformFromState lets providers edit these outputs before they
+	// are accessed by other provider functions or by terraform. In particular, it can
+	// be used to perform upgrades on old pulumi state.  Should be used sparingly.
+	TransformFromState PropertyTransform
 }
+
+type PropertyTransform = func(context.Context, resource.PropertyMap) (resource.PropertyMap, error)
 
 type PreCheckCallback = func(
 	ctx context.Context, config resource.PropertyMap, meta resource.PropertyMap,

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -1195,6 +1195,12 @@ func UnmarshalTerraformState(
 	if err != nil {
 		return nil, err
 	}
+
+	props, err = transformFromState(ctx, r.Schema, props)
+	if err != nil {
+		return nil, err
+	}
+
 	return MakeTerraformState(ctx, r, id, props)
 }
 


### PR DESCRIPTION
This provides a makeshift migration mechanism for TF based providers. `PreCheckCallback` is run before an input is baked into the state, but sometimes we need to make changes after a value is read from the state: when we didn't have the `PreCheckCallback` in place before hand.

- [X] SDK
- [X] PF
- [ ] Tests