### PR TITLE
Augment `makeDetailedDiff` when replace is specified

### DIFF
--- a/internal/testprovider/schema.go
+++ b/internal/testprovider/schema.go
@@ -895,6 +895,19 @@ func CustomizedDiffProvider(f func(data *schemav2.ResourceData)) *schemav2.Provi
 					return err
 				},
 			},
+			"test_replace": {
+				Schema: map[string]*schemav2.Schema{
+					"labels": {Type: schemav2.TypeString, Optional: true, Computed: true},
+				},
+				SchemaVersion: 1,
+				CustomizeDiff: func(ctx context.Context, diff *schemav2.ResourceDiff, i interface{}) error {
+					err := diff.SetNew("labels", "1")
+					if err != nil {
+						return err
+					}
+					return diff.ForceNew("labels")
+				},
+			},
 		},
 	}
 }


### PR DESCRIPTION
This will fix (upon adoption) https://github.com/pulumi/pulumi-aws/issues/2971.

The design discussion for this PR is https://pulumi.slack.com/archives/C02FXTZEZ6W/p1699989102568939.

### Changes

If there is a replace on the underlying TF object (as indicated by `diff.RequiresNew() || diff.Destroy()`) but no associated replace in the wire return (`pulumirpc.DiffResponse.Replaces`), then we set `pulumirpc.DiffResponse.Replaces = pulumirpc.DiffResponse_DIFF_SOME` and insert `__meta` as needing a replace.