### PR TITLE
Bump Go version + refactor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         #
         # When we decide to bump our minimum go version, we need to remember to bump the
         # go version in our go.mod files.
-        go-version: [1.19.x, 1.20.x]
+        go-version: [1.20.x, 1.21.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi-terraform-bridge/v3
 
-go 1.18
+go 1.20
 
 replace (
 	github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20230710100801-03a71d0fca3d

--- a/pf/go.mod
+++ b/pf/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi-terraform-bridge/pf
 
-go 1.19
+go 1.20
 
 replace github.com/pulumi/pulumi-terraform-bridge/v3 => ./..
 

--- a/pf/tests/go.mod
+++ b/pf/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi-terraform-bridge/pf/tests
 
-go 1.19
+go 1.20
 
 require (
 	github.com/hashicorp/terraform-plugin-framework v1.1.1

--- a/pf/tests/main_test.go
+++ b/pf/tests/main_test.go
@@ -45,11 +45,8 @@ func testMain(m *testing.M) (exitCode int, err error) {
 		if teardownError == nil {
 			err = panicError
 		} else {
-			// Wrapping multiple errors was introduced on v1.20.0.  While we
-			// still support go v1.19.0, we need to convert one error into a
-			// string.
-			err = fmt.Errorf("Tests panicked and teardown failed: %w; %s",
-				panicError, teardownError.Error())
+			err = fmt.Errorf("Tests panicked and teardown failed: %w; %w",
+				panicError, teardownError)
 		}
 	}()
 

--- a/pkg/tf2pulumi/convert/eject_test.go
+++ b/pkg/tf2pulumi/convert/eject_test.go
@@ -26,11 +26,13 @@ import (
 	"testing"
 
 	"github.com/blang/semver"
-	bridgetesting "github.com/pulumi/pulumi-terraform-bridge/v3/internal/testing"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	bridgetesting "github.com/pulumi/pulumi-terraform-bridge/v3/internal/testing"
 )
 
 type testLoader struct {
@@ -72,10 +74,6 @@ func (l *testLoader) LoadPackageReference(pkg string, version *semver.Version) (
 		return nil, err
 	}
 	return schemaPackage.Reference(), nil
-}
-
-func isTruthy(s string) bool {
-	return s == "1" || strings.EqualFold(s, "true")
 }
 
 // applyPragmas parses the text from `src` and writes the resulting text to `dst`. It can exclude blocks of
@@ -196,7 +194,7 @@ func TestEject(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			isExperimental := isTruthy(os.Getenv("PULUMI_EXPERIMENTAL"))
+			isExperimental := cmdutil.IsTruthy(os.Getenv("PULUMI_EXPERIMENTAL"))
 
 			pclPath := filepath.Join(tt.path, "pcl")
 			// We want to support running this in experimental mode as well as compatibility mode
@@ -282,7 +280,7 @@ func TestEject(t *testing.T) {
 			}
 
 			// If PULUMI_ACCEPT is set then clear the PCL folder and write the generated files out
-			if isTruthy(os.Getenv("PULUMI_ACCEPT")) {
+			if cmdutil.IsTruthy(os.Getenv("PULUMI_ACCEPT")) {
 				err := os.RemoveAll(pclPath)
 				require.NoError(t, err)
 				err = os.Mkdir(pclPath, 0700)

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/python"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tf2pulumi/convert"
@@ -257,7 +258,7 @@ func getDocsForResource(g *Generator, source DocsSource, kind DocKind,
 		msg := fmt.Sprintf("could not find docs for %v %v. Override the Docs property in the %v mapping. See "+
 			"type tfbridge.DocInfo for details.", kind, formatEntityName(rawname), kind)
 
-		if isTruthy(os.Getenv("PULUMI_MISSING_DOCS_ERROR")) {
+		if cmdutil.IsTruthy(os.Getenv("PULUMI_MISSING_DOCS_ERROR")) {
 			g.error(msg)
 			return entityDocs{}, fmt.Errorf(msg)
 		}

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -1137,12 +1137,12 @@ func (g *Generator) gatherResources() (moduleMap, error) {
 	for _, r := range stableResources(resources) {
 		info := g.info.Resources[r]
 		if info == nil {
-			if ignoreMappingError(g.info.IgnoreMappings, r) {
+			if sliceContains(g.info.IgnoreMappings, r) {
 				g.debug("TF resource %q not found in provider map", r)
 				continue
 			}
 
-			if !ignoreMappingError(g.info.IgnoreMappings, r) && !skipFailBuildOnMissingMapError {
+			if !sliceContains(g.info.IgnoreMappings, r) && !skipFailBuildOnMissingMapError {
 				resourceMappingErrors = multierror.Append(resourceMappingErrors,
 					fmt.Errorf("TF resource %q not mapped to the Pulumi provider", r))
 			} else {
@@ -1335,7 +1335,7 @@ func (g *Generator) gatherDataSources() (moduleMap, error) {
 	for _, ds := range stableResources(sources) {
 		dsinfo := g.info.DataSources[ds]
 		if dsinfo == nil {
-			if ignoreMappingError(g.info.IgnoreMappings, ds) {
+			if sliceContains(g.info.IgnoreMappings, ds) {
 				g.debug("TF data source %q not found in provider map but ignored", ds)
 				continue
 			}
@@ -1903,9 +1903,9 @@ func cleanDir(fs afero.Fs, dirPath string, exclusions codegen.StringSet) error {
 	return nil
 }
 
-func ignoreMappingError(s []string, str string) bool {
-	for _, v := range s {
-		if v == str {
+func sliceContains[T comparable](slice []T, target T) bool {
+	for _, v := range slice {
+		if v == target {
 			return true
 		}
 	}

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -1124,9 +1124,9 @@ func (g *Generator) gatherResources() (moduleMap, error) {
 	}
 	modules := make(moduleMap)
 
-	skipFailBuildOnMissingMapError := isTruthy(os.Getenv("PULUMI_SKIP_MISSING_MAPPING_ERROR")) || isTruthy(os.Getenv(
-		"PULUMI_SKIP_PROVIDER_MAP_ERROR"))
-	skipFailBuildOnExtraMapError := isTruthy(os.Getenv("PULUMI_SKIP_EXTRA_MAPPING_ERROR"))
+	skipFailBuildOnMissingMapError := cmdutil.IsTruthy(os.Getenv("PULUMI_SKIP_MISSING_MAPPING_ERROR")) ||
+		cmdutil.IsTruthy(os.Getenv("PULUMI_SKIP_PROVIDER_MAP_ERROR"))
+	skipFailBuildOnExtraMapError := cmdutil.IsTruthy(os.Getenv("PULUMI_SKIP_EXTRA_MAPPING_ERROR"))
 
 	// let's keep a list of TF mapping errors that we can present to the user
 	var resourceMappingErrors error
@@ -1303,7 +1303,7 @@ func (g *Generator) gatherResource(rawname string,
 			msg := fmt.Sprintf("there is a custom mapping on resource '%s' for field '%s', but the field was not "+
 				"found in the Terraform metadata and will be ignored. To fix, remove the mapping.", rawname, key)
 
-			if isTruthy(os.Getenv("PULUMI_EXTRA_MAPPING_ERROR")) {
+			if cmdutil.IsTruthy(os.Getenv("PULUMI_EXTRA_MAPPING_ERROR")) {
 				return nil, fmt.Errorf(msg)
 			}
 
@@ -1322,9 +1322,9 @@ func (g *Generator) gatherDataSources() (moduleMap, error) {
 	}
 	modules := make(moduleMap)
 
-	skipFailBuildOnMissingMapError := isTruthy(os.Getenv("PULUMI_SKIP_MISSING_MAPPING_ERROR")) || isTruthy(os.Getenv(
-		"PULUMI_SKIP_PROVIDER_MAP_ERROR"))
-	failBuildOnExtraMapError := isTruthy(os.Getenv("PULUMI_EXTRA_MAPPING_ERROR"))
+	skipFailBuildOnMissingMapError := cmdutil.IsTruthy(os.Getenv("PULUMI_SKIP_MISSING_MAPPING_ERROR")) ||
+		cmdutil.IsTruthy(os.Getenv("PULUMI_SKIP_PROVIDER_MAP_ERROR"))
+	failBuildOnExtraMapError := cmdutil.IsTruthy(os.Getenv("PULUMI_EXTRA_MAPPING_ERROR"))
 
 	// let's keep a list of TF mapping errors that we can present to the user
 	var dataSourceMappingErrors error
@@ -1901,10 +1901,6 @@ func cleanDir(fs afero.Fs, dirPath string, exclusions codegen.StringSet) error {
 	}
 
 	return nil
-}
-
-func isTruthy(s string) bool {
-	return s == "1" || strings.EqualFold(s, "true")
 }
 
 func ignoreMappingError(s []string, str string) bool {

--- a/x/muxer/go.mod
+++ b/x/muxer/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi-terraform-bridge/x/muxer
 
-go 1.19
+go 1.20
 
 require (
 	github.com/hashicorp/go-multierror v1.1.1

--- a/x/muxer/muxer.go
+++ b/x/muxer/muxer.go
@@ -454,8 +454,7 @@ func (m *muxer) GetMapping(ctx context.Context, req *rpc.GetMappingRequest) (*rp
 	result, err := combineMapping(&args)
 	if err != nil {
 		if args.err != nil {
-			// go v1.19.0 only accepts a single %w within fmt.Error, so we convert the second call to %s.
-			return nil, fmt.Errorf("%w (sub-provider GetMapping call failed: %s)", err, args.err.Error())
+			return nil, fmt.Errorf("%w (sub-provider GetMapping call failed: %w)", err, args.err)
 		}
 		return nil, err
 	}


### PR DESCRIPTION
This PR bumps the bridge to the [current minimum supported go version](https://endoflife.date/go). 

It also includes two simple refactors:
- Removing 2 redundant copies of `isTruthy` in favor of `cmdutil.IsTruthy`. Each copy has identical source code.
- Renaming a function called `ignoreMappingError` to `sliceContains`, since all the function does is check if a slice contains a value.