### PR TITLE
Test potential MustApplyAutoAliases speedup

### DIFF
--- a/pkg/tfbridge/auto_aliasing.go
+++ b/pkg/tfbridge/auto_aliasing.go
@@ -175,11 +175,13 @@ func (info *ProviderInfo) ApplyAutoAliases() error {
 		f()
 	}
 
-	if err := md.Set(artifact, aliasMetadataKey, hist); err != nil {
-		// Set fails only when `hist` is not serializable. Because `hist` is
-		// composed of marshallable, non-cyclic types, this is impossible.
-		contract.AssertNoErrorf(err, "History failed to serialize")
-	}
+	/*
+		if err := md.Set(artifact, aliasMetadataKey, hist); err != nil {
+			// Set fails only when `hist` is not serializable. Because `hist` is
+			// composed of marshallable, non-cyclic types, this is impossible.
+			contract.AssertNoErrorf(err, "History failed to serialize")
+		}
+	*/
 
 	return nil
 }
@@ -208,11 +210,13 @@ func aliasResource(
 ) {
 	prev, hasPrev := hist[tfToken]
 	if !hasPrev {
-		// It's not in the history, so it must be new. Stick it in the history for
-		// next time.
-		hist[tfToken] = &tokenHistory[tokens.Type]{
-			Current: computed.Tok,
-		}
+		/*
+			// It's not in the history, so it must be new. Stick it in the history for
+			// next time.
+			hist[tfToken] = &tokenHistory[tokens.Type]{
+				Current: computed.Tok,
+			}
+		*/
 	} else {
 		// We don't do this eagerly because aliasResource is called while
 		// iterating over p.Resources which aliasOrRenameResource mutates.
@@ -226,7 +230,7 @@ func aliasResource(
 	// Note: If the user explicitly sets a MaxItemOne value, that value is respected
 	// and overwrites the current history.'
 
-	if res == nil {
+	if res == nil || hist[tfToken] == nil {
 		return
 	}
 
@@ -261,9 +265,11 @@ func applyResourceMaxItemsOneAliasing(
 		hasH = hasH || fieldHasHist
 		hasI = hasI || fieldHasInfo
 
-		if !hasH {
-			delete(*hist, k)
-		}
+		/*
+			if !hasH {
+				delete(*hist, k)
+			}
+		*/
 		if !hasI {
 			delete(*info, k)
 		}

--- a/pkg/tfbridge/auto_aliasing.go
+++ b/pkg/tfbridge/auto_aliasing.go
@@ -523,5 +523,5 @@ func aliasOrRenameDataSource(
 }
 
 func isTfgen() bool {
-	return GetRuntimeStage() != ResourceStage
+	return getRuntimeStage() != resourceStage
 }

--- a/pkg/tfbridge/runtime.go
+++ b/pkg/tfbridge/runtime.go
@@ -35,6 +35,6 @@ func initRuntimeInfo() runtimeInfo {
 	}
 }
 
-func getRuntimeStage() runtimeStage {
-	return runtime.stage
+func isTfgen() bool {
+	return runtime.stage != resourceStage
 }

--- a/pkg/tfbridge/runtime.go
+++ b/pkg/tfbridge/runtime.go
@@ -1,0 +1,48 @@
+package tfbridge
+
+import (
+	"runtime/debug"
+	"strings"
+)
+
+type RuntimeStage int
+
+const (
+	UnknownStage RuntimeStage = iota
+	TfgenStage
+	ResourceStage
+)
+
+// Holds runtime flags
+type RuntimeInfo struct {
+	Stage RuntimeStage
+}
+
+var runtime = initRuntimeInfo()
+
+func initRuntimeInfo() RuntimeInfo {
+	buildInfo, _ := debug.ReadBuildInfo()
+	stage := UnknownStage
+	if buildInfo != nil {
+		if strings.Contains(buildInfo.Path, "pulumi-tfgen") {
+			stage = TfgenStage
+		} else if strings.Contains(buildInfo.Path, "pulumi-resource") {
+			stage = ResourceStage
+		}
+	}
+	return RuntimeInfo{
+		Stage: stage,
+	}
+}
+
+func ReadRuntimeInfo() RuntimeInfo {
+	return runtime
+}
+
+func GetRuntimeStage() RuntimeStage {
+	return runtime.Stage
+}
+
+func SetRuntimeStage(s RuntimeStage) {
+	runtime.Stage = s
+}

--- a/pkg/tfbridge/runtime.go
+++ b/pkg/tfbridge/runtime.go
@@ -35,14 +35,6 @@ func initRuntimeInfo() runtimeInfo {
 	}
 }
 
-func readRuntimeInfo() runtimeInfo {
-	return runtime
-}
-
 func getRuntimeStage() runtimeStage {
 	return runtime.stage
-}
-
-func setRuntimeStage(s runtimeStage) {
-	runtime.stage = s
 }

--- a/pkg/tfbridge/runtime.go
+++ b/pkg/tfbridge/runtime.go
@@ -5,44 +5,44 @@ import (
 	"strings"
 )
 
-type RuntimeStage int
+type runtimeStage int
 
 const (
-	UnknownStage RuntimeStage = iota
-	TfgenStage
-	ResourceStage
+	unknownStage runtimeStage = iota
+	tfgenStage
+	resourceStage
 )
 
 // Holds runtime flags
-type RuntimeInfo struct {
-	Stage RuntimeStage
+type runtimeInfo struct {
+	stage runtimeStage
 }
 
 var runtime = initRuntimeInfo()
 
-func initRuntimeInfo() RuntimeInfo {
+func initRuntimeInfo() runtimeInfo {
 	buildInfo, _ := debug.ReadBuildInfo()
-	stage := UnknownStage
+	stage := unknownStage
 	if buildInfo != nil {
 		if strings.Contains(buildInfo.Path, "pulumi-tfgen") {
-			stage = TfgenStage
+			stage = tfgenStage
 		} else if strings.Contains(buildInfo.Path, "pulumi-resource") {
-			stage = ResourceStage
+			stage = resourceStage
 		}
 	}
-	return RuntimeInfo{
-		Stage: stage,
+	return runtimeInfo{
+		stage: stage,
 	}
 }
 
-func ReadRuntimeInfo() RuntimeInfo {
+func readRuntimeInfo() runtimeInfo {
 	return runtime
 }
 
-func GetRuntimeStage() RuntimeStage {
-	return runtime.Stage
+func getRuntimeStage() runtimeStage {
+	return runtime.stage
 }
 
-func SetRuntimeStage(s RuntimeStage) {
-	runtime.Stage = s
+func setRuntimeStage(s runtimeStage) {
+	runtime.stage = s
 }


### PR DESCRIPTION
toward https://github.com/pulumi/pulumi-terraform-bridge/issues/1410

Uses the build path for the binary to identify when we are in plugin runtime and  disable sections of `ApplyAutoAliases` that are only needed for generating the bridge metadata file. 

```
❯ (cd provider; go test -run="^$" -bench="BenchmarkProvider.*Gen$" -benchtime=10s)
goos: darwin
goarch: arm64
pkg: github.com/pulumi/pulumi-aws/provider/v6
BenchmarkProviderGen-12      	      58	 204080193 ns/op
BenchmarkProviderNoGen-12    	      68	 174488096 ns/op
PASS
```

I've extracted the bit of trying to guess whether we're in a tfgen binary or a plugin binary to it's own module so we could change out the implementation more easily in the future. 