### PR TITLE
Respect schema secrets in Check

### DIFF
--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -605,8 +605,12 @@ func (p *Provider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (*pul
 
 	// After all is said and done, we need to go back and return only what got populated as a diff from the origin.
 	pinputs := MakeTerraformOutputs(p.tf, inputs, res.TF.Schema(), res.Schema.Fields, assets, false, p.supportsSecrets)
-	minputs, err := plugin.MarshalProperties(pinputs, plugin.MarshalOptions{
-		Label: fmt.Sprintf("%s.inputs", label), KeepUnknowns: true})
+
+	pinputsWithSecrets := MarkSchemaSecrets(ctx, res.TF.Schema(), res.Schema.Fields,
+		resource.NewObjectProperty(pinputs)).ObjectValue()
+
+	minputs, err := plugin.MarshalProperties(pinputsWithSecrets, plugin.MarshalOptions{
+		Label: fmt.Sprintf("%s.inputs", label), KeepUnknowns: true, KeepSecrets: true})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/1380 

Similarly to Plugin Framework resources, SDKv2 based resources will now proactively mark properties as secrets in the results of Check method if the upstream schema says that these properties are sensitive or else if SchemaInfo in the bridged provider specifies the Secret true option.