### PR TITLE
Fix broken commit link in generated messages

### DIFF
--- a/.github/workflows/update-providers-test.yml
+++ b/.github/workflows/update-providers-test.yml
@@ -33,7 +33,7 @@ jobs:
             {
                "target-bridge-version": ${{ toJSON(github.sha) }},
                "pr-reviewers": ${{ toJSON( github.triggering_actor || 't0yv0' ) }},
-               "pr-description": "This PR was created to test a pulumi/pulumi-terraform-bridge feature.\n\n- pulumi/pulumi-terraform-bridge#${{ github.event.number }}\n\n- https://github.com/pulumi/pulumi-terraform-bridge/${{github.sha}}\n\nDO NOT MERGE.",
+               "pr-description": "This PR was created to test a pulumi/pulumi-terraform-bridge feature.\n\n- pulumi/pulumi-terraform-bridge#${{ github.event.number }}\n\n- https://github.com/pulumi/pulumi-terraform-bridge/commit/${{github.sha}}\n\nDO NOT MERGE.",
                "automerge": false
             }
     strategy:


### PR DESCRIPTION
Before: https://github.com/pulumi/pulumi-terraform-bridge/${{github.sha}}
After: https://github.com/pulumi/pulumi-terraform-bridge/commit/${{github.sha}}