### PR TITLE
Use a realistic example to increase convertExamples branch coverage

### DIFF
--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -876,6 +876,10 @@ func TestParseImports_WithOverride(t *testing.T) {
 }
 
 func TestConvertExamples(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skipf("Skipping on windows to avoid failing on incorrect newline handling")
+	}
+
 	inmem := afero.NewMemMapFs()
 	info := testprovider.ProviderMiniRandom()
 	g, err := NewGenerator(GeneratorOptions{

--- a/pkg/tfgen/test_data/convertExamples/wavefront_dashboard_json.md
+++ b/pkg/tfgen/test_data/convertExamples/wavefront_dashboard_json.md
@@ -1,0 +1,275 @@
+Provides a Wavefront Dashboard JSON resource. This allows dashboards to be created, updated, and deleted.
+
+## Example Usage
+
+```hcl
+resource "wavefront_dashboard_json" "test_dashboard_json" {
+  dashboard_json = <<-EOF
+    {
+      "acl": {
+        "canModify": [
+          "group-uuid",
+          "role-uuid"
+        ],
+        "canView": [
+          "group-uuid",
+          "role-uuid"
+        ]
+      },
+      "name": "Terraform Test Dashboard Json",
+      "description": "a",
+      "eventFilterType": "BYCHART",
+      "eventQuery": "",
+      "defaultTimeWindow": "",
+      "url": "tftestimport",
+      "displayDescription": false,
+      "displaySectionTableOfContents": true,
+      "displayQueryParameters": false,
+      "sections": [
+        {
+          "name": "section 1",
+          "rows": [
+            {
+              "charts": [
+                {
+                  "name": "chart 1",
+                  "sources": [
+                    {
+                      "name": "source 1",
+                      "query": "ts()",
+                      "scatterPlotSource": "Y",
+                      "querybuilderEnabled": false,
+                      "sourceDescription": ""
+                    }
+                  ],
+                  "units": "someunit",
+                  "base": 0,
+                  "noDefaultEvents": false,
+                  "interpolatePoints": false,
+                  "includeObsoleteMetrics": false,
+                  "description": "This is chart 1, showing something",
+                  "chartSettings": {
+                    "type": "markdown-widget",
+                    "max": 100,
+                    "expectedDataSpacing": 120,
+                    "windowing": "full",
+                    "windowSize": 10,
+                    "autoColumnTags": false,
+                    "columnTags": "deprecated",
+                    "tagMode": "all",
+                    "numTags": 2,
+                    "customTags": [
+                      "tag1",
+                      "tag2"
+                    ],
+                    "groupBySource": true,
+                    "y1Max": 100,
+                    "y1Units": "units",
+                    "y0ScaleSIBy1024": true,
+                    "y1ScaleSIBy1024": true,
+                    "y0UnitAutoscaling": true,
+                    "y1UnitAutoscaling": true,
+                    "fixedLegendEnabled": true,
+                    "fixedLegendUseRawStats": true,
+                    "fixedLegendPosition": "RIGHT",
+                    "fixedLegendDisplayStats": [
+                      "stat1",
+                      "stat2"
+                    ],
+                    "fixedLegendFilterSort": "TOP",
+                    "fixedLegendFilterLimit": 1,
+                    "fixedLegendFilterField": "CURRENT",
+                    "plainMarkdownContent": "markdown content"
+                  },
+                  "chartAttributes": {
+                    "dashboardLinks": {
+                      "*": {
+                        "variables": {
+                          "xxx": "xxx"
+                        },
+                        "destination": "/dashboards/xxxx"
+                      }
+                    }
+                  },
+                  "summarization": "MEAN"
+                }
+              ],
+              "heightFactor": 50
+            }
+          ]
+        }
+      ],
+      "parameterDetails": {
+        "param": {
+          "hideFromView": false,
+          "description": null,
+          "allowAll": null,
+          "tagKey": null,
+          "queryValue": null,
+          "dynamicFieldType": null,
+          "reverseDynSort": null,
+          "parameterType": "SIMPLE",
+          "label": "test",
+          "defaultValue": "Label",
+          "valuesToReadableStrings": {
+            "Label": "test"
+          },
+          "selectedLabel": "Label",
+          "value": "test"
+        }
+      },
+      "tags": {
+        "customerTags": [
+          "terraform"
+        ]
+      }
+    }
+  EOF
+}
+```
+
+*
+*Note:
+** If there are dynamic variables in the Wavefront dashboard json, then these variables must be present in a separate file as mentioned in the section below.
+
+## Reading from an External File
+
+Below is the example dashboard with sections and parameters from an external file.
+
+```hcl
+resource "wavefront_dashboard_json" "test_dashboard_json" {
+
+  dashboard_json = templatefile("./<dashboard_file_path>.txt",
+                                  {
+                                    section1   = file("<path>/section1.json"),
+                                    section2   = file("<path>/section2.json"),
+                                    parameters = file("<path>/params.json")
+                                  }
+                                )
+}
+```
+
+The sample files are listed below.
+
+* dashboard_file.txt
+
+```hcl
+{
+  "name": "Terraform Test Dashboard JSON",
+  "description": "a",
+  "eventFilterType": "BYCHART",
+  "eventQuery": "",
+  "defaultTimeWindow": "",
+  "url": "tftestimport",
+  "displayDescription": false,
+  "displaySectionTableOfContents": true,
+  "displayQueryParameters": false,
+  "sections": [
+        ${section1},
+        ${section2}
+      ],
+  "parameterDetails": ${parameters},
+  "tags": {
+    "customerTags": ["terraform"]
+  }
+}
+```
+
+* section1.json
+
+```json
+{
+  "name": "section 1",
+  "rows": [
+    {
+      "charts": [
+        {
+          "name": "chart 1",
+          "sources": [
+            {
+              "name": "source 1",
+              "query": "ts()",
+              "scatterPlotSource": "Y",
+              "querybuilderEnabled": false,
+              "sourceDescription": ""
+            }
+          ],
+          "units": "someunit",
+          "base": 0,
+          "noDefaultEvents": false,
+          "interpolatePoints": false,
+          "includeObsoleteMetrics": false,
+          "description": "This is chart 1, showing something",
+          "chartSettings": {
+            "type": "markdown-widget",
+            "max": 100,
+            "expectedDataSpacing": 120,
+            "windowing": "full",
+            "windowSize": 10,
+            "autoColumnTags": false,
+            "columnTags": "deprecated",
+            "tagMode": "all",
+            "numTags": 2,
+            "customTags": [
+              "tag1",
+              "tag2"
+            ],
+            "groupBySource": true,
+            "y1Max": 100,
+            "y1Units": "units",
+            "y0ScaleSIBy1024": true,
+            "y1ScaleSIBy1024": true,
+            "y0UnitAutoscaling": true,
+            "y1UnitAutoscaling": true,
+            "fixedLegendEnabled": true,
+            "fixedLegendUseRawStats": true,
+            "fixedLegendPosition": "RIGHT",
+            "fixedLegendDisplayStats": [
+              "stat1",
+              "stat2"
+            ],
+            "fixedLegendFilterSort": "TOP",
+            "fixedLegendFilterLimit": 1,
+            "fixedLegendFilterField": "CURRENT",
+            "plainMarkdownContent": "markdown content"
+          },
+          "summarization": "MEAN"
+        }
+      ],
+      "heightFactor": 50
+    }
+  ]
+}
+```
+
+* parameters.json
+
+```json
+{
+  "param": {
+    "hideFromView": false,
+    "description": null,
+    "allowAll": null,
+    "tagKey": null,
+    "queryValue": null,
+    "dynamicFieldType": null,
+    "reverseDynSort": null,
+    "parameterType": "SIMPLE",
+    "label": "test",
+    "defaultValue": "Label",
+    "valuesToReadableStrings": {
+      "Label": "test"
+    },
+    "selectedLabel": "Label",
+    "value": "test"
+  }
+}
+```
+
+## Import
+
+Dashboard JSON can be imported by using the `id`, e.g.:
+
+```sh<break>
+$ pulumi import wavefront:index/dashboardJson:DashboardJson dashboard_json tftestimport
+<break>```<break>

--- a/pkg/tfgen/test_data/convertExamples/wavefront_dashboard_json_out.md
+++ b/pkg/tfgen/test_data/convertExamples/wavefront_dashboard_json_out.md
@@ -1,0 +1,823 @@
+Provides a Wavefront Dashboard JSON resource. This allows dashboards to be created, updated, and deleted.
+
+{{% examples %}}
+## Example Usage
+{{% example %}}
+
+```typescript
+import * as pulumi from "@pulumi/pulumi";
+import * as wavefront from "@pulumi/wavefront";
+
+const testDashboardJson = new wavefront.DashboardJson("testDashboardJson", {dashboardJson: `  {
+    "acl": {
+      "canModify": [
+        "group-uuid",
+        "role-uuid"
+      ],
+      "canView": [
+        "group-uuid",
+        "role-uuid"
+      ]
+    },
+    "name": "Terraform Test Dashboard Json",
+    "description": "a",
+    "eventFilterType": "BYCHART",
+    "eventQuery": "",
+    "defaultTimeWindow": "",
+    "url": "tftestimport",
+    "displayDescription": false,
+    "displaySectionTableOfContents": true,
+    "displayQueryParameters": false,
+    "sections": [
+      {
+        "name": "section 1",
+        "rows": [
+          {
+            "charts": [
+              {
+                "name": "chart 1",
+                "sources": [
+                  {
+                    "name": "source 1",
+                    "query": "ts()",
+                    "scatterPlotSource": "Y",
+                    "querybuilderEnabled": false,
+                    "sourceDescription": ""
+                  }
+                ],
+                "units": "someunit",
+                "base": 0,
+                "noDefaultEvents": false,
+                "interpolatePoints": false,
+                "includeObsoleteMetrics": false,
+                "description": "This is chart 1, showing something",
+                "chartSettings": {
+                  "type": "markdown-widget",
+                  "max": 100,
+                  "expectedDataSpacing": 120,
+                  "windowing": "full",
+                  "windowSize": 10,
+                  "autoColumnTags": false,
+                  "columnTags": "deprecated",
+                  "tagMode": "all",
+                  "numTags": 2,
+                  "customTags": [
+                    "tag1",
+                    "tag2"
+                  ],
+                  "groupBySource": true,
+                  "y1Max": 100,
+                  "y1Units": "units",
+                  "y0ScaleSIBy1024": true,
+                  "y1ScaleSIBy1024": true,
+                  "y0UnitAutoscaling": true,
+                  "y1UnitAutoscaling": true,
+                  "fixedLegendEnabled": true,
+                  "fixedLegendUseRawStats": true,
+                  "fixedLegendPosition": "RIGHT",
+                  "fixedLegendDisplayStats": [
+                    "stat1",
+                    "stat2"
+                  ],
+                  "fixedLegendFilterSort": "TOP",
+                  "fixedLegendFilterLimit": 1,
+                  "fixedLegendFilterField": "CURRENT",
+                  "plainMarkdownContent": "markdown content"
+                },
+                "chartAttributes": {
+                  "dashboardLinks": {
+                    "*": {
+                      "variables": {
+                        "xxx": "xxx"
+                      },
+                      "destination": "/dashboards/xxxx"
+                    }
+                  }
+                },
+                "summarization": "MEAN"
+              }
+            ],
+            "heightFactor": 50
+          }
+        ]
+      }
+    ],
+    "parameterDetails": {
+      "param": {
+        "hideFromView": false,
+        "description": null,
+        "allowAll": null,
+        "tagKey": null,
+        "queryValue": null,
+        "dynamicFieldType": null,
+        "reverseDynSort": null,
+        "parameterType": "SIMPLE",
+        "label": "test",
+        "defaultValue": "Label",
+        "valuesToReadableStrings": {
+          "Label": "test"
+        },
+        "selectedLabel": "Label",
+        "value": "test"
+      }
+    },
+    "tags": {
+      "customerTags": [
+        "terraform"
+      ]
+    }
+  }
+
+`});
+```
+```python
+import pulumi
+import pulumi_wavefront as wavefront
+
+test_dashboard_json = wavefront.DashboardJson("testDashboardJson", dashboard_json="""  {
+    "acl": {
+      "canModify": [
+        "group-uuid",
+        "role-uuid"
+      ],
+      "canView": [
+        "group-uuid",
+        "role-uuid"
+      ]
+    },
+    "name": "Terraform Test Dashboard Json",
+    "description": "a",
+    "eventFilterType": "BYCHART",
+    "eventQuery": "",
+    "defaultTimeWindow": "",
+    "url": "tftestimport",
+    "displayDescription": false,
+    "displaySectionTableOfContents": true,
+    "displayQueryParameters": false,
+    "sections": [
+      {
+        "name": "section 1",
+        "rows": [
+          {
+            "charts": [
+              {
+                "name": "chart 1",
+                "sources": [
+                  {
+                    "name": "source 1",
+                    "query": "ts()",
+                    "scatterPlotSource": "Y",
+                    "querybuilderEnabled": false,
+                    "sourceDescription": ""
+                  }
+                ],
+                "units": "someunit",
+                "base": 0,
+                "noDefaultEvents": false,
+                "interpolatePoints": false,
+                "includeObsoleteMetrics": false,
+                "description": "This is chart 1, showing something",
+                "chartSettings": {
+                  "type": "markdown-widget",
+                  "max": 100,
+                  "expectedDataSpacing": 120,
+                  "windowing": "full",
+                  "windowSize": 10,
+                  "autoColumnTags": false,
+                  "columnTags": "deprecated",
+                  "tagMode": "all",
+                  "numTags": 2,
+                  "customTags": [
+                    "tag1",
+                    "tag2"
+                  ],
+                  "groupBySource": true,
+                  "y1Max": 100,
+                  "y1Units": "units",
+                  "y0ScaleSIBy1024": true,
+                  "y1ScaleSIBy1024": true,
+                  "y0UnitAutoscaling": true,
+                  "y1UnitAutoscaling": true,
+                  "fixedLegendEnabled": true,
+                  "fixedLegendUseRawStats": true,
+                  "fixedLegendPosition": "RIGHT",
+                  "fixedLegendDisplayStats": [
+                    "stat1",
+                    "stat2"
+                  ],
+                  "fixedLegendFilterSort": "TOP",
+                  "fixedLegendFilterLimit": 1,
+                  "fixedLegendFilterField": "CURRENT",
+                  "plainMarkdownContent": "markdown content"
+                },
+                "chartAttributes": {
+                  "dashboardLinks": {
+                    "*": {
+                      "variables": {
+                        "xxx": "xxx"
+                      },
+                      "destination": "/dashboards/xxxx"
+                    }
+                  }
+                },
+                "summarization": "MEAN"
+              }
+            ],
+            "heightFactor": 50
+          }
+        ]
+      }
+    ],
+    "parameterDetails": {
+      "param": {
+        "hideFromView": false,
+        "description": null,
+        "allowAll": null,
+        "tagKey": null,
+        "queryValue": null,
+        "dynamicFieldType": null,
+        "reverseDynSort": null,
+        "parameterType": "SIMPLE",
+        "label": "test",
+        "defaultValue": "Label",
+        "valuesToReadableStrings": {
+          "Label": "test"
+        },
+        "selectedLabel": "Label",
+        "value": "test"
+      }
+    },
+    "tags": {
+      "customerTags": [
+        "terraform"
+      ]
+    }
+  }
+
+""")
+```
+```csharp
+using System.Collections.Generic;
+using System.Linq;
+using Pulumi;
+using Wavefront = Pulumi.Wavefront;
+
+return await Deployment.RunAsync(() => 
+{
+    var testDashboardJson = new Wavefront.DashboardJson("testDashboardJson", new()
+    {
+        JSON = @"  {
+    ""acl"": {
+      ""canModify"": [
+        ""group-uuid"",
+        ""role-uuid""
+      ],
+      ""canView"": [
+        ""group-uuid"",
+        ""role-uuid""
+      ]
+    },
+    ""name"": ""Terraform Test Dashboard Json"",
+    ""description"": ""a"",
+    ""eventFilterType"": ""BYCHART"",
+    ""eventQuery"": """",
+    ""defaultTimeWindow"": """",
+    ""url"": ""tftestimport"",
+    ""displayDescription"": false,
+    ""displaySectionTableOfContents"": true,
+    ""displayQueryParameters"": false,
+    ""sections"": [
+      {
+        ""name"": ""section 1"",
+        ""rows"": [
+          {
+            ""charts"": [
+              {
+                ""name"": ""chart 1"",
+                ""sources"": [
+                  {
+                    ""name"": ""source 1"",
+                    ""query"": ""ts()"",
+                    ""scatterPlotSource"": ""Y"",
+                    ""querybuilderEnabled"": false,
+                    ""sourceDescription"": """"
+                  }
+                ],
+                ""units"": ""someunit"",
+                ""base"": 0,
+                ""noDefaultEvents"": false,
+                ""interpolatePoints"": false,
+                ""includeObsoleteMetrics"": false,
+                ""description"": ""This is chart 1, showing something"",
+                ""chartSettings"": {
+                  ""type"": ""markdown-widget"",
+                  ""max"": 100,
+                  ""expectedDataSpacing"": 120,
+                  ""windowing"": ""full"",
+                  ""windowSize"": 10,
+                  ""autoColumnTags"": false,
+                  ""columnTags"": ""deprecated"",
+                  ""tagMode"": ""all"",
+                  ""numTags"": 2,
+                  ""customTags"": [
+                    ""tag1"",
+                    ""tag2""
+                  ],
+                  ""groupBySource"": true,
+                  ""y1Max"": 100,
+                  ""y1Units"": ""units"",
+                  ""y0ScaleSIBy1024"": true,
+                  ""y1ScaleSIBy1024"": true,
+                  ""y0UnitAutoscaling"": true,
+                  ""y1UnitAutoscaling"": true,
+                  ""fixedLegendEnabled"": true,
+                  ""fixedLegendUseRawStats"": true,
+                  ""fixedLegendPosition"": ""RIGHT"",
+                  ""fixedLegendDisplayStats"": [
+                    ""stat1"",
+                    ""stat2""
+                  ],
+                  ""fixedLegendFilterSort"": ""TOP"",
+                  ""fixedLegendFilterLimit"": 1,
+                  ""fixedLegendFilterField"": ""CURRENT"",
+                  ""plainMarkdownContent"": ""markdown content""
+                },
+                ""chartAttributes"": {
+                  ""dashboardLinks"": {
+                    ""*"": {
+                      ""variables"": {
+                        ""xxx"": ""xxx""
+                      },
+                      ""destination"": ""/dashboards/xxxx""
+                    }
+                  }
+                },
+                ""summarization"": ""MEAN""
+              }
+            ],
+            ""heightFactor"": 50
+          }
+        ]
+      }
+    ],
+    ""parameterDetails"": {
+      ""param"": {
+        ""hideFromView"": false,
+        ""description"": null,
+        ""allowAll"": null,
+        ""tagKey"": null,
+        ""queryValue"": null,
+        ""dynamicFieldType"": null,
+        ""reverseDynSort"": null,
+        ""parameterType"": ""SIMPLE"",
+        ""label"": ""test"",
+        ""defaultValue"": ""Label"",
+        ""valuesToReadableStrings"": {
+          ""Label"": ""test""
+        },
+        ""selectedLabel"": ""Label"",
+        ""value"": ""test""
+      }
+    },
+    ""tags"": {
+      ""customerTags"": [
+        ""terraform""
+      ]
+    }
+  }
+
+",
+    });
+
+});
+```
+```go
+package main
+
+import (
+	"github.com/pulumi/pulumi-wavefront/sdk/v3/go/wavefront"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		_, err := wavefront.NewDashboardJson(ctx, "testDashboardJson", &wavefront.DashboardJsonArgs{
+			DashboardJson: pulumi.String(`  {
+    "acl": {
+      "canModify": [
+        "group-uuid",
+        "role-uuid"
+      ],
+      "canView": [
+        "group-uuid",
+        "role-uuid"
+      ]
+    },
+    "name": "Terraform Test Dashboard Json",
+    "description": "a",
+    "eventFilterType": "BYCHART",
+    "eventQuery": "",
+    "defaultTimeWindow": "",
+    "url": "tftestimport",
+    "displayDescription": false,
+    "displaySectionTableOfContents": true,
+    "displayQueryParameters": false,
+    "sections": [
+      {
+        "name": "section 1",
+        "rows": [
+          {
+            "charts": [
+              {
+                "name": "chart 1",
+                "sources": [
+                  {
+                    "name": "source 1",
+                    "query": "ts()",
+                    "scatterPlotSource": "Y",
+                    "querybuilderEnabled": false,
+                    "sourceDescription": ""
+                  }
+                ],
+                "units": "someunit",
+                "base": 0,
+                "noDefaultEvents": false,
+                "interpolatePoints": false,
+                "includeObsoleteMetrics": false,
+                "description": "This is chart 1, showing something",
+                "chartSettings": {
+                  "type": "markdown-widget",
+                  "max": 100,
+                  "expectedDataSpacing": 120,
+                  "windowing": "full",
+                  "windowSize": 10,
+                  "autoColumnTags": false,
+                  "columnTags": "deprecated",
+                  "tagMode": "all",
+                  "numTags": 2,
+                  "customTags": [
+                    "tag1",
+                    "tag2"
+                  ],
+                  "groupBySource": true,
+                  "y1Max": 100,
+                  "y1Units": "units",
+                  "y0ScaleSIBy1024": true,
+                  "y1ScaleSIBy1024": true,
+                  "y0UnitAutoscaling": true,
+                  "y1UnitAutoscaling": true,
+                  "fixedLegendEnabled": true,
+                  "fixedLegendUseRawStats": true,
+                  "fixedLegendPosition": "RIGHT",
+                  "fixedLegendDisplayStats": [
+                    "stat1",
+                    "stat2"
+                  ],
+                  "fixedLegendFilterSort": "TOP",
+                  "fixedLegendFilterLimit": 1,
+                  "fixedLegendFilterField": "CURRENT",
+                  "plainMarkdownContent": "markdown content"
+                },
+                "chartAttributes": {
+                  "dashboardLinks": {
+                    "*": {
+                      "variables": {
+                        "xxx": "xxx"
+                      },
+                      "destination": "/dashboards/xxxx"
+                    }
+                  }
+                },
+                "summarization": "MEAN"
+              }
+            ],
+            "heightFactor": 50
+          }
+        ]
+      }
+    ],
+    "parameterDetails": {
+      "param": {
+        "hideFromView": false,
+        "description": null,
+        "allowAll": null,
+        "tagKey": null,
+        "queryValue": null,
+        "dynamicFieldType": null,
+        "reverseDynSort": null,
+        "parameterType": "SIMPLE",
+        "label": "test",
+        "defaultValue": "Label",
+        "valuesToReadableStrings": {
+          "Label": "test"
+        },
+        "selectedLabel": "Label",
+        "value": "test"
+      }
+    },
+    "tags": {
+      "customerTags": [
+        "terraform"
+      ]
+    }
+  }
+
+`),
+		})
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}
+```
+```java
+package generated_program;
+
+import com.pulumi.Context;
+import com.pulumi.Pulumi;
+import com.pulumi.core.Output;
+import com.pulumi.wavefront.DashboardJson;
+import com.pulumi.wavefront.DashboardJsonArgs;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Map;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+public class App {
+    public static void main(String[] args) {
+        Pulumi.run(App::stack);
+    }
+
+    public static void stack(Context ctx) {
+        var testDashboardJson = new DashboardJson("testDashboardJson", DashboardJsonArgs.builder()        
+            .dashboardJson("""
+  {
+    "acl": {
+      "canModify": [
+        "group-uuid",
+        "role-uuid"
+      ],
+      "canView": [
+        "group-uuid",
+        "role-uuid"
+      ]
+    },
+    "name": "Terraform Test Dashboard Json",
+    "description": "a",
+    "eventFilterType": "BYCHART",
+    "eventQuery": "",
+    "defaultTimeWindow": "",
+    "url": "tftestimport",
+    "displayDescription": false,
+    "displaySectionTableOfContents": true,
+    "displayQueryParameters": false,
+    "sections": [
+      {
+        "name": "section 1",
+        "rows": [
+          {
+            "charts": [
+              {
+                "name": "chart 1",
+                "sources": [
+                  {
+                    "name": "source 1",
+                    "query": "ts()",
+                    "scatterPlotSource": "Y",
+                    "querybuilderEnabled": false,
+                    "sourceDescription": ""
+                  }
+                ],
+                "units": "someunit",
+                "base": 0,
+                "noDefaultEvents": false,
+                "interpolatePoints": false,
+                "includeObsoleteMetrics": false,
+                "description": "This is chart 1, showing something",
+                "chartSettings": {
+                  "type": "markdown-widget",
+                  "max": 100,
+                  "expectedDataSpacing": 120,
+                  "windowing": "full",
+                  "windowSize": 10,
+                  "autoColumnTags": false,
+                  "columnTags": "deprecated",
+                  "tagMode": "all",
+                  "numTags": 2,
+                  "customTags": [
+                    "tag1",
+                    "tag2"
+                  ],
+                  "groupBySource": true,
+                  "y1Max": 100,
+                  "y1Units": "units",
+                  "y0ScaleSIBy1024": true,
+                  "y1ScaleSIBy1024": true,
+                  "y0UnitAutoscaling": true,
+                  "y1UnitAutoscaling": true,
+                  "fixedLegendEnabled": true,
+                  "fixedLegendUseRawStats": true,
+                  "fixedLegendPosition": "RIGHT",
+                  "fixedLegendDisplayStats": [
+                    "stat1",
+                    "stat2"
+                  ],
+                  "fixedLegendFilterSort": "TOP",
+                  "fixedLegendFilterLimit": 1,
+                  "fixedLegendFilterField": "CURRENT",
+                  "plainMarkdownContent": "markdown content"
+                },
+                "chartAttributes": {
+                  "dashboardLinks": {
+                    "*": {
+                      "variables": {
+                        "xxx": "xxx"
+                      },
+                      "destination": "/dashboards/xxxx"
+                    }
+                  }
+                },
+                "summarization": "MEAN"
+              }
+            ],
+            "heightFactor": 50
+          }
+        ]
+      }
+    ],
+    "parameterDetails": {
+      "param": {
+        "hideFromView": false,
+        "description": null,
+        "allowAll": null,
+        "tagKey": null,
+        "queryValue": null,
+        "dynamicFieldType": null,
+        "reverseDynSort": null,
+        "parameterType": "SIMPLE",
+        "label": "test",
+        "defaultValue": "Label",
+        "valuesToReadableStrings": {
+          "Label": "test"
+        },
+        "selectedLabel": "Label",
+        "value": "test"
+      }
+    },
+    "tags": {
+      "customerTags": [
+        "terraform"
+      ]
+    }
+  }
+
+            """)
+            .build());
+
+    }
+}
+```
+```yaml
+resources:
+  testDashboardJson:
+    type: wavefront:DashboardJson
+    properties:
+      dashboardJson: |2+
+          {
+            "acl": {
+              "canModify": [
+                "group-uuid",
+                "role-uuid"
+              ],
+              "canView": [
+                "group-uuid",
+                "role-uuid"
+              ]
+            },
+            "name": "Terraform Test Dashboard Json",
+            "description": "a",
+            "eventFilterType": "BYCHART",
+            "eventQuery": "",
+            "defaultTimeWindow": "",
+            "url": "tftestimport",
+            "displayDescription": false,
+            "displaySectionTableOfContents": true,
+            "displayQueryParameters": false,
+            "sections": [
+              {
+                "name": "section 1",
+                "rows": [
+                  {
+                    "charts": [
+                      {
+                        "name": "chart 1",
+                        "sources": [
+                          {
+                            "name": "source 1",
+                            "query": "ts()",
+                            "scatterPlotSource": "Y",
+                            "querybuilderEnabled": false,
+                            "sourceDescription": ""
+                          }
+                        ],
+                        "units": "someunit",
+                        "base": 0,
+                        "noDefaultEvents": false,
+                        "interpolatePoints": false,
+                        "includeObsoleteMetrics": false,
+                        "description": "This is chart 1, showing something",
+                        "chartSettings": {
+                          "type": "markdown-widget",
+                          "max": 100,
+                          "expectedDataSpacing": 120,
+                          "windowing": "full",
+                          "windowSize": 10,
+                          "autoColumnTags": false,
+                          "columnTags": "deprecated",
+                          "tagMode": "all",
+                          "numTags": 2,
+                          "customTags": [
+                            "tag1",
+                            "tag2"
+                          ],
+                          "groupBySource": true,
+                          "y1Max": 100,
+                          "y1Units": "units",
+                          "y0ScaleSIBy1024": true,
+                          "y1ScaleSIBy1024": true,
+                          "y0UnitAutoscaling": true,
+                          "y1UnitAutoscaling": true,
+                          "fixedLegendEnabled": true,
+                          "fixedLegendUseRawStats": true,
+                          "fixedLegendPosition": "RIGHT",
+                          "fixedLegendDisplayStats": [
+                            "stat1",
+                            "stat2"
+                          ],
+                          "fixedLegendFilterSort": "TOP",
+                          "fixedLegendFilterLimit": 1,
+                          "fixedLegendFilterField": "CURRENT",
+                          "plainMarkdownContent": "markdown content"
+                        },
+                        "chartAttributes": {
+                          "dashboardLinks": {
+                            "*": {
+                              "variables": {
+                                "xxx": "xxx"
+                              },
+                              "destination": "/dashboards/xxxx"
+                            }
+                          }
+                        },
+                        "summarization": "MEAN"
+                      }
+                    ],
+                    "heightFactor": 50
+                  }
+                ]
+              }
+            ],
+            "parameterDetails": {
+              "param": {
+                "hideFromView": false,
+                "description": null,
+                "allowAll": null,
+                "tagKey": null,
+                "queryValue": null,
+                "dynamicFieldType": null,
+                "reverseDynSort": null,
+                "parameterType": "SIMPLE",
+                "label": "test",
+                "defaultValue": "Label",
+                "valuesToReadableStrings": {
+                  "Label": "test"
+                },
+                "selectedLabel": "Label",
+                "value": "test"
+              }
+            },
+            "tags": {
+              "customerTags": [
+                "terraform"
+              ]
+            }
+          }
+```
+
+*
+*Note:
+** If there are dynamic variables in the Wavefront dashboard json, then these variables must be present in a separate file as mentioned in the section below.
+{{% /example %}}
+{{% /examples %}}
+
+## Import
+
+Dashboard JSON can be imported by using the `id`, e.g.:
+
+```sh
+ $ pulumi import wavefront:index/dashboardJson:DashboardJson dashboard_json tftestimport
+```
+ 


### PR DESCRIPTION
Covers this condition:

    skippedExamples && stripSubsectionsWithErrors && !isFrontMatter

Also adds a golden test for the generated content.

Note that although convertExamples shows up as covered in our reporting right now, the coverage is very low quality, for example tweaking the generated text still passes. The new test pins this a little better.

To discover tests like these, build a provider against a local bridge version and inject panics into uncovered lines to recover function parameters. The technique is a bit tedious but seems to work here.

