### PR TITLE
Allow tfgen to use pulumi convert for examples conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ This repo on its own isn't particularly interesting, until it is used to create 
 
 We use git tags and [GitHub Releases](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository).
 1. Maintainers will push a new semver [tag](https://github.com/pulumi/pulumi-terraform-bridge/tags) when appropriate
-1. Maintainers will then generate a Release with Changelog using [GitHub Releases](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository), using the tag pushed in the 
+1. Maintainers will then generate a Release with Changelog using [GitHub Releases](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository), using the tag pushed in the
 first step.
-1. Finally, maintainers will roll out bridge updates across Pulumi providers via manually running the [bridge update 
+1. Finally, maintainers will roll out bridge updates across Pulumi providers via manually running the [bridge update
 workflow in CI Management](https://github.com/pulumi/ci-mgmt/actions/workflows/update-bridge-ecosystem-providers.yml).
 
 ### Adapting a New Terraform Provider
@@ -106,3 +106,4 @@ tfgen, the command that generates Pulumi schema/code for a bridged provider supp
 * `PULUMI_SKIP_MISSING_MAPPING_ERROR`: If truthy, tfgen will not fail if a data source or resource in the TF provider is not mapped to the Pulumi provider. Instead, a warning is printed. Default is `false`.
 * `PULUMI_SKIP_EXTRA_MAPPING_ERROR`: If truthy, tfgen will not fail if a mapped data source or resource does not exist in the TF provider. Instead, warning is printed. Default is `false`.
 * `PULUMI_MISSING_DOCS_ERROR`: If truthy, tfgen will fail if docs cannot be found for a data source or resource. Default is `false`.
+* `PULUMI_CONVERT`: If truthy, tfgen will shell out to `pulumi convert` for converting example code from TF HCL to Pulumi PCL

--- a/pkg/tfgen/convert_cli.go
+++ b/pkg/tfgen/convert_cli.go
@@ -340,7 +340,9 @@ func (*cliConverter) convertViaPulumiCLI(
 
 	outputFileBytes, err := os.ReadFile(outputFile)
 	if err != nil {
-		return nil, fmt.Errorf("convertViaPulumiCLI: failed to read output file: %w", err)
+		return nil, fmt.Errorf("convertViaPulumiCLI: failed to read output file: %w, "+
+			"check if your Pulumi CLI version is recent enough to include pulumi-converter-terraform v1.0.9",
+			err)
 	}
 
 	var result map[string]translatedExample

--- a/pkg/tfgen/convert_cli.go
+++ b/pkg/tfgen/convert_cli.go
@@ -363,8 +363,7 @@ func (cc *cliConverter) convertPCL(
 		return "", diagnostics, nil
 	}
 
-	opts := cc.opts
-	if opts == nil {
+	if cc.opts == nil {
 		var opts []pcl.BindOption
 		opts = append(opts, pcl.AllowMissingProperties)
 		opts = append(opts, pcl.AllowMissingVariables)
@@ -372,7 +371,6 @@ func (cc *cliConverter) convertPCL(
 		if cc.pluginHost != nil {
 			opts = append(opts, pcl.PluginHost(cc.pluginHost))
 			loader := newLoader(cc.pluginHost)
-			//loader.BindCurrentPackage(*spec, cc.packageName)
 			opts = append(opts, pcl.Loader(loader))
 		}
 		if cc.packageCache != nil {
@@ -381,7 +379,7 @@ func (cc *cliConverter) convertPCL(
 		cc.opts = opts
 	}
 
-	program, programDiags, err := pcl.BindProgram(pulumiParser.Files, opts...)
+	program, programDiags, err := pcl.BindProgram(pulumiParser.Files, cc.opts...)
 	if err != nil {
 		return "", diagnostics, fmt.Errorf("pcl.BindProgram failed: %w", err)
 	}

--- a/pkg/tfgen/convert_cli.go
+++ b/pkg/tfgen/convert_cli.go
@@ -311,16 +311,20 @@ func (*cliConverter) convertViaPulumiCLI(
 		mappingsArgs = append(mappingsArgs, "--mappings", mappingsFile(m.name))
 	}
 
-	cmd := exec.Command(pulumiPath, append([]string{"convert",
+	cmdArgs := []string{
+		"convert",
 		"--from", "terraform",
 		"--language", "pcl",
 		"--out", outDir,
 		"--generate-only",
-	}, mappingsArgs...)...)
+	}
+
+	cmdArgs = append(cmdArgs, mappingsArgs...)
+	cmdArgs = append(cmdArgs, "--", "--convert-examples", filepath.Base(examplesJSON.Name()))
+
+	cmd := exec.Command(pulumiPath, cmdArgs...)
 
 	cmd.Dir = filepath.Dir(examplesJSON.Name())
-	cmd.Env = append(os.Environ(),
-		"PULUMI_CONVERT_EXAMPLES="+filepath.Base(examplesJSON.Name()))
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout, cmd.Stderr = &stdout, &stderr

--- a/pkg/tfgen/convert_cli.go
+++ b/pkg/tfgen/convert_cli.go
@@ -96,13 +96,12 @@ func (g *Generator) cliConverter() *cliConverter {
 	if g.cliConverterState != nil {
 		return g.cliConverterState
 	}
-	packageName := string(g.pkg)
 	g.cliConverterState = &cliConverter{
 		generator:    g,
 		hcls:         map[string]struct{}{},
 		info:         g.info,
 		packageCache: g.packageCache,
-		packageName:  packageName,
+		packageName:  string(g.pkg),
 		pluginHost:   g.pluginHost,
 		pcls:         map[string]translatedExample{},
 	}
@@ -279,14 +278,16 @@ func (*cliConverter) convertViaPulumiCLI(
 		return filepath.Join(mappingsDir, fmt.Sprintf("%s.json", name))
 	}
 
-	// Write out mappings files if necessary.
-	for i, m := range mappings {
-		if i == 0 {
-			if err := os.MkdirAll(mappingsDir, 0755); err != nil {
-				return nil, fmt.Errorf("convertViaPulumiCLI: failed to write "+
-					"mappings folder: %w", err)
-			}
+	// Prepare mappings folder if necessary.
+	if len(mappings) > 0 {
+		if err := os.MkdirAll(mappingsDir, 0755); err != nil {
+			return nil, fmt.Errorf("convertViaPulumiCLI: failed to write "+
+				"mappings folder: %w", err)
 		}
+	}
+
+	// Write out mappings files if necessary.
+	for _, m := range mappings {
 		mpi := tfbridge.MarshalProviderInfo(&m.info)
 		bytes, err := json.Marshal(mpi)
 		if err != nil {

--- a/pkg/tfgen/convert_cli.go
+++ b/pkg/tfgen/convert_cli.go
@@ -41,9 +41,9 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
-var (
-	cliConverterEnabled bool = cmdutil.IsTruthy(os.Getenv("PULUMI_CONVERT"))
-)
+func cliConverterEnabled() bool {
+	return cmdutil.IsTruthy(os.Getenv("PULUMI_CONVERT"))
+}
 
 // Integrates with `pulumi convert` command for converting TF examples.
 //

--- a/pkg/tfgen/convert_cli.go
+++ b/pkg/tfgen/convert_cli.go
@@ -1,0 +1,435 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfgen
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+
+	"github.com/hashicorp/hcl/v2"
+
+	hcl2java "github.com/pulumi/pulumi-java/pkg/codegen/java"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	hcl2yaml "github.com/pulumi/pulumi-yaml/pkg/pulumiyaml/codegen"
+	hcl2dotnet "github.com/pulumi/pulumi/pkg/v3/codegen/dotnet"
+	hcl2go "github.com/pulumi/pulumi/pkg/v3/codegen/go"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
+	hcl2nodejs "github.com/pulumi/pulumi/pkg/v3/codegen/nodejs"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
+	hcl2python "github.com/pulumi/pulumi/pkg/v3/codegen/python"
+	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+var (
+	cliConverterEnabled bool = cmdutil.IsTruthy(os.Getenv("PULUMI_CONVERT"))
+)
+
+// Integrates with `pulumi convert` command for converting TF examples.
+//
+// Pulumi CLI now supprts a handy `pulumi convert` command. This file implements integrating with
+// this command for the purposes of initial conversion of Terraform examples into PCL language. This
+// integration is preferable to linking the functionality in as it allows bridged providers to not
+// build-depend on the TF converter.
+//
+// Note that once examples are converted to PCL, they continue to be processed with in-process
+// target language specific generators to produce TypeScript, YAML, Python etc target code.
+type cliConverter struct {
+	packageName  string                // name of the provider such as "gcp"
+	info         tfbridge.ProviderInfo // provider declaration
+	pluginHost   plugin.Host           // the plugin host for PCL conversion
+	packageCache *pcl.PackageCache     // the package cache for PCL conversion
+
+	hcls map[string]struct{} // set of observed HCL snippets
+
+	generator interface {
+		convertHCL(hcl, path, exampleTitle string, languages []string) (string, error)
+		convertExamplesInner(
+			docs string,
+			path examplePath,
+			stripSubsectionsWithErrors bool,
+			convertHCL func(hcl, path, exampleTitle string,
+				languages []string) (string, error),
+		) string
+	}
+
+	convertExamplesList []struct {
+		docs                       string
+		path                       examplePath
+		stripSubsectionsWithErrors bool
+	}
+
+	currentPackageSpec *pschema.PackageSpec
+
+	pcls map[string]translatedExample // translations indexed by HCL
+	opts []pcl.BindOption             // options cache; do not set
+}
+
+// Represents a partially converted example. PCL is the Pulumi dialect of HCL.
+type translatedExample struct {
+	PCL         string          `json:"pcl"`
+	Diagnostics hcl.Diagnostics `json:"diagnostics"`
+}
+
+// Get or create the cliConverter associated with the Generator.
+func (g *Generator) cliConverter() *cliConverter {
+	if g.cliConverterState != nil {
+		return g.cliConverterState
+	}
+	packageName := string(g.pkg)
+	infoCopy := g.info
+	infoCopy.Name = packageName // correct "google-beta" to "gcp"
+	g.cliConverterState = &cliConverter{
+		generator:    g,
+		hcls:         map[string]struct{}{},
+		info:         infoCopy,
+		packageCache: g.packageCache,
+		packageName:  packageName,
+		pluginHost:   g.pluginHost,
+		pcls:         map[string]translatedExample{},
+	}
+	return g.cliConverterState
+}
+
+// Instead of converting examples, detect HCL literals involved and record placeholders for later.
+func (cc *cliConverter) StartConvertingExamples(
+	docs string,
+	path examplePath,
+	stripSubsectionsWithErrors bool,
+) string {
+	// Record inner HCL conversions and discard the result.
+	cc.generator.convertExamplesInner(docs, path, stripSubsectionsWithErrors, cc.recordHCL)
+	// Record the convertExamples job for later.
+	e := struct {
+		docs                       string
+		path                       examplePath
+		stripSubsectionsWithErrors bool
+	}{
+		docs:                       docs,
+		path:                       path,
+		stripSubsectionsWithErrors: stripSubsectionsWithErrors,
+	}
+	cc.convertExamplesList = append(cc.convertExamplesList, e)
+	// Return a placeholder referencing the convertExampleJob by position.
+	return fmt.Sprintf("{convertExamples:%d}", len(cc.convertExamplesList)-1)
+}
+
+// Replace all convertExamples placeholders with actual values by rendering them.
+func (cc *cliConverter) FinishConvertingExamples(p pschema.PackageSpec) pschema.PackageSpec {
+	// Remember partially constructed PackageSpec so that Convert can access it.
+	cc.currentPackageSpec = &p
+
+	err := cc.bulkConvert()
+	contract.AssertNoErrorf(err, "bulk converting examples failed")
+
+	bytes, err := json.Marshal(p)
+	contract.AssertNoErrorf(err, "json.Marshal failed on PackageSpec")
+	re := regexp.MustCompile("[{]convertExamples[:]([^}]+)[}]")
+
+	// Convert all stubs populated by StartConvertingExamples.
+	fixedBytes := re.ReplaceAllFunc(bytes, func(match []byte) []byte {
+		groups := re.FindSubmatch(match)
+		i, err := strconv.Atoi(string(groups[1]))
+		contract.AssertNoErrorf(err, "strconv.Atoi")
+		ex := cc.convertExamplesList[i]
+		source := cc.generator.convertExamplesInner(ex.docs, ex.path,
+			ex.stripSubsectionsWithErrors, cc.generator.convertHCL)
+		// JSON-escaping to splice into JSON string literals.
+		bytes, err := json.Marshal(source)
+		contract.AssertNoErrorf(err, "json.Masrhal(sourceCode)")
+		return bytes[1 : len(bytes)-1]
+	})
+
+	var result pschema.PackageSpec
+	err = json.Unmarshal(fixedBytes, &result)
+	contract.AssertNoErrorf(err, "json.Unmarshal failed to recover PackageSpec")
+	return result
+}
+
+// During FinishConvertingExamples pass, generator calls back into this function to continue
+// PCL->lang translation from a pre-computed HCL->PCL translation table cc.pcls.
+func (cc *cliConverter) Convert(hclCode string, lang string) (string, hcl.Diagnostics, error) {
+	example, ok := cc.pcls[hclCode]
+	contract.Assertf(ok, "unexpected new HCL snippet in Convert; should have seen it before")
+	if example.Diagnostics.HasErrors() {
+		return "", example.Diagnostics, nil
+	}
+	source, diags, err := cc.convertPCL(cc.currentPackageSpec, example.PCL, lang)
+	return source, diags.Extend(example.Diagnostics), err
+}
+
+// Convert all observed HCL snippets from cc.hcls to PCL in one pass, populate cc.pcls.
+func (cc *cliConverter) bulkConvert() error {
+	examples := map[string]string{}
+	n := 0
+	for hcl := range cc.hcls {
+		examples[fmt.Sprintf("e%d", n)] = hcl
+		n++
+	}
+	result, err := cc.convertViaPulumiCLI(examples, []tfbridge.ProviderInfo{cc.info})
+	if err != nil {
+		return err
+	}
+	for k, hcl := range examples {
+		cc.pcls[hcl] = result[k]
+	}
+	return nil
+}
+
+// Calls pulumi convert to bulk-convert examples.
+//
+// To facilitate high-throughput conversion, an `examples.json` protocol is employed to convert
+// examples in batches. See pulumi/pulumi-converter-terraform#29 for where the support is
+// introduced.
+//
+// Source examples are passed in as a map from ID to raw TF code.
+//
+// This may need to be coarse-grain parallelized to speed up larger providers at the cost of more
+// memory, for example run 4 instances of `pulumi convert` on 25% of examples each.
+func (*cliConverter) convertViaPulumiCLI(
+	examples map[string]string,
+	mappings []tfbridge.ProviderInfo,
+) (
+	output map[string]translatedExample,
+	finalError error,
+) {
+	outDir, err := os.MkdirTemp("", "bridge-examples-output")
+	if err != nil {
+		finalError = fmt.Errorf("convertViaPulumiCLI: failed to create a temp dir "+
+			" bridge-examples-output: %w", err)
+		return
+	}
+	defer func() {
+		if err := os.RemoveAll(outDir); err != nil {
+			if finalError == nil {
+				finalError = fmt.Errorf("convertViaPulumiCLI: failed to clean up "+
+					"temp bridge-examples-output dir: %w", err)
+			}
+		}
+	}()
+
+	examplesJSON, err := os.CreateTemp("", "bridge-examples.json")
+	if err != nil {
+		finalError = fmt.Errorf("convertViaPulumiCLI: failed to create a temp "+
+			" bridge-examples.json file: %w", err)
+		return
+	}
+	defer func() {
+		if err := os.Remove(examplesJSON.Name()); err != nil {
+			if finalError == nil {
+				finalError = fmt.Errorf("convertViaPulumiCLI: failed to clean up "+
+					"temp bridge-examples.json file: %w", err)
+			}
+		}
+	}()
+
+	// Write example to bridge-examples.json.
+	examplesBytes, err := json.Marshal(examples)
+	if err != nil {
+		finalError = fmt.Errorf("convertViaPulumiCLI: failed to marshal examples "+
+			"to JSON: %w", err)
+		return
+	}
+	if err := os.WriteFile(examplesJSON.Name(), examplesBytes, 0655); err != nil {
+		finalError = fmt.Errorf("convertViaPulumiCLI: failed to write a temp "+
+			"bridge-examples.json file: %w", err)
+		return
+	}
+
+	mappingsDir := filepath.Join(outDir, "mappings")
+
+	mappingsFile := func(i int, p tfbridge.ProviderInfo) string {
+		return filepath.Join(mappingsDir, fmt.Sprintf("%s.json", p.Name))
+	}
+
+	// Write out mappings files if necessary.
+	for i, m := range mappings {
+		if i == 0 {
+			if err := os.MkdirAll(mappingsDir, 0755); err != nil {
+				finalError = fmt.Errorf("convertViaPulumiCLI: failed to write "+
+					"mappings folder: %w", err)
+				return
+			}
+		}
+		mpi := tfbridge.MarshalProviderInfo(&m)
+		bytes, err := json.Marshal(mpi)
+		if err != nil {
+			finalError = fmt.Errorf("convertViaPulumiCLI: failed to write "+
+				"mappings folder: %w", err)
+			return
+		}
+		mf := mappingsFile(i, m)
+		if err := os.WriteFile(mf, bytes, 0655); err != nil {
+			finalError = fmt.Errorf("convertViaPulumiCLI: failed to write "+
+				"mappings file: %w", err)
+			return
+		}
+	}
+
+	pulumiPath, err := exec.LookPath("pulumi")
+	if err != nil {
+		finalError = fmt.Errorf("convertViaPulumiCLI: pulumi executalbe not "+
+			"in PATH: %w", err)
+		return
+	}
+
+	var mappingsArgs []string
+	for i, m := range mappings {
+		mappingsArgs = append(mappingsArgs, "--mappings", mappingsFile(i, m))
+	}
+
+	cmd := exec.Command(pulumiPath, append([]string{"convert",
+		"--from", "terraform",
+		"--language", "pcl",
+		"--out", outDir,
+		"--generate-only",
+	}, mappingsArgs...)...)
+
+	cmd.Dir = filepath.Dir(examplesJSON.Name())
+	cmd.Env = append(os.Environ(),
+		"PULUMI_CONVERT_EXAMPLES="+filepath.Base(examplesJSON.Name()))
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+
+	if err := cmd.Run(); err != nil {
+		finalError = fmt.Errorf("convertViaPulumiCLI: pulumi command failed: %w\n"+
+			"Stdout:\n%s\n\n"+
+			"Stderr:\n%s\n\n",
+			err, stdout.String(), stderr.String())
+		return
+	}
+
+	outputFile := filepath.Join(outDir, filepath.Base(examplesJSON.Name()))
+
+	outputFileBytes, err := os.ReadFile(outputFile)
+	if err != nil {
+		finalError = fmt.Errorf("convertViaPulumiCLI: failed to read output file: %w", err)
+		return
+	}
+
+	var result map[string]translatedExample
+	if err := json.Unmarshal(outputFileBytes, &result); err != nil {
+		finalError = fmt.Errorf("convertViaPulumiCLI: failed to unmarshal output "+
+			"file: %w", err)
+		return
+	}
+
+	return result, nil
+}
+
+// Conversion from PCL to the target language still happens in-process temporarily, which is really
+// unfortunate because it makes another plugin loader necessary. This should eventually also happen
+// through pulumi convert, but it needs to have bulk interface enabled for every language.
+func (cc *cliConverter) convertPCL(
+	spec *pschema.PackageSpec,
+	source string,
+	languageName string,
+) (string, hcl.Diagnostics, error) {
+	pulumiParser := syntax.NewParser()
+
+	err := pulumiParser.ParseFile(bytes.NewBufferString(source), "example.pp")
+	contract.AssertNoErrorf(err, "pulumiParser.ParseFile returned an error")
+
+	var diagnostics hcl.Diagnostics
+
+	diagnostics = append(diagnostics, pulumiParser.Diagnostics...)
+	if diagnostics.HasErrors() {
+		return "", diagnostics, nil
+	}
+
+	opts := cc.opts
+	if opts == nil {
+		var opts []pcl.BindOption
+		opts = append(opts, pcl.AllowMissingProperties)
+		opts = append(opts, pcl.AllowMissingVariables)
+		opts = append(opts, pcl.SkipResourceTypechecking)
+		if cc.pluginHost != nil {
+			opts = append(opts, pcl.PluginHost(cc.pluginHost))
+			loader := newLoader(cc.pluginHost)
+			//loader.BindCurrentPackage(*spec, cc.packageName)
+			opts = append(opts, pcl.Loader(loader))
+		}
+		if cc.packageCache != nil {
+			opts = append(opts, pcl.Cache(cc.packageCache))
+		}
+		cc.opts = opts
+	}
+
+	program, programDiags, err := pcl.BindProgram(pulumiParser.Files, opts...)
+	if err != nil {
+		return "", diagnostics, fmt.Errorf("pcl.BindProgram failed: %w", err)
+	}
+
+	diagnostics = append(diagnostics, programDiags...)
+	if diagnostics.HasErrors() {
+		return "", diagnostics, nil
+	}
+
+	var genDiags hcl.Diagnostics
+	var generatedFiles map[string][]byte
+
+	switch languageName {
+	case "typescript":
+		generatedFiles, genDiags, err = hcl2nodejs.GenerateProgram(program)
+		diagnostics = append(diagnostics, genDiags...)
+	case "python":
+		generatedFiles, genDiags, err = hcl2python.GenerateProgram(program)
+		diagnostics = append(diagnostics, genDiags...)
+	case "csharp":
+		generatedFiles, genDiags, err = hcl2dotnet.GenerateProgram(program)
+		diagnostics = append(diagnostics, genDiags...)
+	case "go":
+		generatedFiles, genDiags, err = hcl2go.GenerateProgram(program)
+		diagnostics = append(diagnostics, genDiags...)
+	case "yaml":
+		generatedFiles, genDiags, err = hcl2yaml.GenerateProgram(program)
+		diagnostics = append(diagnostics, genDiags...)
+	case "java":
+		generatedFiles, genDiags, err = hcl2java.GenerateProgram(program)
+		diagnostics = append(diagnostics, genDiags...)
+	default:
+		err = fmt.Errorf("Unsupported language: %q", languageName)
+	}
+	if err != nil {
+		return "", diagnostics, fmt.Errorf("GenerateProgram failed: %w", err)
+	}
+	if len(generatedFiles) != 1 {
+		err := fmt.Errorf("expected 1 file to be generated, got %d", len(generatedFiles))
+		return "", diagnostics, err
+	}
+	var key string
+	for n := range generatedFiles {
+		key = n
+	}
+	return string(generatedFiles[key]), diagnostics, nil
+}
+
+// Act as a convertHCL stub that does not actually convert but spies on the literals involved.
+func (cc *cliConverter) recordHCL(
+	hcl, path, exampleTitle string, languages []string,
+) (string, error) {
+	h := cc.hcls
+	h[hcl] = struct{}{}
+	return "{convertHCL}", nil
+}

--- a/pkg/tfgen/convert_cli_test.go
+++ b/pkg/tfgen/convert_cli_test.go
@@ -160,6 +160,8 @@ output "someOutput" {
 				Color: colors.Never,
 			}),
 		})
+		assert.NoError(t, err)
+
 		err = g.Generate()
 		assert.NoError(t, err)
 

--- a/pkg/tfgen/convert_cli_test.go
+++ b/pkg/tfgen/convert_cli_test.go
@@ -99,7 +99,10 @@ output "someOutput" {
 	out, err := cc.convertViaPulumiCLI(map[string]string{
 		"example1": simpleResourceTF,
 		"example2": simpleDataSourceTF,
-	}, []tfbridge.ProviderInfo{p})
+	}, []struct {
+		name string
+		info tfbridge.ProviderInfo
+	}{{info: p, name: "simple"}})
 
 	require.NoError(t, err)
 	assert.Equal(t, 2, len(out))

--- a/pkg/tfgen/convert_cli_test.go
+++ b/pkg/tfgen/convert_cli_test.go
@@ -27,7 +27,6 @@ import (
 )
 
 func TestConvertViaPulumiCLI(t *testing.T) {
-	t.Skipf("TODO[pulumi/pulumi-converter-terraform#36] enable when converter can accept bulk examples")
 	p := tfbridge.ProviderInfo{
 		Name: "simple",
 		P: sdkv2.NewProvider(&schema.Provider{

--- a/pkg/tfgen/convert_cli_test.go
+++ b/pkg/tfgen/convert_cli_test.go
@@ -1,0 +1,111 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfgen
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	sdkv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestConvertViaPulumiCLI(t *testing.T) {
+	p := tfbridge.ProviderInfo{
+		Name: "simple",
+		P: sdkv2.NewProvider(&schema.Provider{
+			ResourcesMap: map[string]*schema.Resource{
+				"simple_resource": {
+					Schema: map[string]*schema.Schema{},
+				},
+			},
+			DataSourcesMap: map[string]*schema.Resource{
+				"simple_data_source": {
+					Schema: map[string]*schema.Schema{},
+				},
+			},
+		}),
+		Resources: map[string]*tfbridge.ResourceInfo{
+			"simple_resource": {
+				Tok: "simple:index:resource",
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"input_one": {
+						Name: "renamedInput1",
+					},
+				},
+			},
+		},
+		DataSources: map[string]*tfbridge.DataSourceInfo{},
+	}
+
+	simpleResourceTF := `
+resource "simple_resource" "a_resource" {
+    input_one = "hello"
+    input_two = true
+}
+
+output "some_output" {
+    value = simple_resource.a_resource.result
+}`
+	simpleDataSourceTF := `
+data "simple_data_source" "a_data_source" {
+    input_one = "hello"
+    input_two = true
+}
+
+output "some_output" {
+    value = data.simple_data_source.a_data_source.result
+}`
+
+	simpleResourceExpectPCL := `resource "aResource" "simple:index:resource" {
+  __logicalName = "a_resource"
+  renamedInput1 = "hello"
+  inputTwo      = true
+}
+
+output "someOutput" {
+  value = aResource.result
+}
+`
+
+	simpleDataSourceExpectPCL := `aDataSource = invoke("simple:index:dataSource", {
+  inputOne = "hello"
+  inputTwo = true
+})
+
+output "someOutput" {
+  value = aDataSource.result
+}
+`
+	cc := &cliConverter{}
+
+	out, err := cc.convertViaPulumiCLI(map[string]string{
+		"example1": simpleResourceTF,
+		"example2": simpleDataSourceTF,
+	}, []tfbridge.ProviderInfo{p})
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(out))
+
+	assert.Equal(t, simpleResourceExpectPCL, out["example1"].PCL)
+	assert.Equal(t, simpleDataSourceExpectPCL, out["example2"].PCL)
+
+	assert.Empty(t, out["example1"].Diagnostics)
+	assert.Empty(t, out["example2"].Diagnostics)
+}

--- a/pkg/tfgen/convert_cli_test.go
+++ b/pkg/tfgen/convert_cli_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 func TestConvertViaPulumiCLI(t *testing.T) {
+	t.Skipf("TODO[pulumi/pulumi-converter-terraform#36] enable when converter can accept bulk examples")
 	p := tfbridge.ProviderInfo{
 		Name: "simple",
 		P: sdkv2.NewProvider(&schema.Provider{

--- a/pkg/tfgen/convert_cli_test.go
+++ b/pkg/tfgen/convert_cli_test.go
@@ -16,6 +16,7 @@ package tfgen
 
 import (
 	"io"
+	"runtime"
 	"testing"
 
 	bridgetesting "github.com/pulumi/pulumi-terraform-bridge/v3/internal/testing"
@@ -31,6 +32,13 @@ import (
 )
 
 func TestConvertViaPulumiCLI(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// Currently there is a test issue in CI/test setup:
+		//
+		// convertViaPulumiCLI: failed to clean up temp bridge-examples.json file: The
+		// process cannot access the file because it is being used by another process..
+		t.Skipf("Skipping on Windows due to a test setup issue")
+	}
 	p := tfbridge.ProviderInfo{
 		Name: "simple",
 		P: sdkv2.NewProvider(&schema.Provider{

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -1302,6 +1302,11 @@ func (g *Generator) convertExamples(docs string, path examplePath, stripSubsecti
 		return fmt.Sprintf("{{%% examples %%}}\n%s\n{{%% /examples %%}}", docs)
 	}
 
+	if cliConverterEnabled {
+		return g.cliConverter().StartConvertingExamples(docs, path,
+			stripSubsectionsWithErrors)
+	}
+
 	return g.convertExamplesInner(docs, path, stripSubsectionsWithErrors, g.convertHCL)
 }
 
@@ -1557,7 +1562,11 @@ func (g *Generator) convertHCLToString(hclCode, path, languageName string) (stri
 	var diags hcl.Diagnostics
 	var err error
 
-	convertedHcl, diags, err = g.legacyConvert(hclCode, fileName, languageName)
+	if cliConverterEnabled {
+		convertedHcl, diags, err = g.cliConverter().Convert(hclCode, languageName)
+	} else {
+		convertedHcl, diags, err = g.legacyConvert(hclCode, fileName, languageName)
+	}
 
 	// By observation on the GCP provider, convert.Convert() will either panic (in which case the wrapped method above
 	// will return an error) or it will return a non-zero value for diags.

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -1302,7 +1302,7 @@ func (g *Generator) convertExamples(docs string, path examplePath, stripSubsecti
 		return fmt.Sprintf("{{%% examples %%}}\n%s\n{{%% /examples %%}}", docs)
 	}
 
-	if cliConverterEnabled {
+	if cliConverterEnabled() {
 		return g.cliConverter().StartConvertingExamples(docs, path,
 			stripSubsectionsWithErrors)
 	}
@@ -1562,7 +1562,7 @@ func (g *Generator) convertHCLToString(hclCode, path, languageName string) (stri
 	var diags hcl.Diagnostics
 	var err error
 
-	if cliConverterEnabled {
+	if cliConverterEnabled() {
 		convertedHcl, diags, err = g.cliConverter().Convert(hclCode, languageName)
 	} else {
 		convertedHcl, diags, err = g.legacyConvert(hclCode, fileName, languageName)

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -30,6 +30,7 @@ import (
 	"unicode"
 
 	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/hcl/v2"
 	bf "github.com/russross/blackfriday/v2"
 	"github.com/spf13/afero"
 	"golang.org/x/text/cases"
@@ -1301,6 +1302,18 @@ func (g *Generator) convertExamples(docs string, path examplePath, stripSubsecti
 		return fmt.Sprintf("{{%% examples %%}}\n%s\n{{%% /examples %%}}", docs)
 	}
 
+	return g.convertExamplesInner(docs, path, stripSubsectionsWithErrors, g.convertHCL)
+}
+
+// The inner implementation of examples conversion is parameterized by convertHCL so that it can be
+// executed either normally or in symbolic mode.
+func (g *Generator) convertExamplesInner(
+	docs string,
+	path examplePath,
+	stripSubsectionsWithErrors bool,
+	convertHCL func(hcl, path, exampleTitle string, languages []string) (string, error),
+) (result string) {
+
 	output := &bytes.Buffer{}
 
 	writeTrailingNewline := func(buf *bytes.Buffer) {
@@ -1363,7 +1376,7 @@ func (g *Generator) convertExamples(docs string, path examplePath, stripSubsecti
 						}
 
 						langs := genLanguageToSlice(g.language)
-						codeBlock, err := g.convertHCL(hcl, path.String(), exampleTitle, langs)
+						codeBlock, err := convertHCL(hcl, path.String(), exampleTitle, langs)
 
 						if err != nil {
 							skippedExamples = true
@@ -1510,18 +1523,41 @@ func (g *Generator) convert(input afero.Fs, languageName string) (files map[stri
 	return
 }
 
-// convertHCLToString hides the implementation details of the upstream implementation for HCL conversion and provides
-// simplified parameters and return values
-func (g *Generator) convertHCLToString(hcl, path, languageName string) (string, error) {
+func (g *Generator) legacyConvert(
+	hclCode, fileName, languageName string,
+) (string, hcl.Diagnostics, error) {
 	input := afero.NewMemMapFs()
-	fileName := fmt.Sprintf("/%s.tf", strings.ReplaceAll(path, "/", "-"))
 	f, err := input.Create(fileName)
 	contract.AssertNoErrorf(err, "err != nil")
-	_, err = f.Write([]byte(hcl))
+	_, err = f.Write([]byte(hclCode))
 	contract.AssertNoErrorf(err, "err != nil")
 	contract.IgnoreClose(f)
 
 	files, diags, err := g.convert(input, languageName)
+	if diags.All.HasErrors() || err != nil {
+		return "", diags.All, err
+	}
+
+	contract.Assertf(len(files) == 1, `len(files) == 1`)
+
+	convertedHcl := ""
+	for _, output := range files {
+		convertedHcl = strings.TrimSpace(string(output))
+	}
+	return convertedHcl, diags.All, nil
+}
+
+// convertHCLToString hides the implementation details of the upstream implementation for HCL conversion and provides
+// simplified parameters and return values
+func (g *Generator) convertHCLToString(hclCode, path, languageName string) (string, error) {
+
+	fileName := fmt.Sprintf("/%s.tf", strings.ReplaceAll(path, "/", "-"))
+
+	var convertedHcl string
+	var diags hcl.Diagnostics
+	var err error
+
+	convertedHcl, diags, err = g.legacyConvert(hclCode, fileName, languageName)
 
 	// By observation on the GCP provider, convert.Convert() will either panic (in which case the wrapped method above
 	// will return an error) or it will return a non-zero value for diags.
@@ -1534,23 +1570,16 @@ func (g *Generator) convertHCLToString(hcl, path, languageName string) (string, 
 		}
 		return "", fmt.Errorf("failed to convert HCL for %s to %v: %w", path, languageName, err)
 	}
-	if diags.All.HasErrors() {
+	if diags.HasErrors() {
 		// Remove the temp filename from the error, since it will be confusing to users of the bridge who do not know
 		// we write an example to a temp file internally in order to pass to convert.Convert().
 		//
 		// fileName starts with a "/" which is not present in the resulting error, so we need to skip the first rune.
-		errMsg := strings.ReplaceAll(diags.All.Error(), fileName[1:], "")
+		errMsg := strings.ReplaceAll(diags.Error(), fileName[1:], "")
 
 		g.warn("failed to convert HCL for %s to %v: %v", path, languageName, errMsg)
-		g.coverageTracker.languageConversionFailure(languageName, diags.All)
+		g.coverageTracker.languageConversionFailure(languageName, diags)
 		return "", fmt.Errorf(errMsg)
-	}
-
-	contract.Assertf(len(files) == 1, `len(files) == 1`)
-
-	convertedHcl := ""
-	for _, output := range files {
-		convertedHcl = strings.TrimSpace(string(output))
 	}
 
 	g.coverageTracker.languageConversionSuccess(languageName, convertedHcl)

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -79,6 +79,8 @@ type Generator struct {
 	// Set if we can't find the docs repo and we have already printed a warning
 	// message.
 	noDocsRepo bool
+
+	cliConverterState *cliConverter
 }
 
 type Language string

--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -946,6 +946,11 @@ func (g *Generator) convertExamplesInSchema(spec pschema.PackageSpec) pschema.Pa
 		path := newExamplePathForFunction(token)
 		spec.Functions[token] = g.convertExamplesInFunctionSpec(path, function)
 	}
+
+	if cliConverterEnabled {
+		return g.cliConverter().FinishConvertingExamples(spec)
+	}
+
 	return spec
 }
 

--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -947,7 +947,7 @@ func (g *Generator) convertExamplesInSchema(spec pschema.PackageSpec) pschema.Pa
 		spec.Functions[token] = g.convertExamplesInFunctionSpec(path, function)
 	}
 
-	if cliConverterEnabled {
+	if cliConverterEnabled() {
 		return g.cliConverter().FinishConvertingExamples(spec)
 	}
 

--- a/pkg/tfgen/test_data/TestConvertViaPulumiCLI/schema.json
+++ b/pkg/tfgen/test_data/TestConvertViaPulumiCLI/schema.json
@@ -22,6 +22,7 @@
   },
   "resources": {
     "simple:index:resource": {
+      "description": "{{% examples %}}\n## Example Usage\n{{% example %}}\n\n```java\npackage generated_program;\n\nimport com.pulumi.Context;\nimport com.pulumi.Pulumi;\nimport com.pulumi.core.Output;\nimport com.pulumi.simple.resource;\nimport com.pulumi.simple.ResourceArgs;\nimport java.util.List;\nimport java.util.ArrayList;\nimport java.util.Map;\nimport java.io.File;\nimport java.nio.file.Files;\nimport java.nio.file.Paths;\n\npublic class App {\n    public static void main(String[] args) {\n        Pulumi.run(App::stack);\n    }\n\n    public static void stack(Context ctx) {\n        var aResource = new Resource(\"aResource\", ResourceArgs.builder()        \n            .renamedInput1(\"hello\")\n            .inputTwo(true)\n            .build());\n\n        ctx.export(\"someOutput\", aResource.result());\n    }\n}\n```\n```yaml\nresources:\n  a_resource:\n    type: simple:resource\n    properties:\n      renamedInput1: hello\n      inputTwo: true\noutputs:\n  someOutput: ${a_resource.result}\n```\n\n##Extras\n{{% /example %}}\n{{% /examples %}}",
       "stateInputs": {
         "description": "Input properties used for looking up and filtering resource resources.\n",
         "type": "object"

--- a/pkg/tfgen/test_data/TestConvertViaPulumiCLI/schema.json
+++ b/pkg/tfgen/test_data/TestConvertViaPulumiCLI/schema.json
@@ -1,0 +1,48 @@
+{
+  "name": "simple",
+  "attribution": "This Pulumi package is based on the [`simple` Terraform Provider](https://github.com/terraform-providers/terraform-provider-simple).",
+  "meta": {
+    "moduleFormat": "(.*)(?:/[^/]*)"
+  },
+  "language": {
+    "nodejs": {
+      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-simple)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-simple` repo](/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-simple` repo](https://github.com/terraform-providers/terraform-provider-simple/issues).",
+      "compatibility": "tfbridge20",
+      "disableUnionOutputTypes": true
+    },
+    "python": {
+      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-simple)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-simple` repo](/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-simple` repo](https://github.com/terraform-providers/terraform-provider-simple/issues).",
+      "compatibility": "tfbridge20",
+      "pyproject": {}
+    }
+  },
+  "config": {},
+  "provider": {
+    "description": "The provider type for the simple package. By default, resources use package-wide configuration\nsettings, however an explicit `Provider` instance may be created and passed during resource\nconstruction to achieve fine-grained programmatic control over provider settings. See the\n[documentation](https://www.pulumi.com/docs/reference/programming-model/#providers) for more information.\n"
+  },
+  "resources": {
+    "simple:index:resource": {
+      "stateInputs": {
+        "description": "Input properties used for looking up and filtering resource resources.\n",
+        "type": "object"
+      }
+    }
+  },
+  "functions": {
+    "simple:index:dataSource": {
+      "outputs": {
+        "description": "A collection of values returned by dataSource.\n",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The provider-assigned unique ID for this managed resource.\n"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/1352

Requires a modified  pulumi/pulumi-converter-terraform#29 

A new option is added for tfgen, via the environment variable PULUMI_CONVERT. IF this option is truthy, `make tfgen` will now be using `pulumi convert` when converting examples, specifically for the TF HCL to Pulumi PCL phase of the conversion.

How this was tested. Tried on these providers:

- pulumi-wavefront
- pulumi-gcp

Ensured conversion rates improve. Ensured COVERAGE_OUTPUT_DIR, if set, continues to populate sensible conversion metrics.  Ensured printed warnings and example conversion metrics out of `make tfgen` are still sensible.

When rolling this out to providers, recommend making sure that Pulumi CLI in use is pinned first, as the repositories are sensitive to small changes in the generated examples and a floating Pulumi CLI reference can introduce breaking CI checks.
