### PR TITLE
Dependencies: update references to the new release

### DIFF
--- a/pf/go.mod
+++ b/pf/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.10.0
 	github.com/hashicorp/terraform-plugin-go v0.16.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
-	github.com/pulumi/pulumi-terraform-bridge/v3 v3.60.0
+	github.com/pulumi/pulumi-terraform-bridge/v3 v3.62.0
 	github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.6
 	github.com/stretchr/testify v1.8.4
 	google.golang.org/grpc v1.57.0

--- a/pf/tests/go.mod
+++ b/pf/tests/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-provider-tls/shim v0.0.0-00010101000000-000000000000
 	github.com/pulumi/pulumi-terraform-bridge/pf v0.0.0
 	github.com/pulumi/pulumi-terraform-bridge/testing v0.0.1
-	github.com/pulumi/pulumi-terraform-bridge/v3 v3.60.0
+	github.com/pulumi/pulumi-terraform-bridge/v3 v3.62.0
 	github.com/stretchr/testify v1.8.4
 	github.com/terraform-providers/terraform-provider-random/randomshim v0.0.0
 )


### PR DESCRIPTION
We have a bit of an automation gap around releases to keep these up-to-date. My preference would be to remove ./pf module if we can take a breaking change here https://github.com/pulumi/pulumi-terraform-bridge/issues/1445 instead of automating, doing manually for now, to keep referencing the right bridge module from the ./pf module.
