### PR TITLE
Fix missing nil check on docInfo for doc discovery

### DIFF
--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -259,9 +259,11 @@ func getDocsForResource(g *Generator, source DocsSource, kind DocKind,
 		msg := fmt.Sprintf("could not find docs for %v %v. Override the Docs property in the %v mapping. See "+
 			"type tfbridge.DocInfo for details.", kind, formatEntityName(rawname), kind)
 
-		if cmdutil.IsTruthy(os.Getenv("PULUMI_MISSING_DOCS_ERROR")) && !info.GetDocs().AllowMissing {
-			g.error(msg)
-			return entityDocs{}, fmt.Errorf(msg)
+		if cmdutil.IsTruthy(os.Getenv("PULUMI_MISSING_DOCS_ERROR")) {
+			if docInfo == nil || !docInfo.AllowMissing {
+				g.error(msg)
+				return entityDocs{}, fmt.Errorf(msg)
+			}
 		}
 
 		// Ideally, we would still want to still return an error here and let upstream callers handle it, but at the

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -1164,6 +1164,12 @@ func TestErrorMissingDocs(t *testing.T) {
 			docs:                 tfbridge.DocInfo{AllowMissing: true},
 			forbidMissingDocsEnv: "true",
 		},
+		// DocInfo is nil so we error because docs are missing
+		{
+			source:               mockSource{},
+			forbidMissingDocsEnv: "true",
+			expectErr:            true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1185,6 +1191,18 @@ func TestErrorMissingDocs(t *testing.T) {
 			}
 		})
 	}
+}
+func TestErrorNilDocs(t *testing.T) {
+	t.Run("", func(t *testing.T) {
+		g := &Generator{
+			sink: mockSink{t},
+		}
+		rawName := "nil_docs"
+		t.Setenv("PULUMI_MISSING_DOCS_ERROR", "true")
+		info := mockNilDocsResource{token: tokens.Token(rawName)}
+		_, err := getDocsForResource(g, mockSource{}, ResourceDocs, rawName, &info)
+		assert.NotNil(t, err)
+	})
 }
 
 type mockSource map[string]string
@@ -1238,6 +1256,15 @@ func (r *mockResource) GetDocs() *tfbridge.DocInfo {
 
 func (r *mockResource) GetTok() tokens.Token {
 	return r.token
+}
+
+type mockNilDocsResource struct {
+	token tokens.Token
+	mockResource
+}
+
+func (nr *mockNilDocsResource) GetDocs() *tfbridge.DocInfo {
+	return nil
 }
 
 func readfile(t *testing.T, file string) string {


### PR DESCRIPTION
This change adds a nil check on docInfo for handling of missing docs settings, without which an upgrade in GCP panicked on creation of a new resource whose docs could not be found.

With this change, `getDocsForResource` behaves in the following way:

1. Check if `PULUMI_MISSING_DOCS_ERROR` is set to true - if no, continue with a warning
2. if yes, verify the resource has any docs info - if no, return a docs error as per env var setting
3. if yes, there is docs info, check if `AllowMissing` is set to true - if no, return a docs error as docs are missing and we expect an error as per env var setting
4. if yes, continue with a warning, as we allow docs to be missed.

