### PR TITLE
Introduce a flag to skip CheckConfg validations when using PF

### DIFF
--- a/pf/tfbridge/provider_checkconfig.go
+++ b/pf/tfbridge/provider_checkconfig.go
@@ -83,9 +83,14 @@ func (p *provider) CheckConfigWithContext(
 	// Store for use in subsequent ApplyDefaultInfoValues.
 	p.lastKnownProviderConfig = news
 
-	checkFailures, err := p.validateProviderConfig(ctx, urn, news)
-	if err != nil {
-		return nil, nil, err
+	var checkFailures []plugin.CheckFailure
+	var err error
+
+	if !p.info.SkipValidateProviderConfigForPluginFramework {
+		checkFailures, err = p.validateProviderConfig(ctx, urn, news)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 
 	// Ensure propreties marked secret in the schema have secret values.

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -120,6 +120,14 @@ type ProviderInfo struct {
 	// the bridge completed its original version based on the TF schema.
 	// A hook to enable custom schema modifications specific to a provider.
 	SchemaPostProcessor func(spec *pschema.PackageSpec)
+
+	// Disables validation of provider-level configuration for Plugin Framework based providers.
+	// Hybrid providers that utilize a mixture of Plugin Framework and SDKv2 based resources may
+	// opt into this to workaround slowdown in PF validators, since their configuration is
+	// already being checked by SDKv2 based validators.
+	//
+	// See also: pulumi/pulumi-terraform-bridge#1448
+	SkipValidateProviderConfigForPluginFramework bool
 }
 
 // Send logs or status logs to the user.


### PR DESCRIPTION
This is intended as a workaround for a performance issue, see:

https://github.com/pulumi/pulumi-terraform-bridge/issues/1448