### PR TITLE
Complete set of numeric types in MakeTerraformOutput

### DIFF
--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -1006,9 +1006,9 @@ func MakeTerraformOutput(p shim.Provider, v interface{},
 		switch val.Kind() {
 		case reflect.Bool:
 			return resource.NewBoolProperty(val.Bool())
-		case reflect.Int:
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 			return resource.NewNumberProperty(float64(val.Int()))
-		case reflect.Float64:
+		case reflect.Float32, reflect.Float64:
 			return resource.NewNumberProperty(val.Float())
 		case reflect.String:
 			// If the string is the special unknown property sentinel, reflect back an unknown computed property.  Note that

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -1077,7 +1077,7 @@ func MakeTerraformOutput(p shim.Provider, v interface{},
 			obj := MakeTerraformOutputs(p, outs, tfflds, psflds, assets, rawNames || useRawNames(tfs), supportsSecrets)
 			return resource.NewObjectProperty(obj)
 		default:
-			contract.Failf("Unexpected TF output property value: %#v", v)
+			contract.Failf("Unexpected TF output property value: %#v with type %#T", v, v)
 			return resource.NewNullProperty()
 		}
 	}

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -2413,3 +2413,34 @@ func TestExtractDefaultIntegerInputs(t *testing.T) {
 	})
 	assert.Equal(t, expected, ins)
 }
+
+func TestOutputNumberTypes(t *testing.T) {
+	tfs := shimv1.NewSchemaMap(map[string]*schemav1.Schema{
+		"aaa": {Type: schemav1.TypeInt},
+		"bbb": {Type: schemav1.TypeInt},
+		"ccc": {Type: schemav1.TypeInt},
+		"ddd": {Type: schemav1.TypeInt},
+		"eee": {Type: schemav1.TypeInt},
+		"fff": {Type: schemav1.TypeFloat},
+		"ggg": {Type: schemav1.TypeFloat},
+	})
+	inputs := map[string]interface{}{
+		"aaa": int8(50),
+		"bbb": int16(50),
+		"ccc": int32(50),
+		"ddd": int64(50),
+		"eee": int(50),
+		"fff": float32(50),
+		"ggg": float64(50),
+	}
+	outputs := MakeTerraformOutputs(shimv1.NewProvider(testTFProvider), inputs, tfs, map[string]*SchemaInfo{}, AssetTable{}, false, true)
+	assert.Equal(t, resource.PropertyMap{
+		"aaa": resource.NewNumberProperty(50),
+		"bbb": resource.NewNumberProperty(50),
+		"ccc": resource.NewNumberProperty(50),
+		"ddd": resource.NewNumberProperty(50),
+		"eee": resource.NewNumberProperty(50),
+		"fff": resource.NewNumberProperty(50),
+		"ggg": resource.NewNumberProperty(50),
+	}, outputs)
+}

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -2433,7 +2433,15 @@ func TestOutputNumberTypes(t *testing.T) {
 		"fff": float32(50),
 		"ggg": float64(50),
 	}
-	outputs := MakeTerraformOutputs(shimv1.NewProvider(testTFProvider), inputs, tfs, map[string]*SchemaInfo{}, AssetTable{}, false, true)
+	outputs := MakeTerraformOutputs(
+		shimv1.NewProvider(testTFProvider),
+		inputs,
+		tfs,
+		map[string]*SchemaInfo{},
+		AssetTable{},
+		false,
+		true,
+	)
 	assert.Equal(t, resource.PropertyMap{
 		"aaa": resource.NewNumberProperty(50),
 		"bbb": resource.NewNumberProperty(50),


### PR DESCRIPTION
This should fix #1441.

We were not correctly handling all terraform output types, missing out on int8, int16 etc...

The regression test added with this PR reproduced the issue.