### PR TITLE
Make computed outputs optional

### DIFF
--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -569,7 +569,7 @@ func (v *variable) optional() bool {
 		return true
 	}
 
-	//if we have an explicit marked as optional then let's return that
+	// if we have an explicit marked as optional then let's return that
 	if v.info != nil && v.info.MarkAsOptional != nil {
 		return *v.info.MarkAsOptional
 	}
@@ -579,6 +579,9 @@ func (v *variable) optional() bool {
 	// Note that config values with custom defaults are _not_ considered optional unless they are marked as such.
 	customDefault := !v.config && v.info != nil && v.info.HasDefault()
 	if v.out {
+		if v.schema != nil && v.schema.Computed() && !customDefault {
+			return true
+		}
 		return v.schema != nil && v.schema.Optional() && !v.schema.Computed() && !customDefault
 	}
 	return (v.schema != nil && v.schema.Optional() || v.schema.Computed()) || customDefault


### PR DESCRIPTION
Changes to address https://github.com/pulumi/pulumi-terraform-bridge/issues/1239

Not sure if it does the right thing though. I ran it for `pulumi-oci` and it produced a 100k line diff in the schema, essentially removing all required outputs.

`pulumi-oci` results here https://github.com/pulumi/pulumi-oci/pull/264