### PR TITLE
RFC: record aliases in provider

### DIFF
--- a/pf/internal/schemashim/datasource_map.go
+++ b/pf/internal/schemashim/datasource_map.go
@@ -53,3 +53,7 @@ func (m *schemaOnlyDataSourceMap) Range(each func(key string, value shim.Resourc
 func (*schemaOnlyDataSourceMap) Set(key string, value shim.Resource) {
 	panic("Set not supported - is it possible to treat this as immutable?")
 }
+
+func (*schemaOnlyDataSourceMap) AddAlias(alias, target string) {
+	panic("AddAlias not supported")
+}

--- a/pf/internal/schemashim/resource_map.go
+++ b/pf/internal/schemashim/resource_map.go
@@ -55,3 +55,7 @@ func (m *schemaOnlyResourceMap) Range(each func(key string, value shim.Resource)
 func (*schemaOnlyResourceMap) Set(key string, value shim.Resource) {
 	panic("Set not supported - is it possible to treat this as immutable?")
 }
+
+func (*schemaOnlyResourceMap) AddAlias(alias, target string) {
+	panic("AddAlias not supported")
+}

--- a/pf/tfbridge/packed_provider_info.go
+++ b/pf/tfbridge/packed_provider_info.go
@@ -1,0 +1,70 @@
+package tfbridge
+
+import (
+	"github.com/json-iterator/go"
+	pfmuxer "github.com/pulumi/pulumi-terraform-bridge/pf/internal/muxer"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	shimUtil "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/util"
+)
+
+func UnpackProviderInfo(jsonProviderInfo []byte, bareProvider shim.Provider) (*tfbridge.ProviderInfo, error) {
+	var marshalled WithProviderAliases
+	jsoni := jsoniter.ConfigCompatibleWithStandardLibrary
+	err := jsoni.Unmarshal(jsonProviderInfo, &marshalled)
+	if err != nil {
+		return nil, err
+	}
+	info := marshalled.Info.Unmarshal()
+	info.P = bareProvider
+
+	// Set the maps inside the provider
+	for a, t := range marshalled.ResourceAliases {
+		info.P.ResourcesMap().AddAlias(a, t)
+	}
+	for a, t := range marshalled.DatasourceAliases {
+		info.P.DataSourcesMap().AddAlias(a, t)
+	}
+
+	return info, nil
+}
+
+func PackProviderInfo(info *tfbridge.ProviderInfo) ([]byte, error) {
+	var resources shimUtil.AliasingResourceMap
+	var datasources shimUtil.AliasingResourceMap
+	if p, ok := info.P.(*shimUtil.AliasingProvider); ok {
+		resources = p.ResourceMap
+		datasources = p.DataSourceMap
+	} else if p, ok := info.P.(*pfmuxer.ProviderShim); ok {
+		resources = p.ResourcesMap().(shimUtil.AliasingResourceMap)
+		datasources = p.DataSourcesMap().(shimUtil.AliasingResourceMap)
+	} else {
+		panic("can't find aliases from this provider")
+	}
+
+	resourceAliases := make(map[string]string)
+	resources.RangeAliases(func(alias, target string) bool {
+		resourceAliases[alias] = target
+		return true
+	})
+
+	datasourceAliases := make(map[string]string)
+	datasources.RangeAliases(func(alias, target string) bool {
+		datasourceAliases[alias] = target
+		return true
+	})
+
+	marshalled := WithProviderAliases{
+		Info:              *tfbridge.MarshalProviderInfo(info),
+		ResourceAliases:   resourceAliases,
+		DatasourceAliases: datasourceAliases,
+	}
+	jsoni := jsoniter.ConfigCompatibleWithStandardLibrary
+	return jsoni.Marshal(marshalled)
+}
+
+type WithProviderAliases struct {
+	Info              tfbridge.MarshallableProviderInfo `json:"info"`
+	ResourceAliases   map[string]string                 `json:"resource_aliases,omitempty"`
+	DatasourceAliases map[string]string                 `json:"datasource_aliases,omitempty"`
+}

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -1237,7 +1237,7 @@ func (p *ProviderInfo) RenameResourceWithAlias(resourceName string, legacyTok to
 			currentInfo.Tok.Name().String()))
 	p.Resources[resourceName] = &currentInfo
 	p.Resources[legacyResourceName] = &legacyInfo
-	p.P.ResourcesMap().Set(legacyResourceName, p.P.ResourcesMap().Get(resourceName))
+	p.P.ResourcesMap().AddAlias(legacyResourceName, resourceName)
 }
 
 const (
@@ -1276,7 +1276,7 @@ func (p *ProviderInfo) RenameDataSource(resourceName string, legacyTok tokens.Mo
 			currentInfo.Tok.Name().String()))
 	p.DataSources[resourceName] = &currentInfo
 	p.DataSources[legacyResourceName] = &legacyInfo
-	p.P.DataSourcesMap().Set(legacyResourceName, p.P.DataSourcesMap().Get(resourceName))
+	p.P.DataSourcesMap().AddAlias(legacyResourceName, resourceName)
 }
 
 func generateResourceName(packageName tokens.Package, moduleName string, moduleMemberName string) string {

--- a/pkg/tfshim/schema/resource.go
+++ b/pkg/tfshim/schema/resource.go
@@ -78,3 +78,7 @@ func (m ResourceMap) Range(each func(key string, value shim.Resource) bool) {
 func (m ResourceMap) Set(key string, value shim.Resource) {
 	m[key] = value
 }
+
+func (m ResourceMap) AddAlias(alias, target string) {
+	m.Set(alias, m.Get(target))
+}

--- a/pkg/tfshim/sdk-v1/resource.go
+++ b/pkg/tfshim/sdk-v1/resource.go
@@ -144,3 +144,7 @@ func (m v1ResourceMap) Range(each func(key string, value shim.Resource) bool) {
 func (m v1ResourceMap) Set(key string, value shim.Resource) {
 	m[key] = value.(v1Resource).tf
 }
+
+func (m v1ResourceMap) AddAlias(alias, target string) {
+	m.Set(alias, m.Get(target))
+}

--- a/pkg/tfshim/sdk-v2/resource.go
+++ b/pkg/tfshim/sdk-v2/resource.go
@@ -155,3 +155,7 @@ func (m v2ResourceMap) Range(each func(key string, value shim.Resource) bool) {
 func (m v2ResourceMap) Set(key string, value shim.Resource) {
 	m[key] = value.(v2Resource).tf
 }
+
+func (m v2ResourceMap) AddAlias(alias, target string) {
+	m.Set(alias, m.Get(target))
+}

--- a/pkg/tfshim/shim.go
+++ b/pkg/tfshim/shim.go
@@ -180,6 +180,8 @@ type ResourceMap interface {
 	Range(each func(key string, value Resource) bool)
 
 	Set(key string, value Resource)
+
+	AddAlias(alias, target string)
 }
 
 type Provider interface {

--- a/pkg/tfshim/tfplugin5/resource.go
+++ b/pkg/tfshim/tfplugin5/resource.go
@@ -140,3 +140,7 @@ func (m resourceMap) Range(each func(key string, value shim.Resource) bool) {
 func (m resourceMap) Set(key string, value shim.Resource) {
 	m[key] = value.(*resource)
 }
+
+func (m resourceMap) AddAlias(alias, target string) {
+	m.Set(alias, m.Get(target))
+}

--- a/pkg/tfshim/util/aliasing_provider.go
+++ b/pkg/tfshim/util/aliasing_provider.go
@@ -1,0 +1,85 @@
+package util
+
+import (
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+)
+
+type AliasingProvider struct {
+	Provider      shim.Provider
+	ResourceMap   AliasingResourceMap
+	DataSourceMap AliasingResourceMap
+}
+
+var _ = (shim.Provider)((*AliasingProvider)(nil))
+
+func (p *AliasingProvider) Schema() shim.SchemaMap {
+	return p.Provider.Schema()
+}
+
+func (p *AliasingProvider) ResourcesMap() shim.ResourceMap {
+	return p.ResourceMap
+}
+
+func (p *AliasingProvider) DataSourcesMap() shim.ResourceMap {
+	return p.DataSourceMap
+}
+
+func (p *AliasingProvider) Validate(c shim.ResourceConfig) ([]string, []error) {
+	return p.Provider.Validate(c)
+}
+
+func (p *AliasingProvider) ValidateResource(t string, c shim.ResourceConfig) ([]string, []error) {
+	return p.Provider.ValidateResource(t, c)
+}
+
+func (p *AliasingProvider) ValidateDataSource(t string, c shim.ResourceConfig) ([]string, []error) {
+	return p.Provider.ValidateDataSource(t, c)
+}
+
+func (p *AliasingProvider) Configure(c shim.ResourceConfig) error {
+	return p.Provider.Configure(c)
+}
+
+func (p *AliasingProvider) Diff(t string, s shim.InstanceState, c shim.ResourceConfig) (shim.InstanceDiff, error) {
+	return p.Provider.Diff(t, s, c)
+}
+
+func (p *AliasingProvider) Apply(t string, s shim.InstanceState, d shim.InstanceDiff) (shim.InstanceState, error) {
+	return p.Provider.Apply(t, s, d)
+}
+
+func (p *AliasingProvider) Refresh(t string, s shim.InstanceState, c shim.ResourceConfig) (shim.InstanceState, error) {
+	return p.Provider.Refresh(t, s, c)
+}
+
+func (p *AliasingProvider) ReadDataDiff(t string, c shim.ResourceConfig) (shim.InstanceDiff, error) {
+	return p.Provider.ReadDataDiff(t, c)
+}
+
+func (p *AliasingProvider) ReadDataApply(t string, d shim.InstanceDiff) (shim.InstanceState, error) {
+	return p.Provider.ReadDataApply(t, d)
+}
+
+func (p *AliasingProvider) Meta() interface{} {
+	return p.Provider.Meta()
+}
+
+func (p *AliasingProvider) Stop() error {
+	return p.Provider.Stop()
+}
+
+func (p *AliasingProvider) InitLogging() {
+	p.Provider.InitLogging()
+}
+
+func (p *AliasingProvider) NewDestroyDiff() shim.InstanceDiff {
+	return p.Provider.NewDestroyDiff()
+}
+
+func (p *AliasingProvider) NewResourceConfig(object map[string]interface{}) shim.ResourceConfig {
+	return p.Provider.NewResourceConfig(object)
+}
+
+func (p *AliasingProvider) IsSet(v interface{}) ([]interface{}, bool) {
+	return p.Provider.IsSet(v)
+}

--- a/pkg/tfshim/util/aliasing_resource_map.go
+++ b/pkg/tfshim/util/aliasing_resource_map.go
@@ -1,0 +1,72 @@
+package util
+
+import (
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+)
+
+type AliasingResourceMap interface {
+	shim.ResourceMap
+	RangeAliases(each func(key, value string) bool)
+}
+
+type aliasingMap struct {
+	inner   shim.ResourceMap
+	aliases map[string]string
+}
+
+// A resource map that only supports modification by aliasing (Set is a panic)
+// and that can export all the aliases applied
+func NewAliasingResourceMap(inner shim.ResourceMap) AliasingResourceMap {
+	return &aliasingMap{inner: inner, aliases: make(map[string]string)}
+}
+
+func (a *aliasingMap) Get(key string) shim.Resource {
+	r, _ := a.GetOk(key)
+	return r
+}
+
+func (a *aliasingMap) GetOk(key string) (shim.Resource, bool) {
+	if otherKey, ok := a.aliases[key]; ok {
+		key = otherKey
+	}
+	return a.inner.GetOk(key)
+}
+
+func (a *aliasingMap) Range(each func(key string, value shim.Resource) bool) {
+	a.inner.Range(func(key string, value shim.Resource) bool {
+		if _, ok := a.aliases[key]; !ok {
+			return each(key, value)
+		}
+		return true
+	})
+	a.RangeAliases(func(alias, target string) bool {
+		return each(alias, a.inner.Get(target))
+	})
+}
+
+func (a *aliasingMap) Len() int {
+	n := a.inner.Len()
+	a.RangeAliases(func(k, v string) bool {
+		if _, ok := a.inner.GetOk(k); !ok {
+			n = n + 1
+		}
+		return true
+	})
+	return n
+}
+
+func (a *aliasingMap) Set(key string, value shim.Resource) {
+	panic("AliasingResourceMap does not allow Set")
+}
+
+func (a *aliasingMap) RangeAliases(each func(alias, target string) bool) {
+	for alias, target := range a.aliases {
+		if !each(alias, target) {
+			return
+		}
+	}
+}
+
+func (a *aliasingMap) AddAlias(alias, target string) {
+	a.aliases[alias] = target
+}

--- a/pkg/tfshim/util/filter.go
+++ b/pkg/tfshim/util/filter.go
@@ -152,4 +152,8 @@ func (f *filteringMap) Set(key string, value shim.Resource) {
 	f.inner.Set(key, value)
 }
 
+func (f *filteringMap) AddAlias(alias, target string) {
+	f.inner.AddAlias(alias, target)
+}
+
 var _ shim.ResourceMap = (*filteringMap)(nil)


### PR DESCRIPTION
This needs some cleaning still, but outlines a possible approach for recording the aliases in the provider shim so we can fully pack and unpack the provider info. 

I've tested this locally using the aws provider (https://github.com/pulumi/pulumi-aws/pull/2902). It appears to be working, and to offer a fairly significant speed up (>150ms in my local testing). 

Feedback that would be most helpful:
1) ideas for how to test
2) Any suggestions for how to inject the aliasing with a lighter touch