### PR TITLE
Draft: Must apply auto alias speedup with global

### DIFF
--- a/pkg/tfbridge/auto_aliasing.go
+++ b/pkg/tfbridge/auto_aliasing.go
@@ -175,11 +175,13 @@ func (info *ProviderInfo) ApplyAutoAliases() error {
 		f()
 	}
 
-	if err := md.Set(artifact, aliasMetadataKey, hist); err != nil {
-		// Set fails only when `hist` is not serializable. Because `hist` is
-		// composed of marshallable, non-cyclic types, this is impossible.
-		contract.AssertNoErrorf(err, "History failed to serialize")
-	}
+	/*
+		if err := md.Set(artifact, aliasMetadataKey, hist); err != nil {
+			// Set fails only when `hist` is not serializable. Because `hist` is
+			// composed of marshallable, non-cyclic types, this is impossible.
+			contract.AssertNoErrorf(err, "History failed to serialize")
+		}
+	*/
 
 	return nil
 }
@@ -208,11 +210,13 @@ func aliasResource(
 ) {
 	prev, hasPrev := hist[tfToken]
 	if !hasPrev {
-		// It's not in the history, so it must be new. Stick it in the history for
-		// next time.
-		hist[tfToken] = &tokenHistory[tokens.Type]{
-			Current: computed.Tok,
-		}
+		/*
+			// It's not in the history, so it must be new. Stick it in the history for
+			// next time.
+			hist[tfToken] = &tokenHistory[tokens.Type]{
+				Current: computed.Tok,
+			}
+		*/
 	} else {
 		// We don't do this eagerly because aliasResource is called while
 		// iterating over p.Resources which aliasOrRenameResource mutates.
@@ -226,7 +230,7 @@ func aliasResource(
 	// Note: If the user explicitly sets a MaxItemOne value, that value is respected
 	// and overwrites the current history.'
 
-	if res == nil {
+	if res == nil || hist[tfToken] == nil {
 		return
 	}
 
@@ -261,9 +265,11 @@ func applyResourceMaxItemsOneAliasing(
 		hasH = hasH || fieldHasHist
 		hasI = hasI || fieldHasInfo
 
-		if !hasH {
-			delete(*hist, k)
-		}
+		/*
+			if !hasH {
+				delete(*hist, k)
+			}
+		*/
 		if !hasI {
 			delete(*info, k)
 		}

--- a/pkg/tfbridge/auto_aliasing.go
+++ b/pkg/tfbridge/auto_aliasing.go
@@ -16,8 +16,6 @@ package tfbridge
 
 import (
 	"github.com/Masterminds/semver"
-	"runtime/debug"
-	"strings"
 
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	md "github.com/pulumi/pulumi-terraform-bridge/v3/unstable/metadata"
@@ -125,8 +123,7 @@ func (info *ProviderInfo) ApplyAutoAliases() error {
 		return err
 	}
 
-	buildInfo, _ := debug.ReadBuildInfo()
-	isTfgen := buildInfo != nil && strings.Contains(buildInfo.Path, "pulumi-tfgen")
+	isTfgen := ReadRuntimeInfo().IsTfgen
 
 	var currentVersion int
 	// If version is missing, we assume the current version is the most recent major

--- a/pkg/tfbridge/runtime.go
+++ b/pkg/tfbridge/runtime.go
@@ -1,0 +1,18 @@
+package tfbridge
+
+// Holds runtime flags
+type RuntimeInfo struct {
+	IsTfgen bool
+}
+
+var runtime = RuntimeInfo{
+	IsTfgen: false,
+}
+
+func ReadRuntimeInfo() RuntimeInfo {
+	return runtime
+}
+
+func SetRuntimeIsTfgen() {
+	runtime.IsTfgen = true
+}

--- a/pkg/tfgen/init.go
+++ b/pkg/tfgen/init.go
@@ -1,0 +1,24 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfgen
+
+import (
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+)
+
+// Flag that this program is importing tfgen
+func init() {
+	tfbridge.SetRuntimeIsTfgen()
+}


### PR DESCRIPTION
Trying to get the same results as https://github.com/pulumi/pulumi-terraform-bridge/pull/1414 using a global variable. Unfortunately, this does not work, the init for the tfgen package is being run and setting the global flag before pulumi-resource-aws main builds the provider info, so the provider startup is still slow with this code. Posting this here as WIP in case others have an idea for how to thread the needle better.