### PR TITLE
Downstream check replacement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 env:
   GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
 
-name: Pull Request & Downstream Testing
+name: Pull Request
 
 on: [pull_request]
 
@@ -52,51 +52,3 @@ jobs:
         uses: codecov/codecov-action@v3
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-  downstream-test:
-    name: Test ${{ matrix.provider }} Downstream
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        provider: [ "azuread", "random", ]
-    steps:
-      - name: Install Node.js
-        uses: actions/setup-node@v1
-        with:
-          node-version: '14.x'
-      - name: Install Python
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.9.x
-      - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v1.0.1
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.1.0
-        with:
-          repo: pulumi/pulumictl
-
-      - name: Check out source code
-        uses: actions/checkout@master
-      - name: Install Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: 1.21.x
-          cache-dependency-path: |
-            **/go.sum
-      # Required to pin Gradle < 8.0 until downstram tests upgrade to compatible pulumi-java release.
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-        with:
-          gradle-version: "7.6"
-      - name: Test Downstream
-        uses: pulumi/action-test-provider-downstream@releases/v7
-        env:
-          GOPROXY: "https://proxy.golang.org"
-        with:
-          downstream-name: pulumi-${{ matrix.provider }}
-          downstream-url: https://github.com/pulumi/pulumi-${{ matrix.provider }}
-          pulumi-bot-token: ${{ secrets.PULUMI_BOT_TOKEN }}
-          github-actions-token: ${{ secrets.GITHUB_TOKEN }}
-          use-provider-dir: true
-          replacements: github.com/pulumi/pulumi-terraform-bridge/v3=pulumi-terraform-bridge,github.com/pulumi/pulumi-terraform-bridge/x/muxer=pulumi-terraform-bridge/x/muxer,github.com/pulumi/pulumi-terraform-bridge/pf=pulumi-terraform-bridge/pf

--- a/.github/workflows/update-providers-test.yml
+++ b/.github/workflows/update-providers-test.yml
@@ -7,16 +7,16 @@ on:
   workflow_dispatch:
     inputs: {}
 
-  # Alternatively, they can be triggered by opening a feature-* branch. Not having these enabled on
-  # normal branches and PRs is intentional as the checks consume a lot of resources.
-  push:
-    branches:
-    - feature-**
-    paths-ignore:
-    - CHANGELOG.md
-    tags-ignore:
-    - "*"
-    - "**"
+  # # Alternatively, they can be triggered by opening a feature-* branch. Not having these enabled on
+  # # normal branches and PRs is intentional as the checks consume a lot of resources.
+  # push:
+  #   branches:
+  #   - feature-**
+  #   paths-ignore:
+  #   - CHANGELOG.md
+  #   tags-ignore:
+  #   - "*"
+  #   - "**"
 
 jobs:
   build:
@@ -41,50 +41,18 @@ jobs:
       matrix:
         provider:
           - pulumi-aiven
-          # - pulumi-akamai
-          # - pulumi-alicloud
-          # - pulumi-auth0
-          # - pulumi-aws
-          # - pulumi-azure
-          # - pulumi-azuread
-          # - pulumi-azuredevops
-          # - pulumi-civo
-          # - pulumi-cloudamqp
-          # - pulumi-cloudflare
-          # - pulumi-cloudinit
-          # - pulumi-consul
-          # - pulumi-datadog
-          # - pulumi-digitalocean
-          # - pulumi-dnsimple
-          # - pulumi-docker
-          # - pulumi-equinix-metal
-          # - pulumi-f5bigip
-          # - pulumi-fastly
-          # - pulumi-gcp
-          # - pulumi-github
-          # - pulumi-gitlab
-          # - pulumi-hcloud
-          # - pulumi-kafka
-          # - pulumi-keycloak
-          # - pulumi-kong
-          # - pulumi-linode
-          # - pulumi-mailgun
-          # - pulumi-mongodbatlas
-          # - pulumi-mysql
-          # - pulumi-newrelic
-          # - pulumi-ns1
-          # - pulumi-okta
-          # - pulumi-openstack
-          # - pulumi-pagerduty
-          # - pulumi-postgresql
-          # - pulumi-rabbitmq
-          # - pulumi-rancher2
-          # - pulumi-random
-          # - pulumi-signalfx
-          # - pulumi-splunk
-          # - pulumi-spotinst
-          # - pulumi-tls
-          # - pulumi-vault
-          # - pulumi-venafi
-          # - pulumi-vsphere
-          # - pulumi-wavefront
+          - pulumi-auth0
+          - pulumi-aws
+          - pulumi-azure
+          - pulumi-azuread
+          - pulumi-cloudflare
+          - pulumi-datadog
+          - pulumi-digitalocean
+          - pulumi-docker
+          - pulumi-fastly
+          - pulumi-gcp
+          - pulumi-github
+          - pulumi-hcloud
+          - pulumi-okta
+          - pulumi-random
+          - pulumi-tls

--- a/.github/workflows/update-providers-test.yml
+++ b/.github/workflows/update-providers-test.yml
@@ -1,4 +1,4 @@
-name: Test the bridge by attemping to update providers
+name: Test the bridge by previewing provider bridge upgrades
 
 on:
 

--- a/.github/workflows/update-providers-test.yml
+++ b/.github/workflows/update-providers-test.yml
@@ -20,10 +20,10 @@ jobs:
           event-type: upgrade-bridge
           client-payload: |-
             {
-               {"target-bridge-version": ${{ toJSON(github.sha) }} },
-               {"pr-reviewers": ${{ toJSON(github.triggerring_actor) }} },
-               {"pr-description": "This PR was created to test a pulumi/pulumi-terraform-bridge feature. DO NOT MERGE.",
-               {"automerge": false}
+               "target-bridge-version": ${{ toJSON(github.sha) }},
+               "pr-reviewers": ${{ toJSON( github.triggering_actor || 't0yv0' ) }},
+               "pr-description": "This PR was created to test a pulumi/pulumi-terraform-bridge feature. DO NOT MERGE.",
+               "automerge": false
             }
     strategy:
       fail-fast: false

--- a/.github/workflows/update-providers-test.yml
+++ b/.github/workflows/update-providers-test.yml
@@ -1,0 +1,79 @@
+name: Test the bridge by attemping to update providers
+
+on:
+  workflow_dispatch:
+    inputs:
+      bridgeVersion:
+        description: 'Version of Bridge to upgrade to'
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Test upgrading ${{ matrix.provider }} to pulumi-terraform-bridge ${{ github.event.inputs.bridgeVersion }}
+    steps:
+      - name: Trigger upgrade
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          repository: pulumi/${{ matrix.provider }}
+          event-type: upgrade-bridge
+          client-payload: |-
+            {
+               {"target-bridge-version": ${{ toJSON(github.sha) }} },
+               {"pr-reviewers": ${{ toJSON(github.triggerring_actor) }} },
+               {"pr-description": "This PR was created to test a pulumi/pulumi-terraform-bridge feature. DO NOT MERGE.",
+               {"automerge": false}
+            }
+    strategy:
+      fail-fast: false
+      matrix:
+        provider:
+          - pulumi-aiven
+          # - pulumi-akamai
+          # - pulumi-alicloud
+          # - pulumi-auth0
+          # - pulumi-aws
+          # - pulumi-azure
+          # - pulumi-azuread
+          # - pulumi-azuredevops
+          # - pulumi-civo
+          # - pulumi-cloudamqp
+          # - pulumi-cloudflare
+          # - pulumi-cloudinit
+          # - pulumi-consul
+          # - pulumi-datadog
+          # - pulumi-digitalocean
+          # - pulumi-dnsimple
+          # - pulumi-docker
+          # - pulumi-equinix-metal
+          # - pulumi-f5bigip
+          # - pulumi-fastly
+          # - pulumi-gcp
+          # - pulumi-github
+          # - pulumi-gitlab
+          # - pulumi-hcloud
+          # - pulumi-kafka
+          # - pulumi-keycloak
+          # - pulumi-kong
+          # - pulumi-linode
+          # - pulumi-mailgun
+          # - pulumi-mongodbatlas
+          # - pulumi-mysql
+          # - pulumi-newrelic
+          # - pulumi-ns1
+          # - pulumi-okta
+          # - pulumi-openstack
+          # - pulumi-pagerduty
+          # - pulumi-postgresql
+          # - pulumi-rabbitmq
+          # - pulumi-rancher2
+          # - pulumi-random
+          # - pulumi-signalfx
+          # - pulumi-splunk
+          # - pulumi-spotinst
+          # - pulumi-tls
+          # - pulumi-vault
+          # - pulumi-venafi
+          # - pulumi-vsphere
+          # - pulumi-wavefront

--- a/.github/workflows/update-providers-test.yml
+++ b/.github/workflows/update-providers-test.yml
@@ -1,16 +1,27 @@
 name: Test the bridge by attemping to update providers
 
 on:
+
+  # These checks can be triggerred manually from the Actions tab, which already lets you specify
+  # which branch of the bridge to use for testing.
   workflow_dispatch:
-    inputs:
-      bridgeVersion:
-        description: 'Version of Bridge to upgrade to'
-        required: true
+    inputs: {}
+
+  # Alternatively, they can be triggered by opening a feature-* branch. Not having these enabled on
+  # normal branches and PRs is intentional as the checks consume a lot of resources.
+  push:
+    branches:
+    - feature-**
+    paths-ignore:
+    - CHANGELOG.md
+    tags-ignore:
+    - "*"
+    - "**"
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Test upgrading ${{ matrix.provider }} to pulumi-terraform-bridge ${{ github.event.inputs.bridgeVersion }}
+    name: Test upgrading ${{ matrix.provider }} to pulumi-terraform-bridge ${{ github.sha }}
     steps:
       - name: Trigger upgrade
         uses: peter-evans/repository-dispatch@v2
@@ -22,7 +33,7 @@ jobs:
             {
                "target-bridge-version": ${{ toJSON(github.sha) }},
                "pr-reviewers": ${{ toJSON( github.triggering_actor || 't0yv0' ) }},
-               "pr-description": "This PR was created to test a pulumi/pulumi-terraform-bridge feature. DO NOT MERGE.",
+               "pr-description": "This PR was created to test a pulumi/pulumi-terraform-bridge feature.\n\n- pulumi/pulumi-terraform-bridge#${{ github.event.number }}\n\n- https://github.com/pulumi/pulumi-terraform-bridge/${{github.sha}}\n\nDO NOT MERGE.",
                "automerge": false
             }
     strategy:

--- a/.github/workflows/update-providers.yml
+++ b/.github/workflows/update-providers.yml
@@ -21,7 +21,7 @@ jobs:
           client-payload: |-
             {
                "target-bridge-version": ${{ toJSON(github.sha) }},
-               "pr-reviewers": ${{ toJSON(github.triggerring_actor && github.triggerring_actor || "t0yv0") }},
+               "pr-reviewers": ${{ toJSON( github.triggering_actor || 't0yv0' ) }},
                "pr-description": "This PR was created to test a pulumi/pulumi-terraform-bridge feature. DO NOT MERGE.",
                "automerge": false
             }

--- a/.github/workflows/update-providers.yml
+++ b/.github/workflows/update-providers.yml
@@ -20,10 +20,10 @@ jobs:
           event-type: upgrade-bridge
           client-payload: |-
             {
-               {"target-bridge-version": ${{ toJSON(github.sha) }} },
-               {"pr-reviewers": ${{ toJSON(github.triggerring_actor) }} },
-               {"pr-description": "This PR was created to test a pulumi/pulumi-terraform-bridge feature. DO NOT MERGE.",
-               {"automerge": false}
+               "target-bridge-version": ${{ toJSON(github.sha) }},
+               "pr-reviewers": ${{ toJSON(github.triggerring_actor && github.triggerring_actor || "t0yv0") }},
+               "pr-description": "This PR was created to test a pulumi/pulumi-terraform-bridge feature. DO NOT MERGE.",
+               "automerge": false
             }
     strategy:
       fail-fast: false

--- a/.github/workflows/update-providers.yml
+++ b/.github/workflows/update-providers.yml
@@ -1,5 +1,4 @@
-name: Test the bridge by attemping to update providers
-
+name: Update Providers with new bridge version
 on:
   workflow_dispatch:
     inputs:
@@ -7,73 +6,71 @@ on:
         description: 'Version of Bridge to upgrade to'
         required: true
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Test upgrading ${{ matrix.provider }} to pulumi-terraform-bridge ${{ github.event.inputs.bridgeVersion }}
+    name: Upgrade ${{ matrix.provider }} to pulumi-terraform-bridge ${{ github.event.inputs.bridgeVersion }}
     steps:
-      - name: Trigger upgrade
-        uses: peter-evans/repository-dispatch@v2
+      - name: Install pulumictl
+        uses: jaxxstorm/action-install-gh-release@v1.1.0
         with:
-          token: ${{ secrets.PULUMI_BOT_TOKEN }}
-          repository: pulumi/${{ matrix.provider }}
-          event-type: upgrade-bridge
-          client-payload: |-
-            {
-               "target-bridge-version": ${{ toJSON(github.sha) }},
-               "pr-reviewers": ${{ toJSON( github.triggering_actor || 't0yv0' ) }},
-               "pr-description": "This PR was created to test a pulumi/pulumi-terraform-bridge feature. DO NOT MERGE.",
-               "automerge": false
-            }
+          repo: pulumi/pulumictl
+      - name: Trigger Update
+        run: pulumictl dispatch -r pulumi/${{ matrix.provider }} -c update-bridge ${{ github.event.inputs.bridgeVersion }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN}}
     strategy:
       fail-fast: false
       matrix:
         provider:
           - pulumi-aiven
-          # - pulumi-akamai
-          # - pulumi-alicloud
-          # - pulumi-auth0
-          # - pulumi-aws
-          # - pulumi-azure
-          # - pulumi-azuread
-          # - pulumi-azuredevops
-          # - pulumi-civo
-          # - pulumi-cloudamqp
-          # - pulumi-cloudflare
-          # - pulumi-cloudinit
-          # - pulumi-consul
-          # - pulumi-datadog
-          # - pulumi-digitalocean
-          # - pulumi-dnsimple
-          # - pulumi-docker
-          # - pulumi-equinix-metal
-          # - pulumi-f5bigip
-          # - pulumi-fastly
-          # - pulumi-gcp
-          # - pulumi-github
-          # - pulumi-gitlab
-          # - pulumi-hcloud
-          # - pulumi-kafka
-          # - pulumi-keycloak
-          # - pulumi-kong
-          # - pulumi-linode
-          # - pulumi-mailgun
-          # - pulumi-mongodbatlas
-          # - pulumi-mysql
-          # - pulumi-newrelic
-          # - pulumi-ns1
-          # - pulumi-okta
-          # - pulumi-openstack
-          # - pulumi-pagerduty
-          # - pulumi-postgresql
-          # - pulumi-rabbitmq
-          # - pulumi-rancher2
-          # - pulumi-random
-          # - pulumi-signalfx
-          # - pulumi-splunk
-          # - pulumi-spotinst
-          # - pulumi-tls
-          # - pulumi-vault
-          # - pulumi-venafi
-          # - pulumi-vsphere
-          # - pulumi-wavefront
+          - pulumi-akamai
+          - pulumi-alicloud
+          - pulumi-auth0
+          - pulumi-aws
+          - pulumi-azure
+          - pulumi-azuread
+          - pulumi-azuredevops
+          - pulumi-civo
+          - pulumi-cloudamqp
+          - pulumi-cloudflare
+          - pulumi-cloudinit
+          - pulumi-consul
+          - pulumi-datadog
+          - pulumi-digitalocean
+          - pulumi-dnsimple
+          - pulumi-docker
+          - pulumi-equinix-metal
+          - pulumi-f5bigip
+          - pulumi-fastly
+          - pulumi-gcp
+          - pulumi-github
+          - pulumi-gitlab
+          - pulumi-hcloud
+          - pulumi-kafka
+          - pulumi-keycloak
+          - pulumi-kong
+          - pulumi-linode
+          - pulumi-mailgun
+          - pulumi-mongodbatlas
+          - pulumi-mysql
+          - pulumi-newrelic
+          - pulumi-ns1
+          - pulumi-okta
+          - pulumi-openstack
+          - pulumi-pagerduty
+          - pulumi-postgresql
+          - pulumi-rabbitmq
+          - pulumi-rancher2
+          - pulumi-random
+          - pulumi-signalfx
+          - pulumi-splunk
+          - pulumi-spotinst
+          - pulumi-tls
+          - pulumi-vault
+          - pulumi-venafi
+          - pulumi-vsphere
+          - pulumi-wavefront

--- a/.github/workflows/update-providers.yml
+++ b/.github/workflows/update-providers.yml
@@ -1,4 +1,5 @@
-name: Update Providers with new bridge version
+name: Test the bridge by attemping to update providers
+
 on:
   workflow_dispatch:
     inputs:
@@ -6,71 +7,73 @@ on:
         description: 'Version of Bridge to upgrade to'
         required: true
 
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Upgrade ${{ matrix.provider }} to pulumi-terraform-bridge ${{ github.event.inputs.bridgeVersion }}
+    name: Test upgrading ${{ matrix.provider }} to pulumi-terraform-bridge ${{ github.event.inputs.bridgeVersion }}
     steps:
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.1.0
+      - name: Trigger upgrade
+        uses: peter-evans/repository-dispatch@v2
         with:
-          repo: pulumi/pulumictl
-      - name: Trigger Update
-        run: pulumictl dispatch -r pulumi/${{ matrix.provider }} -c update-bridge ${{ github.event.inputs.bridgeVersion }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN}}
+          token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          repository: pulumi/${{ matrix.provider }}
+          event-type: upgrade-bridge
+          client-payload: |-
+            {
+               {"target-bridge-version": ${{ toJSON(github.sha) }} },
+               {"pr-reviewers": ${{ toJSON(github.triggerring_actor) }} },
+               {"pr-description": "This PR was created to test a pulumi/pulumi-terraform-bridge feature. DO NOT MERGE.",
+               {"automerge": false}
+            }
     strategy:
       fail-fast: false
       matrix:
         provider:
           - pulumi-aiven
-          - pulumi-akamai
-          - pulumi-alicloud
-          - pulumi-auth0
-          - pulumi-aws
-          - pulumi-azure
-          - pulumi-azuread
-          - pulumi-azuredevops
-          - pulumi-civo
-          - pulumi-cloudamqp
-          - pulumi-cloudflare
-          - pulumi-cloudinit
-          - pulumi-consul
-          - pulumi-datadog
-          - pulumi-digitalocean
-          - pulumi-dnsimple
-          - pulumi-docker
-          - pulumi-equinix-metal
-          - pulumi-f5bigip
-          - pulumi-fastly
-          - pulumi-gcp
-          - pulumi-github
-          - pulumi-gitlab
-          - pulumi-hcloud
-          - pulumi-kafka
-          - pulumi-keycloak
-          - pulumi-kong
-          - pulumi-linode
-          - pulumi-mailgun
-          - pulumi-mongodbatlas
-          - pulumi-mysql
-          - pulumi-newrelic
-          - pulumi-ns1
-          - pulumi-okta
-          - pulumi-openstack
-          - pulumi-pagerduty
-          - pulumi-postgresql
-          - pulumi-rabbitmq
-          - pulumi-rancher2
-          - pulumi-random
-          - pulumi-signalfx
-          - pulumi-splunk
-          - pulumi-spotinst
-          - pulumi-tls
-          - pulumi-vault
-          - pulumi-venafi
-          - pulumi-vsphere
-          - pulumi-wavefront
+          # - pulumi-akamai
+          # - pulumi-alicloud
+          # - pulumi-auth0
+          # - pulumi-aws
+          # - pulumi-azure
+          # - pulumi-azuread
+          # - pulumi-azuredevops
+          # - pulumi-civo
+          # - pulumi-cloudamqp
+          # - pulumi-cloudflare
+          # - pulumi-cloudinit
+          # - pulumi-consul
+          # - pulumi-datadog
+          # - pulumi-digitalocean
+          # - pulumi-dnsimple
+          # - pulumi-docker
+          # - pulumi-equinix-metal
+          # - pulumi-f5bigip
+          # - pulumi-fastly
+          # - pulumi-gcp
+          # - pulumi-github
+          # - pulumi-gitlab
+          # - pulumi-hcloud
+          # - pulumi-kafka
+          # - pulumi-keycloak
+          # - pulumi-kong
+          # - pulumi-linode
+          # - pulumi-mailgun
+          # - pulumi-mongodbatlas
+          # - pulumi-mysql
+          # - pulumi-newrelic
+          # - pulumi-ns1
+          # - pulumi-okta
+          # - pulumi-openstack
+          # - pulumi-pagerduty
+          # - pulumi-postgresql
+          # - pulumi-rabbitmq
+          # - pulumi-rancher2
+          # - pulumi-random
+          # - pulumi-signalfx
+          # - pulumi-splunk
+          # - pulumi-spotinst
+          # - pulumi-tls
+          # - pulumi-vault
+          # - pulumi-venafi
+          # - pulumi-vsphere
+          # - pulumi-wavefront


### PR DESCRIPTION
Implements a replacement for downstream checks.

Requires https://github.com/pulumi/ci-mgmt/pull/691

Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/1166



Testing. Starting from this branch at commit e787c3.

I started this:
https://github.com/pulumi/pulumi-terraform-bridge/actions/runs/6539012605

Which started this:
https://github.com/pulumi/pulumi-aiven/actions/runs/6539014556/job/17756157909

Which opened this: https://github.com/pulumi/pulumi-aiven/pull/401

