### PR TITLE
Propagate target Pulumi version

### DIFF
--- a/.github/workflows/update-providers-test.yml
+++ b/.github/workflows/update-providers-test.yml
@@ -11,6 +11,11 @@ on:
         type: string
         default: ""
         required: false
+      bridgeVersion:
+        description: 'Version of Bridge to upgrade to; defaults to current sha'
+        type: string
+        default: ""
+        required: false
 
   # # Alternatively, they can be triggered by opening a feature-* branch. Not having these enabled on
   # # normal branches and PRs is intentional as the checks consume a lot of resources.
@@ -46,7 +51,7 @@ jobs:
           client-payload: |-
             {
                "target-pulumi-version": ${{ toJSON(github.event.inputs.pulumiVersion) }},
-               "target-bridge-version": ${{ toJSON(github.sha) }},
+               "target-bridge-version": ${{ toJSON(github.event.inputs.bridgeVersion != "" && github.event.inputs.bridgeVersion || github.sha) }},
                "pr-reviewers": ${{ toJSON( github.triggering_actor || 't0yv0' ) }},
                "pr-description": "This PR was created to test a pulumi/pulumi-terraform-bridge feature.\n\n- pulumi/pulumi-terraform-bridge#${{ github.event.number }}\n\n- https://github.com/pulumi/pulumi-terraform-bridge/commit/${{github.sha}}\n\nDO NOT MERGE.",
                "automerge": false

--- a/.github/workflows/update-providers-test.yml
+++ b/.github/workflows/update-providers-test.yml
@@ -41,7 +41,7 @@ jobs:
         uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.PULUMI_BOT_TOKEN }}
-          repository: pulumi/${{ matrix.provider }}
+          repository: pulumi/pulumi-${{ matrix.provider }}
           event-type: upgrade-bridge
           client-payload: |-
             {

--- a/.github/workflows/update-providers-test.yml
+++ b/.github/workflows/update-providers-test.yml
@@ -5,7 +5,12 @@ on:
   # These checks can be triggerred manually from the Actions tab, which already lets you specify
   # which branch of the bridge to use for testing.
   workflow_dispatch:
-    inputs: {}
+    inputs:
+      pulumiVersion:
+        description: pulumi/pulumi version to use
+        type: string
+        default: ""
+        required: false
 
   # # Alternatively, they can be triggered by opening a feature-* branch. Not having these enabled on
   # # normal branches and PRs is intentional as the checks consume a lot of resources.
@@ -40,6 +45,7 @@ jobs:
           event-type: upgrade-bridge
           client-payload: |-
             {
+               "target-pulumi-version": ${{ toJSON(github.event.inputs.pulumiVersion) }},
                "target-bridge-version": ${{ toJSON(github.sha) }},
                "pr-reviewers": ${{ toJSON( github.triggering_actor || 't0yv0' ) }},
                "pr-description": "This PR was created to test a pulumi/pulumi-terraform-bridge feature.\n\n- pulumi/pulumi-terraform-bridge#${{ github.event.number }}\n\n- https://github.com/pulumi/pulumi-terraform-bridge/commit/${{github.sha}}\n\nDO NOT MERGE.",


### PR DESCRIPTION
This change permits testing pre-release pulumi/pulumi versions through provider PRs.