### PR TITLE
Use TF Diff Attributes to set diff response changes when SkipDetailedDiffForChanges feature flag is set

### DIFF
--- a/internal/testprovider/schema.go
+++ b/internal/testprovider/schema.go
@@ -881,7 +881,7 @@ func AssertProvider(f func(data *schemav2.ResourceData)) *schemav2.Provider {
 	}
 }
 
-func AssertCustomizedDiffProvider(f func(data *schemav2.ResourceData)) *schemav2.Provider {
+func CustomizedDiffProvider(f func(data *schemav2.ResourceData)) *schemav2.Provider {
 	return &schemav2.Provider{
 		Schema: map[string]*schemav2.Schema{},
 		ResourcesMap: map[string]*schemav2.Resource{
@@ -890,44 +890,11 @@ func AssertCustomizedDiffProvider(f func(data *schemav2.ResourceData)) *schemav2
 					"labels": {Type: schemav2.TypeString, Optional: true, Computed: true},
 				},
 				SchemaVersion: 1,
-				MigrateState: func(v int, is *terraformv2.InstanceState, p interface{}) (*terraformv2.InstanceState, error) {
-					return is, nil
-				},
-				Create: func(data *schemav2.ResourceData, p interface{}) error {
-					data.SetId("0")
-					f(data)
-					return nil
-				},
-				Read: func(data *schemav2.ResourceData, p interface{}) error {
-					f(data)
-					return nil
-				},
-				Update: func(data *schemav2.ResourceData, p interface{}) error {
-					f(data)
-					return nil
-				},
-				Delete: func(data *schemav2.ResourceData, p interface{}) error {
-					f(data)
-					return nil
-				},
-				Timeouts: &schemav2.ResourceTimeout{
-					Create: Timeout(time.Second * 120),
-				},
-				Importer: &schemav2.ResourceImporter{
-					StateContext: func(_ context.Context, state *schemav2.ResourceData,
-						_ interface{}) ([]*schemav2.ResourceData, error) {
-
-						return []*schemav2.ResourceData{state}, nil
-					},
-				},
 				CustomizeDiff: func(ctx context.Context, diff *schemav2.ResourceDiff, i interface{}) error {
 					err := diff.SetNew("labels", "1")
 					return err
 				},
 			},
-		},
-		ConfigureFunc: func(data *schemav2.ResourceData) (interface{}, error) {
-			return nil, nil
 		},
 	}
 }

--- a/internal/testprovider/schema.go
+++ b/internal/testprovider/schema.go
@@ -880,3 +880,54 @@ func AssertProvider(f func(data *schemav2.ResourceData)) *schemav2.Provider {
 		},
 	}
 }
+
+func AssertCustomizedDiffProvider(f func(data *schemav2.ResourceData)) *schemav2.Provider {
+	return &schemav2.Provider{
+		Schema: map[string]*schemav2.Schema{},
+		ResourcesMap: map[string]*schemav2.Resource{
+			"test_resource": {
+				Schema: map[string]*schemav2.Schema{
+					"labels": {Type: schemav2.TypeString, Optional: true, Computed: true},
+				},
+				SchemaVersion: 1,
+				MigrateState: func(v int, is *terraformv2.InstanceState, p interface{}) (*terraformv2.InstanceState, error) {
+					return is, nil
+				},
+				Create: func(data *schemav2.ResourceData, p interface{}) error {
+					data.SetId("0")
+					f(data)
+					return nil
+				},
+				Read: func(data *schemav2.ResourceData, p interface{}) error {
+					f(data)
+					return nil
+				},
+				Update: func(data *schemav2.ResourceData, p interface{}) error {
+					f(data)
+					return nil
+				},
+				Delete: func(data *schemav2.ResourceData, p interface{}) error {
+					f(data)
+					return nil
+				},
+				Timeouts: &schemav2.ResourceTimeout{
+					Create: Timeout(time.Second * 120),
+				},
+				Importer: &schemav2.ResourceImporter{
+					StateContext: func(_ context.Context, state *schemav2.ResourceData,
+						_ interface{}) ([]*schemav2.ResourceData, error) {
+
+						return []*schemav2.ResourceData{state}, nil
+					},
+				},
+				CustomizeDiff: func(ctx context.Context, diff *schemav2.ResourceDiff, i interface{}) error {
+					err := diff.SetNew("labels", "1")
+					return err
+				},
+			},
+		},
+		ConfigureFunc: func(data *schemav2.ResourceData) (interface{}, error) {
+			return nil, nil
+		},
+	}
+}

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -132,7 +132,7 @@ type ProviderInfo struct {
 	// Disables using detailed diff to determine diff changes and falls back on the length of TF Diff Attributes.
 	//
 	// See https://github.com/pulumi/pulumi-terraform-bridge/issues/1501
-	SkipDetailedDiffForChanges bool
+	XSkipDetailedDiffForChanges bool
 }
 
 // Send logs or status logs to the user.

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -128,6 +128,11 @@ type ProviderInfo struct {
 	//
 	// See also: pulumi/pulumi-terraform-bridge#1448
 	SkipValidateProviderConfigForPluginFramework bool
+
+	// Disables using detailed diff to determine diff changes and falls back on the length of TF Diff Attributes.
+	//
+	// See https://github.com/pulumi/pulumi-terraform-bridge/issues/1501
+	SkipDetailedDiffForChanges bool
 }
 
 // Send logs or status logs to the user.

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -661,6 +661,15 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 	doIgnoreChanges(ctx, res.TF.Schema(), res.Schema.Fields, olds, news, req.GetIgnoreChanges(), diff)
 	detailedDiff, changes := makeDetailedDiff(ctx, res.TF.Schema(), res.Schema.Fields, olds, news, diff)
 
+	// There are some providers/situations which `makeDetailedDiff` distorts the expected changes, leading
+	// to changes being dropped by Pulumi.
+	// Until we address https://github.com/pulumi/pulumi-terraform-bridge/issues/1501, it is safer to refer
+	// to the Terraform Diff attribute length for setting the DiffResponse.
+	// We will still use `detailedDiff` for diff display purposes.
+	if p.info.SkipDetailedDiffForChanges && len(diff.Attributes()) > 0 {
+		changes = pulumirpc.DiffResponse_DIFF_SOME
+	}
+
 	// If there were changes in this diff, check to see if we have a replacement.
 	var replaces []string
 	var replaced map[string]bool

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -663,10 +663,12 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 
 	// There are some providers/situations which `makeDetailedDiff` distorts the expected changes, leading
 	// to changes being dropped by Pulumi.
-	// Until we address https://github.com/pulumi/pulumi-terraform-bridge/issues/1501, it is safer to refer
-	// to the Terraform Diff attribute length for setting the DiffResponse.
+	// Until we fix `makeDetailedDiff`, it is safer to refer to the Terraform Diff attribute length for setting
+	// the DiffResponse.
 	// We will still use `detailedDiff` for diff display purposes.
-	if p.info.SkipDetailedDiffForChanges && len(diff.Attributes()) > 0 {
+
+	// See also https://github.com/pulumi/pulumi-terraform-bridge/issues/1501.
+	if p.info.XSkipDetailedDiffForChanges && len(diff.Attributes()) > 0 {
 		changes = pulumirpc.DiffResponse_DIFF_SOME
 	}
 

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -1795,7 +1795,7 @@ func TestTransformOutputs(t *testing.T) {
 
 func TestSkipDetailedDiff(t *testing.T) {
 	provider := func(t *testing.T) *Provider {
-		p := testprovider.AssertCustomizedDiffProvider(func(data *schema.ResourceData) {})
+		p := testprovider.CustomizedDiffProvider(func(data *schema.ResourceData) {})
 		return &Provider{
 			tf:     shimv2.NewProvider(p),
 			config: shimv2.NewSchemaMap(p.Schema),


### PR DESCRIPTION
This PR presents an alternative fix for #1491.

Because `makeDetailedDiff` can distort the expected changes for a diff set via custom diffs in the upstream provider logic, we should not, in all cases, rely on it to provide us with an accurate `pulumirpc.DiffResponse.Changes` result. This PR does two things:

- Rely on the terraform Diff Attributes length to tell the engine that there are changes via the diff
- Gate this behavior behind a new feature flag, `SkipDetailedDiffForChanges`.

This code will continue to rely on `makeDetailedDiff` for setting the `DetailedDiff` field in all cases.

I have verified that this succeeds against [these test cases](https://github.com/pulumi/pulumi-gcp/pull/1310/files#diff-2e4fffe32720b3d310b4336cfdde6519ab1bf6d9e0d82b418299817fdf42a29fR191) when the GCP provider sets `SkipDetailedDiffForChanges` to True, and fails when set to False.

Fixes #1491 in the context of unblocking the GCP release.

