### PR TITLE
Speedup example converter

### DIFF
--- a/pkg/tfgen/convert_cli.go
+++ b/pkg/tfgen/convert_cli.go
@@ -223,7 +223,7 @@ func (cc *cliConverter) convertViaPulumiCliBatchedParallel(
 	map[string]translatedExample,
 	error,
 ) {
-	batch := 1000
+	batch := 36
 	if b, ok := os.LookupEnv("PULUMI_CONVERT_BATCH"); ok {
 		if n, err := strconv.Atoi(b); err == nil {
 			batch = n
@@ -237,8 +237,8 @@ func (cc *cliConverter) convertViaPulumiCliBatchedParallel(
 		}
 	}
 
-	transform := func(examples map[string]string) (map[string]translatedExample, error) {
-		return cc.convertViaPulumiCLI(examples, mappings)
+	transform := func(ex map[string]string) (map[string]translatedExample, error) {
+		return cc.convertViaPulumiCLI(ex, mappings)
 	}
 
 	return parTransformMap(examples, transform, workers, batch)

--- a/pkg/tfgen/convert_cli.go
+++ b/pkg/tfgen/convert_cli.go
@@ -223,14 +223,14 @@ func (cc *cliConverter) convertViaPulumiCliBatchedParallel(
 	map[string]translatedExample,
 	error,
 ) {
-	batch := 36
+	batch := 256 // default
 	if b, ok := os.LookupEnv("PULUMI_CONVERT_BATCH"); ok {
 		if n, err := strconv.Atoi(b); err == nil {
 			batch = n
 		}
 	}
 
-	workers := -1 // use nCPU
+	workers := 2 // default
 	if b, ok := os.LookupEnv("PULUMI_CONVERT_WORKERS"); ok {
 		if n, err := strconv.Atoi(b); err == nil {
 			workers = n

--- a/pkg/tfgen/convert_cli_test.go
+++ b/pkg/tfgen/convert_cli_test.go
@@ -130,10 +130,7 @@ output "someOutput" {
 		out, err := cc.convertViaPulumiCLI(map[string]string{
 			"example1": simpleResourceTF,
 			"example2": simpleDataSourceTF,
-		}, []struct {
-			name string
-			info tfbridge.ProviderInfo
-		}{{info: p, name: "simple"}})
+		}, []mapping{{info: p, name: "simple"}})
 
 		require.NoError(t, err)
 		assert.Equal(t, 2, len(out))

--- a/pkg/tfgen/par.go
+++ b/pkg/tfgen/par.go
@@ -1,0 +1,106 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfgen
+
+import (
+	"fmt"
+	"runtime"
+	"sync"
+)
+
+// Transforms a large map in batches of up to batch elements, using workers number of goroutines. If
+// workers is -1, uses one worker per CPU.
+func parTransformMap[K comparable, T any, U any](
+	inputs map[K]T,
+	transform func(map[K]T) (map[K]U, error),
+	workers int,
+	batch int,
+) (map[K]U, error) {
+	if batch < 1 {
+		return nil, fmt.Errorf("batch cannot be less than 1")
+	}
+	n := workers
+	if workers < 1 {
+		n = runtime.NumCPU()
+		if n < 2 {
+			n = 2
+		}
+	}
+
+	keys := []K{}
+	keyIndex := map[K]int{}
+	for k := range inputs {
+		keys = append(keys, k)
+		keyIndex[k] = len(keys) - 1
+	}
+
+	translations := make([]U, len(keys))
+	errors := make([]error, n)
+
+	ch := make(chan []K)
+
+	// Start n workers to do convertViaPulumiCLI work
+	wg := sync.WaitGroup{}
+	wg.Add(n)
+
+	for i := 0; i < n; i++ {
+		go func(worker int) {
+			defer wg.Done()
+			for keyBatch := range ch {
+				ex := map[K]T{}
+				for _, k := range keyBatch {
+					ex[k] = inputs[k]
+				}
+				out, err := transform(ex)
+				if err != nil {
+					errors[worker] = err
+					return
+				}
+				for _, k := range keyBatch {
+					translations[keyIndex[k]] = out[k]
+				}
+			}
+		}(i)
+	}
+
+	// Queue up work in batches.
+	remainingKeys := keys
+	for len(remainingKeys) > 0 {
+		var keyBatch []K
+		if len(remainingKeys) >= batch {
+			keyBatch, remainingKeys = remainingKeys, nil
+		} else {
+			keyBatch, remainingKeys = keys[:batch], keys[batch:]
+		}
+		ch <- keyBatch
+	}
+	close(ch)
+
+	// Wait till workers are done.
+	wg.Wait()
+
+	for _, e := range errors {
+		// Returning the first error here, could instead consider merging them.
+		if e != nil {
+			return nil, e
+		}
+	}
+
+	translatedMap := map[K]U{}
+	for _, k := range keys {
+		translatedMap[k] = translations[keyIndex[k]]
+	}
+	return translatedMap, nil
+}

--- a/pkg/tfgen/par.go
+++ b/pkg/tfgen/par.go
@@ -79,10 +79,10 @@ func parTransformMap[K comparable, T any, U any](
 	remainingKeys := keys
 	for len(remainingKeys) > 0 {
 		var keyBatch []K
-		if len(remainingKeys) >= batch {
+		if len(remainingKeys) <= batch {
 			keyBatch, remainingKeys = remainingKeys, nil
 		} else {
-			keyBatch, remainingKeys = keys[:batch], keys[batch:]
+			keyBatch, remainingKeys = remainingKeys[:batch], remainingKeys[batch:]
 		}
 		ch <- keyBatch
 	}

--- a/pkg/tfgen/par_test.go
+++ b/pkg/tfgen/par_test.go
@@ -1,0 +1,77 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfgen
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParTransformMap(t *testing.T) {
+	inputs := map[int]int{
+		1:  2,
+		2:  4,
+		4:  8,
+		8:  16,
+		16: 32,
+	}
+
+	inputsBad := map[int]int{
+		1:  2,
+		2:  4,
+		4:  -8,
+		8:  16,
+		16: 32,
+	}
+
+	type testCase struct {
+		inputs  map[int]int
+		workers int
+		batch   int
+	}
+
+	increment := func(m map[int]int) (map[int]int, error) {
+		out := map[int]int{}
+		for k, v := range m {
+			if v < 0 {
+				return nil, fmt.Errorf("neg")
+			}
+			out[k] = v + 1
+		}
+		return out, nil
+	}
+
+	testCases := []testCase{
+		{inputs, -1, 3},
+		{inputs, 2, 3},
+		{inputs, 4, 3},
+		{inputsBad, -1, 3},
+		{inputsBad, 2, 3},
+		{inputsBad, 4, 3},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(fmt.Sprintf("w%d__b%d", tc.workers, tc.batch), func(t *testing.T) {
+			actual, actualErr := parTransformMap(tc.inputs, increment, tc.workers, tc.batch)
+			expect, expectErr := increment(tc.inputs)
+			assert.Equal(t, expectErr, actualErr)
+			assert.Equal(t, expect, actual)
+		})
+	}
+}


### PR DESCRIPTION
This loads all cores. I experimented with batch sizes on pulumi-aws measuring wall clock time for `make tfgen` on my machine that reports 12 NumCPU to go runtime. Seems to like smaller batches a little better but it's not very significant.

```
|  P |   B | time  |
|----+-----+-------|
| 12 |  32 | 7:40s |
| 12 |  64 | 8:18s |
| 12 | 128 | 8:41s |
```

Let me also try to put the parmap inside the converter.

Sister PR is https://github.com/pulumi/pulumi-converter-terraform/pull/73
