### PR TITLE
Structured argument parsing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/spf13/afero v1.9.5
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.4
+	github.com/yuin/goldmark v1.5.2
 	github.com/zclconf/go-cty v1.14.0
 	golang.org/x/crypto v0.14.0
 	golang.org/x/mod v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -2363,6 +2363,8 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/goldmark v1.5.2 h1:ALmeCk/px5FSm1MAcFBAsVKZjDuMVj8Tm7FFIlMJnqU=
+github.com/yuin/goldmark v1.5.2/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43/go.mod h1:aX5oPXxHm3bOH+xeAttToC8pqch2ScQN/JoXYupl6xs=
 github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50/go.mod h1:NUSPSUX/bi6SeDMUh6brw0nXpxHnc96TguQh0+r/ssA=
 github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f/go.mod h1:GlGEuHIJweS1mbCqG+7vt2nvWLzLLnRHbXz5JKd/Qbg=

--- a/pf/go.mod
+++ b/pf/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.3.5 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
+	github.com/yuin/goldmark v1.5.2 // indirect
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
 	golang.org/x/tools v0.14.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20230706204954-ccb25ca9f130 // indirect

--- a/pf/go.sum
+++ b/pf/go.sum
@@ -1831,6 +1831,8 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/goldmark v1.5.2 h1:ALmeCk/px5FSm1MAcFBAsVKZjDuMVj8Tm7FFIlMJnqU=
+github.com/yuin/goldmark v1.5.2/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43/go.mod h1:aX5oPXxHm3bOH+xeAttToC8pqch2ScQN/JoXYupl6xs=
 github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50/go.mod h1:NUSPSUX/bi6SeDMUh6brw0nXpxHnc96TguQh0+r/ssA=
 github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f/go.mod h1:GlGEuHIJweS1mbCqG+7vt2nvWLzLLnRHbXz5JKd/Qbg=

--- a/pf/tests/go.mod
+++ b/pf/tests/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v5 v5.3.5 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
+	github.com/yuin/goldmark v1.5.2 // indirect
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
 	golang.org/x/tools v0.14.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20230706204954-ccb25ca9f130 // indirect

--- a/pf/tests/go.sum
+++ b/pf/tests/go.sum
@@ -2377,6 +2377,8 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/goldmark v1.5.2 h1:ALmeCk/px5FSm1MAcFBAsVKZjDuMVj8Tm7FFIlMJnqU=
+github.com/yuin/goldmark v1.5.2/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43/go.mod h1:aX5oPXxHm3bOH+xeAttToC8pqch2ScQN/JoXYupl6xs=
 github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50/go.mod h1:NUSPSUX/bi6SeDMUh6brw0nXpxHnc96TguQh0+r/ssA=
 github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f/go.mod h1:GlGEuHIJweS1mbCqG+7vt2nvWLzLLnRHbXz5JKd/Qbg=

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -1099,14 +1099,16 @@ func prefixMatcher(prefix string) func(string) int {
 var cleanDescriptionPrefixFns = []func(string) int{
 	// Cut Leading ':' and '-'
 	prefixMatcher("-"),
-	prefixMatcher(":"),
 	prefixMatcher("–"), // This is an en-dash (Unicode 8211)
+	prefixMatcher(":"),
 	// Cut leading "(Optional.*)"
 	//
 	// This needs to be a function and not a regex because we want the final ')' cut
 	// to balance with the first '('.
 	nestedParensMatcher("Optional"),
 	nestedParensMatcher("Required"),
+	nestedParensMatcher("Computed"),
+	nestedParensMatcher("Forces new resource"),
 }
 
 func cleanDescription(path docsPath, desc string) string {

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -1064,8 +1064,9 @@ func renderMdNode(src []byte, n ast.Node) []byte {
 
 func nestedParensMatcher(trigger string) func(string) int {
 	trigger = "(" + trigger
+	lower := strings.ToLower(trigger)
 	return func(s string) int {
-		if !strings.HasPrefix(s, trigger) {
+		if !strings.HasPrefix(s, trigger) && !strings.HasPrefix(s, lower) {
 			return 0
 		}
 

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -33,6 +33,9 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	bf "github.com/russross/blackfriday/v2"
 	"github.com/spf13/afero"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/text"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
@@ -800,40 +803,46 @@ var nestedObjectRegexps = []*regexp.Regexp{
 	regexp.MustCompile("`([a-z_]+)`.*following"),
 
 	// For example:
-	// athena_workgroup.html.markdown: "#### result_configuration Argument Reference"
-	regexp.MustCompile("(?i)## ([a-z_]+).* argument reference"),
-
-	// For example:
-	// elasticsearch_domain.html.markdown: "### advanced_security_options"
-	regexp.MustCompile("###+ ([a-z_]+).*"),
-
-	// For example:
-	// dynamodb_table.html.markdown: "### `server_side_encryption`"
-	regexp.MustCompile("###+ `([a-z_]+).*`"),
-
-	// For example:
-	// route53_record.html.markdown: "### Failover Routing Policy"
-	regexp.MustCompile("###+ ([a-zA-Z_ ]+).*"),
-
-	// For example:
 	// sql_database_instance.html.markdown:
 	// "The optional `settings.ip_configuration.authorized_networks[]`` sublist supports:"
 	regexp.MustCompile("`([a-zA-Z_.\\[\\]]+)`.*supports:"),
 }
 
-// getNestedBlockName take a line of a Terraform docs Markdown page and returns the name of the nested block it
-// describes. If the line does not describe a nested block, an empty string is returned.
-//
-// Examples of nested blocks include (but are not limited to):
-//
-// - "The `private_cluster_config` block supports:" -> "private_cluster_config"
-// - "The optional settings.backup_configuration subblock supports:" -> "settings.backup_configuration"
-func getNestedBlockName(line string) string {
+var nestedHeadingRegexps = []*regexp.Regexp{
+	// For example:
+	// athena_workgroup.html.markdown: "#### result_configuration Argument Reference"
+	regexp.MustCompile("(?i)([a-z_]+).* argument reference"),
+
+	// For example:
+	// elasticsearch_domain.html.markdown: "### advanced_security_options"
+	regexp.MustCompile("^([a-z_]+)"),
+
+	// For example:
+	// dynamodb_table.html.markdown: "### `server_side_encryption`"
+	regexp.MustCompile("`([a-z_]+).*`"),
+
+	// For example:
+	// lb_listner_rule.html.markdown: "### Action Blocks"
+	regexp.MustCompile("([a-zA-Z_ ]+?) (Blocks)"),
+
+	// For example:
+	// route53_record.html.markdown: "### Failover Routing Policy"
+	regexp.MustCompile("([a-zA-Z_ ]+)(Blocks)?"),
+}
+
+func isHeadingTarget(src []byte, n *ast.Heading) string {
+	if n.Level <= 2 {
+		return ""
+	}
+	return findNestingTarget(nestedHeadingRegexps, n.Text(src))
+}
+
+func findNestingTarget(typ []*regexp.Regexp, text []byte) string {
 	nested := ""
-	for _, match := range nestedObjectRegexps {
-		matches := match.FindStringSubmatch(line)
+	for _, match := range typ {
+		matches := match.FindSubmatch(text)
 		if len(matches) >= 2 {
-			nested = strings.ToLower(matches[1])
+			nested = strings.ToLower(string(matches[1]))
 			nested = strings.Replace(nested, " ", "_", -1)
 			nested = strings.TrimSuffix(nested, "[]")
 			parts := strings.Split(nested, ".")
@@ -845,69 +854,259 @@ func getNestedBlockName(line string) string {
 	return nested
 }
 
+// getNestedBlockName take a line of a Terraform docs Markdown page and returns the name of the nested block it
+// describes. If the line does not describe a nested block, an empty string is returned.
+//
+// Examples of nested blocks include (but are not limited to):
+//
+// - "The `private_cluster_config` block supports:" -> "private_cluster_config"
+// - "The optional settings.backup_configuration subblock supports:" -> "settings.backup_configuration"
+func getNestedBlockName(line []byte) string { return findNestingTarget(nestedObjectRegexps, line) }
+
 func parseArgReferenceSection(subsection []string, ret *entityDocs) {
-	var lastMatch string
-	var nested docsPath
+	ret.ensure()
+	src := []byte(strings.Join(subsection, "\n"))
+	node := goldmark.New().Parser().Parse(
+		text.NewReader(src))
 
-	addNewHeading := func(name, desc, line string) {
-		// found a property bullet, extract the name and description
-		if nested != "" {
-			// We found this line within a nested field. We should record it as such.
-			if ret.Arguments[nested] == nil {
-				totalArgumentsFromDocs++
+	type namedNode struct {
+		node     ast.Node
+		name     string
+		writable bool
+	}
+	var parent, child, latest, latestParent *namedNode
+	setLatest := func() { latest, latestParent = child, parent }
+
+	skipPrint := map[ast.Node]bool{}
+
+	baked := map[docsPath]struct{}{}
+	unbaked := map[docsPath]struct{}{}
+
+	// The algorithm for this parse works on a single descend + ascend pass.
+	//
+	// During descent, significant nodes such as new headings are marked. During
+	// ascent, nodes are written to ret.
+
+	descend := func(node ast.Node) ast.WalkStatus {
+		switch node.Kind() {
+		case ast.KindThematicBreak:
+			for k := range unbaked {
+				baked[k] = struct{}{}
 			}
-			ret.Arguments[nested.join(name)] = &argumentDocs{desc}
-		} else {
-			if genericNestedRegexp.MatchString(line) {
-				return
+			unbaked = map[docsPath]struct{}{}
+		case ast.KindListItem:
+			// We have entered a new item
+			if name := nodeItemName(src, node); name != "" && child == nil {
+				var key docsPath
+				if parent == nil {
+					child = nil
+					parent = &namedNode{node, name, true}
+					key = docsPath(name)
+				} else {
+					child = &namedNode{node, name, true}
+					key = docsPath(parent.name).join(name)
+				}
+				setLatest()
+
+				_, isBaked := baked[key]
+				if v, ok := ret.Arguments[key]; ok && !isBaked {
+					v.description = ""
+				}
+				unbaked[key] = struct{}{}
 			}
-			ret.Arguments[docsPath(name)] = &argumentDocs{description: desc}
-			totalArgumentsFromDocs++
+		case ast.KindHeading:
+			target := isHeadingTarget(src, node.(*ast.Heading))
+			if target != "" {
+				child = &namedNode{node, target, true}
+				parent = child
+				setLatest()
+				return ast.WalkSkipChildren
+			}
+		case ast.KindCodeSpan, ast.KindCodeBlock:
+			if nxt := node.NextSibling(); nxt != nil && nxt.Kind() == ast.KindText {
+				// Observe annotations like:
+				//
+				//	Inside of `dns` section the following argument are supported:
+				//
+				// When we find these, it overrides the current node.
+				txt := fmt.Sprintf("`%s` %s", string(node.Text(src)),
+					string(nxt.Text(src)))
+				target := getNestedBlockName([]byte(txt))
+				if target != "" {
+					// Setting both child an parent effectively sets
+					// this until the list ends (and we reset).
+					p := node.Parent()
+					child = &namedNode{p, target, false}
+					parent = child
+					setLatest()
+					return ast.WalkSkipChildren
+				}
+			}
+		case ast.KindText:
+			if genericNestedRegexp.Match(node.Text(src)) {
+				if latestParent != nil {
+					latestParent.writable = false
+					parent = latestParent
+				}
+				skipPrint[node.Parent()] = true
+				return ast.WalkSkipChildren
+			}
+		}
+		return ast.WalkContinue
+	}
+
+	write := func(node ast.Node) ast.WalkStatus {
+		// If we are not able to serialize node, exit early
+		switch node.(type) {
+		case *ast.Paragraph, *ast.TextBlock, *ast.FencedCodeBlock, *ast.ThematicBreak, *ast.Heading:
+		default:
+			return ast.WalkContinue
+		}
+
+		var key docsPath
+		if child != nil && parent != child {
+			if child.writable {
+				key = docsPath(parent.name).join(child.name)
+			}
+		} else if latest != nil && parent == nil {
+			if latest.writable {
+				key = docsPath(latestParent.name).join(latest.name)
+			}
+		} else if parent != nil {
+			if parent.writable {
+				key = docsPath(parent.name)
+			}
+		} else if latestParent != nil {
+			if latestParent.writable {
+				key = docsPath(latestParent.name)
+			}
+		}
+
+		if key == "" {
+			return ast.WalkContinue
+		}
+
+		desc := string(renderMdNode(src, node))
+
+		arg := ret.Arguments[key]
+		if arg == nil {
+			arg = &argumentDocs{}
+			ret.Arguments[key] = arg
+		}
+		arg.description += desc
+		return ast.WalkContinue
+	}
+
+	// Identify the transition points between arguments.
+	err := ast.Walk(node, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if entering {
+			return descend(node), nil
+		}
+
+		if node.Kind() == ast.KindList {
+			// When we exit a list, clear our current state
+			if !entering {
+				parent = nil
+				child = nil
+			}
+			return ast.WalkContinue, nil
+		}
+
+		defer func() {
+			if child != nil && child.node == node {
+				child = nil
+			} else if parent != nil && parent.node == node {
+				parent = nil
+			}
+		}()
+
+		// Write the state on exit:
+
+		// There are several early exit conditions:
+		if (latest == nil && latestParent == nil) || // Don't have a node to write to
+			node == latestParent.node && latestParent == child ||
+			skipPrint[node] { // Is a marker node
+			return ast.WalkContinue, nil
+		}
+
+		return write(node), nil
+	})
+	contract.AssertNoErrorf(err, "An error is never returned")
+
+	for k, v := range ret.Arguments {
+		v.description = cleanDescription(k, v.description)
+	}
+}
+
+func renderMdNode(src []byte, n ast.Node) []byte {
+	var b bytes.Buffer
+	b.WriteString("\n\n")
+	switch n := n.(type) {
+	case *ast.Paragraph, *ast.TextBlock:
+		for i := 0; i < n.Lines().Len(); i++ {
+			line := n.Lines().At(i)
+			b.Write(line.Value(src))
+		}
+	case *ast.FencedCodeBlock:
+		b.WriteString("```")
+		b.Write(n.Language(src))
+		b.WriteRune('\n')
+		for i := 0; i < n.Lines().Len(); i++ {
+			line := n.Lines().At(i)
+			b.Write(line.Value(src))
+		}
+		b.WriteString("```")
+	case *ast.ThematicBreak:
+		b.WriteRune('\n')
+	case *ast.Heading:
+		b.WriteString(strings.Repeat("#", n.Level) + " ")
+		b.Write(n.Text(src))
+	default:
+		n.Dump(src, 0)
+		panic(n)
+	}
+	return b.Bytes()
+}
+
+var cleanDescriptionPrefixes = []*regexp.Regexp{
+	regexp.MustCompile(`^[:-]`),
+	regexp.MustCompile(`^\(Optional.*?\)`),
+	regexp.MustCompile(`^\(Required.*?\)`),
+}
+
+func cleanDescription(path docsPath, desc string) string {
+	name := path.leaf()
+	valid := append(cleanDescriptionPrefixes, regexp.MustCompile("^"+regexp.QuoteMeta("`"+name+"`")))
+	changed := true
+	desc = strings.TrimLeftFunc(desc, unicode.IsSpace)
+	for changed {
+		changed = false
+		for _, c := range valid {
+			if found := len(c.FindString(desc)); found > 0 {
+				desc = desc[found:]
+				desc = strings.TrimLeftFunc(desc,
+					unicode.IsSpace)
+				changed = true
+			}
 		}
 	}
+	return strings.TrimRightFunc(desc, unicode.IsSpace)
+}
 
-	extendExistingHeading := func(line string) {
-		line = "\n" + strings.TrimSpace(line)
-		if nested != "" {
-			ret.Arguments[nested.join(lastMatch)].description += line
-		} else {
-			if genericNestedRegexp.MatchString(line) {
-				lastMatch = ""
-				nested = ""
-				return
-			}
-			ret.Arguments[docsPath(lastMatch)].description += line
+func nodeItemName(src []byte, node ast.Node) string {
+	if node == nil {
+		return ""
+	}
+	var name string
+	contract.AssertNoErrorf(ast.Walk(node, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if node.Kind() == ast.KindCodeSpan {
+			name = string(node.Text(src))
+			return ast.WalkStop, nil
 		}
-	}
+		return ast.WalkContinue, nil
+	}), "We don't return an error")
 
-	var hadSpace bool
-	for _, line := range subsection {
-		if name, desc, matchFound := parseArgFromMarkdownLine(line); matchFound {
-			// We have found a new
-			addNewHeading(name, desc, line)
-			lastMatch = name
-		} else if strings.TrimSpace(line) == "---" {
-			// --- is a markdown section break. This probably indicates the
-			// section is over, but we take it to mean that the current
-			// heading is over.
-			lastMatch = ""
-		} else if nestedBlockCurrentLine := getNestedBlockName(line); hadSpace && nestedBlockCurrentLine != "" {
-			nested = docsPath(nestedBlockCurrentLine)
-			lastMatch = ""
-		} else if !isBlank(line) && lastMatch != "" {
-			extendExistingHeading(line)
-		} else if nestedBlockCurrentLine := getNestedBlockName(line); nestedBlockCurrentLine != "" {
-			nested = docsPath(nestedBlockCurrentLine)
-			lastMatch = ""
-		} else if lastMatch != "" {
-			extendExistingHeading(line)
-		}
-		hadSpace = isBlank(line)
-	}
-
-	for _, v := range ret.Arguments {
-		v.description = strings.TrimRightFunc(v.description, unicode.IsSpace)
-	}
+	return name
 }
 
 func parseAttributesReferenceSection(subsection []string, ret *entityDocs) {

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -874,14 +874,8 @@ func parseArgReferenceSection(subsection []string, ret *entityDocs) {
 		name     string
 		listItem bool
 	}
-	var current []*namedNode
-	var latest []*namedNode
-	setLatest := func() {
-		latest = current[:0] // Zero out latest without re-allocation
-		for _, n := range current {
-			latest = append(latest, n)
-		}
-	}
+	var current, latest []*namedNode
+	setLatest := func() { latest = append(latest[:0], current...) }
 	keyOf := func(path []*namedNode) docsPath {
 		if len(path) == 0 {
 			return ""
@@ -973,14 +967,15 @@ func parseArgReferenceSection(subsection []string, ret *entityDocs) {
 			return ast.WalkContinue
 		}
 
-		var key docsPath
+		var stack []*namedNode
 		if len(latest) > len(current) {
-			key = keyOf(latest)
+			stack = latest
 		} else {
-			key = keyOf(current)
+			stack = current
 		}
 
-		if key == "" {
+		key := keyOf(stack)
+		if key == "" || !stack[len(stack)-1].listItem {
 			return ast.WalkContinue
 		}
 

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -1163,7 +1163,9 @@ var cleanDescriptionPrefixFns = []func(string) int{
 	nestedParensMatcher("Optional"),
 	nestedParensMatcher("Required"),
 	nestedParensMatcher("Computed"),
+	nestedParensMatcher("Sensitive"),
 	nestedParensMatcher("Forces new resource"),
+	nestedParensMatcher("Requirement"),
 }
 
 func cleanDescription(path docsPath, desc string) string {

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -1068,25 +1068,64 @@ func renderMdNode(src []byte, n ast.Node) []byte {
 	return b.Bytes()
 }
 
-var cleanDescriptionPrefixes = []*regexp.Regexp{
-	regexp.MustCompile(`^[:-]`),
-	regexp.MustCompile(`^\(Optional.*?\)`),
-	regexp.MustCompile(`^\(Required.*?\)`),
+func nestedParensMatcher(trigger string) func(string) int {
+	trigger = "(" + trigger
+	return func(s string) int {
+		if !strings.HasPrefix(s, trigger) {
+			return 0
+		}
+
+		depth := 1
+		for i := len(trigger); i < len(s); i++ {
+			switch s[i] {
+			case '(':
+				depth++
+			case ')':
+				depth--
+				if depth == 0 {
+					return i + 1
+				}
+			}
+		}
+		// No matching paren was found, so return nothing found
+		return 0
+	}
+}
+
+var cleanDescriptionPrefixFns = []func(string) int{
+	// Cut Leading ':' and '-'
+	func(s string) int {
+		var i int
+		for i < len(s) && (s[i] == ':' || s[i] == '-') {
+			i++
+		}
+		return i
+	},
+	// Cut leading "(Optional.*)"
+	//
+	// This needs to be a function and not a regex because we want the final ')' cut
+	// to balance with the first '('.
+	nestedParensMatcher("Optional"),
+	nestedParensMatcher("Required"),
 }
 
 func cleanDescription(path docsPath, desc string) string {
-	name := path.leaf()
-	valid := append(cleanDescriptionPrefixes, regexp.MustCompile("^"+regexp.QuoteMeta("`"+name+"`")))
+	name := "`" + path.leaf() + "`"
+	valid := append(cleanDescriptionPrefixFns, func(s string) int {
+		if strings.HasPrefix(s, name) {
+			return len(name)
+		}
+		return 0
+	})
 	changed := true
 	desc = strings.TrimLeftFunc(desc, unicode.IsSpace)
 	for changed {
 		changed = false
 		for _, c := range valid {
-			if found := len(c.FindString(desc)); found > 0 {
-				desc = desc[found:]
-				desc = strings.TrimLeftFunc(desc,
-					unicode.IsSpace)
+			if cut := c(desc); cut != 0 {
 				changed = true
+				desc = desc[cut:]
+				desc = strings.TrimLeftFunc(desc, unicode.IsSpace)
 			}
 		}
 	}

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -906,7 +906,7 @@ func parseArgReferenceSection(subsection []string, ret *entityDocs) {
 			unbaked = map[docsPath]struct{}{}
 		case ast.KindListItem:
 			// We have entered a new item
-			if name := nodeItemName(src, node); name != "" {
+			if name := nodeItemName(src, node.(*ast.ListItem)); name != "" {
 				current = append(current, &namedNode{node, name, true})
 				key := keyOf(current)
 				setLatest()
@@ -1121,14 +1121,17 @@ func cleanDescription(path docsPath, desc string) string {
 	return strings.TrimRightFunc(desc, unicode.IsSpace)
 }
 
-func nodeItemName(src []byte, node ast.Node) string {
+func nodeItemName(src []byte, node *ast.ListItem) string {
 	if node == nil {
 		return ""
 	}
 	var name string
 	contract.AssertNoErrorf(ast.Walk(node, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
-		if node.Kind() == ast.KindCodeSpan {
+		switch node := node.(type) {
+		case *ast.CodeSpan:
 			name = string(node.Text(src))
+			return ast.WalkStop, nil
+		case *ast.Text:
 			return ast.WalkStop, nil
 		}
 		return ast.WalkContinue, nil

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -212,6 +212,11 @@ func TestCleanDescription(t *testing.T) {
 			expected: "Match versions by tag prefix. Applied on any prefix match.",
 		},
 		{
+			path:     "tag_prefixes",
+			desc:     "`tag_prefixes` - (optional) Match versions by tag prefix.",
+			expected: "Match versions by tag prefix.",
+		},
+		{
 			path: "tag_prefixes",
 			desc: "`tag_prefixes` -" + `
   (Required (Optimal (Actual))) Match versions (only versions) by tag prefix. Applied on any prefix match.

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -240,6 +240,17 @@ func TestCleanDescription(t *testing.T) {
 			desc:     "",
 			expected: "",
 		},
+		{
+			path: "foo",
+			// This is an en-dash, not a hyphen
+			desc:     "`foo` – (Optional) Description",
+			expected: "Description",
+		},
+		{
+			path:     "foo.bar",
+			desc:     "`foo.bar` - (Required) ;)",
+			expected: ";)",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -251,6 +251,16 @@ func TestCleanDescription(t *testing.T) {
 			desc:     "`foo.bar` - (Required) ;)",
 			expected: ";)",
 		},
+		{
+			path:     "bar",
+			desc:     "`bar` - (Computed) is computed",
+			expected: "is computed",
+		},
+		{
+			path:     "bar",
+			desc:     "`bar` - (Forces new resource) replace",
+			expected: "replace",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -258,7 +258,7 @@ func TestCleanDescription(t *testing.T) {
 			desc: "`tag_prefixes` -" + `
   () (Optional) versions by tag prefix. Applied on any prefix match.
 `,
-			expected: "() (Optional) versions by tag prefix. Applied on any prefix match.",
+			expected: "versions by tag prefix. Applied on any prefix match.",
 		},
 		{
 			path:     "foo",
@@ -290,6 +290,11 @@ func TestCleanDescription(t *testing.T) {
 			path:     "bar",
 			desc:     "`bar` - (Forces new resource) replace",
 			expected: "replace",
+		},
+		{
+			path:     "bar",
+			desc:     "`bar` - ((some-thing)) bar",
+			expected: "bar",
 		},
 	}
 

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -841,7 +841,8 @@ func TestGetNestedBlockName(t *testing.T) {
 				text.NewReader(src))
 			assert.Equal(t, tt.expected, isHeadingTarget(src, parsed.FirstChild().(*ast.Heading)))
 		} else {
-			assert.Equal(t, tt.expected, getNestedBlockName([]byte(tt.input)))
+			actual, _ := getNestedBlockName([]byte(tt.input))
+			assert.Equal(t, tt.expected, actual)
 		}
 	}
 }

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -189,6 +189,36 @@ func TestURLRewrite(t *testing.T) {
 	}
 }
 
+func TestRenderMarkdown(t *testing.T) {
+	t.Parallel()
+	tests := []string{
+		"\n- foo bar",
+		`
+- top
+- foo
+  bar`,
+		"foo:\n* bar",
+		"\n- > bar",
+		`
+- foo
+  * bar
+    - middle
+  * fizz
+- buzz`,
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run("", func(t *testing.T) {
+			src := []byte(tt)
+			node := goldmark.New().Parser().Parse(
+				text.NewReader(src))
+			actual := renderMdNode(src, node)
+			assert.Equal(t, tt, string(actual))
+		})
+	}
+}
+
 func TestCleanDescription(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen/internal/testprovider"
@@ -45,6 +44,65 @@ import (
 var (
 	accept = cmdutil.IsTruthy(os.Getenv("PULUMI_ACCEPT"))
 )
+
+func TestEntityDocsParsing(t *testing.T) {
+	t.Parallel()
+	baseDir := filepath.Join("test_data", "resources")
+
+	dir, err := os.ReadDir(baseDir)
+	require.NoError(t, err)
+
+	for _, d := range dir {
+		if !d.IsDir() {
+			continue
+		}
+		source := filepath.Join(baseDir, d.Name(), "upstream.md")
+		expect := filepath.Join(baseDir, d.Name(), "docs.json")
+		t.Run(d.Name(), func(t *testing.T) {
+			sourceBytes, err := os.ReadFile(source)
+			require.NoError(t, err)
+
+			nilSink := diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{
+				Color: colors.Never,
+			})
+
+			entityDocs, err := getDocsForResource(&Generator{
+				sink: nilSink,
+			}, simpleSource{
+				d.Name(): sourceBytes,
+			}, ResourceDocs, d.Name(), &tfbridge.ResourceInfo{})
+			require.NoError(t, err)
+
+			actualBytes, err := json.MarshalIndent(entityDocs, "", "  ")
+			require.NoError(t, err)
+			if pulumiAccept {
+				err := os.WriteFile(expect, actualBytes, 0600)
+				assert.NoError(t, err)
+			} else {
+				expectedBytes, err := os.ReadFile(expect)
+				require.NoError(t, err)
+				assert.JSONEq(t, string(expectedBytes), string(actualBytes))
+			}
+		})
+	}
+}
+
+type simpleSource map[string][]byte
+
+func (s simpleSource) getResource(name string, _ *tfbridge.DocInfo) (*DocFile, error) {
+	f, ok := s[name]
+	if !ok {
+		return nil, nil
+	}
+	return &DocFile{
+		Content:  f,
+		FileName: name,
+	}, nil
+}
+
+func (s simpleSource) getDatasource(name string, info *tfbridge.DocInfo) (*DocFile, error) {
+	return s.getResource(name, info)
+}
 
 type testcase struct {
 	Input    string
@@ -289,9 +347,7 @@ func TestArgumentRegex(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run("", func(t *testing.T) {
-			ret := entityDocs{
-				Arguments: make(map[docsPath]*argumentDocs),
-			}
+			ret := entityDocs{Arguments: make(map[docsPath]*argumentDocs)}
 			parseArgReferenceSection(tt.input, &ret)
 
 			assert.Equal(t, tt.expected, ret.Arguments)
@@ -852,7 +908,7 @@ func TestParseImports_NoOverrides(t *testing.T) {
 		parser.parseImports(tt.input)
 		actual := parser.ret.Import
 		if tt.expectedFile != "" {
-			if accept {
+			if pulumiAccept {
 				writefile(t, tt.expectedFile, []byte(actual))
 			}
 			tt.expected = readfile(t, tt.expectedFile)

--- a/pkg/tfgen/test_data/resources/bigquery_table/docs.json
+++ b/pkg/tfgen/test_data/resources/bigquery_table/docs.json
@@ -116,10 +116,7 @@
       "description": "The number of rows at the top of the sheet\nthat BigQuery will skip when reading the data. At least one of `range` or\n`skip_leading_rows` must be set."
     },
     "hive_partitioning_options.mode": {
-      "description": "When set, what mode of hive partitioning to use when\nreading data. The following modes are supported.\n\nAUTO: automatically infer partition key name(s) and type(s).\n\nSTRINGS: automatically infer partition key name(s). All types are\nNot all storage formats support hive partitioning. Requesting hive\npartitioning on an unsupported format will lead to an error.\nCurrently supported formats are: JSON, CSV, ORC, Avro and Parquet."
-    },
-    "hive_partitioning_options.mode.CUSTOM": {
-      "description": "CUSTOM: when set to `CUSTOM`, you must encode the partition key schema within the `source_uri_prefix` by setting `source_uri_prefix` to `gs://bucket/path_to_table/{key1:TYPE1}/{key2:TYPE2}/{key3:TYPE3}`."
+      "description": "When set, what mode of hive partitioning to use when\nreading data. The following modes are supported.\n\nAUTO: automatically infer partition key name(s) and type(s).\n\nSTRINGS: automatically infer partition key name(s). All types are\nNot all storage formats support hive partitioning. Requesting hive\npartitioning on an unsupported format will lead to an error.\nCurrently supported formats are: JSON, CSV, ORC, Avro and Parquet.\n\nCUSTOM: when set to `CUSTOM`, you must encode the partition key schema within the `source_uri_prefix` by setting `source_uri_prefix` to `gs://bucket/path_to_table/{key1:TYPE1}/{key2:TYPE2}/{key3:TYPE3}`."
     },
     "json_options.encoding": {
       "description": "The character encoding of the data. The supported values are UTF-8, UTF-16BE, UTF-16LE, UTF-32BE, and UTF-32LE. The default value is UTF-8."

--- a/pkg/tfgen/test_data/resources/bigquery_table/docs.json
+++ b/pkg/tfgen/test_data/resources/bigquery_table/docs.json
@@ -125,7 +125,7 @@
       "description": "The number of rows at the top of the sheet\nthat BigQuery will skip when reading the data. At least one of `range` or\n`skip_leading_rows` must be set."
     },
     "hive_partitioning_options.mode": {
-      "description": "When set, what mode of hive partitioning to use when\nreading data. The following modes are supported.\n\nAUTO: automatically infer partition key name(s) and type(s).\n\nSTRINGS: automatically infer partition key name(s). All types are\nNot all storage formats support hive partitioning. Requesting hive\npartitioning on an unsupported format will lead to an error.\nCurrently supported formats are: JSON, CSV, ORC, Avro and Parquet.\n\nCUSTOM: when set to `CUSTOM`, you must encode the partition key schema within the `source_uri_prefix` by setting `source_uri_prefix` to `gs://bucket/path_to_table/{key1:TYPE1}/{key2:TYPE2}/{key3:TYPE3}`."
+      "description": "When set, what mode of hive partitioning to use when\nreading data. The following modes are supported.\n* AUTO: automatically infer partition key name(s) and type(s).\n* STRINGS: automatically infer partition key name(s). All types are\n  Not all storage formats support hive partitioning. Requesting hive\n  partitioning on an unsupported format will lead to an error.\n  Currently supported formats are: JSON, CSV, ORC, Avro and Parquet.\n* CUSTOM: when set to `CUSTOM`, you must encode the partition key schema within the `source_uri_prefix` by setting `source_uri_prefix` to `gs://bucket/path_to_table/{key1:TYPE1}/{key2:TYPE2}/{key3:TYPE3}`."
     },
     "json_options.encoding": {
       "description": "The character encoding of the data. The supported values are UTF-8, UTF-16BE, UTF-16LE, UTF-32BE, and UTF-32LE. The default value is UTF-8."

--- a/pkg/tfgen/test_data/resources/bigquery_table/docs.json
+++ b/pkg/tfgen/test_data/resources/bigquery_table/docs.json
@@ -85,8 +85,17 @@
     "external_data_configuration.max_bad_records": {
       "description": "The maximum number of bad records that\nBigQuery can ignore when reading data."
     },
+    "external_data_configuration.metadata_cache_mode": {
+      "description": "Metadata Cache Mode for the table. Set this to enable caching of metadata from external data source. Valid values are `AUTOMATIC` and `MANUAL`."
+    },
+    "external_data_configuration.object_metadata": {
+      "description": "Object Metadata is used to create Object Tables. Object Tables contain a listing of objects (with their metadata) found at the sourceUris. If `object_metadata` is set, `source_format` should be omitted."
+    },
     "external_data_configuration.parquet_options": {
       "description": "Additional properties to set if\n`source_format` is set to \"PARQUET\". Structure is documented below."
+    },
+    "external_data_configuration.reference_file_schema_uri": {
+      "description": "When creating an external table, the user can provide a reference file with the table schema. This is enabled for the following formats: AVRO, PARQUET, ORC."
     },
     "external_data_configuration.schema": {
       "description": "A JSON schema for the external table. Schema is required\nfor CSV and JSON formats if autodetect is not on. Schema is disallowed\nfor Google Cloud Bigtable, Cloud Datastore backups, Avro, Iceberg, ORC and Parquet formats.\n~\u003e**NOTE:** Because this field expects a JSON string, any changes to the\nstring will create a diff, even if the JSON itself hasn't changed.\nFurthermore drift for this field cannot not be detected because BigQuery\nonly uses this schema to compute the effective schema for the table, therefore\nany changes on the configured value will force the table to be recreated.\nThis schema is effectively only applied when creating a table from an external\ndatasource, after creation the computed schema will be stored in\n`google_bigquery_table.schema`\n\n~\u003e**NOTE:** If you set `external_data_configuration.connection_id`, the\ntable schema must be specified using the top-level `schema` field\ndocumented above."
@@ -171,15 +180,6 @@
     },
     "range_partitioning.range": {
       "description": "Information required to partition based on ranges.\nStructure is documented below."
-    },
-    "external_data_configuration.reference_file_schema_uri": {
-      "description": "When creating an external table, the user can provide a reference file with the table schema. This is enabled for the following formats: AVRO, PARQUET, ORC."
-    },
-    "external_data_configuration.metadata_cache_mode": {
-      "description": "Metadata Cache Mode for the table. Set this to enable caching of metadata from external data source. Valid values are `AUTOMATIC` and `MANUAL`."
-    },
-    "external_data_configuration.object_metadata": {
-      "description": "Object Metadata is used to create Object Tables. Object Tables contain a listing of objects (with their metadata) found at the sourceUris. If `object_metadata` is set, `source_format` should be omitted."
     },
     "referenced_table.dataset_id": {
       "description": "The ID of the dataset containing this table."

--- a/pkg/tfgen/test_data/resources/bigquery_table/docs.json
+++ b/pkg/tfgen/test_data/resources/bigquery_table/docs.json
@@ -1,0 +1,256 @@
+{
+  "Description": "Creates a table resource in a dataset for Google BigQuery. For more information see\n[the official documentation](https://cloud.google.com/bigquery/docs/) and\n[API](https://cloud.google.com/bigquery/docs/reference/rest/v2/tables).\n\n\u003e **Note**: On newer versions of the provider, you must explicitly set `deletion_protection=false`\n(and run `pulumi update` to write the field to state) in order to destroy an instance.\nIt is recommended to not set this field (or set it to true) until you're ready to destroy.\n\n## Example Usage\n\n```hcl\nresource \"google_bigquery_dataset\" \"default\" {\n  dataset_id                  = \"foo\"\n  friendly_name               = \"test\"\n  description                 = \"This is a test description\"\n  location                    = \"EU\"\n  default_table_expiration_ms = 3600000\n\n  labels = {\n    env = \"default\"\n  }\n}\n\nresource \"google_bigquery_table\" \"default\" {\n  dataset_id = google_bigquery_dataset.default.dataset_id\n  table_id   = \"bar\"\n\n  time_partitioning {\n    type = \"DAY\"\n  }\n\n  labels = {\n    env = \"default\"\n  }\n\n  schema = \u003c\u003cEOF\n[\n  {\n    \"name\": \"permalink\",\n    \"type\": \"STRING\",\n    \"mode\": \"NULLABLE\",\n    \"description\": \"The Permalink\"\n  },\n  {\n    \"name\": \"state\",\n    \"type\": \"STRING\",\n    \"mode\": \"NULLABLE\",\n    \"description\": \"State where the head office is located\"\n  }\n]\nEOF\n\n}\n\nresource \"google_bigquery_table\" \"sheet\" {\n  dataset_id = google_bigquery_dataset.default.dataset_id\n  table_id   = \"sheet\"\n\n  external_data_configuration {\n    autodetect    = true\n    source_format = \"GOOGLE_SHEETS\"\n\n    google_sheets_options {\n      skip_leading_rows = 1\n    }\n\n    source_uris = [\n      \"https://docs.google.com/spreadsheets/d/123456789012345\",\n    ]\n  }\n}\n```",
+  "Arguments": {
+    "avro_options.use_avro_logical_types": {
+      "description": "If is set to true, indicates whether\nto interpret logical types as the corresponding BigQuery data type\n(for example, TIMESTAMP), instead of using the raw type (for example, INTEGER)."
+    },
+    "clustering": {
+      "description": "Specifies column names to use for data clustering.\nUp to four top-level columns are allowed, and should be specified in\ndescending priority order."
+    },
+    "column_references.referenced_column": {
+      "description": "The column in the primary key that are\nreferenced by the referencingColumn"
+    },
+    "column_references.referencing_column": {
+      "description": "The column that composes the foreign key."
+    },
+    "csv_options.allow_jagged_rows": {
+      "description": "Indicates if BigQuery should accept rows\nthat are missing trailing optional columns."
+    },
+    "csv_options.allow_quoted_newlines": {
+      "description": "Indicates if BigQuery should allow\nquoted data sections that contain newline characters in a CSV file.\nThe default value is false."
+    },
+    "csv_options.encoding": {
+      "description": "The character encoding of the data. The supported\nvalues are UTF-8 or ISO-8859-1."
+    },
+    "csv_options.field_delimiter": {
+      "description": "The separator for fields in a CSV file."
+    },
+    "csv_options.quote": {
+      "description": "The value that is used to quote data sections in a\nCSV file. If your data does not contain quoted sections, set the\nproperty value to an empty string. If your data contains quoted newline\ncharacters, you must also set the `allow_quoted_newlines` property to true.\nThe API-side default is `\"`, specified in the provider escaped as `\\\"`. Due to\nlimitations with default values, this value is required to be\nexplicitly set."
+    },
+    "csv_options.skip_leading_rows": {
+      "description": "The number of rows at the top of a CSV\nfile that BigQuery will skip when reading the data."
+    },
+    "dataset_id": {
+      "description": "The dataset ID to create the table in.\nChanging this forces a new resource to be created."
+    },
+    "deletion_protection": {
+      "description": "Whether or not to allow the provider to destroy the instance. Unless this field is set to false\nin state, a `=destroy` or `=update` that would delete the instance will fail."
+    },
+    "description": {
+      "description": "The field description."
+    },
+    "encryption_configuration": {
+      "description": "Specifies how the table should be encrypted.\nIf left blank, the table will be encrypted with a Google-managed key; that process\nis transparent to the user.  Structure is documented below."
+    },
+    "encryption_configuration.kms_key_name": {
+      "description": "The self link or full name of a key which should be used to\nencrypt this table.  Note that the default bigquery service account will need to have\nencrypt/decrypt permissions on this key - you may want to see the\n`google_bigquery_default_service_account` datasource and the\n`google_kms_crypto_key_iam_binding` resource."
+    },
+    "expiration_time": {
+      "description": "The time when this table expires, in\nmilliseconds since the epoch. If not present, the table will persist\nindefinitely. Expired tables will be deleted and their storage\nreclaimed."
+    },
+    "external_data_configuration": {
+      "description": "Describes the data format,\nlocation, and other properties of a table stored outside of BigQuery.\nBy defining these properties, the data source can then be queried as\nif it were a standard BigQuery table. Structure is documented below."
+    },
+    "external_data_configuration.autodetect": {
+      "description": "Let BigQuery try to autodetect the schema\nand format of the table."
+    },
+    "external_data_configuration.avro_options": {
+      "description": "Additional options if `source_format` is set to\n\"AVRO\".  Structure is documented below."
+    },
+    "external_data_configuration.compression": {
+      "description": "The compression type of the data source.\nValid values are \"NONE\" or \"GZIP\"."
+    },
+    "external_data_configuration.connection_id": {
+      "description": "The connection specifying the credentials to be used to read\nexternal storage, such as Azure Blob, Cloud Storage, or S3. The `connection_id` can have\nthe form `{{project}}.{{location}}.{{connection_id}}`\nor `projects/{{project}}/locations/{{location}}/connections/{{connection_id}}`.\n\n~\u003e**NOTE:** If you set `external_data_configuration.connection_id`, the\ntable schema must be specified using the top-level `schema` field\ndocumented above."
+    },
+    "external_data_configuration.csv_options": {
+      "description": "Additional properties to set if\n`source_format` is set to \"CSV\". Structure is documented below."
+    },
+    "external_data_configuration.file_set_spec_type": {
+      "description": "Specifies how source URIs are interpreted for constructing the file set to load.\nBy default source URIs are expanded against the underlying storage.\nOther options include specifying manifest files. Only applicable to object storage systems. Docs"
+    },
+    "external_data_configuration.google_sheets_options": {
+      "description": "Additional options if\n`source_format` is set to \"GOOGLE_SHEETS\". Structure is\ndocumented below."
+    },
+    "external_data_configuration.hive_partitioning_options": {
+      "description": "When set, configures hive partitioning\nsupport. Not all storage formats support hive partitioning -- requesting hive\npartitioning on an unsupported format will lead to an error, as will providing\nan invalid specification. Structure is documented below."
+    },
+    "external_data_configuration.ignore_unknown_values": {
+      "description": "Indicates if BigQuery should\nallow extra values that are not represented in the table schema.\nIf true, the extra values are ignored. If false, records with\nextra columns are treated as bad records, and if there are too\nmany bad records, an invalid error is returned in the job result.\nThe default value is false."
+    },
+    "external_data_configuration.json_options": {
+      "description": "Additional properties to set if\n`source_format` is set to \"JSON\". Structure is documented below."
+    },
+    "external_data_configuration.max_bad_records": {
+      "description": "The maximum number of bad records that\nBigQuery can ignore when reading data."
+    },
+    "external_data_configuration.parquet_options": {
+      "description": "Additional properties to set if\n`source_format` is set to \"PARQUET\". Structure is documented below."
+    },
+    "external_data_configuration.schema": {
+      "description": "A JSON schema for the external table. Schema is required\nfor CSV and JSON formats if autodetect is not on. Schema is disallowed\nfor Google Cloud Bigtable, Cloud Datastore backups, Avro, Iceberg, ORC and Parquet formats.\n~\u003e**NOTE:** Because this field expects a JSON string, any changes to the\nstring will create a diff, even if the JSON itself hasn't changed.\nFurthermore drift for this field cannot not be detected because BigQuery\nonly uses this schema to compute the effective schema for the table, therefore\nany changes on the configured value will force the table to be recreated.\nThis schema is effectively only applied when creating a table from an external\ndatasource, after creation the computed schema will be stored in\n`google_bigquery_table.schema`\n\n~\u003e**NOTE:** If you set `external_data_configuration.connection_id`, the\ntable schema must be specified using the top-level `schema` field\ndocumented above."
+    },
+    "external_data_configuration.source_format": {
+      "description": "The data format. Please see sourceFormat under\n[ExternalDataConfiguration](https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#externaldataconfiguration)\nin Bigquery's public API documentation for supported formats. To use \"GOOGLE_SHEETS\"\nthe `scopes` must include \"https://www.googleapis.com/auth/drive.readonly\"."
+    },
+    "external_data_configuration.source_uris": {
+      "description": "A list of the fully-qualified URIs that point to\nyour data in Google Cloud."
+    },
+    "foreign_keys.column_references": {
+      "description": "The pair of the foreign key column and primary key column.\nStructure is documented below."
+    },
+    "foreign_keys.name": {
+      "description": "Set only if the foreign key constraint is named."
+    },
+    "foreign_keys.referenced_table": {
+      "description": "The table that holds the primary key\nand is referenced by this foreign key.\nStructure is documented below."
+    },
+    "friendly_name": {
+      "description": "A descriptive name for the table."
+    },
+    "google_sheets_options.range": {
+      "description": "Range of a sheet to query from. Only used when\nnon-empty. At least one of `range` or `skip_leading_rows` must be set.\nTypical format: \"sheet_name!top_left_cell_id:bottom_right_cell_id\"\nFor example: \"sheet1!A1:B20\""
+    },
+    "google_sheets_options.skip_leading_rows": {
+      "description": "The number of rows at the top of the sheet\nthat BigQuery will skip when reading the data. At least one of `range` or\n`skip_leading_rows` must be set."
+    },
+    "hive_partitioning_options.mode": {
+      "description": "When set, what mode of hive partitioning to use when\nreading data. The following modes are supported.\n\nAUTO: automatically infer partition key name(s) and type(s).\n\nSTRINGS: automatically infer partition key name(s). All types are\nNot all storage formats support hive partitioning. Requesting hive\npartitioning on an unsupported format will lead to an error.\nCurrently supported formats are: JSON, CSV, ORC, Avro and Parquet."
+    },
+    "hive_partitioning_options.mode.CUSTOM": {
+      "description": "CUSTOM: when set to `CUSTOM`, you must encode the partition key schema within the `source_uri_prefix` by setting `source_uri_prefix` to `gs://bucket/path_to_table/{key1:TYPE1}/{key2:TYPE2}/{key3:TYPE3}`."
+    },
+    "json_options.encoding": {
+      "description": "The character encoding of the data. The supported values are UTF-8, UTF-16BE, UTF-16LE, UTF-32BE, and UTF-32LE. The default value is UTF-8."
+    },
+    "labels": {
+      "description": "A mapping of labels to assign to the resource."
+    },
+    "materialized_view": {
+      "description": "If specified, configures this table as a materialized view.\nStructure is documented below."
+    },
+    "materialized_view.allow_non_incremental_definition": {
+      "description": "Allow non incremental materialized view definition.\nThe default value is false."
+    },
+    "materialized_view.enable_refresh": {
+      "description": "Specifies whether to use BigQuery's automatic refresh for this materialized view when the base table is updated.\nThe default value is true."
+    },
+    "materialized_view.query": {
+      "description": "A query whose result is persisted."
+    },
+    "materialized_view.refresh_interval_ms": {
+      "description": "The maximum frequency at which this materialized view will be refreshed.\nThe default value is 1800000"
+    },
+    "max_staleness": {
+      "description": "The maximum staleness of data that could be returned when the table (or stale MV) is queried. Staleness encoded as a string encoding of sql IntervalValue type."
+    },
+    "parquet_options.enable_list_inference": {
+      "description": "Indicates whether to use schema inference specifically for Parquet LIST logical type."
+    },
+    "parquet_options.enum_as_string": {
+      "description": "Indicates whether to infer Parquet ENUM logical type as STRING instead of BYTES by default."
+    },
+    "primary_key.columns": {
+      "description": "The columns that are composed of the primary key constraint."
+    },
+    "project": {
+      "description": "The ID of the project in which the resource belongs. If it\nis not provided, the provider project is used."
+    },
+    "range.end": {
+      "description": "End of the range partitioning, exclusive."
+    },
+    "range.interval": {
+      "description": "The width of each range within the partition."
+    },
+    "range.start": {
+      "description": "Start of the range partitioning, inclusive."
+    },
+    "range_partitioning": {
+      "description": "If specified, configures range-based\npartitioning for this table. Structure is documented below."
+    },
+    "range_partitioning.field": {
+      "description": "The field used to determine how to create a range-based\npartition."
+    },
+    "range_partitioning.range": {
+      "description": "Information required to partition based on ranges.\nStructure is documented below."
+    },
+    "external_data_configuration.reference_file_schema_uri": {
+      "description": "When creating an external table, the user can provide a reference file with the table schema. This is enabled for the following formats: AVRO, PARQUET, ORC."
+    },
+    "external_data_configuration.metadata_cache_mode": {
+      "description": "Metadata Cache Mode for the table. Set this to enable caching of metadata from external data source. Valid values are `AUTOMATIC` and `MANUAL`."
+    },
+    "external_data_configuration.object_metadata": {
+      "description": "Object Metadata is used to create Object Tables. Object Tables contain a listing of objects (with their metadata) found at the sourceUris. If `object_metadata` is set, `source_format` should be omitted."
+    },
+    "referenced_table.dataset_id": {
+      "description": "The ID of the dataset containing this table."
+    },
+    "referenced_table.project_id": {
+      "description": "The ID of the project containing this table."
+    },
+    "referenced_table.table_id": {
+      "description": "The ID of the table. The ID must contain only\nletters (a-z, A-Z), numbers (0-9), or underscores (_). The maximum\nlength is 1,024 characters. Certain operations allow suffixing of\nthe table ID with a partition decorator, such as\nsample_table$20190123."
+    },
+    "require_partition_filter": {
+      "description": "If set to true, queries over this table\nrequire a partition filter that can be used for partition elimination to be\nspecified."
+    },
+    "schema": {
+      "description": "\u003ca name=\"schema\"\u003e\u003c/a\u003e`schema` - (Optional) A JSON schema for the table.\n\n~\u003e**NOTE:** Because this field expects a JSON string, any changes to the\nstring will create a diff, even if the JSON itself hasn't changed.\nIf the API returns a different value for the same schema, e.g. it\nswitched the order of values or replaced `STRUCT` field type with `RECORD`\nfield type, we currently cannot suppress the recurring diff this causes.\nAs a workaround, we recommend using the schema as returned by the API.\n\n~\u003e**NOTE:**  If you use `external_data_configuration`\ndocumented below and do **not** set\n`external_data_configuration.connection_id`, schemas must be specified\nwith `external_data_configuration.schema`. Otherwise, schemas must be\nspecified with this top-level field."
+    },
+    "source_uri_prefix": {
+      "description": "When hive partition detection is requested,\na common for all source uris must be required. The prefix must end immediately\nbefore the partition key encoding begins. For example, consider files following\nthis data layout. `gs://bucket/path_to_table/dt=2019-06-01/country=USA/id=7/file.avro`\n`gs://bucket/path_to_table/dt=2019-05-31/country=CA/id=3/file.avro` When hive\npartitioning is requested with either AUTO or STRINGS detection, the common prefix\ncan be either of `gs://bucket/path_to_table` or `gs://bucket/path_to_table/`.\nNote that when `mode` is set to `CUSTOM`, you must encode the partition key schema within the `source_uri_prefix` by setting `source_uri_prefix` to `gs://bucket/path_to_table/{key1:TYPE1}/{key2:TYPE2}/{key3:TYPE3}`."
+    },
+    "table_constraints": {
+      "description": "Defines the primary key and foreign keys. \nStructure is documented below."
+    },
+    "table_constraints.foreign_keys": {
+      "description": "Present only if the table has a foreign key.\nThe foreign key is not enforced.\nStructure is documented below."
+    },
+    "table_constraints.primary_key": {
+      "description": "Represents the primary key constraint\non a table's columns. Present only if the table has a primary key.\nThe primary key is not enforced.\nStructure is documented below."
+    },
+    "table_id": {
+      "description": "A unique ID for the resource.\nChanging this forces a new resource to be created."
+    },
+    "time_partitioning": {
+      "description": "If specified, configures time-based\npartitioning for this table. Structure is documented below."
+    },
+    "time_partitioning.expiration_ms": {
+      "description": "Number of milliseconds for which to keep the\nstorage for a partition."
+    },
+    "time_partitioning.field": {
+      "description": "The field used to determine how to create a time-based\npartition. If time-based partitioning is enabled without this value, the\ntable is partitioned based on the load time."
+    },
+    "time_partitioning.require_partition_filter": {
+      "description": "If set to true, queries over this table\nrequire a partition filter that can be used for partition elimination to be\nspecified."
+    },
+    "time_partitioning.type": {
+      "description": "The supported types are DAY, HOUR, MONTH, and YEAR,\nwhich will generate one partition per day, hour, month, and year, respectively."
+    },
+    "view": {
+      "description": "If specified, configures this table as a view.\nStructure is documented below."
+    },
+    "view.query": {
+      "description": "A query that BigQuery executes when the view is referenced."
+    },
+    "view.use_legacy_sql": {
+      "description": "Specifies whether to use BigQuery's legacy SQL for this view.\nThe default value is true. If set to false, the view will use BigQuery's standard SQL."
+    }
+  },
+  "Attributes": {
+    "creation_time": "The time when this table was created, in milliseconds since the epoch.",
+    "etag": "A hash of the resource.",
+    "id": "an identifier for the resource with format `projects/{{project}}/datasets/{{dataset}}/tables/{{name}}`",
+    "kms_key_version": "The self link or full name of the kms key version used to encrypt this table.",
+    "last_modified_time": "The time when this table was last modified, in milliseconds since the epoch.",
+    "location": "The geographic location where the table resides. This value is inherited from the dataset.",
+    "num_bytes": "The size of this table in bytes, excluding any data in the streaming buffer.",
+    "num_long_term_bytes": "The number of bytes in the table that are considered \"long-term storage\".",
+    "num_rows": "The number of rows of data in this table, excluding any data in the streaming buffer.",
+    "self_link": "The URI of the created resource.",
+    "type": "Describes the table type."
+  },
+  "Import": "## Import\n\nBigQuery tables imported using any of these accepted formats: \u003cbreak\u003e\u003cbreak\u003e```sh\u003cbreak\u003e $ pulumi import MISSING_TOK default projects/{{project}}/datasets/{{dataset_id}}/tables/{{table_id}} \u003cbreak\u003e```\u003cbreak\u003e\u003cbreak\u003e \u003cbreak\u003e\u003cbreak\u003e```sh\u003cbreak\u003e $ pulumi import MISSING_TOK default {{project}}/{{dataset_id}}/{{table_id}} \u003cbreak\u003e```\u003cbreak\u003e\u003cbreak\u003e \u003cbreak\u003e\u003cbreak\u003e```sh\u003cbreak\u003e $ pulumi import MISSING_TOK default {{dataset_id}}/{{table_id}} \u003cbreak\u003e```\u003cbreak\u003e\u003cbreak\u003e"
+}

--- a/pkg/tfgen/test_data/resources/bigquery_table/upstream.md
+++ b/pkg/tfgen/test_data/resources/bigquery_table/upstream.md
@@ -1,0 +1,452 @@
+---
+subcategory: "BigQuery"
+description: |-
+  Creates a table resource in a dataset for Google BigQuery.
+---
+
+# google_bigquery_table
+
+Creates a table resource in a dataset for Google BigQuery. For more information see
+[the official documentation](https://cloud.google.com/bigquery/docs/) and
+[API](https://cloud.google.com/bigquery/docs/reference/rest/v2/tables).
+
+-> **Note**: On newer versions of the provider, you must explicitly set `deletion_protection=false`
+(and run `pulumi update` to write the field to state) in order to destroy an instance.
+It is recommended to not set this field (or set it to true) until you're ready to destroy.
+
+## Example Usage
+
+```hcl
+resource "google_bigquery_dataset" "default" {
+  dataset_id                  = "foo"
+  friendly_name               = "test"
+  description                 = "This is a test description"
+  location                    = "EU"
+  default_table_expiration_ms = 3600000
+
+  labels = {
+    env = "default"
+  }
+}
+
+resource "google_bigquery_table" "default" {
+  dataset_id = google_bigquery_dataset.default.dataset_id
+  table_id   = "bar"
+
+  time_partitioning {
+    type = "DAY"
+  }
+
+  labels = {
+    env = "default"
+  }
+
+  schema = <<EOF
+[
+  {
+    "name": "permalink",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "The Permalink"
+  },
+  {
+    "name": "state",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "State where the head office is located"
+  }
+]
+EOF
+
+}
+
+resource "google_bigquery_table" "sheet" {
+  dataset_id = google_bigquery_dataset.default.dataset_id
+  table_id   = "sheet"
+
+  external_data_configuration {
+    autodetect    = true
+    source_format = "GOOGLE_SHEETS"
+
+    google_sheets_options {
+      skip_leading_rows = 1
+    }
+
+    source_uris = [
+      "https://docs.google.com/spreadsheets/d/123456789012345",
+    ]
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `dataset_id` - (Required) The dataset ID to create the table in.
+    Changing this forces a new resource to be created.
+
+* `table_id` - (Required) A unique ID for the resource.
+    Changing this forces a new resource to be created.
+
+* `project` - (Optional) The ID of the project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
+* `description` - (Optional) The field description.
+
+* `expiration_time` - (Optional) The time when this table expires, in
+    milliseconds since the epoch. If not present, the table will persist
+    indefinitely. Expired tables will be deleted and their storage
+    reclaimed.
+
+* `external_data_configuration` - (Optional) Describes the data format,
+    location, and other properties of a table stored outside of BigQuery.
+    By defining these properties, the data source can then be queried as
+    if it were a standard BigQuery table. Structure is [documented below](#nested_external_data_configuration).
+
+* `friendly_name` - (Optional) A descriptive name for the table.
+
+* `max_staleness`: (Optional) The maximum staleness of data that could be returned when the table (or stale MV) is queried. Staleness encoded as a string encoding of sql IntervalValue type.
+
+* `encryption_configuration` - (Optional) Specifies how the table should be encrypted.
+    If left blank, the table will be encrypted with a Google-managed key; that process
+    is transparent to the user.  Structure is [documented below](#nested_encryption_configuration).
+
+* `labels` - (Optional) A mapping of labels to assign to the resource.
+
+* <a name="schema"></a>`schema` - (Optional) A JSON schema for the table.
+
+    ~>**NOTE:** Because this field expects a JSON string, any changes to the
+    string will create a diff, even if the JSON itself hasn't changed.
+    If the API returns a different value for the same schema, e.g. it
+    switched the order of values or replaced `STRUCT` field type with `RECORD`
+    field type, we currently cannot suppress the recurring diff this causes.
+    As a workaround, we recommend using the schema as returned by the API.
+
+    ~>**NOTE:**  If you use `external_data_configuration`
+    [documented below](#nested_external_data_configuration) and do **not** set
+    `external_data_configuration.connection_id`, schemas must be specified
+    with `external_data_configuration.schema`. Otherwise, schemas must be
+    specified with this top-level field.
+
+* `time_partitioning` - (Optional) If specified, configures time-based
+    partitioning for this table. Structure is [documented below](#nested_time_partitioning).
+
+* `range_partitioning` - (Optional) If specified, configures range-based
+    partitioning for this table. Structure is [documented below](#nested_range_partitioning).
+
+* `clustering` - (Optional) Specifies column names to use for data clustering.
+    Up to four top-level columns are allowed, and should be specified in
+    descending priority order.
+
+* `view` - (Optional) If specified, configures this table as a view.
+    Structure is [documented below](#nested_view).
+
+* `materialized_view` - (Optional) If specified, configures this table as a materialized view.
+    Structure is [documented below](#nested_materialized_view).
+
+* `deletion_protection` - (Optional) Whether or not to allow the provider to destroy the instance. Unless this field is set to false
+in state, a `=destroy` or `=update` that would delete the instance will fail.
+
+* `table_constraints` - (Optional) Defines the primary key and foreign keys. 
+    Structure is [documented below](#nested_table_constraints).
+
+<a name="nested_external_data_configuration"></a>The `external_data_configuration` block supports:
+
+* `autodetect` - (Required) - Let BigQuery try to autodetect the schema
+    and format of the table.
+
+* `compression` (Optional) - The compression type of the data source.
+    Valid values are "NONE" or "GZIP".
+
+* `connection_id` (Optional) - The connection specifying the credentials to be used to read
+    external storage, such as Azure Blob, Cloud Storage, or S3. The `connection_id` can have
+    the form `{{project}}.{{location}}.{{connection_id}}`
+    or `projects/{{project}}/locations/{{location}}/connections/{{connection_id}}`.
+
+    ~>**NOTE:** If you set `external_data_configuration.connection_id`, the
+    table schema must be specified using the top-level `schema` field
+    [documented above](#schema).
+
+* `csv_options` (Optional) - Additional properties to set if
+    `source_format` is set to "CSV". Structure is [documented below](#nested_csv_options).
+
+* `json_options` (Optional) - Additional properties to set if
+    `source_format` is set to "JSON". Structure is [documented below](#nested_json_options).
+
+* `parquet_options` (Optional) - Additional properties to set if
+    `source_format` is set to "PARQUET". Structure is [documented below](#nested_parquet_options).
+
+* `google_sheets_options` (Optional) - Additional options if
+    `source_format` is set to "GOOGLE_SHEETS". Structure is
+    [documented below](#nested_google_sheets_options).
+
+* `hive_partitioning_options` (Optional) - When set, configures hive partitioning
+    support. Not all storage formats support hive partitioning -- requesting hive
+    partitioning on an unsupported format will lead to an error, as will providing
+    an invalid specification. Structure is [documented below](#nested_hive_partitioning_options).
+
+* `avro_options` (Optional) - Additional options if `source_format` is set to
+    "AVRO".  Structure is [documented below](#nested_avro_options).
+
+* `ignore_unknown_values` (Optional) - Indicates if BigQuery should
+    allow extra values that are not represented in the table schema.
+    If true, the extra values are ignored. If false, records with
+    extra columns are treated as bad records, and if there are too
+    many bad records, an invalid error is returned in the job result.
+    The default value is false.
+
+* `max_bad_records` (Optional) - The maximum number of bad records that
+    BigQuery can ignore when reading data.
+
+* `schema` - (Optional) A JSON schema for the external table. Schema is required
+    for CSV and JSON formats if autodetect is not on. Schema is disallowed
+    for Google Cloud Bigtable, Cloud Datastore backups, Avro, Iceberg, ORC and Parquet formats.
+    ~>**NOTE:** Because this field expects a JSON string, any changes to the
+    string will create a diff, even if the JSON itself hasn't changed.
+    Furthermore drift for this field cannot not be detected because BigQuery
+    only uses this schema to compute the effective schema for the table, therefore
+    any changes on the configured value will force the table to be recreated.
+    This schema is effectively only applied when creating a table from an external
+    datasource, after creation the computed schema will be stored in
+    `google_bigquery_table.schema`
+
+    ~>**NOTE:** If you set `external_data_configuration.connection_id`, the
+    table schema must be specified using the top-level `schema` field
+    [documented above](#schema).
+
+* `source_format` (Optional) - The data format. Please see sourceFormat under
+    [ExternalDataConfiguration](https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#externaldataconfiguration)
+    in Bigquery's public API documentation for supported formats. To use "GOOGLE_SHEETS"
+    the `scopes` must include "https://www.googleapis.com/auth/drive.readonly".
+
+* `source_uris` - (Required) A list of the fully-qualified URIs that point to
+    your data in Google Cloud.
+
+* `file_set_spec_type` - (Optional) Specifies how source URIs are interpreted for constructing the file set to load.
+    By default source URIs are expanded against the underlying storage.
+    Other options include specifying manifest files. Only applicable to object storage systems. [Docs](cloud/bigquery/docs/reference/rest/v2/tables#filesetspectype)
+
+* `reference_file_schema_uri` - (Optional) When creating an external table, the user can provide a reference file with the table schema. This is enabled for the following formats: AVRO, PARQUET, ORC.
+
+* `metadata_cache_mode` - (Optional) Metadata Cache Mode for the table. Set this to enable caching of metadata from external data source. Valid values are `AUTOMATIC` and `MANUAL`.
+
+* `object_metadata` - (Optional) Object Metadata is used to create Object Tables. Object Tables contain a listing of objects (with their metadata) found at the sourceUris. If `object_metadata` is set, `source_format` should be omitted.
+
+<a name="nested_csv_options"></a>The `csv_options` block supports:
+
+* `quote` (Required) - The value that is used to quote data sections in a
+    CSV file. If your data does not contain quoted sections, set the
+    property value to an empty string. If your data contains quoted newline
+    characters, you must also set the `allow_quoted_newlines` property to true.
+    The API-side default is `"`, specified in the provider escaped as `\"`. Due to
+    limitations with default values, this value is required to be
+    explicitly set.
+
+* `allow_jagged_rows` (Optional) - Indicates if BigQuery should accept rows
+    that are missing trailing optional columns.
+
+* `allow_quoted_newlines` (Optional) - Indicates if BigQuery should allow
+    quoted data sections that contain newline characters in a CSV file.
+    The default value is false.
+
+* `encoding` (Optional) - The character encoding of the data. The supported
+    values are UTF-8 or ISO-8859-1.
+
+* `field_delimiter` (Optional) - The separator for fields in a CSV file.
+
+* `skip_leading_rows` (Optional) - The number of rows at the top of a CSV
+    file that BigQuery will skip when reading the data.
+
+<a name="nested_json_options"></a>The `json_options` block supports:
+
+* `encoding` (Optional) - The character encoding of the data. The supported values are UTF-8, UTF-16BE, UTF-16LE, UTF-32BE, and UTF-32LE. The default value is UTF-8.
+
+<a name="nested_google_sheets_options"></a>The `google_sheets_options` block supports:
+
+* `range` (Optional) - Range of a sheet to query from. Only used when
+    non-empty. At least one of `range` or `skip_leading_rows` must be set.
+    Typical format: "sheet_name!top_left_cell_id:bottom_right_cell_id"
+    For example: "sheet1!A1:B20"
+
+* `skip_leading_rows` (Optional) - The number of rows at the top of the sheet
+    that BigQuery will skip when reading the data. At least one of `range` or
+    `skip_leading_rows` must be set.
+
+<a name="nested_hive_partitioning_options"></a>The `hive_partitioning_options` block supports:
+
+* `mode` (Optional) - When set, what mode of hive partitioning to use when
+    reading data. The following modes are supported.
+    * AUTO: automatically infer partition key name(s) and type(s).
+    * STRINGS: automatically infer partition key name(s). All types are
+      Not all storage formats support hive partitioning. Requesting hive
+      partitioning on an unsupported format will lead to an error.
+      Currently supported formats are: JSON, CSV, ORC, Avro and Parquet.
+    * CUSTOM: when set to `CUSTOM`, you must encode the partition key schema within the `source_uri_prefix` by setting `source_uri_prefix` to `gs://bucket/path_to_table/{key1:TYPE1}/{key2:TYPE2}/{key3:TYPE3}`.
+
+* `require_partition_filter` - (Optional) If set to true, queries over this table
+    require a partition filter that can be used for partition elimination to be
+    specified.
+
+* `source_uri_prefix` (Optional) - When hive partition detection is requested,
+    a common for all source uris must be required. The prefix must end immediately
+    before the partition key encoding begins. For example, consider files following
+    this data layout. `gs://bucket/path_to_table/dt=2019-06-01/country=USA/id=7/file.avro`
+    `gs://bucket/path_to_table/dt=2019-05-31/country=CA/id=3/file.avro` When hive
+    partitioning is requested with either AUTO or STRINGS detection, the common prefix
+    can be either of `gs://bucket/path_to_table` or `gs://bucket/path_to_table/`.
+    Note that when `mode` is set to `CUSTOM`, you must encode the partition key schema within the `source_uri_prefix` by setting `source_uri_prefix` to `gs://bucket/path_to_table/{key1:TYPE1}/{key2:TYPE2}/{key3:TYPE3}`.
+
+<a name="nested_avro_options"></a>The `avro_options` block supports:
+
+* `use_avro_logical_types` (Optional) - If is set to true, indicates whether
+    to interpret logical types as the corresponding BigQuery data type
+    (for example, TIMESTAMP), instead of using the raw type (for example, INTEGER).
+
+<a name="nested_parquet_options"></a>The `parquet_options` block supports:
+
+* `enum_as_string` (Optional) - Indicates whether to infer Parquet ENUM logical type as STRING instead of BYTES by default.
+
+* `enable_list_inference` (Optional) - Indicates whether to use schema inference specifically for Parquet LIST logical type.
+
+<a name="nested_time_partitioning"></a>The `time_partitioning` block supports:
+
+* `expiration_ms` -  (Optional) Number of milliseconds for which to keep the
+    storage for a partition.
+
+* `field` - (Optional) The field used to determine how to create a time-based
+    partition. If time-based partitioning is enabled without this value, the
+    table is partitioned based on the load time.
+
+* `type` - (Required) The supported types are DAY, HOUR, MONTH, and YEAR,
+    which will generate one partition per day, hour, month, and year, respectively.
+
+* `require_partition_filter` - (Optional) If set to true, queries over this table
+    require a partition filter that can be used for partition elimination to be
+    specified.
+
+<a name="nested_range_partitioning"></a>The `range_partitioning` block supports:
+
+* `field` - (Required) The field used to determine how to create a range-based
+    partition.
+
+* `range` - (Required) Information required to partition based on ranges.
+    Structure is [documented below](#nested_range).
+
+<a name="nested_range"></a>The `range` block supports:
+
+* `start` - (Required) Start of the range partitioning, inclusive.
+
+* `end` - (Required) End of the range partitioning, exclusive.
+
+* `interval` - (Required) The width of each range within the partition.
+
+<a name="nested_view"></a>The `view` block supports:
+
+* `query` - (Required) A query that BigQuery executes when the view is referenced.
+
+* `use_legacy_sql` - (Optional) Specifies whether to use BigQuery's legacy SQL for this view.
+    The default value is true. If set to false, the view will use BigQuery's standard SQL.
+
+<a name="nested_materialized_view"></a>The `materialized_view` block supports:
+
+* `query` - (Required) A query whose result is persisted.
+
+* `enable_refresh` - (Optional) Specifies whether to use BigQuery's automatic refresh for this materialized view when the base table is updated.
+    The default value is true.
+
+* `refresh_interval_ms` - (Optional) The maximum frequency at which this materialized view will be refreshed.
+    The default value is 1800000
+
+* `allow_non_incremental_definition` - (Optional) Allow non incremental materialized view definition.
+    The default value is false.
+
+<a name="nested_encryption_configuration"></a>The `encryption_configuration` block supports the following arguments:
+
+* `kms_key_name` - (Required) The self link or full name of a key which should be used to
+    encrypt this table.  Note that the default bigquery service account will need to have
+    encrypt/decrypt permissions on this key - you may want to see the
+    `google_bigquery_default_service_account` datasource and the
+    `google_kms_crypto_key_iam_binding` resource.
+
+<a name="nested_table_constraints"></a>The `table_constraints` block supports:
+
+* `primary_key` - (Optional) Represents the primary key constraint
+    on a table's columns. Present only if the table has a primary key.
+    The primary key is not enforced.
+    Structure is [documented below](#nested_primary_key).
+
+* `foreign_keys` - (Optional) Present only if the table has a foreign key.
+    The foreign key is not enforced.
+    Structure is [documented below](#nested_foreign_keys).
+
+<a name="nested_primary_key"></a>The `primary_key` block supports:
+
+* `columns`: (Required) The columns that are composed of the primary key constraint.
+
+<a name="nested_foreign_keys"></a>The `foreign_keys` block supports:
+
+* `name`: (Optional) Set only if the foreign key constraint is named.
+
+* `referenced_table`: (Required) The table that holds the primary key
+    and is referenced by this foreign key.
+    Structure is [documented below](#nested_referenced_table).
+
+* `column_references`: (Required) The pair of the foreign key column and primary key column.
+    Structure is [documented below](#nested_column_references).
+
+<a name="nested_referenced_table"></a>The `referenced_table` block supports:
+
+* `project_id`: (Required) The ID of the project containing this table.
+
+* `dataset_id`: (Required) The ID of the dataset containing this table.
+
+* `table_id`: (Required) The ID of the table. The ID must contain only
+	letters (a-z, A-Z), numbers (0-9), or underscores (_). The maximum
+	length is 1,024 characters. Certain operations allow suffixing of
+	the table ID with a partition decorator, such as
+	sample_table$20190123.
+
+<a name="nested_column_references"></a>The `column_references` block supports:
+
+* `referencing_column`: (Required) The column that composes the foreign key.
+
+* `referenced_column`: (Required) The column in the primary key that are
+    referenced by the referencingColumn
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are
+exported:
+
+* `id` - an identifier for the resource with format `projects/{{project}}/datasets/{{dataset}}/tables/{{name}}`
+
+* `creation_time` - The time when this table was created, in milliseconds since the epoch.
+
+* `etag` - A hash of the resource.
+
+* `kms_key_version` - The self link or full name of the kms key version used to encrypt this table.
+
+* `last_modified_time` - The time when this table was last modified, in milliseconds since the epoch.
+
+* `location` - The geographic location where the table resides. This value is inherited from the dataset.
+
+* `num_bytes` - The size of this table in bytes, excluding any data in the streaming buffer.
+
+* `num_long_term_bytes` - The number of bytes in the table that are considered "long-term storage".
+
+* `num_rows` - The number of rows of data in this table, excluding any data in the streaming buffer.
+
+* `self_link` - The URI of the created resource.
+
+* `type` - Describes the table type.
+
+## Import
+
+BigQuery tables imported using any of these accepted formats:
+
+```
+$ terraform import google_bigquery_table.default projects/{{project}}/datasets/{{dataset_id}}/tables/{{table_id}}
+$ terraform import google_bigquery_table.default {{project}}/{{dataset_id}}/{{table_id}}
+$ terraform import google_bigquery_table.default {{dataset_id}}/{{table_id}}
+```

--- a/pkg/tfgen/test_data/resources/bigtable_instance/docs.json
+++ b/pkg/tfgen/test_data/resources/bigtable_instance/docs.json
@@ -1,0 +1,48 @@
+{
+  "Description": "## +---\n\nsubcategory: \"Cloud Bigtable\"\ndescription: |-\n  Creates a Google Bigtable instance.\n---\n\n# google_bigtable_instance\n\nCreates a Google Bigtable instance. For more information see:\n\n* [API documentation](https://cloud.google.com/bigtable/docs/reference/admin/rest/v2/projects.instances.clusters)\n* How-to Guides\n    * [Official Documentation](https://cloud.google.com/bigtable/docs)\n\n## Example Usage\n\n### Simple Instance\n\n```hcl\nresource \"google_bigtable_instance\" \"production-instance\" {\n  name = \"tf-instance\"\n\n  cluster {\n    cluster_id   = \"tf-instance-cluster\"\n    num_nodes    = 1\n    storage_type = \"HDD\"\n  }\n\n  labels = {\n    my-label = \"prod-label\"\n  }\n}\n```\n\n### Replicated Instance\n\n```hcl\nresource \"google_bigtable_instance\" \"production-instance\" {\n  name = \"tf-instance\"\n\n  # A cluster with fixed number of nodes.\n  cluster {\n    cluster_id   = \"tf-instance-cluster1\"\n    num_nodes    = 1\n    storage_type = \"HDD\"\n    zone    = \"us-central1-c\"\n  }\n\n  # a cluster with auto scaling.\n  cluster {\n    cluster_id   = \"tf-instance-cluster2\"\n    storage_type = \"HDD\"\n    zone    = \"us-central1-b\"\n    autoscaling_config {\n      min_nodes = 1\n      max_nodes = 3\n      cpu_target = 50\n    }\n  }\n\n  labels = {\n    my-label = \"prod-label\"\n  }\n}\n```",
+  "Arguments": {
+    "cluster": {
+      "description": "A block of cluster configuration options. This can be specified at least once, and up \nto as many as possible within 8 cloud regions. Removing the field entirely from the config will cause the provider\nto default to the backend value. See structure below."
+    },
+    "cluster.autoscaling_config": {
+      "description": "[Autoscaling](https://cloud.google.com/bigtable/docs/autoscaling#parameters) config for the cluster, contains the following arguments:\n\n`min_nodes` - (Required) The minimum number of nodes for autoscaling.\n\n`max_nodes` - (Required) The maximum number of nodes for autoscaling.\n\n`cpu_target` - (Required) The target CPU utilization for autoscaling, in percentage. Must be between 10 and 80.\n\n`storage_target` - The target storage utilization for autoscaling, in GB, for each node in a cluster. This number is limited between 2560 (2.5TiB) and 5120 (5TiB) for a SSD cluster and between 8192 (8TiB) and 16384 (16 TiB) for an HDD cluster. If not set, whatever is already set for the cluster will not change, or if the cluster is just being created, it will use the default value of 2560 for SSD clusters and 8192 for HDD clusters.\n\n!\u003e **Warning**: Only one of `autoscaling_config` or `num_nodes` should be set for a cluster. If both are set, `num_nodes` is ignored. If none is set, autoscaling will be disabled and sized to the current node count."
+    },
+    "cluster.cluster_id": {
+      "description": "The ID of the Cloud Bigtable cluster. Must be 6-30 characters and must only contain hyphens, lowercase letters and numbers."
+    },
+    "cluster.num_nodes": {
+      "description": "The number of nodes in the cluster.\nIf no value is set, Cloud Bigtable automatically allocates nodes based on your data footprint and optimized for 50% storage utilization."
+    },
+    "cluster.zone": {
+      "description": "The zone to create the Cloud Bigtable cluster in. If it not\nspecified, the provider zone is used. Each cluster must have a different zone in the same region. Zones that support\nBigtable instances are noted on the [Cloud Bigtable locations page](https://cloud.google.com/bigtable/docs/locations)."
+    },
+    "deletion_protection": {
+      "description": "Whether or not to allow this provider to destroy the instance. Unless this field is set to false\nin the statefile, a `pulumi destroy` or `pulumi up` that would delete the instance will fail."
+    },
+    "display_name": {
+      "description": "The human-readable display name of the Bigtable instance. Defaults to the instance `name`."
+    },
+    "instance_type": {
+      "description": "The instance type to create. One of `\"DEVELOPMENT\"` or `\"PRODUCTION\"`. Defaults to `\"PRODUCTION\"`.\nIt is recommended to leave this field unspecified since the distinction between `\"DEVELOPMENT\"` and `\"PRODUCTION\"` instances is going away,\nand all instances will become `\"PRODUCTION\"` instances. This means that new and existing `\"DEVELOPMENT\"` instances will be converted to\n`\"PRODUCTION\"` instances. It is recommended for users to use `\"PRODUCTION\"` instances in any case, since a 1-node `\"PRODUCTION\"` instance\nis functionally identical to a `\"DEVELOPMENT\"` instance, but without the accompanying restrictions."
+    },
+    "kms_key_name": {
+      "description": "Describes the Cloud KMS encryption key that will be used to protect the destination Bigtable cluster. The requirements for this key are: 1) The Cloud Bigtable service account associated with the project that contains this cluster must be granted the `cloudkms.cryptoKeyEncrypterDecrypter` role on the CMEK key. 2) Only regional keys can be used and the region of the CMEK key must match the region of the cluster.\n\n\u003e **Note**: Removing the field entirely from the config will cause the provider to default to the backend value.\n\n!\u003e **Warning**: Modifying this field will cause the provider to delete/recreate the entire resource.\n\n!\u003e **Warning:** Modifying the `storage_type`, `zone` or `kms_key_name` of an existing cluster (by\n`cluster_id`) will cause the provider to delete/recreate the entire\n`google_bigtable_instance` resource. If these values are changing, use a new\n`cluster_id`."
+    },
+    "labels": {
+      "description": "A set of key/value label pairs to assign to the resource. Label keys must follow the requirements at https://cloud.google.com/resource-manager/docs/creating-managing-labels#requirements."
+    },
+    "name": {
+      "description": "The name (also called Instance Id in the Cloud Console) of the Cloud Bigtable instance. Must be 6-33 characters and must only contain hyphens, lowercase letters and numbers."
+    },
+    "project": {
+      "description": "The ID of the project in which the resource belongs. If it\nis not provided, the provider project is used."
+    },
+    "storage_type": {
+      "description": "The storage type to use. One of `\"SSD\"` or\n`\"HDD\"`. Defaults to `\"SSD\"`."
+    }
+  },
+  "Attributes": {
+    "id": "an identifier for the resource with format `projects/{{project}}/instances/{{name}}`"
+  },
+  "Import": "## Import\n\nBigtable Instances can be imported using any of these accepted formats: \u003cbreak\u003e\u003cbreak\u003e```sh\u003cbreak\u003e $ pulumi import MISSING_TOK default projects/{{project}}/instances/{{name}} \u003cbreak\u003e```\u003cbreak\u003e\u003cbreak\u003e \u003cbreak\u003e\u003cbreak\u003e```sh\u003cbreak\u003e $ pulumi import MISSING_TOK default {{project}}/{{name}} \u003cbreak\u003e```\u003cbreak\u003e\u003cbreak\u003e \u003cbreak\u003e\u003cbreak\u003e```sh\u003cbreak\u003e $ pulumi import MISSING_TOK default {{name}} \u003cbreak\u003e```\u003cbreak\u003e\u003cbreak\u003e"
+}

--- a/pkg/tfgen/test_data/resources/bigtable_instance/docs.json
+++ b/pkg/tfgen/test_data/resources/bigtable_instance/docs.json
@@ -5,7 +5,19 @@
       "description": "A block of cluster configuration options. This can be specified at least once, and up \nto as many as possible within 8 cloud regions. Removing the field entirely from the config will cause the provider\nto default to the backend value. See structure below."
     },
     "cluster.autoscaling_config": {
-      "description": "[Autoscaling](https://cloud.google.com/bigtable/docs/autoscaling#parameters) config for the cluster, contains the following arguments:\n\n`min_nodes` - (Required) The minimum number of nodes for autoscaling.\n\n`max_nodes` - (Required) The maximum number of nodes for autoscaling.\n\n`cpu_target` - (Required) The target CPU utilization for autoscaling, in percentage. Must be between 10 and 80.\n\n`storage_target` - The target storage utilization for autoscaling, in GB, for each node in a cluster. This number is limited between 2560 (2.5TiB) and 5120 (5TiB) for a SSD cluster and between 8192 (8TiB) and 16384 (16 TiB) for an HDD cluster. If not set, whatever is already set for the cluster will not change, or if the cluster is just being created, it will use the default value of 2560 for SSD clusters and 8192 for HDD clusters.\n\n!\u003e **Warning**: Only one of `autoscaling_config` or `num_nodes` should be set for a cluster. If both are set, `num_nodes` is ignored. If none is set, autoscaling will be disabled and sized to the current node count."
+      "description": "[Autoscaling](https://cloud.google.com/bigtable/docs/autoscaling#parameters) config for the cluster, contains the following arguments:"
+    },
+    "cluster.autoscaling_config.cpu_target": {
+      "description": "The target CPU utilization for autoscaling, in percentage. Must be between 10 and 80."
+    },
+    "cluster.autoscaling_config.max_nodes": {
+      "description": "The maximum number of nodes for autoscaling."
+    },
+    "cluster.autoscaling_config.min_nodes": {
+      "description": "The minimum number of nodes for autoscaling."
+    },
+    "cluster.autoscaling_config.storage_target": {
+      "description": "The target storage utilization for autoscaling, in GB, for each node in a cluster. This number is limited between 2560 (2.5TiB) and 5120 (5TiB) for a SSD cluster and between 8192 (8TiB) and 16384 (16 TiB) for an HDD cluster. If not set, whatever is already set for the cluster will not change, or if the cluster is just being created, it will use the default value of 2560 for SSD clusters and 8192 for HDD clusters.\n\n!\u003e **Warning**: Only one of `autoscaling_config` or `num_nodes` should be set for a cluster. If both are set, `num_nodes` is ignored. If none is set, autoscaling will be disabled and sized to the current node count."
     },
     "cluster.cluster_id": {
       "description": "The ID of the Cloud Bigtable cluster. Must be 6-30 characters and must only contain hyphens, lowercase letters and numbers."

--- a/pkg/tfgen/test_data/resources/bigtable_instance/upstream.md
+++ b/pkg/tfgen/test_data/resources/bigtable_instance/upstream.md
@@ -1,0 +1,156 @@
++---
+subcategory: "Cloud Bigtable"
+description: |-
+  Creates a Google Bigtable instance.
+---
+
+# google_bigtable_instance
+
+Creates a Google Bigtable instance. For more information see:
+
+* [API documentation](https://cloud.google.com/bigtable/docs/reference/admin/rest/v2/projects.instances.clusters)
+* How-to Guides
+    * [Official Documentation](https://cloud.google.com/bigtable/docs)
+
+## Example Usage - Simple Instance
+
+```hcl
+resource "google_bigtable_instance" "production-instance" {
+  name = "tf-instance"
+
+  cluster {
+    cluster_id   = "tf-instance-cluster"
+    num_nodes    = 1
+    storage_type = "HDD"
+  }
+
+  labels = {
+    my-label = "prod-label"
+  }
+}
+```
+
+## Example Usage - Replicated Instance
+
+```hcl
+resource "google_bigtable_instance" "production-instance" {
+  name = "tf-instance"
+
+  # A cluster with fixed number of nodes.
+  cluster {
+    cluster_id   = "tf-instance-cluster1"
+    num_nodes    = 1
+    storage_type = "HDD"
+    zone    = "us-central1-c"
+  }
+
+  # a cluster with auto scaling.
+  cluster {
+    cluster_id   = "tf-instance-cluster2"
+    storage_type = "HDD"
+    zone    = "us-central1-b"
+    autoscaling_config {
+      min_nodes = 1
+      max_nodes = 3
+      cpu_target = 50
+    }
+  }
+
+  labels = {
+    my-label = "prod-label"
+  }
+}
+```
+
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name (also called Instance Id in the Cloud Console) of the Cloud Bigtable instance. Must be 6-33 characters and must only contain hyphens, lowercase letters and numbers.
+
+* `cluster` - (Required) A block of cluster configuration options. This can be specified at least once, and up 
+to as many as possible within 8 cloud regions. Removing the field entirely from the config will cause the provider
+to default to the backend value. See [structure below](#nested_cluster).
+
+-----
+
+* `project` - (Optional) The ID of the project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
+* `instance_type` - (Optional, Deprecated) The instance type to create. One of `"DEVELOPMENT"` or `"PRODUCTION"`. Defaults to `"PRODUCTION"`.
+    It is recommended to leave this field unspecified since the distinction between `"DEVELOPMENT"` and `"PRODUCTION"` instances is going away,
+    and all instances will become `"PRODUCTION"` instances. This means that new and existing `"DEVELOPMENT"` instances will be converted to
+    `"PRODUCTION"` instances. It is recommended for users to use `"PRODUCTION"` instances in any case, since a 1-node `"PRODUCTION"` instance
+    is functionally identical to a `"DEVELOPMENT"` instance, but without the accompanying restrictions.
+
+* `display_name` - (Optional) The human-readable display name of the Bigtable instance. Defaults to the instance `name`.
+
+* `deletion_protection` - (Optional) Whether or not to allow this provider to destroy the instance. Unless this field is set to false
+in the statefile, a `pulumi destroy` or `pulumi up` that would delete the instance will fail.
+
+* `labels` - (Optional) A set of key/value label pairs to assign to the resource. Label keys must follow the requirements at https://cloud.google.com/resource-manager/docs/creating-managing-labels#requirements.
+
+
+-----
+
+<a name="nested_cluster"></a>The `cluster` block supports the following arguments:
+
+* `cluster_id` - (Required) The ID of the Cloud Bigtable cluster. Must be 6-30 characters and must only contain hyphens, lowercase letters and numbers.
+
+* `zone` - (Optional) The zone to create the Cloud Bigtable cluster in. If it not
+specified, the provider zone is used. Each cluster must have a different zone in the same region. Zones that support
+Bigtable instances are noted on the [Cloud Bigtable locations page](https://cloud.google.com/bigtable/docs/locations).
+
+* `num_nodes` - (Optional) The number of nodes in the cluster.
+If no value is set, Cloud Bigtable automatically allocates nodes based on your data footprint and optimized for 50% storage utilization.
+
+* `autoscaling_config` - (Optional) [Autoscaling](https://cloud.google.com/bigtable/docs/autoscaling#parameters) config for the cluster, contains the following arguments:
+
+  * `min_nodes` - (Required) The minimum number of nodes for autoscaling.
+  * `max_nodes` - (Required) The maximum number of nodes for autoscaling.
+  * `cpu_target` - (Required) The target CPU utilization for autoscaling, in percentage. Must be between 10 and 80.
+  * `storage_target` - The target storage utilization for autoscaling, in GB, for each node in a cluster. This number is limited between 2560 (2.5TiB) and 5120 (5TiB) for a SSD cluster and between 8192 (8TiB) and 16384 (16 TiB) for an HDD cluster. If not set, whatever is already set for the cluster will not change, or if the cluster is just being created, it will use the default value of 2560 for SSD clusters and 8192 for HDD clusters.
+
+!> **Warning**: Only one of `autoscaling_config` or `num_nodes` should be set for a cluster. If both are set, `num_nodes` is ignored. If none is set, autoscaling will be disabled and sized to the current node count.
+
+* `storage_type` - (Optional) The storage type to use. One of `"SSD"` or
+`"HDD"`. Defaults to `"SSD"`.
+
+* `kms_key_name` - (Optional) Describes the Cloud KMS encryption key that will be used to protect the destination Bigtable cluster. The requirements for this key are: 1) The Cloud Bigtable service account associated with the project that contains this cluster must be granted the `cloudkms.cryptoKeyEncrypterDecrypter` role on the CMEK key. 2) Only regional keys can be used and the region of the CMEK key must match the region of the cluster.
+
+-> **Note**: Removing the field entirely from the config will cause the provider to default to the backend value.
+
+!> **Warning**: Modifying this field will cause the provider to delete/recreate the entire resource.
+
+!> **Warning:** Modifying the `storage_type`, `zone` or `kms_key_name` of an existing cluster (by
+`cluster_id`) will cause the provider to delete/recreate the entire
+`google_bigtable_instance` resource. If these values are changing, use a new
+`cluster_id`.
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are exported:
+
+* `id` - an identifier for the resource with format `projects/{{project}}/instances/{{name}}`
+
+## Timeouts
+
+This resource provides the following
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options:
+
+- `create` - Default is 60 minutes.
+- `update` - Default is 60 minutes.
+- `read` - Default is 60 minutes.
+
+Adding clusters to existing instances can take a long time. Consider setting a higher value to timeouts if you plan on doing that.
+
+## Import
+
+Bigtable Instances can be imported using any of these accepted formats:
+
+```
+$ terraform import google_bigtable_instance.default projects/{{project}}/instances/{{name}}
+$ terraform import google_bigtable_instance.default {{project}}/{{name}}
+$ terraform import google_bigtable_instance.default {{name}}
+```

--- a/pkg/tfgen/test_data/resources/lb_listener_rule/docs.json
+++ b/pkg/tfgen/test_data/resources/lb_listener_rule/docs.json
@@ -89,7 +89,7 @@
       "description": "The value of query parameter"
     },
     "condition": {
-      "description": "A Condition block. Multiple condition blocks of different types can be set and all must be satisfied for the rule to match. Condition blocks are documented below.\n\nOne or more condition blocks can be set per rule. Most condition types can only be specified once per rule except for `http-header` and `query-string` which can be specified multiple times."
+      "description": "A Condition block. Multiple condition blocks of different types can be set and all must be satisfied for the rule to match. Condition blocks are documented below."
     },
     "condition.host_header": {
       "description": "Contains a single `values` item which is a list of host header patterns to match. The maximum size of each pattern is 128 characters. Comparison is case insensitive. Wildcard characters supported: * (matches 0 or more characters) and ? (matches exactly 1 character). Only one pattern needs to match for the condition to be satisfied."

--- a/pkg/tfgen/test_data/resources/lb_listener_rule/docs.json
+++ b/pkg/tfgen/test_data/resources/lb_listener_rule/docs.json
@@ -89,7 +89,7 @@
       "description": "The value of query parameter"
     },
     "condition": {
-      "description": "A Condition block. Multiple condition blocks of different types can be set and all must be satisfied for the rule to match. Condition blocks are documented below."
+      "description": "A Condition block. Multiple condition blocks of different types can be set and all must be satisfied for the rule to match. Condition blocks are documented below.\n\nOne or more condition blocks can be set per rule. Most condition types can only be specified once per rule except for `http-header` and `query-string` which can be specified multiple times."
     },
     "condition.host_header": {
       "description": "Contains a single `values` item which is a list of host header patterns to match. The maximum size of each pattern is 128 characters. Comparison is case insensitive. Wildcard characters supported: * (matches 0 or more characters) and ? (matches exactly 1 character). Only one pattern needs to match for the condition to be satisfied."
@@ -143,7 +143,7 @@
       "description": "Query string value pattern to match."
     },
     "query_string.values": {
-      "description": "Query string pairs or values to match. Query String Value blocks documented below. Multiple `values` blocks can be specified, see example above. Maximum size of each string is 128 characters. Comparison is case insensitive. Wildcard characters supported: * (matches 0 or more characters) and ? (matches exactly 1 character). To search for a literal '\\*' or '?' character in a query string, escape the character with a backslash (\\\\). Only one pair needs to match for the condition to be satisfied.\n\nQuery String Value Blocks (for `query_string.values`) support the following:"
+      "description": "Query string pairs or values to match. Query String Value blocks documented below. Multiple `values` blocks can be specified, see example above. Maximum size of each string is 128 characters. Comparison is case insensitive. Wildcard characters supported: * (matches 0 or more characters) and ? (matches exactly 1 character). To search for a literal '\\*' or '?' character in a query string, escape the character with a backslash (\\\\). Only one pair needs to match for the condition to be satisfied."
     },
     "redirect.host": {
       "description": "The hostname. This component is not percent-encoded. The hostname can contain `#{host}`. Defaults to `#{host}`."

--- a/pkg/tfgen/test_data/resources/lb_listener_rule/docs.json
+++ b/pkg/tfgen/test_data/resources/lb_listener_rule/docs.json
@@ -1,0 +1,188 @@
+{
+  "Description": "Provides a Load Balancer Listener Rule resource.\n\n\u003e **Note:** `aws_alb_listener_rule` is known as `aws_lb_listener_rule`. The functionality is identical.\n\n## Example Usage\n\n```terraform\nresource \"aws_lb\" \"front_end\" {\n  # ...\n}\n\nresource \"aws_lb_listener\" \"front_end\" {\n  # Other parameters\n}\n\nresource \"aws_lb_listener_rule\" \"static\" {\n  listener_arn = aws_lb_listener.front_end.arn\n  priority     = 100\n\n  action {\n    type             = \"forward\"\n    target_group_arn = aws_lb_target_group.static.arn\n  }\n\n  condition {\n    path_pattern {\n      values = [\"/static/*\"]\n    }\n  }\n\n  condition {\n    host_header {\n      values = [\"example.com\"]\n    }\n  }\n}\n\n# Forward action\n\nresource \"aws_lb_listener_rule\" \"host_based_weighted_routing\" {\n  listener_arn = aws_lb_listener.front_end.arn\n  priority     = 99\n\n  action {\n    type             = \"forward\"\n    target_group_arn = aws_lb_target_group.static.arn\n  }\n\n  condition {\n    host_header {\n      values = [\"my-service.*.mycompany.io\"]\n    }\n  }\n}\n\n# Weighted Forward action\n\nresource \"aws_lb_listener_rule\" \"host_based_routing\" {\n  listener_arn = aws_lb_listener.front_end.arn\n  priority     = 99\n\n  action {\n    type = \"forward\"\n    forward {\n      target_group {\n        arn    = aws_lb_target_group.main.arn\n        weight = 80\n      }\n\n      target_group {\n        arn    = aws_lb_target_group.canary.arn\n        weight = 20\n      }\n\n      stickiness {\n        enabled  = true\n        duration = 600\n      }\n    }\n  }\n\n  condition {\n    host_header {\n      values = [\"my-service.*.mycompany.io\"]\n    }\n  }\n}\n\n# Redirect action\n\nresource \"aws_lb_listener_rule\" \"redirect_http_to_https\" {\n  listener_arn = aws_lb_listener.front_end.arn\n\n  action {\n    type = \"redirect\"\n\n    redirect {\n      port        = \"443\"\n      protocol    = \"HTTPS\"\n      status_code = \"HTTP_301\"\n    }\n  }\n\n  condition {\n    http_header {\n      http_header_name = \"X-Forwarded-For\"\n      values           = [\"192.168.1.*\"]\n    }\n  }\n}\n\n# Fixed-response action\n\nresource \"aws_lb_listener_rule\" \"health_check\" {\n  listener_arn = aws_lb_listener.front_end.arn\n\n  action {\n    type = \"fixed-response\"\n\n    fixed_response {\n      content_type = \"text/plain\"\n      message_body = \"HEALTHY\"\n      status_code  = \"200\"\n    }\n  }\n\n  condition {\n    query_string {\n      key   = \"health\"\n      value = \"check\"\n    }\n\n    query_string {\n      value = \"bar\"\n    }\n  }\n}\n\n# Authenticate-cognito Action\n\nresource \"aws_cognito_user_pool\" \"pool\" {\n  # ...\n}\n\nresource \"aws_cognito_user_pool_client\" \"client\" {\n  # ...\n}\n\nresource \"aws_cognito_user_pool_domain\" \"domain\" {\n  # ...\n}\n\nresource \"aws_lb_listener_rule\" \"admin\" {\n  listener_arn = aws_lb_listener.front_end.arn\n\n  action {\n    type = \"authenticate-cognito\"\n\n    authenticate_cognito {\n      user_pool_arn       = aws_cognito_user_pool.pool.arn\n      user_pool_client_id = aws_cognito_user_pool_client.client.id\n      user_pool_domain    = aws_cognito_user_pool_domain.domain.domain\n    }\n  }\n\n  action {\n    type             = \"forward\"\n    target_group_arn = aws_lb_target_group.static.arn\n  }\n}\n\n# Authenticate-oidc Action\n\nresource \"aws_lb_listener_rule\" \"oidc\" {\n  listener_arn = aws_lb_listener.front_end.arn\n\n  action {\n    type = \"authenticate-oidc\"\n\n    authenticate_oidc {\n      authorization_endpoint = \"https://example.com/authorization_endpoint\"\n      client_id              = \"client_id\"\n      client_secret          = \"client_secret\"\n      issuer                 = \"https://example.com\"\n      token_endpoint         = \"https://example.com/token_endpoint\"\n      user_info_endpoint     = \"https://example.com/user_info_endpoint\"\n    }\n  }\n\n  action {\n    type             = \"forward\"\n    target_group_arn = aws_lb_target_group.static.arn\n  }\n}\n```",
+  "Arguments": {
+    "action": {
+      "description": "An Action block. Action blocks are documented below."
+    },
+    "action.authenticate_cognito": {
+      "description": "Information for creating an authenticate action using Cognito. Required if `type` is `authenticate-cognito`."
+    },
+    "action.authenticate_oidc": {
+      "description": "Information for creating an authenticate action using OIDC. Required if `type` is `authenticate-oidc`."
+    },
+    "action.fixed_response": {
+      "description": "Information for creating an action that returns a custom HTTP response. Required if `type` is `fixed-response`."
+    },
+    "action.forward": {
+      "description": "Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`."
+    },
+    "action.redirect": {
+      "description": "Information for creating a redirect action. Required if `type` is `redirect`."
+    },
+    "action.target_group_arn": {
+      "description": "The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead."
+    },
+    "action.type": {
+      "description": "The type of routing action. Valid values are `forward`, `redirect`, `fixed-response`, `authenticate-cognito` and `authenticate-oidc`."
+    },
+    "authenticate_cognito.authentication_request_extra_params": {
+      "description": "The query parameters to include in the redirect request to the authorization endpoint. Max: 10."
+    },
+    "authenticate_cognito.on_unauthenticated_request": {
+      "description": "The behavior if the user is not authenticated. Valid values: `deny`, `allow` and `authenticate`"
+    },
+    "authenticate_cognito.scope": {
+      "description": "The set of user claims to be requested from the IdP."
+    },
+    "authenticate_cognito.session_cookie_name": {
+      "description": "The name of the cookie used to maintain session information."
+    },
+    "authenticate_cognito.session_timeout": {
+      "description": "The maximum duration of the authentication session, in seconds."
+    },
+    "authenticate_cognito.user_pool_arn": {
+      "description": "The ARN of the Cognito user pool."
+    },
+    "authenticate_cognito.user_pool_client_id": {
+      "description": "The ID of the Cognito user pool client."
+    },
+    "authenticate_cognito.user_pool_domain": {
+      "description": "The domain prefix or fully-qualified domain name of the Cognito user pool."
+    },
+    "authenticate_oidc.authentication_request_extra_params": {
+      "description": "The query parameters to include in the redirect request to the authorization endpoint. Max: 10."
+    },
+    "authenticate_oidc.authorization_endpoint": {
+      "description": "The authorization endpoint of the IdP."
+    },
+    "authenticate_oidc.client_id": {
+      "description": "The OAuth 2.0 client identifier."
+    },
+    "authenticate_oidc.client_secret": {
+      "description": "The OAuth 2.0 client secret."
+    },
+    "authenticate_oidc.issuer": {
+      "description": "The OIDC issuer identifier of the IdP."
+    },
+    "authenticate_oidc.on_unauthenticated_request": {
+      "description": "The behavior if the user is not authenticated. Valid values: `deny`, `allow` and `authenticate`"
+    },
+    "authenticate_oidc.scope": {
+      "description": "The set of user claims to be requested from the IdP."
+    },
+    "authenticate_oidc.session_cookie_name": {
+      "description": "The name of the cookie used to maintain session information."
+    },
+    "authenticate_oidc.session_timeout": {
+      "description": "The maximum duration of the authentication session, in seconds."
+    },
+    "authenticate_oidc.token_endpoint": {
+      "description": "The token endpoint of the IdP."
+    },
+    "authenticate_oidc.user_info_endpoint": {
+      "description": "The user info endpoint of the IdP."
+    },
+    "authentication_request_extra_params.key": {
+      "description": "The key of query parameter"
+    },
+    "authentication_request_extra_params.value": {
+      "description": "The value of query parameter"
+    },
+    "condition": {
+      "description": "A Condition block. Multiple condition blocks of different types can be set and all must be satisfied for the rule to match. Condition blocks are documented below."
+    },
+    "condition.host_header": {
+      "description": "Contains a single `values` item which is a list of host header patterns to match. The maximum size of each pattern is 128 characters. Comparison is case insensitive. Wildcard characters supported: * (matches 0 or more characters) and ? (matches exactly 1 character). Only one pattern needs to match for the condition to be satisfied."
+    },
+    "condition.http_header": {
+      "description": "HTTP headers to match. HTTP Header block fields documented below."
+    },
+    "condition.http_request_method": {
+      "description": "Contains a single `values` item which is a list of HTTP request methods or verbs to match. Maximum size is 40 characters. Only allowed characters are A-Z, hyphen (-) and underscore (\\_). Comparison is case sensitive. Wildcards are not supported. Only one needs to match for the condition to be satisfied. AWS recommends that GET and HEAD requests are routed in the same way because the response to a HEAD request may be cached."
+    },
+    "condition.path_pattern": {
+      "description": "Contains a single `values` item which is a list of path patterns to match against the request URL. Maximum size of each pattern is 128 characters. Comparison is case sensitive. Wildcard characters supported: * (matches 0 or more characters) and ? (matches exactly 1 character). Only one pattern needs to match for the condition to be satisfied. Path pattern is compared only to the path of the URL, not to its query string. To compare against the query string, use a `query_string` condition."
+    },
+    "condition.query_string": {
+      "description": "Query strings to match. Query String block fields documented below."
+    },
+    "condition.source_ip": {
+      "description": "Contains a single `values` item which is a list of source IP CIDR notations to match. You can use both IPv4 and IPv6 addresses. Wildcards are not supported. Condition is satisfied if the source IP address of the request matches one of the CIDR blocks. Condition is not satisfied by the addresses in the `X-Forwarded-For` header, use `http_header` condition instead.\n\n\u003e **NOTE::** Exactly one of `host_header`, `http_header`, `http_request_method`, `path_pattern`, `query_string` or `source_ip` must be set per condition."
+    },
+    "fixed_response.content_type": {
+      "description": "The content type. Valid values are `text/plain`, `text/css`, `text/html`, `application/javascript` and `application/json`."
+    },
+    "fixed_response.message_body": {
+      "description": "The message body."
+    },
+    "fixed_response.status_code": {
+      "description": "The HTTP response code. Valid values are `2XX`, `4XX`, or `5XX`."
+    },
+    "forward.stickiness": {
+      "description": "The target group stickiness for the rule."
+    },
+    "forward.target_group": {
+      "description": "One or more target groups block."
+    },
+    "http_header.http_header_name": {
+      "description": "Name of HTTP header to search. The maximum size is 40 characters. Comparison is case insensitive. Only RFC7240 characters are supported. Wildcards are not supported. You cannot use HTTP header condition to specify the host header, use a `host-header` condition instead."
+    },
+    "http_header.values": {
+      "description": "List of header value patterns to match. Maximum size of each pattern is 128 characters. Comparison is case insensitive. Wildcard characters supported: * (matches 0 or more characters) and ? (matches exactly 1 character). If the same header appears multiple times in the request they will be searched in order until a match is found. Only one pattern needs to match for the condition to be satisfied. To require that all of the strings are a match, create one condition block per string."
+    },
+    "listener_arn": {
+      "description": "The ARN of the listener to which to attach the rule."
+    },
+    "priority": {
+      "description": "The priority for the rule between `1` and `50000`. Leaving it unset will automatically set the rule with next available priority after currently existing highest rule. A listener can't have multiple rules with the same priority."
+    },
+    "query_string.key": {
+      "description": "Query string key pattern to match."
+    },
+    "query_string.value": {
+      "description": "Query string value pattern to match."
+    },
+    "query_string.values": {
+      "description": "Query string pairs or values to match. Query String Value blocks documented below. Multiple `values` blocks can be specified, see example above. Maximum size of each string is 128 characters. Comparison is case insensitive. Wildcard characters supported: * (matches 0 or more characters) and ? (matches exactly 1 character). To search for a literal '\\*' or '?' character in a query string, escape the character with a backslash (\\\\). Only one pair needs to match for the condition to be satisfied.\n\nQuery String Value Blocks (for `query_string.values`) support the following:"
+    },
+    "redirect.host": {
+      "description": "The hostname. This component is not percent-encoded. The hostname can contain `#{host}`. Defaults to `#{host}`."
+    },
+    "redirect.path": {
+      "description": "The absolute path, starting with the leading \"/\". This component is not percent-encoded. The path can contain #{host}, #{path}, and #{port}. Defaults to `/#{path}`."
+    },
+    "redirect.port": {
+      "description": "The port. Specify a value from `1` to `65535` or `#{port}`. Defaults to `#{port}`."
+    },
+    "redirect.protocol": {
+      "description": "The protocol. Valid values are `HTTP`, `HTTPS`, or `#{protocol}`. Defaults to `#{protocol}`."
+    },
+    "redirect.query": {
+      "description": "The query parameters, URL-encoded when necessary, but not percent-encoded. Do not include the leading \"?\". Defaults to `#{query}`."
+    },
+    "redirect.status_code": {
+      "description": "The HTTP redirect code. The redirect is either permanent (`HTTP_301`) or temporary (`HTTP_302`)."
+    },
+    "stickiness.duration": {
+      "description": "The time period, in seconds, during which requests from a client should be routed to the same target group. The range is 1-604800 seconds (7 days)."
+    },
+    "stickiness.enabled": {
+      "description": "Indicates whether target group stickiness is enabled."
+    },
+    "tags": {
+      "description": "A map of tags to assign to the resource. .If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level."
+    },
+    "target_group.arn": {
+      "description": "The Amazon Resource Name (ARN) of the target group."
+    },
+    "target_group.weight": {
+      "description": "The weight. The range is 0 to 999."
+    }
+  },
+  "Attributes": {
+    "arn": "The ARN of the rule (matches `id`)",
+    "id": "The ARN of the rule (matches `arn`)",
+    "tags_all": "A map of tags assigned to the resource, including those inherited from the provider `default_tags` configuration block."
+  },
+  "Import": "## Import\n\nUsing `pulumi import`, import rules using their ARN. For example:\n\n```sh\u003cbreak\u003e\n$ pulumi import  front_end arn:aws:elasticloadbalancing:us-west-2:187416307283:listener-rule/app/test/8e4497da625e2d8a/9ab28ade35828f96/67b3d2d36dd7c26b\n\u003cbreak\u003e```\u003cbreak\u003e\n"
+}

--- a/pkg/tfgen/test_data/resources/lb_listener_rule/upstream.md
+++ b/pkg/tfgen/test_data/resources/lb_listener_rule/upstream.md
@@ -1,0 +1,347 @@
+---
+subcategory: "ELB (Elastic Load Balancing)"
+layout: "aws"
+page_title: "AWS: aws_lb_listener_rule"
+description: |-
+  Provides a Load Balancer Listener Rule resource.
+---
+
+# Resource: aws_lb_listener_rule
+
+Provides a Load Balancer Listener Rule resource.
+
+~> **Note:** `aws_alb_listener_rule` is known as `aws_lb_listener_rule`. The functionality is identical.
+
+## Example Usage
+
+```terraform
+resource "aws_lb" "front_end" {
+  # ...
+}
+
+resource "aws_lb_listener" "front_end" {
+  # Other parameters
+}
+
+resource "aws_lb_listener_rule" "static" {
+  listener_arn = aws_lb_listener.front_end.arn
+  priority     = 100
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.static.arn
+  }
+
+  condition {
+    path_pattern {
+      values = ["/static/*"]
+    }
+  }
+
+  condition {
+    host_header {
+      values = ["example.com"]
+    }
+  }
+}
+
+# Forward action
+
+resource "aws_lb_listener_rule" "host_based_weighted_routing" {
+  listener_arn = aws_lb_listener.front_end.arn
+  priority     = 99
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.static.arn
+  }
+
+  condition {
+    host_header {
+      values = ["my-service.*.mycompany.io"]
+    }
+  }
+}
+
+# Weighted Forward action
+
+resource "aws_lb_listener_rule" "host_based_routing" {
+  listener_arn = aws_lb_listener.front_end.arn
+  priority     = 99
+
+  action {
+    type = "forward"
+    forward {
+      target_group {
+        arn    = aws_lb_target_group.main.arn
+        weight = 80
+      }
+
+      target_group {
+        arn    = aws_lb_target_group.canary.arn
+        weight = 20
+      }
+
+      stickiness {
+        enabled  = true
+        duration = 600
+      }
+    }
+  }
+
+  condition {
+    host_header {
+      values = ["my-service.*.mycompany.io"]
+    }
+  }
+}
+
+# Redirect action
+
+resource "aws_lb_listener_rule" "redirect_http_to_https" {
+  listener_arn = aws_lb_listener.front_end.arn
+
+  action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+
+  condition {
+    http_header {
+      http_header_name = "X-Forwarded-For"
+      values           = ["192.168.1.*"]
+    }
+  }
+}
+
+# Fixed-response action
+
+resource "aws_lb_listener_rule" "health_check" {
+  listener_arn = aws_lb_listener.front_end.arn
+
+  action {
+    type = "fixed-response"
+
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "HEALTHY"
+      status_code  = "200"
+    }
+  }
+
+  condition {
+    query_string {
+      key   = "health"
+      value = "check"
+    }
+
+    query_string {
+      value = "bar"
+    }
+  }
+}
+
+# Authenticate-cognito Action
+
+resource "aws_cognito_user_pool" "pool" {
+  # ...
+}
+
+resource "aws_cognito_user_pool_client" "client" {
+  # ...
+}
+
+resource "aws_cognito_user_pool_domain" "domain" {
+  # ...
+}
+
+resource "aws_lb_listener_rule" "admin" {
+  listener_arn = aws_lb_listener.front_end.arn
+
+  action {
+    type = "authenticate-cognito"
+
+    authenticate_cognito {
+      user_pool_arn       = aws_cognito_user_pool.pool.arn
+      user_pool_client_id = aws_cognito_user_pool_client.client.id
+      user_pool_domain    = aws_cognito_user_pool_domain.domain.domain
+    }
+  }
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.static.arn
+  }
+}
+
+# Authenticate-oidc Action
+
+resource "aws_lb_listener_rule" "oidc" {
+  listener_arn = aws_lb_listener.front_end.arn
+
+  action {
+    type = "authenticate-oidc"
+
+    authenticate_oidc {
+      authorization_endpoint = "https://example.com/authorization_endpoint"
+      client_id              = "client_id"
+      client_secret          = "client_secret"
+      issuer                 = "https://example.com"
+      token_endpoint         = "https://example.com/token_endpoint"
+      user_info_endpoint     = "https://example.com/user_info_endpoint"
+    }
+  }
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.static.arn
+  }
+}
+```
+
+## Argument Reference
+
+This resource supports the following arguments:
+
+* `listener_arn` - (Required, Forces New Resource) The ARN of the listener to which to attach the rule.
+* `priority` - (Optional) The priority for the rule between `1` and `50000`. Leaving it unset will automatically set the rule with next available priority after currently existing highest rule. A listener can't have multiple rules with the same priority.
+* `action` - (Required) An Action block. Action blocks are documented below.
+* `condition` - (Required) A Condition block. Multiple condition blocks of different types can be set and all must be satisfied for the rule to match. Condition blocks are documented below.
+* `tags` - (Optional) A map of tags to assign to the resource. .If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+
+### Action Blocks
+
+Action Blocks (for `action`) support the following:
+
+* `type` - (Required) The type of routing action. Valid values are `forward`, `redirect`, `fixed-response`, `authenticate-cognito` and `authenticate-oidc`.
+* `target_group_arn` - (Optional) The ARN of the Target Group to which to route traffic. Specify only if `type` is `forward` and you want to route to a single target group. To route to one or more target groups, use a `forward` block instead.
+* `forward` - (Optional) Information for creating an action that distributes requests among one or more target groups. Specify only if `type` is `forward`. If you specify both `forward` block and `target_group_arn` attribute, you can specify only one target group using `forward` and it must be the same target group specified in `target_group_arn`.
+* `redirect` - (Optional) Information for creating a redirect action. Required if `type` is `redirect`.
+* `fixed_response` - (Optional) Information for creating an action that returns a custom HTTP response. Required if `type` is `fixed-response`.
+* `authenticate_cognito` - (Optional) Information for creating an authenticate action using Cognito. Required if `type` is `authenticate-cognito`.
+* `authenticate_oidc` - (Optional) Information for creating an authenticate action using OIDC. Required if `type` is `authenticate-oidc`.
+
+Forward Blocks (for `forward`) support the following:
+
+* `target_group` - (Required) One or more target groups block.
+* `stickiness` - (Optional) The target group stickiness for the rule.
+
+Target Group Blocks (for `target_group`) supports the following:
+
+* `arn` - (Required) The Amazon Resource Name (ARN) of the target group.
+* `weight` - (Optional) The weight. The range is 0 to 999.
+
+Target Group Stickiness Config Blocks (for `stickiness`) supports the following:
+
+* `enabled` - (Required) Indicates whether target group stickiness is enabled.
+* `duration` - (Optional) The time period, in seconds, during which requests from a client should be routed to the same target group. The range is 1-604800 seconds (7 days).
+
+Redirect Blocks (for `redirect`) support the following:
+
+~> **NOTE::** You can reuse URI components using the following reserved keywords: `#{protocol}`, `#{host}`, `#{port}`, `#{path}` (the leading "/" is removed) and `#{query}`.
+
+* `host` - (Optional) The hostname. This component is not percent-encoded. The hostname can contain `#{host}`. Defaults to `#{host}`.
+* `path` - (Optional) The absolute path, starting with the leading "/". This component is not percent-encoded. The path can contain #{host}, #{path}, and #{port}. Defaults to `/#{path}`.
+* `port` - (Optional) The port. Specify a value from `1` to `65535` or `#{port}`. Defaults to `#{port}`.
+* `protocol` - (Optional) The protocol. Valid values are `HTTP`, `HTTPS`, or `#{protocol}`. Defaults to `#{protocol}`.
+* `query` - (Optional) The query parameters, URL-encoded when necessary, but not percent-encoded. Do not include the leading "?". Defaults to `#{query}`.
+* `status_code` - (Required) The HTTP redirect code. The redirect is either permanent (`HTTP_301`) or temporary (`HTTP_302`).
+
+Fixed-response Blocks (for `fixed_response`) support the following:
+
+* `content_type` - (Required) The content type. Valid values are `text/plain`, `text/css`, `text/html`, `application/javascript` and `application/json`.
+* `message_body` - (Optional) The message body.
+* `status_code` - (Optional) The HTTP response code. Valid values are `2XX`, `4XX`, or `5XX`.
+
+Authenticate Cognito Blocks (for `authenticate_cognito`) supports the following:
+
+* `authentication_request_extra_params` - (Optional) The query parameters to include in the redirect request to the authorization endpoint. Max: 10.
+* `on_unauthenticated_request` - (Optional) The behavior if the user is not authenticated. Valid values: `deny`, `allow` and `authenticate`
+* `scope` - (Optional) The set of user claims to be requested from the IdP.
+* `session_cookie_name` - (Optional) The name of the cookie used to maintain session information.
+* `session_timeout` - (Optional) The maximum duration of the authentication session, in seconds.
+* `user_pool_arn` - (Required) The ARN of the Cognito user pool.
+* `user_pool_client_id` - (Required) The ID of the Cognito user pool client.
+* `user_pool_domain` - (Required) The domain prefix or fully-qualified domain name of the Cognito user pool.
+
+Authenticate OIDC Blocks (for `authenticate_oidc`) supports the following:
+
+* `authentication_request_extra_params` - (Optional) The query parameters to include in the redirect request to the authorization endpoint. Max: 10.
+* `authorization_endpoint` - (Required) The authorization endpoint of the IdP.
+* `client_id` - (Required) The OAuth 2.0 client identifier.
+* `client_secret` - (Required) The OAuth 2.0 client secret.
+* `issuer` - (Required) The OIDC issuer identifier of the IdP.
+* `on_unauthenticated_request` - (Optional) The behavior if the user is not authenticated. Valid values: `deny`, `allow` and `authenticate`
+* `scope` - (Optional) The set of user claims to be requested from the IdP.
+* `session_cookie_name` - (Optional) The name of the cookie used to maintain session information.
+* `session_timeout` - (Optional) The maximum duration of the authentication session, in seconds.
+* `token_endpoint` - (Required) The token endpoint of the IdP.
+* `user_info_endpoint` - (Required) The user info endpoint of the IdP.
+
+Authentication Request Extra Params Blocks (for `authentication_request_extra_params`) supports the following:
+
+* `key` - (Required) The key of query parameter
+* `value` - (Required) The value of query parameter
+
+### Condition Blocks
+
+One or more condition blocks can be set per rule. Most condition types can only be specified once per rule except for `http-header` and `query-string` which can be specified multiple times.
+
+Condition Blocks (for `condition`) support the following:
+
+* `host_header` - (Optional) Contains a single `values` item which is a list of host header patterns to match. The maximum size of each pattern is 128 characters. Comparison is case insensitive. Wildcard characters supported: * (matches 0 or more characters) and ? (matches exactly 1 character). Only one pattern needs to match for the condition to be satisfied.
+* `http_header` - (Optional) HTTP headers to match. [HTTP Header block](#http-header-blocks) fields documented below.
+* `http_request_method` - (Optional) Contains a single `values` item which is a list of HTTP request methods or verbs to match. Maximum size is 40 characters. Only allowed characters are A-Z, hyphen (-) and underscore (\_). Comparison is case sensitive. Wildcards are not supported. Only one needs to match for the condition to be satisfied. AWS recommends that GET and HEAD requests are routed in the same way because the response to a HEAD request may be cached.
+* `path_pattern` - (Optional) Contains a single `values` item which is a list of path patterns to match against the request URL. Maximum size of each pattern is 128 characters. Comparison is case sensitive. Wildcard characters supported: * (matches 0 or more characters) and ? (matches exactly 1 character). Only one pattern needs to match for the condition to be satisfied. Path pattern is compared only to the path of the URL, not to its query string. To compare against the query string, use a `query_string` condition.
+* `query_string` - (Optional) Query strings to match. [Query String block](#query-string-blocks) fields documented below.
+* `source_ip` - (Optional) Contains a single `values` item which is a list of source IP CIDR notations to match. You can use both IPv4 and IPv6 addresses. Wildcards are not supported. Condition is satisfied if the source IP address of the request matches one of the CIDR blocks. Condition is not satisfied by the addresses in the `X-Forwarded-For` header, use `http_header` condition instead.
+
+~> **NOTE::** Exactly one of `host_header`, `http_header`, `http_request_method`, `path_pattern`, `query_string` or `source_ip` must be set per condition.
+
+#### HTTP Header Blocks
+
+HTTP Header Blocks (for `http_header`) support the following:
+
+* `http_header_name` - (Required) Name of HTTP header to search. The maximum size is 40 characters. Comparison is case insensitive. Only RFC7240 characters are supported. Wildcards are not supported. You cannot use HTTP header condition to specify the host header, use a `host-header` condition instead.
+* `values` - (Required) List of header value patterns to match. Maximum size of each pattern is 128 characters. Comparison is case insensitive. Wildcard characters supported: * (matches 0 or more characters) and ? (matches exactly 1 character). If the same header appears multiple times in the request they will be searched in order until a match is found. Only one pattern needs to match for the condition to be satisfied. To require that all of the strings are a match, create one condition block per string.
+
+#### Query String Blocks
+
+Query String Blocks (for `query_string`) support the following:
+
+* `values` - (Required) Query string pairs or values to match. Query String Value blocks documented below. Multiple `values` blocks can be specified, see example above. Maximum size of each string is 128 characters. Comparison is case insensitive. Wildcard characters supported: * (matches 0 or more characters) and ? (matches exactly 1 character). To search for a literal '\*' or '?' character in a query string, escape the character with a backslash (\\). Only one pair needs to match for the condition to be satisfied.
+
+Query String Value Blocks (for `query_string.values`) support the following:
+
+* `key` - (Optional) Query string key pattern to match.
+* `value` - (Required) Query string value pattern to match.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `id` - The ARN of the rule (matches `arn`)
+* `arn` - The ARN of the rule (matches `id`)
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider `default_tags` configuration block.
+
+## Import
+
+
+
+```terraform
+import {
+  to = aws_lb_listener_rule.front_end
+  id = "arn:aws:elasticloadbalancing:us-west-2:187416307283:listener-rule/app/test/8e4497da625e2d8a/9ab28ade35828f96/67b3d2d36dd7c26b"
+}
+```
+
+Using `pulumi import`, import rules using their ARN. For example:
+
+```console
+% pulumi import aws_lb_listener_rule.front_end arn:aws:elasticloadbalancing:us-west-2:187416307283:listener-rule/app/test/8e4497da625e2d8a/9ab28ade35828f96/67b3d2d36dd7c26b
+```

--- a/pkg/tfgen/test_data/resources/libvirt_network/docs.json
+++ b/pkg/tfgen/test_data/resources/libvirt_network/docs.json
@@ -4,9 +4,6 @@
     "addresses": {
       "description": "A list of (0 or 1) IPv4 and (0 or 1) IPv6 subnets in\nCIDR notation.  This defines the subnets associated to that network.\nThis argument is also used to define the address on the real host.\nIf `dhcp {  enabled = true }` addresses is also used to define the address range served by\nthe DHCP server.\nNo DHCP server will be started if `addresses` is omitted."
     },
-    "altering_libvirt": {
-      "description": "The optional `xml` block relates to the generated network XML.\n\nCurrently the following attributes are supported:"
-    },
     "altering_libvirt.xslt": {
       "description": ""
     },

--- a/pkg/tfgen/test_data/resources/libvirt_network/docs.json
+++ b/pkg/tfgen/test_data/resources/libvirt_network/docs.json
@@ -1,0 +1,75 @@
+{
+  "Description": "Manages a VM network resource within libvirt. For more information see\n[the official documentation](https://libvirt.org/formatnetwork.html).\n\n## Example Usage\n\n```hcl\nresource \"libvirt_network\" \"kube_network\" {\n  # the name used by libvirt\n  name = \"k8snet\"\n\n  # mode can be: \"nat\" (default), \"none\", \"route\", \"open\", \"bridge\"\n  mode = \"nat\"\n\n  #  the domain used by the DNS server in this network\n  domain = \"k8s.local\"\n\n  #  list of subnets the addresses allowed for domains connected\n  # also derived to define the host addresses\n  # also derived to define the addresses served by the DHCP server\n  addresses = [\"10.17.3.0/24\", \"2001:db8:ca2:2::1/64\"]\n\n  # (optional) the bridge device defines the name of a bridge device\n  # which will be used to construct the virtual network.\n  # (only necessary in \"bridge\" mode)\n  # bridge = \"br7\"\n\n  # (optional) the MTU for the network. If not supplied, the underlying device's\n  # default is used (usually 1500)\n  # mtu = 9000\n\n  # (Optional) DNS configuration\n  dns {\n    # (Optional, default false)\n    # Set to true, if no other option is specified and you still want to \n    # enable dns.\n    enabled = true\n    # (Optional, default false)\n    # true: DNS requests under this domain will only be resolved by the\n    # virtual network's own DNS server\n    # false: Unresolved requests will be forwarded to the host's\n    # upstream DNS server if the virtual network's DNS server does not\n    # have an answer.\n￼   local_only = true\n\n    # (Optional) one or more DNS forwarder entries.  One or both of\n    # \"address\" and \"domain\" must be specified.  The format is:\n    # forwarders {\n    #     address = \"my address\"\n    #     domain = \"my domain\"\n    #  } \n    # \n\n    # (Optional) one or more DNS host entries.  Both of\n    # \"ip\" and \"hostname\" must be specified.  The format is:\n    # hosts  {\n    #     hostname = \"my_hostname\"\n    #     ip = \"my.ip.address.1\"\n    #   }\n    # hosts {\n    #     hostname = \"my_hostname\"\n    #     ip = \"my.ip.address.2\"\n    #   }\n    # \n\n    # (Optional) one or more static routes.\n    # \"cidr\" and \"gateway\" must be specified. The format is:\n    # routes {\n    #     cidr = \"10.17.0.0/16\"\n    #     gateway = \"10.18.0.2\"\n    #   }\n  }\n\n  # (Optional) Dnsmasq options configuration\n  dnsmasq_options {\n    # (Optional) one or more option entries.\n    # \"option_name\" muast be specified while \"option_value\" is\n\t# optional to also support value-less options.  The format is:\n    # options  {\n    #     option_name = \"server\"\n    #     option_value = \"/base.domain/my.ip.address.1\"\n    #   }\n    # options  {\n    #     option_name = \"no-hosts\"\n    #   }\n    # options {\n    #     option_name = \"address\"\n    #     ip = \"/.api.base.domain/my.ip.address.2\"\n    #   }\n    #\n  }\n\n}\n```",
+  "Arguments": {
+    "addresses": {
+      "description": "A list of (0 or 1) IPv4 and (0 or 1) IPv6 subnets in\nCIDR notation.  This defines the subnets associated to that network.\nThis argument is also used to define the address on the real host.\nIf `dhcp {  enabled = true }` addresses is also used to define the address range served by\nthe DHCP server.\nNo DHCP server will be started if `addresses` is omitted."
+    },
+    "altering_libvirt.xslt": {
+      "description": ""
+    },
+    "autostart": {
+      "description": "Set to `true` to start the network on host boot up.\nIf not specified `false` is assumed."
+    },
+    "bridge": {
+      "description": "The bridge device defines the name of a bridge\ndevice which will be used to construct the virtual network (when not provided,\nit will be automatically obtained by libvirt in `none`, `nat`, `route` and `open` modes)."
+    },
+    "dns": {
+      "description": "configuration of DNS specific settings for the network"
+    },
+    "dns.dhcp": {
+      "description": "DHCP configuration. \nYou need to use it in conjuction with the adresses variable."
+    },
+    "dns.dnsmasq_options": {
+      "description": "configuration of Dnsmasq options for the network\nYou need to provide a list of option name and value pairs."
+    },
+    "dns.enabled": {
+      "description": "when false, disable the DHCP server\n```hcl\nresource \"libvirt_network\" \"test_net\" {\nname      = \"networktest\"\nmode      = \"nat\"\ndomain    = \"k8s.local\"\naddresses = [\"10.17.3.0/24\"]\ndhcp {\nenabled = true\n}\n```"
+    },
+    "dns.forwarders": {
+      "description": "Either `address`, `domain`, or both must be set"
+    },
+    "dns.hosts": {
+      "description": "a DNS host entry block. You can have one or more of these\nblocks in your DNS definition. You must specify both `ip` and `hostname`.\n\nAn advanced example of round-robin DNS (using DNS host templates) follows:\n\n```hcl\nresource \"libvirt_network\" \"my_network\" {\n...\ndns {\nhosts { flatten(data.libvirt_network_dns_host_template.hosts.*.rendered) }\n}\n...\n}\n\ndata \"libvirt_network_dns_host_template\" \"hosts\" {\ncount    = var.host_count\nip       = var.host_ips[count.index]\nhostname = \"my_host\"\n}\n```\n\nAn advanced example of setting up multiple SRV records using DNS SRV templates is:\n\n```hcl\ndata \"libvirt_network_dns_srv_template\" \"etcd_cluster\" {\ncount    = var.etcd_count\nservice  = \"etcd-server\"\nprotocol = \"tcp\"\ndomain   = var.discovery_domain\ntarget   = \"${var.cluster_name}-etcd-${count.index}.${discovery_domain}\"\n}\n\nresource \"libvirt_network\" \"k8snet\" {\n...\ndns {\nsrvs = [ flatten(data.libvirt_network_dns_srv_template.etcd_cluster.*.rendered) ]\n}\n...\n}\n```"
+    },
+    "dns.local_only": {
+      "description": "true/false: true means 'do not forward unresolved requests for this domain to the part DNS server"
+    },
+    "dns.options": {
+      "description": "a Dnsmasq option entry block. You can have one or more of these\nblocks in your definition. You must specify `option_name` while `option_value` is\noptional to support value-less options.\n\nAn example of setting Dnsmasq options (using Dnsmasq option templates) follows:\n\n```hcl\nresource \"libvirt_network\" \"my_network\" {\n...\ndnsmasq_options {\noptions { flatten(data.libvirt_network_dnsmasq_options_template.options.*.rendered) }\n}\n...\n}\n\ndata \"libvirt_network_dnsmasq_options_template\" \"options\" {\ncount = length(var.libvirt_dnsmasq_options)\noption_name = keys(var.libvirt_dnsmasq_options)[count.index]\noption_value = values(var.libvirt_dnsmasq_options)[count.index]\n}\n```"
+    },
+    "dns.srvs": {
+      "description": "a DNS SRV entry block. You can have one or more of these blocks\nin your DNS definition. You must specify `service` and `protocol`."
+    },
+    "domain": {
+      "description": "The domain used by the DNS server."
+    },
+    "mode": {
+      "description": "One of:"
+    },
+    "mtu": {
+      "description": "The MTU to set for the underlying network interfaces. When\nnot supplied, libvirt will use the default for the interface, usually 1500.\nLibvirt version 5.1 and greater will advertise this value to nodes via DHCP."
+    },
+    "name": {
+      "description": "A unique name for the resource, required by libvirt.\nChanging this forces a new resource to be created."
+    },
+    "nat": {
+      "description": "it is the default network mode. This is a configuration that\nallows guest OS to get outbound connectivity regardless of whether the host\nuses ethernet, wireless, dialup, or VPN networking without requiring any\nspecific admin configuration. In the absence of host networking, it at\nleast allows guests to talk directly to each other."
+    },
+    "none": {
+      "description": "the guests can talk to each other and the host OS, but cannot reach\nany other machines on the LAN."
+    },
+    "open": {
+      "description": "similar to `route`, but no firewall rules are added."
+    },
+    "route": {
+      "description": "this is a variant on the default network which routes traffic from\nthe virtual network to the LAN **without applying any NAT**. It requires that\nthe IP address range be pre-configured in the routing tables of the router\non the host network."
+    },
+    "routes": {
+      "description": "a list of static routes. A `cidr` and a `gateway` must\nbe provided. The `gateway` must be reachable via the bridge interface."
+    }
+  },
+  "Attributes": {
+    "id": "a unique identifier for the resource"
+  },
+  "Import": ""
+}

--- a/pkg/tfgen/test_data/resources/libvirt_network/docs.json
+++ b/pkg/tfgen/test_data/resources/libvirt_network/docs.json
@@ -4,6 +4,9 @@
     "addresses": {
       "description": "A list of (0 or 1) IPv4 and (0 or 1) IPv6 subnets in\nCIDR notation.  This defines the subnets associated to that network.\nThis argument is also used to define the address on the real host.\nIf `dhcp {  enabled = true }` addresses is also used to define the address range served by\nthe DHCP server.\nNo DHCP server will be started if `addresses` is omitted."
     },
+    "altering_libvirt": {
+      "description": "The optional `xml` block relates to the generated network XML.\n\nCurrently the following attributes are supported:"
+    },
     "altering_libvirt.xslt": {
       "description": ""
     },
@@ -13,32 +16,32 @@
     "bridge": {
       "description": "The bridge device defines the name of a bridge\ndevice which will be used to construct the virtual network (when not provided,\nit will be automatically obtained by libvirt in `none`, `nat`, `route` and `open` modes)."
     },
-    "dns": {
-      "description": "configuration of DNS specific settings for the network"
-    },
-    "dns.dhcp": {
+    "dhcp": {
       "description": "DHCP configuration. \nYou need to use it in conjuction with the adresses variable."
     },
-    "dns.dnsmasq_options": {
-      "description": "configuration of Dnsmasq options for the network\nYou need to provide a list of option name and value pairs."
+    "dhcp.enabled": {
+      "description": "when false, disable the DHCP server\n\n```hcl\n\t\t\t\tresource \"libvirt_network\" \"test_net\" {\n\t\t\t\t\tname      = \"networktest\"\n\t\t\t\t\tmode      = \"nat\"\n\t\t\t\t\tdomain    = \"k8s.local\"\n\t\t\t\t\taddresses = [\"10.17.3.0/24\"]\n\t\t\t\t\tdhcp {\n\t\t\t\t\t\tenabled = true\n\t\t\t\t\t}\n```"
     },
-    "dns.enabled": {
-      "description": "when false, disable the DHCP server\n```hcl\nresource \"libvirt_network\" \"test_net\" {\nname      = \"networktest\"\nmode      = \"nat\"\ndomain    = \"k8s.local\"\naddresses = [\"10.17.3.0/24\"]\ndhcp {\nenabled = true\n}\n```"
+    "dns": {
+      "description": "configuration of DNS specific settings for the network"
     },
     "dns.forwarders": {
       "description": "Either `address`, `domain`, or both must be set"
     },
     "dns.hosts": {
-      "description": "a DNS host entry block. You can have one or more of these\nblocks in your DNS definition. You must specify both `ip` and `hostname`.\n\nAn advanced example of round-robin DNS (using DNS host templates) follows:\n\n```hcl\nresource \"libvirt_network\" \"my_network\" {\n...\ndns {\nhosts { flatten(data.libvirt_network_dns_host_template.hosts.*.rendered) }\n}\n...\n}\n\ndata \"libvirt_network_dns_host_template\" \"hosts\" {\ncount    = var.host_count\nip       = var.host_ips[count.index]\nhostname = \"my_host\"\n}\n```\n\nAn advanced example of setting up multiple SRV records using DNS SRV templates is:\n\n```hcl\ndata \"libvirt_network_dns_srv_template\" \"etcd_cluster\" {\ncount    = var.etcd_count\nservice  = \"etcd-server\"\nprotocol = \"tcp\"\ndomain   = var.discovery_domain\ntarget   = \"${var.cluster_name}-etcd-${count.index}.${discovery_domain}\"\n}\n\nresource \"libvirt_network\" \"k8snet\" {\n...\ndns {\nsrvs = [ flatten(data.libvirt_network_dns_srv_template.etcd_cluster.*.rendered) ]\n}\n...\n}\n```"
+      "description": "a DNS host entry block. You can have one or more of these\nblocks in your DNS definition. You must specify both `ip` and `hostname`.\n\nAn advanced example of round-robin DNS (using DNS host templates) follows:\n\n```hcl\nresource \"libvirt_network\" \"my_network\" {\n  ...\n  dns {\n    hosts { flatten(data.libvirt_network_dns_host_template.hosts.*.rendered) }\n  }\n  ...\n}\n\ndata \"libvirt_network_dns_host_template\" \"hosts\" {\n  count    = var.host_count\n  ip       = var.host_ips[count.index]\n  hostname = \"my_host\"\n}\n```\n\nAn advanced example of setting up multiple SRV records using DNS SRV templates is:\n\n```hcl\ndata \"libvirt_network_dns_srv_template\" \"etcd_cluster\" {\n  count    = var.etcd_count\n  service  = \"etcd-server\"\n  protocol = \"tcp\"\n  domain   = var.discovery_domain\n  target   = \"${var.cluster_name}-etcd-${count.index}.${discovery_domain}\"\n}\n\nresource \"libvirt_network\" \"k8snet\" {\n  ...\n  dns {\n    srvs = [ flatten(data.libvirt_network_dns_srv_template.etcd_cluster.*.rendered) ]\n  }\n  ...\n}\n```"
     },
     "dns.local_only": {
       "description": "true/false: true means 'do not forward unresolved requests for this domain to the part DNS server"
     },
-    "dns.options": {
-      "description": "a Dnsmasq option entry block. You can have one or more of these\nblocks in your definition. You must specify `option_name` while `option_value` is\noptional to support value-less options.\n\nAn example of setting Dnsmasq options (using Dnsmasq option templates) follows:\n\n```hcl\nresource \"libvirt_network\" \"my_network\" {\n...\ndnsmasq_options {\noptions { flatten(data.libvirt_network_dnsmasq_options_template.options.*.rendered) }\n}\n...\n}\n\ndata \"libvirt_network_dnsmasq_options_template\" \"options\" {\ncount = length(var.libvirt_dnsmasq_options)\noption_name = keys(var.libvirt_dnsmasq_options)[count.index]\noption_value = values(var.libvirt_dnsmasq_options)[count.index]\n}\n```"
-    },
     "dns.srvs": {
       "description": "a DNS SRV entry block. You can have one or more of these blocks\nin your DNS definition. You must specify `service` and `protocol`."
+    },
+    "dnsmasq_options": {
+      "description": "configuration of Dnsmasq options for the network\nYou need to provide a list of option name and value pairs."
+    },
+    "dnsmasq_options.options": {
+      "description": "a Dnsmasq option entry block. You can have one or more of these\nblocks in your definition. You must specify `option_name` while `option_value` is\noptional to support value-less options.\n\nAn example of setting Dnsmasq options (using Dnsmasq option templates) follows:\n\n```hcl\n        resource \"libvirt_network\" \"my_network\" {\n          ...\n          dnsmasq_options {\n            options { flatten(data.libvirt_network_dnsmasq_options_template.options.*.rendered) }\n          }\n          ...\n        }\n\n        data \"libvirt_network_dnsmasq_options_template\" \"options\" {\n          count = length(var.libvirt_dnsmasq_options)\n          option_name = keys(var.libvirt_dnsmasq_options)[count.index]\n          option_value = values(var.libvirt_dnsmasq_options)[count.index]\n        }\n```"
     },
     "domain": {
       "description": "The domain used by the DNS server."
@@ -46,23 +49,26 @@
     "mode": {
       "description": "One of:"
     },
+    "mode.bridge": {
+      "description": "use a pre-existing host bridge. The guests will effectively be\ndirectly connected to the physical network (i.e. their IP addresses will\nall be on the subnet of the physical network, and there will be no\nrestrictions on inbound or outbound connections). The `bridge` network\nattribute is mandatory in this case."
+    },
+    "mode.nat": {
+      "description": "it is the default network mode. This is a configuration that\nallows guest OS to get outbound connectivity regardless of whether the host\nuses ethernet, wireless, dialup, or VPN networking without requiring any\nspecific admin configuration. In the absence of host networking, it at\nleast allows guests to talk directly to each other."
+    },
+    "mode.none": {
+      "description": "the guests can talk to each other and the host OS, but cannot reach\nany other machines on the LAN."
+    },
+    "mode.open": {
+      "description": "similar to `route`, but no firewall rules are added."
+    },
+    "mode.route": {
+      "description": "this is a variant on the default network which routes traffic from\nthe virtual network to the LAN **without applying any NAT**. It requires that\nthe IP address range be pre-configured in the routing tables of the router\non the host network."
+    },
     "mtu": {
       "description": "The MTU to set for the underlying network interfaces. When\nnot supplied, libvirt will use the default for the interface, usually 1500.\nLibvirt version 5.1 and greater will advertise this value to nodes via DHCP."
     },
     "name": {
       "description": "A unique name for the resource, required by libvirt.\nChanging this forces a new resource to be created."
-    },
-    "nat": {
-      "description": "it is the default network mode. This is a configuration that\nallows guest OS to get outbound connectivity regardless of whether the host\nuses ethernet, wireless, dialup, or VPN networking without requiring any\nspecific admin configuration. In the absence of host networking, it at\nleast allows guests to talk directly to each other."
-    },
-    "none": {
-      "description": "the guests can talk to each other and the host OS, but cannot reach\nany other machines on the LAN."
-    },
-    "open": {
-      "description": "similar to `route`, but no firewall rules are added."
-    },
-    "route": {
-      "description": "this is a variant on the default network which routes traffic from\nthe virtual network to the LAN **without applying any NAT**. It requires that\nthe IP address range be pre-configured in the routing tables of the router\non the host network."
     },
     "routes": {
       "description": "a list of static routes. A `cidr` and a `gateway` must\nbe provided. The `gateway` must be reachable via the bridge interface."

--- a/pkg/tfgen/test_data/resources/libvirt_network/upstream.md
+++ b/pkg/tfgen/test_data/resources/libvirt_network/upstream.md
@@ -1,0 +1,247 @@
+---
+layout: "libvirt"
+page_title: "Libvirt: libvirt_network"
+sidebar_current: "docs-libvirt-network"
+description: |-
+  Manages a virtual machine (network) in libvirt
+---
+
+# libvirt\_network
+
+Manages a VM network resource within libvirt. For more information see
+[the official documentation](https://libvirt.org/formatnetwork.html).
+
+## Example Usage
+
+```hcl
+resource "libvirt_network" "kube_network" {
+  # the name used by libvirt
+  name = "k8snet"
+
+  # mode can be: "nat" (default), "none", "route", "open", "bridge"
+  mode = "nat"
+
+  #  the domain used by the DNS server in this network
+  domain = "k8s.local"
+
+  #  list of subnets the addresses allowed for domains connected
+  # also derived to define the host addresses
+  # also derived to define the addresses served by the DHCP server
+  addresses = ["10.17.3.0/24", "2001:db8:ca2:2::1/64"]
+
+  # (optional) the bridge device defines the name of a bridge device
+  # which will be used to construct the virtual network.
+  # (only necessary in "bridge" mode)
+  # bridge = "br7"
+
+  # (optional) the MTU for the network. If not supplied, the underlying device's
+  # default is used (usually 1500)
+  # mtu = 9000
+
+  # (Optional) DNS configuration
+  dns {
+    # (Optional, default false)
+    # Set to true, if no other option is specified and you still want to 
+    # enable dns.
+    enabled = true
+    # (Optional, default false)
+    # true: DNS requests under this domain will only be resolved by the
+    # virtual network's own DNS server
+    # false: Unresolved requests will be forwarded to the host's
+    # upstream DNS server if the virtual network's DNS server does not
+    # have an answer.
+￼   local_only = true
+
+    # (Optional) one or more DNS forwarder entries.  One or both of
+    # "address" and "domain" must be specified.  The format is:
+    # forwarders {
+    #     address = "my address"
+    #     domain = "my domain"
+    #  } 
+    # 
+
+    # (Optional) one or more DNS host entries.  Both of
+    # "ip" and "hostname" must be specified.  The format is:
+    # hosts  {
+    #     hostname = "my_hostname"
+    #     ip = "my.ip.address.1"
+    #   }
+    # hosts {
+    #     hostname = "my_hostname"
+    #     ip = "my.ip.address.2"
+    #   }
+    # 
+
+    # (Optional) one or more static routes.
+    # "cidr" and "gateway" must be specified. The format is:
+    # routes {
+    #     cidr = "10.17.0.0/16"
+    #     gateway = "10.18.0.2"
+    #   }
+  }
+
+  # (Optional) Dnsmasq options configuration
+  dnsmasq_options {
+    # (Optional) one or more option entries.
+    # "option_name" muast be specified while "option_value" is
+	# optional to also support value-less options.  The format is:
+    # options  {
+    #     option_name = "server"
+    #     option_value = "/base.domain/my.ip.address.1"
+    #   }
+    # options  {
+    #     option_name = "no-hosts"
+    #   }
+    # options {
+    #     option_name = "address"
+    #     ip = "/.api.base.domain/my.ip.address.2"
+    #   }
+    #
+  }
+
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) A unique name for the resource, required by libvirt.
+  Changing this forces a new resource to be created.
+* `domain` - (Optional) The domain used by the DNS server.
+* `addresses` - (Optional) A list of (0 or 1) IPv4 and (0 or 1) IPv6 subnets in
+  CIDR notation.  This defines the subnets associated to that network.
+  This argument is also used to define the address on the real host.
+  If `dhcp {  enabled = true }` addresses is also used to define the address range served by
+  the DHCP server.
+  No DHCP server will be started if `addresses` is omitted.
+* `mode` -  One of:
+    - `none`: the guests can talk to each other and the host OS, but cannot reach
+    any other machines on the LAN.
+    - `nat`: it is the default network mode. This is a configuration that
+    allows guest OS to get outbound connectivity regardless of whether the host
+    uses ethernet, wireless, dialup, or VPN networking without requiring any
+    specific admin configuration. In the absence of host networking, it at
+    least allows guests to talk directly to each other.
+    - `route`: this is a variant on the default network which routes traffic from
+    the virtual network to the LAN **without applying any NAT**. It requires that
+    the IP address range be pre-configured in the routing tables of the router
+    on the host network.
+    - `open`: similar to `route`, but no firewall rules are added.
+    - `bridge`: use a pre-existing host bridge. The guests will effectively be
+    directly connected to the physical network (i.e. their IP addresses will
+    all be on the subnet of the physical network, and there will be no
+    restrictions on inbound or outbound connections). The `bridge` network
+    attribute is mandatory in this case.
+* `bridge` - (Optional) The bridge device defines the name of a bridge
+   device which will be used to construct the virtual network (when not provided,
+   it will be automatically obtained by libvirt in `none`, `nat`, `route` and `open` modes).
+* `mtu` - (Optional) The MTU to set for the underlying network interfaces. When
+   not supplied, libvirt will use the default for the interface, usually 1500.
+   Libvirt version 5.1 and greater will advertise this value to nodes via DHCP.
+* `autostart` - (Optional) Set to `true` to start the network on host boot up.
+  If not specified `false` is assumed.
+* `routes` - (Optional) a list of static routes. A `cidr` and a `gateway` must
+  be provided. The `gateway` must be reachable via the bridge interface.
+* `dns` - (Optional) configuration of DNS specific settings for the network
+
+Inside of `dns` section the following argument are supported:
+* `local_only` - (Optional) true/false: true means 'do not forward unresolved requests for this domain to the part DNS server
+* `forwarders` - (Optional) Either `address`, `domain`, or both must be set
+* `srvs` - (Optional) a DNS SRV entry block. You can have one or more of these blocks
+   in your DNS definition. You must specify `service` and `protocol`.
+* `hosts` - (Optional) a DNS host entry block. You can have one or more of these
+   blocks in your DNS definition. You must specify both `ip` and `hostname`.
+
+An advanced example of round-robin DNS (using DNS host templates) follows:
+
+```hcl
+resource "libvirt_network" "my_network" {
+  ...
+  dns {
+    hosts { flatten(data.libvirt_network_dns_host_template.hosts.*.rendered) }
+  }
+  ...
+}
+
+data "libvirt_network_dns_host_template" "hosts" {
+  count    = var.host_count
+  ip       = var.host_ips[count.index]
+  hostname = "my_host"
+}
+```
+
+An advanced example of setting up multiple SRV records using DNS SRV templates is:
+
+```hcl
+data "libvirt_network_dns_srv_template" "etcd_cluster" {
+  count    = var.etcd_count
+  service  = "etcd-server"
+  protocol = "tcp"
+  domain   = var.discovery_domain
+  target   = "${var.cluster_name}-etcd-${count.index}.${discovery_domain}"
+}
+
+resource "libvirt_network" "k8snet" {
+  ...
+  dns {
+    srvs = [ flatten(data.libvirt_network_dns_srv_template.etcd_cluster.*.rendered) ]
+  }
+  ...
+}
+```
+
+* `dhcp` - (Optional) DHCP configuration. 
+   You need to use it in conjuction with the adresses variable.
+  * `enabled` - (Optional) when false, disable the DHCP server
+```hcl
+				resource "libvirt_network" "test_net" {
+					name      = "networktest"
+					mode      = "nat"
+					domain    = "k8s.local"
+					addresses = ["10.17.3.0/24"]
+					dhcp {
+						enabled = true
+					}
+```
+
+* `dnsmasq_options` - (Optional) configuration of Dnsmasq options for the network
+  You need to provide a list of option name and value pairs.
+
+  * `options` - (Optional) a Dnsmasq option entry block. You can have one or more of these
+   blocks in your definition. You must specify `option_name` while `option_value` is
+   optional to support value-less options.
+
+  An example of setting Dnsmasq options (using Dnsmasq option templates) follows:
+
+```hcl
+        resource "libvirt_network" "my_network" {
+          ...
+          dnsmasq_options {
+            options { flatten(data.libvirt_network_dnsmasq_options_template.options.*.rendered) }
+          }
+          ...
+        }
+
+        data "libvirt_network_dnsmasq_options_template" "options" {
+          count = length(var.libvirt_dnsmasq_options)
+          option_name = keys(var.libvirt_dnsmasq_options)[count.index]
+          option_value = values(var.libvirt_dnsmasq_options)[count.index]
+        }
+```
+
+### Altering libvirt's generated network XML definition
+
+The optional `xml` block relates to the generated network XML.
+
+Currently the following attributes are supported:
+
+* `xslt`: specifies a XSLT stylesheet to transform the generated XML definition before creating the network.
+  This is used to support features the provider does not allow to set from the schema.
+  It is not recommended to alter properties and settings that are exposed to the schema, as terraform will insist in changing them back to the known state.
+
+See the domain option with the same name for more information and examples.
+
+## Attributes Reference
+
+* `id` - a unique identifier for the resource

--- a/scripts/compare-docs.sh
+++ b/scripts/compare-docs.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+# This script will stand up example PRs in the target provider
+
+usage() {
+    echo "compare-docs.sh - Create a PR in a provider repo to compare docs changes"
+    echo
+    echo "compare-docs.sh <repo> "
+    echo
+    echo "repo - the path to the repo you are testing against."
+    echo "       For example: ../pulumi-aws"
+}
+
+UPSTREAM_REPO="$1"
+
+if [ "$UPSTREAM_REPO" = "" ]; then
+    echo "missing <repo>"
+    echo
+    usage
+    exit 1
+fi
+
+UPSTREAM_REPO=$(realpath "$UPSTREAM_REPO")
+
+# Gather information about the current PR in pulumi-terraform-bridge:
+
+# The name of the current branch
+BRANCH=$(git symbolic-ref HEAD)
+BRANCH=${BRANCH#refs/heads/} # strip refs/heads
+
+# SHA at origin/master
+ORIGIN_SHA=$(git ls-remote --heads | grep refs/heads/master | awk '{print $1}')
+
+# SHA at the head of origin/${BRANCH}
+HEAD_SHA=$(git ls-remote --heads | grep "$BRANCH" | awk '{print $1}')
+
+# Info about the current PR for display purposes
+PR_INFO="$(gh pr view "$BRANCH" --json url,title,number)"
+PR_NAME="$(echo "$PR_INFO" | jq -r .title) #$(echo "$PR_INFO" | jq .number)"
+PR_URL="$(echo "$PR_INFO" | jq -r .url)"
+
+cd "$UPSTREAM_REPO"
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+
+git checkout -b docs-example "$DEFAULT_BRANCH" || git checkout docs-example
+git fetch
+git reset --hard "origin/$DEFAULT_BRANCH"
+
+replace_bridge() {
+    local cwd="$PWD"
+    cd "$UPSTREAM_REPO/provider"
+    go mod edit \
+       -replace \
+       "github.com/pulumi/pulumi-terraform-bridge/v3=github.com/pulumi/pulumi-terraform-bridge/v3@$1" \
+       -replace \
+       "github.com/pulumi/pulumi-terraform-bridge/pf=github.com/pulumi/pulumi-terraform-bridge/pf@$1" \
+       -replace \
+       "github.com/pulumi/pulumi-terraform-bridge/x/muxer=github.com/pulumi/pulumi-terraform-bridge/x/muxer@$1" \
+       -fmt
+    go mod tidy
+    cd "$cwd"
+}
+
+tfgen() {
+    make tfgen
+    git add provider/go.*
+    git add provider/cmd/pulumi-resource-*/schema.json
+}
+
+# Set the first commit to show master.
+#
+# This is useful when multiple docs changes come between releases.
+replace_bridge "$ORIGIN_SHA"
+tfgen
+git commit -m "Schema generation for bridge master"
+
+# Set the second commit to show the difference between master and the current branch.
+#
+# In general, this is the commit that we are interested in.
+replace_bridge "$HEAD_SHA"
+tfgen
+git commit -m "Schema generation for $BRANCH - $HEAD_SHA"
+
+# We try to push a new branch
+if git push --set-upstream origin docs-example; then
+    # If we succeed, this is a new branch and we should open an associated PR to better
+    # display the diff.
+    gh pr create \
+       --assignee @me \
+       --draft \
+       --title "Show changes from $PR_NAME" \
+       --body "$(
+    echo "## DO NOT MERGE"
+    echo
+    echo "This PR was created to demonstrate the effects of [$PR_NAME]($PR_URL)."
+    )"
+else
+    # If we failed we try a force push. If this succeeds then there is probably a PR
+    # already from a previous invocation of this script.
+    git push --force --set-upstream origin docs-example
+fi


### PR DESCRIPTION
This is part of the fix for #1358.

2620ecfe2b876116cb1776ce2b436a244ad246e6 adds the new tests on the old parser. This lets 00a1cdea96ccae2bf909f3d556b17bb9987f5f2d show the change in the parse. 

#1358 needs `mode.*` fields to be parsed as associated with `mode`. Currently, each `mode` option is parsed as a sub-field. A future PR will roll unexpected arguments into their parents (actually fixing #1358), but that requires the correct that this PR gives.

---

The effects of this PR can be observed from this test run: https://github.com/pulumi/pulumi-terraform-bridge/actions/runs/6910135157.

Note: this run happened before https://github.com/pulumi/pulumi-terraform-bridge/pull/1408/commits/3583b12595bcc3e0e871ad10f69c1d8cebb1088a

- https://github.com/pulumi/pulumi-aiven/pull/436: No change
- https://github.com/pulumi/pulumi-akamai/pull/334: No change
- https://github.com/pulumi/pulumi-alicloud/pull/503: Most changes are improvements. 
  - The major regression worth calling out is: https://github.com/pulumi/pulumi-alicloud/pull/503#discussion_r1398012963
- https://github.com/pulumi/pulumi-null/pull/52: No change
- https://github.com/pulumi/pulumi-fastly/pull/378: No change
- https://github.com/pulumi/pulumi-ec/pull/195: no change
- https://github.com/pulumi/pulumi-github/pull/502/files: minimal changes, equivalent quality
- https://github.com/pulumi/pulumi-azuredevops/pull/215/: This is blocking
  - https://github.com/pulumi/pulumi-azuredevops/pull/215#discussion_r1398021349
- https://github.com/pulumi/pulumi-oci:
  - Blocked on a panic: https://github.com/pulumi/pulumi-oci/actions/runs/6910194354