### PR TITLE
Revert "Convert examples only for schema lang (#1457)"

### DIFF
--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -96,7 +96,7 @@ const (
 
 func (l Language) shouldConvertExamples() bool {
 	switch l {
-	case Schema:
+	case Golang, NodeJS, Python, CSharp, Schema, PCL:
 		return true
 	}
 	return false

--- a/pkg/tfgen/main.go
+++ b/pkg/tfgen/main.go
@@ -158,16 +158,15 @@ func newTFGenCmd(pkg string, version string, prov tfbridge.ProviderInfo,
 			}
 
 			err := gen(opts)
-			if opts.Language.shouldConvertExamples() {
-				// Exporting collected coverage data to the directory specified by COVERAGE_OUTPUT_DIR
-				if coverageTrackingOutputEnabled {
-					err = coverageTracker.exportResults(coverageOutputDir)
-				} else {
-					fmt.Println("\nAdditional example conversion stats are available by setting COVERAGE_OUTPUT_DIR.")
-				}
-				fmt.Println(coverageTracker.getShortResultSummary())
-				printDocStats()
+
+			// Exporting collected coverage data to the directory specified by COVERAGE_OUTPUT_DIR
+			if coverageTrackingOutputEnabled {
+				err = coverageTracker.exportResults(coverageOutputDir)
+			} else {
+				fmt.Println("\nAdditional example conversion stats are available by setting COVERAGE_OUTPUT_DIR.")
 			}
+			fmt.Println(coverageTracker.getShortResultSummary())
+			printDocStats()
 
 			return err
 		}),


### PR DESCRIPTION
This reverts commit 208af5f67a4fb113f538d7b5006f6e7cf22c2c0e.

It appears this caused examples to drop out in providers builds. 

https://github.com/pulumi/pulumi-wavefront/pull/243/files#diff-dd8795ce491477200148a495c5d962f032c0059a24c69e46ebd62292da1f4f95L19
https://github.com/pulumi/pulumi-wavefront/pull/243/files#diff-2b53060bf768ab7dedcf0fdd6eb4737ab521698637136f642698fd8df1b537cfL44
https://github.com/pulumi/pulumi-okta/pull/421/files#diff-91ea5c561d6680ce81ac0ac976e7775894322d2afc3db4490b0b15bf5ab0f196L60