### PR TITLE
Further improvements in runtime metadata loading

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -208,7 +208,7 @@ require (
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
-	github.com/segmentio/encoding v0.3.5 // indirect
+	github.com/segmentio/encoding v0.3.5
 	github.com/sergi/go-diff v1.3.1 // indirect
 	github.com/skeema/knownhosts v1.2.0 // indirect
 	github.com/spf13/cast v1.5.0 // indirect

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -133,6 +133,12 @@ type ProviderInfo struct {
 	//
 	// See https://github.com/pulumi/pulumi-terraform-bridge/issues/1501
 	XSkipDetailedDiffForChanges bool
+
+	// Enables generation of a trimmed, runtime-only metadata file
+	// to help reduce resource plugin start time
+	//
+	// See also pulumi/pulumi-terraform-bridge#1524
+	GenerateRuntimeMetadata bool
 }
 
 // Send logs or status logs to the user.

--- a/pkg/tfbridge/metadata.go
+++ b/pkg/tfbridge/metadata.go
@@ -61,3 +61,12 @@ func (info *MetadataInfo) assertValid() {
 	contract.Assertf(info.Path != "", "Path must be non-empty")
 
 }
+
+// trim the metadata to just the keys required for the runtime phase
+// in the future this method might also substitute compressed contents within some keys
+func (info *MetadataInfo) ExtractRuntimeMetadata() *MetadataInfo {
+	data, _ := metadata.New(nil)
+	metadata.CloneKey("auto-aliasing", info.Data, data)
+	metadata.CloneKey("mux", info.Data, data)
+	return &MetadataInfo{"runtime-bridge-metadata.json", ProviderMetadata(data)}
+}

--- a/pkg/tfbridge/metadata.go
+++ b/pkg/tfbridge/metadata.go
@@ -66,7 +66,7 @@ func (info *MetadataInfo) assertValid() {
 // in the future this method might also substitute compressed contents within some keys
 func (info *MetadataInfo) ExtractRuntimeMetadata() *MetadataInfo {
 	data, _ := metadata.New(nil)
-	metadata.CloneKey("auto-aliasing", info.Data, data)
+	metadata.CloneKey(aliasMetadataKey, info.Data, data)
 	metadata.CloneKey("mux", info.Data, data)
 	return &MetadataInfo{"runtime-bridge-metadata.json", ProviderMetadata(data)}
 }

--- a/pkg/tfbridge/metadata_test.go
+++ b/pkg/tfbridge/metadata_test.go
@@ -1,0 +1,34 @@
+package tfbridge
+
+import (
+	"testing"
+
+	md "github.com/pulumi/pulumi-terraform-bridge/v3/unstable/metadata"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetadataInfo(t *testing.T) {
+	data, err := md.New(nil)
+	require.NoError(t, err)
+
+	err = md.Set(data, "hi", []string{"hello", "world"})
+	require.NoError(t, err)
+	err = md.Set(data, "auto-aliasing", []string{"1", "2"})
+	require.NoError(t, err)
+	err = md.Set(data, "mux", []string{"a", "b"})
+	require.NoError(t, err)
+
+	marshalled := data.Marshal()
+	require.Equal(t, `{"auto-aliasing":["1","2"],"hi":["hello","world"],"mux":["a","b"]}`, string(marshalled))
+
+	info := NewProviderMetadata(marshalled)
+	assert.Equal(t, "bridge-metadata.json", info.Path)
+	marshalledInfo := (*md.Data)(info.Data).Marshal()
+	assert.Equal(t, `{"auto-aliasing":["1","2"],"hi":["hello","world"],"mux":["a","b"]}`, string(marshalledInfo))
+
+	runtimeMetadata := info.ExtractRuntimeMetadata()
+	assert.Equal(t, "runtime-bridge-metadata.json", runtimeMetadata.Path)
+	runtimeMarshalled := (*md.Data)(runtimeMetadata.Data).Marshal()
+	assert.Equal(t, `{"auto-aliasing":["1","2"],"mux":["a","b"]}`, string(runtimeMarshalled))
+}

--- a/pkg/tfbridge/tokens_test.go
+++ b/pkg/tfbridge/tokens_test.go
@@ -654,7 +654,7 @@ func TestMaxItemsOneAliasing(t *testing.T) {
 	// Save current state into metadata
 	autoAliasing(info, metadata)
 
-	v := string(metadata.Marshal())
+	v := string(metadata.MarshalIndent())
 	expected := `{
     "auto-aliasing": {
         "resources": {
@@ -681,14 +681,14 @@ func TestMaxItemsOneAliasing(t *testing.T) {
 
 	assert.True(t, *info.Resources["pkg_r1"].Fields["f1"].MaxItemsOne)
 	assert.False(t, *info.Resources["pkg_r1"].Fields["f2"].MaxItemsOne)
-	assert.Equal(t, expected, string(metadata.Marshal()))
+	assert.Equal(t, expected, string(metadata.MarshalIndent()))
 
 	// Apply metadata back into the provider again, making sure there isn't a diff
 	autoAliasing(info, metadata)
 
 	assert.True(t, *info.Resources["pkg_r1"].Fields["f1"].MaxItemsOne)
 	assert.False(t, *info.Resources["pkg_r1"].Fields["f2"].MaxItemsOne)
-	assert.Equal(t, expected, string(metadata.Marshal()))
+	assert.Equal(t, expected, string(metadata.MarshalIndent()))
 
 	// Validate that overrides work
 
@@ -716,7 +716,7 @@ func TestMaxItemsOneAliasing(t *testing.T) {
             }
         }
     }
-}`, string(metadata.Marshal()))
+}`, string(metadata.MarshalIndent()))
 }
 
 func TestMaxItemsOneAliasingExpiring(t *testing.T) {
@@ -741,7 +741,7 @@ func TestMaxItemsOneAliasingExpiring(t *testing.T) {
 	// Save current state into metadata
 	autoAliasing(info, metadata)
 
-	v := string(metadata.Marshal())
+	v := string(metadata.MarshalIndent())
 	expected := `{
     "auto-aliasing": {
         "resources": {
@@ -786,7 +786,7 @@ func TestMaxItemsOneAliasingExpiring(t *testing.T) {
             }
         }
     }
-}`, string(metadata.Marshal()))
+}`, string(metadata.MarshalIndent()))
 
 }
 
@@ -817,7 +817,7 @@ func TestMaxItemsOneAliasingNested(t *testing.T) {
 	// Save current state into metadata
 	autoAliasing(info, metadata)
 
-	v := string(metadata.Marshal())
+	v := string(metadata.MarshalIndent())
 	expected := `{
     "auto-aliasing": {
         "resources": {
@@ -851,7 +851,7 @@ func TestMaxItemsOneAliasingNested(t *testing.T) {
 	info = provider(false, true)
 	autoAliasing(info, metadata)
 
-	assert.Equal(t, expected, string(metadata.Marshal()))
+	assert.Equal(t, expected, string(metadata.MarshalIndent()))
 	assert.True(t, *info.Resources["pkg_r1"].Fields["f2"].Elem.Fields["n1"].MaxItemsOne)
 	assert.False(t, *info.Resources["pkg_r1"].Fields["f2"].Elem.Fields["n2"].MaxItemsOne)
 }
@@ -919,7 +919,7 @@ func TestMaxItemsOneAliasingWithAutoNaming(t *testing.T) {
                         }
                     }
                 }
-            }`, string((*md.Data)(p.MetadataInfo.Data).Marshal()))
+            }`, string((*md.Data)(p.MetadataInfo.Data).MarshalIndent()))
 	}
 
 	t.Run("auto-named-then-aliased", func(t *testing.T) {
@@ -1000,7 +1000,7 @@ func TestMaxItemsOneDataSourceAliasing(t *testing.T) {
                         }
                     }
                 }
-            }`, string((*md.Data)(p.MetadataInfo.Data).Marshal()))
+            }`, string((*md.Data)(p.MetadataInfo.Data).MarshalIndent()))
 	}
 
 	t.Run("auto-named-then-aliased", func(t *testing.T) {
@@ -1120,7 +1120,7 @@ func TestAutoAliasingChangeDataSources(t *testing.T) {
 		return func(t *testing.T) {
 			p := provider(t, current, name)
 			require.JSONEq(t, expected,
-				string((*md.Data)(p.MetadataInfo.Data).Marshal()))
+				string((*md.Data)(p.MetadataInfo.Data).MarshalIndent()))
 
 			// Regardless of the input and output, once we apply some name to
 			// our state, reapplying the same name to the new state should be
@@ -1128,7 +1128,7 @@ func TestAutoAliasingChangeDataSources(t *testing.T) {
 			t.Run("idempotent", func(t *testing.T) {
 				p := provider(t, expected, name)
 				require.JSONEq(t, expected,
-					string((*md.Data)(p.MetadataInfo.Data).Marshal()))
+					string((*md.Data)(p.MetadataInfo.Data).MarshalIndent()))
 			})
 		}
 	}

--- a/pkg/tfbridge/x/token_test.go
+++ b/pkg/tfbridge/x/token_test.go
@@ -531,7 +531,7 @@ func TestMaxItemsOneAliasing(t *testing.T) {
 	err = AutoAliasing(info, metadata)
 	require.NoError(t, err)
 
-	v := string(metadata.Marshal())
+	v := string(metadata.MarshalIndent())
 	expected := `{
     "auto-aliasing": {
         "resources": {
@@ -559,7 +559,7 @@ func TestMaxItemsOneAliasing(t *testing.T) {
 
 	assert.True(t, *info.Resources["pkg_r1"].Fields["f1"].MaxItemsOne)
 	assert.False(t, *info.Resources["pkg_r1"].Fields["f2"].MaxItemsOne)
-	assert.Equal(t, expected, string(metadata.Marshal()))
+	assert.Equal(t, expected, string(metadata.MarshalIndent()))
 
 	// Apply metadata back into the provider again, making sure there isn't a diff
 	err = AutoAliasing(info, metadata)
@@ -567,7 +567,7 @@ func TestMaxItemsOneAliasing(t *testing.T) {
 
 	assert.True(t, *info.Resources["pkg_r1"].Fields["f1"].MaxItemsOne)
 	assert.False(t, *info.Resources["pkg_r1"].Fields["f2"].MaxItemsOne)
-	assert.Equal(t, expected, string(metadata.Marshal()))
+	assert.Equal(t, expected, string(metadata.MarshalIndent()))
 
 	// Validate that overrides work
 
@@ -596,7 +596,7 @@ func TestMaxItemsOneAliasing(t *testing.T) {
             }
         }
     }
-}`, string(metadata.Marshal()))
+}`, string(metadata.MarshalIndent()))
 }
 
 func TestMaxItemsOneAliasingExpiring(t *testing.T) {
@@ -623,7 +623,7 @@ func TestMaxItemsOneAliasingExpiring(t *testing.T) {
 	err = AutoAliasing(info, metadata)
 	require.NoError(t, err)
 
-	v := string(metadata.Marshal())
+	v := string(metadata.MarshalIndent())
 	expected := `{
     "auto-aliasing": {
         "resources": {
@@ -669,7 +669,7 @@ func TestMaxItemsOneAliasingExpiring(t *testing.T) {
             }
         }
     }
-}`, string(metadata.Marshal()))
+}`, string(metadata.MarshalIndent()))
 
 }
 
@@ -702,7 +702,7 @@ func TestMaxItemsOneAliasingNested(t *testing.T) {
 	err = AutoAliasing(info, metadata)
 	require.NoError(t, err)
 
-	v := string(metadata.Marshal())
+	v := string(metadata.MarshalIndent())
 	expected := `{
     "auto-aliasing": {
         "resources": {
@@ -737,7 +737,7 @@ func TestMaxItemsOneAliasingNested(t *testing.T) {
 	err = AutoAliasing(info, metadata)
 	require.NoError(t, err)
 
-	assert.Equal(t, expected, string(metadata.Marshal()))
+	assert.Equal(t, expected, string(metadata.MarshalIndent()))
 	assert.True(t, *info.Resources["pkg_r1"].Fields["f2"].Elem.Fields["n1"].MaxItemsOne)
 	assert.False(t, *info.Resources["pkg_r1"].Fields["f2"].Elem.Fields["n2"].MaxItemsOne)
 }

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -947,7 +947,7 @@ func (g *Generator) UnstableGenerateFromSchema(genSchemaResult *GenerateSchemaRe
 
 		if info := g.info.MetadataInfo; info != nil {
 			files[info.Path] = (*metadata.Data)(info.Data).MarshalIndent()
-			if true {
+			if g.info.GenerateRuntimeMetadata {
 				runtimeInfo := info.ExtractRuntimeMetadata()
 				files[runtimeInfo.Path] = (*metadata.Data)(runtimeInfo.Data).Marshal()
 			}

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -946,7 +946,11 @@ func (g *Generator) UnstableGenerateFromSchema(genSchemaResult *GenerateSchemaRe
 		files = map[string][]byte{"schema.json": bytes}
 
 		if info := g.info.MetadataInfo; info != nil {
-			files[info.Path] = (*metadata.Data)(info.Data).Marshal()
+			files[info.Path] = (*metadata.Data)(info.Data).MarshalIndent()
+			if true {
+				runtimeInfo := info.ExtractRuntimeMetadata()
+				files[runtimeInfo.Path] = (*metadata.Data)(runtimeInfo.Data).Marshal()
+			}
 		}
 	case PCL:
 		if g.skipExamples {

--- a/unstable/metadata/metadata.go
+++ b/unstable/metadata/metadata.go
@@ -15,9 +15,8 @@
 package metadata
 
 import (
-	"encoding/json"
-	"github.com/json-iterator/go"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/segmentio/encoding/json"
 )
 
 // The underlying value of a metadata blob.
@@ -26,12 +25,12 @@ type Data struct{ m map[string]*json.RawMessage }
 func New(data []byte) (*Data, error) {
 	m := map[string]*json.RawMessage{}
 	if len(data) > 0 {
-		jsoni := jsoniter.ConfigCompatibleWithStandardLibrary
-		err := jsoni.Unmarshal(data, &m)
+		_, err := json.Parse(data, &m, json.ZeroCopy)
 		if err != nil {
 			return nil, err
 		}
 	}
+
 	return &Data{m}, nil
 }
 
@@ -59,8 +58,7 @@ func Set(d *Data, key string, value any) error {
 		delete(d.m, key)
 		return nil
 	}
-	jsoni := jsoniter.ConfigCompatibleWithStandardLibrary
-	data, err := jsoni.Marshal(value)
+	data, err := json.Marshal(value)
 	if err != nil {
 		return err
 	}
@@ -75,8 +73,7 @@ func Get[T any](d *Data, key string) (T, bool, error) {
 	if !ok {
 		return t, false, nil
 	}
-	jsoni := jsoniter.ConfigCompatibleWithStandardLibrary
-	err := jsoni.Unmarshal(*data, &t)
+	_, err := json.Parse(*data, &t, json.ZeroCopy)
 	return t, true, err
 }
 

--- a/unstable/metadata/metadata_test.go
+++ b/unstable/metadata/metadata_test.go
@@ -33,5 +33,5 @@ func TestMarshal(t *testing.T) {
         "hello",
         "world"
     ]
-}`, string(data.Marshal()))
+}`, string(data.MarshalIndent()))
 }

--- a/unstable/metadata/metadata_test.go
+++ b/unstable/metadata/metadata_test.go
@@ -28,10 +28,34 @@ func TestMarshal(t *testing.T) {
 	err = Set(data, "hi", []string{"hello", "world"})
 	assert.NoError(t, err)
 
+	marshalled := data.MarshalIndent()
 	assert.Equal(t, `{
     "hi": [
         "hello",
         "world"
     ]
-}`, string(data.MarshalIndent()))
+}`, string(marshalled))
+
+	parsed, err := New(marshalled)
+	assert.NoError(t, err)
+	read, _, err := Get[[]string](parsed, "hi")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"hello", "world"}, read)
+}
+
+func TestMarshalIndent(t *testing.T) {
+	data, err := New(nil)
+	require.NoError(t, err)
+
+	err = Set(data, "hi", []string{"hello", "world"})
+	assert.NoError(t, err)
+
+	marshalled := data.Marshal()
+	assert.Equal(t, `{"hi":["hello","world"]}`, string(marshalled))
+
+	parsed, err := New(marshalled)
+	assert.NoError(t, err)
+	read, _, err := Get[[]string](parsed, "hi")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"hello", "world"}, read)
 }


### PR DESCRIPTION
Two changes to further reduce metadata load times for large providers:
1) Use segmentio/encoding/json in zero-copy mode
2) Generate a trimmed, runtime-only copy of metadata

In particular, removing extra whitespace contributed the most improvement suggesting that we may be able to obtain further savings just by shortening or eliminating frequently repeated strings.

This change is equivalent to the first codegen option described in https://github.com/pulumi/pulumi-aws/issues/2799#issuecomment-1802540034 (and combining the two yields no further improvement).

Generation of the runtime-only metadata is controlled via a flag in the ProviderInfo to allow providers to opt in individually. 


### Benchmarks from AWS:
Before changes
```
BenchmarkProviderGen
BenchmarkProviderGen-12             	       6	 189483917 ns/op	331080480 B/op	 2222893 allocs/op
BenchmarkProviderNoGen
BenchmarkProviderNoGen-12           	       7	 160893363 ns/op	287969720 B/op	 1850232 allocs/op
```

With zero-copy deserializer
```
BenchmarkProviderGen
BenchmarkProviderGen-12             	       6	 179858674 ns/op	331078597 B/op	 2222880 allocs/op
BenchmarkProviderNoGen
BenchmarkProviderNoGen-12           	       7	 155430929 ns/op	287963872 B/op	 1850211 allocs/op
```

With zero-copy deserializer and trimmed runtime only metadata
```
BenchmarkRuntimeProviderGen
BenchmarkRuntimeProviderGen-12      	       8	 132763682 ns/op	331080280 B/op	 2222892 allocs/op
BenchmarkRuntimeProviderNoGen
BenchmarkRuntimeProviderNoGen-12    	      10	 108300512 ns/op	287966743 B/op	 1850214 allocs/op
```