### PR TITLE
Refer to Terraform diff to generate a more precise diff

### DIFF
--- a/pkg/tfbridge/diff.go
+++ b/pkg/tfbridge/diff.go
@@ -313,7 +313,7 @@ func makeDetailedDiff(
 	// We want to make sure that we do not ignore these changes, if any.
 	// In order to look up whether our attributes have been added to the Pulumi `diff`, we first need to parse the
 	// Terraform diff paths (of the format `foo.0.bars.1.baz[...]`) to Pulumi (of the format `foo[0].bar[1].baz[...]`.
-	for path, _ := range tfDiff.Attributes() {
+	for path := range tfDiff.Attributes() {
 
 		pulumiPath, specificDiff := parseTFPath(path, tfs, ps)
 		// Look up the resulting path and register any diffs if not present in Pulumi diff.

--- a/pkg/tfbridge/diff.go
+++ b/pkg/tfbridge/diff.go
@@ -364,13 +364,8 @@ func parseTFPath(path string, tfs shim.SchemaMap, ps map[string]*SchemaInfo) (st
 				pulumiPath = pulumiPath + "[" + field + "]"
 			} else {
 				// Ignore special characters from Terraform
-				if field != "%" || field != "#" {
-					// These characters denote, in terraform, a schema object (in the case of "%"),
-					// or a list (in the case of "#").
-					// We drop the special character; this case is a no-op.
-					// These chars are also always final.
-					continue
-				} else {
+				if field != "%" && field != "#" {
+
 					// we do not have a number but a user set obj key.
 					// Since this is not a schema-set field, we do not translate to Pulumi here.
 					pulumiPath = pulumiPath + "." + field


### PR DESCRIPTION
This pull request looks at the Terraform Diff Attributes, checks if they exist in the Pulumi diff generated by `olds` and `news`, and adds any additional diff information to Pulumi diff.


Points of concern: 
- This change is not yet under test; suggestions or help modeling a schema map and schema info are welcome.
- How detailed we can make the property diff on each schema path? There's room for improvement here.


Addresses #1491.
