### PR TITLE
Simplify AutoAliasing datasource check

### DIFF
--- a/pkg/tfbridge/auto_aliasing.go
+++ b/pkg/tfbridge/auto_aliasing.go
@@ -477,6 +477,15 @@ func aliasOrRenameDataSource(
 			MajorVersion: currentVersion,
 		})
 		prev.Current = ds.Tok
+
+		duplicates := []int{}
+		for i, v := range prev.Past {
+			if v.Name != prev.Current {
+				continue
+			}
+			duplicates = append(duplicates, i)
+		}
+		prev.Past = removeIndexes(prev.Past, duplicates)
 	}
 	for _, a := range prev.Past {
 		if a.MajorVersion != currentVersion {
@@ -488,4 +497,31 @@ func aliasOrRenameDataSource(
 			computed.Tok.Module().Name().String(), computed)
 	}
 
+}
+
+// Remove elements at indexes from src, then return the resulting array.
+//
+// indexes must be in sorted order from largest to smallest.
+func removeIndexes[T any](src []T, indexes []int) []T {
+	if len(indexes) == 0 {
+		return src
+	}
+	dst := make([]T, len(src)-len(indexes))
+	indexPtr, dstPtr := 0, 0
+	for i, v := range src {
+		if i == indexes[indexPtr] {
+			indexPtr++
+
+			// We are done, so copy the remaining elements in a block.
+			if indexPtr == len(indexes) {
+				copy(dst[dstPtr:], src[i+1:])
+				break
+			}
+
+			continue
+		}
+		dst[dstPtr] = v
+		dstPtr++
+	}
+	return dst
 }

--- a/pkg/tfbridge/auto_aliasing.go
+++ b/pkg/tfbridge/auto_aliasing.go
@@ -471,18 +471,12 @@ func aliasOrRenameDataSource(
 		return
 	}
 
-	var alreadyPresent bool
-	for _, a := range prev.Past {
-		if a.Name == prev.Current {
-			alreadyPresent = true
-			break
-		}
-	}
-	if !alreadyPresent && ds.Tok != prev.Current {
+	if prev.Current != ds.Tok {
 		prev.Past = append(prev.Past, alias[tokens.ModuleMember]{
 			Name:         prev.Current,
 			MajorVersion: currentVersion,
 		})
+		prev.Current = ds.Tok
 	}
 	for _, a := range prev.Past {
 		if a.MajorVersion != currentVersion {

--- a/pkg/tfbridge/util_test.go
+++ b/pkg/tfbridge/util_test.go
@@ -1,0 +1,61 @@
+package tfbridge
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRemoveIndexes(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		arr      []string
+		indexes  []int
+		expected []string
+	}{
+		{
+			arr:      []string{"a", "b", "c"},
+			indexes:  []int{1},
+			expected: []string{"a", "c"},
+		},
+		{
+			arr:      []string{"a", "b", "c"},
+			indexes:  []int{2},
+			expected: []string{"a", "b"},
+		},
+		{
+			arr:      []string{"a", "b", "c"},
+			indexes:  []int{0},
+			expected: []string{"b", "c"},
+		},
+		{
+			arr:      []string{"a", "b", "c"},
+			indexes:  []int{0, 2},
+			expected: []string{"b"},
+		},
+		{
+			arr:      []string{"a", "b", "c"},
+			indexes:  []int{0, 1},
+			expected: []string{"c"},
+		},
+		{
+			arr:      []string{"a", "b"},
+			expected: []string{"a", "b"},
+		},
+		{
+			arr:      []string{"a", "b"},
+			indexes:  []int{0, 1},
+			expected: []string{},
+		},
+		{}, // Empty inputs
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run("", func(t *testing.T) {
+			actual := removeIndexes(tt.arr, tt.indexes)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
This change correctly modifies `prev.Current` when we detect a mismatch between `prev.Current` and the actively set value. This improves correctness.