### PR TITLE
Convert examples only for schema lang

### DIFF
--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -95,7 +95,7 @@ const (
 
 func (l Language) shouldConvertExamples() bool {
 	switch l {
-	case Golang, NodeJS, Python, CSharp, Schema, PCL:
+	case Schema:
 		return true
 	}
 	return false

--- a/pkg/tfgen/main.go
+++ b/pkg/tfgen/main.go
@@ -158,14 +158,15 @@ func newTFGenCmd(pkg string, version string, prov tfbridge.ProviderInfo,
 			}
 
 			err := gen(opts)
-
-			// Exporting collected coverage data to the directory specified by COVERAGE_OUTPUT_DIR
-			if coverageTrackingOutputEnabled {
-				err = coverageTracker.exportResults(coverageOutputDir)
-			} else {
-				fmt.Println("Additional example conversion stats are available by setting COVERAGE_OUTPUT_DIR.")
+			if opts.Language.shouldConvertExamples() {
+				// Exporting collected coverage data to the directory specified by COVERAGE_OUTPUT_DIR
+				if coverageTrackingOutputEnabled {
+					err = coverageTracker.exportResults(coverageOutputDir)
+				} else {
+					fmt.Println("Additional example conversion stats are available by setting COVERAGE_OUTPUT_DIR.")
+				}
+				fmt.Println(coverageTracker.getShortResultSummary())
 			}
-			fmt.Println(coverageTracker.getShortResultSummary())
 
 			return err
 		}),


### PR DESCRIPTION
@t0yv0 noticed we were unnecessarily converting the hcl examples when calling tfgen for dotnet and other languages.  
This should prevent that, hopefully speeding up some builds and removing some duplicated work.