### PR TITLE
Check for compound default info values in provider schemas

### DIFF
--- a/internal/testprovider/schema_default_info.go
+++ b/internal/testprovider/schema_default_info.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2022, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/testprovider/schema_default_info.go
+++ b/internal/testprovider/schema_default_info.go
@@ -1,0 +1,66 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testprovider
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// Subset of pulumi-random provider.
+func ProviderDefaultInfo() *schema.Provider {
+	resourceRuleset := func() *schema.Resource {
+		return &schema.Resource{
+			Description: "Deploy a ruleset",
+			Schema:      resourceDefaultInfoSchema(),
+		}
+	}
+
+	return &schema.Provider{
+		Schema: map[string]*schema.Schema{},
+		ResourcesMap: map[string]*schema.Resource{
+			"default_ruleset": resourceRuleset(),
+		},
+	}
+}
+
+func resourceDefaultInfoSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:        schema.TypeString,
+			Required:    true,
+			ForceNew:    true,
+			Description: "Name of the ruleset.",
+		},
+		"description": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Brief summary of the ruleset and its intended use.",
+		},
+		"rules": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "List of rules to apply to the ruleset.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"id": {
+						Type:        schema.TypeString,
+						Computed:    true,
+						Description: "Unique rule identifier.",
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -515,7 +515,8 @@ type DefaultInfo struct {
 	ComputeDefault func(ctx context.Context, opts ComputeDefaultOptions) (interface{}, error)
 
 	// Value injects a raw literal value as the default.
-	// Note that this value must be a scalar!
+	// Note that only simple types such as string, int and boolean are currently supported here.
+	// Structs, slices and maps are not yet supported.
 	Value interface{}
 	// EnvVars to use for defaults. If none of these variables have values at runtime, the value of `Value` (if any)
 	// will be used as the default.

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -515,6 +515,7 @@ type DefaultInfo struct {
 	ComputeDefault func(ctx context.Context, opts ComputeDefaultOptions) (interface{}, error)
 
 	// Value injects a raw literal value as the default.
+	// Note that this value must be a scalar!
 	Value interface{}
 	// EnvVars to use for defaults. If none of these variables have values at runtime, the value of `Value` (if any)
 	// will be used as the default.

--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -556,13 +556,43 @@ func (g *schemaGenerator) genProperty(prop *variable) pschema.PropertySpec {
 			}
 			rt := reflect.TypeOf(defaultValue)
 			if rt != nil {
-				switch rt.Kind() {
-				case reflect.Array, reflect.Slice, reflect.Map, reflect.Struct:
+				switch kind := rt.Kind(); kind {
+				case
+					reflect.Bool,
+					reflect.Int,
+					reflect.Int8,
+					reflect.Int16,
+					reflect.Int32,
+					reflect.Int64,
+					reflect.Uint,
+					reflect.Uint8,
+					reflect.Uint16,
+					reflect.Uint32,
+					reflect.Uint64,
+					reflect.Float32,
+					reflect.Float64,
+					reflect.String:
+					// These are fine.
+				case
+					reflect.Uintptr,
+					reflect.Complex64,
+					reflect.Complex128,
+					reflect.Array,
+					reflect.Chan,
+					reflect.Func,
+					reflect.Interface,
+					reflect.Map,
+					reflect.Pointer,
+					reflect.Slice,
+					reflect.Struct,
+					reflect.UnsafePointer:
+					fallthrough
+				default:
 					contract.Failf(
-						"Property %v has a DefaultInfo Value which is not a scalar %v of type %T",
+						"Property %v has a DefaultInfo Value %v of kind %v which is not currently supported.",
 						prop.name,
 						prop.info.Default.Value,
-						prop.info.Default.Value,
+						kind.String(),
 					)
 				}
 			}

--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"sort"
 	"strings"
 
@@ -553,13 +554,13 @@ func (g *schemaGenerator) genProperty(prop *variable) pschema.PropertySpec {
 			if i, ok := defaultValue.(int); ok {
 				defaultValue = float64(i)
 			}
-			// rt := reflect.TypeOf(defaultValue)
-			// if rt != nil {
-			// 	switch rt.Kind() {
-			// 	case reflect.Array, reflect.Slice, reflect.Map, reflect.Struct:
-			// 		contract.Failf("Property %v has a DefaultInfo Value which is not a scalar %v of type %T", prop.name, prop.info.Default.Value, prop.info.Default.Value)
-			// 	}
-			// }
+			rt := reflect.TypeOf(defaultValue)
+			if rt != nil {
+				switch rt.Kind() {
+				case reflect.Array, reflect.Slice, reflect.Map, reflect.Struct:
+					contract.Failf("Property %v has a DefaultInfo Value which is not a scalar %v of type %T", prop.name, prop.info.Default.Value, prop.info.Default.Value)
+				}
+			}
 
 			if len(defaults.EnvVars) != 0 {
 				defaultInfo = &pschema.DefaultSpec{

--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -558,7 +558,12 @@ func (g *schemaGenerator) genProperty(prop *variable) pschema.PropertySpec {
 			if rt != nil {
 				switch rt.Kind() {
 				case reflect.Array, reflect.Slice, reflect.Map, reflect.Struct:
-					contract.Failf("Property %v has a DefaultInfo Value which is not a scalar %v of type %T", prop.name, prop.info.Default.Value, prop.info.Default.Value)
+					contract.Failf(
+						"Property %v has a DefaultInfo Value which is not a scalar %v of type %T",
+						prop.name,
+						prop.info.Default.Value,
+						prop.info.Default.Value,
+					)
 				}
 			}
 

--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -553,6 +553,13 @@ func (g *schemaGenerator) genProperty(prop *variable) pschema.PropertySpec {
 			if i, ok := defaultValue.(int); ok {
 				defaultValue = float64(i)
 			}
+			// rt := reflect.TypeOf(defaultValue)
+			// if rt != nil {
+			// 	switch rt.Kind() {
+			// 	case reflect.Array, reflect.Slice, reflect.Map, reflect.Struct:
+			// 		contract.Failf("Property %v has a DefaultInfo Value which is not a scalar %v of type %T", prop.name, prop.info.Default.Value, prop.info.Default.Value)
+			// 	}
+			// }
 
 			if len(defaults.EnvVars) != 0 {
 				defaultInfo = &pschema.DefaultSpec{

--- a/pkg/tfgen/generate_schema_test.go
+++ b/pkg/tfgen/generate_schema_test.go
@@ -377,19 +377,15 @@ func TestDefaultInfoFails(t *testing.T) {
 		Path: "non-nil",
 		Data: meta,
 	}
-	err = provider.ApplyAutoAliases()
 	require.NoError(t, err)
 	defer func() {
 		r := recover()
-		if r == nil {
-			assert.FailNow(t, "Expected an error.")
-		}
-		if _, ok := r.(string); !ok {
-			assert.FailNow(t, "Expected a string error.")
-		}
-		assert.Contains(t, r, "Property id has a DefaultInfo Value which is not a scalar")
+		assert.Contains(
+			t,
+			r,
+			"Property id has a DefaultInfo Value [default_id] of kind slice which is not currently supported.",
+		)
 	}()
-	_, _ = GenerateSchema(provider, diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{
-		Color: colors.Never,
-	}))
+	// Should panic
+	_, _ = GenerateSchema(provider, diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never}))
 }

--- a/pkg/tfgen/internal/testprovider/defaultinfo.go
+++ b/pkg/tfgen/internal/testprovider/defaultinfo.go
@@ -1,0 +1,76 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testprovider
+
+import (
+	"unicode"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+
+	testproviderdata "github.com/pulumi/pulumi-terraform-bridge/v3/internal/testprovider"
+)
+
+func ProviderDefaultInfo() tfbridge.ProviderInfo {
+
+	member := func(mod string, mem string) tokens.ModuleMember {
+		return tokens.ModuleMember("cloudflare" + ":" + mod + ":" + mem)
+	}
+
+	typ := func(mod string, typ string) tokens.Type {
+		return tokens.Type(member(mod, typ))
+	}
+
+	resource := func(mod string, res string) tokens.Type {
+		fn := string(unicode.ToLower(rune(res[0]))) + res[1:]
+		return typ(mod+"/"+fn, res)
+	}
+
+	return tfbridge.ProviderInfo{
+		P:           shimv2.NewProvider(testproviderdata.ProviderDefaultInfo()),
+		Name:        "default-info",
+		Description: "",
+		Keywords:    []string{"pulumi", "random"},
+		License:     "Apache-2.0",
+		Homepage:    "https://pulumi.io",
+		Repository:  "",
+		Config: map[string]*tfbridge.SchemaInfo{
+			"project": {
+				Default: &tfbridge.DefaultInfo{
+					Value: []string{"default_project"},
+				},
+			},
+		},
+		Resources: map[string]*tfbridge.ResourceInfo{
+			"default_ruleset": {
+				Tok: resource("index", "Ruleset"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"rules": {
+						Elem: &tfbridge.SchemaInfo{
+							Fields: map[string]*tfbridge.SchemaInfo{
+								"id": {
+									Default: &tfbridge.DefaultInfo{
+										Value: []string{"default_id"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
Should address #1325.  
This PR adds an early check for the type of `tfbridge.DefaultInfo.Value` since it only supports scalars.  
It also adds a line in the documentation about it and a regression test.