### PR TITLE
Add missing docs override

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -490,6 +490,11 @@ type DocInfo struct {
 	// this document will satisfy the criteria `docs/pulumiToken.md`
 	// The examples need to wrapped in the correct shortcodes
 	ReplaceExamplesSection bool
+
+	// Don't error when this doc is missing.
+	//
+	// This applies when PULUMI_MISSING_DOCS_ERROR="true".
+	AllowMissing bool
 }
 
 // GetImportDetails returns a string of import instructions defined in the Pulumi provider. Defaults to empty.

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -259,7 +259,7 @@ func getDocsForResource(g *Generator, source DocsSource, kind DocKind,
 		msg := fmt.Sprintf("could not find docs for %v %v. Override the Docs property in the %v mapping. See "+
 			"type tfbridge.DocInfo for details.", kind, formatEntityName(rawname), kind)
 
-		if cmdutil.IsTruthy(os.Getenv("PULUMI_MISSING_DOCS_ERROR")) {
+		if cmdutil.IsTruthy(os.Getenv("PULUMI_MISSING_DOCS_ERROR")) && !info.GetDocs().AllowMissing {
 			g.error(msg)
 			return entityDocs{}, fmt.Errorf(msg)
 		}


### PR DESCRIPTION
During provider updates, we occasionally have missing docs that we accept. We also set `PULUMI_MISSING_DOCS_ERROR=true` during updates so we are made aware. Right now, the solution is to set `tfbridge.DocInfo{Markdown: []byte(" ")}`, which prevents docs from ever showing up.

This PR adds a flag for this scenario, that mitigates the error for missing docs but doesn't preclude the doc showing up in the future.