### PR TITLE
Don't alias deleted resources

### DIFF
--- a/pkg/tfbridge/auto_aliasing.go
+++ b/pkg/tfbridge/auto_aliasing.go
@@ -137,13 +137,19 @@ func (info *ProviderInfo) ApplyAutoAliases() error {
 	applyAliases := []func(){}
 
 	for tfToken, computed := range info.Resources {
-		r, _ := rMap.GetOk(tfToken)
+		r, ok := rMap.GetOk(tfToken)
+		if !ok {
+			continue
+		}
 		aliasResource(info, r, &applyAliases, hist.Resources,
 			computed, tfToken, currentVersion)
 	}
 
 	for tfToken, computed := range info.DataSources {
-		ds, _ := dMap.GetOk(tfToken)
+		ds, ok := dMap.GetOk(tfToken)
+		if !ok {
+			continue
+		}
 		aliasDataSource(info, ds, &applyAliases, hist.DataSources,
 			computed, tfToken, currentVersion)
 	}

--- a/pkg/tfgen/convert_cli.go
+++ b/pkg/tfgen/convert_cli.go
@@ -288,6 +288,7 @@ func (*cliConverter) convertViaPulumiCLI(
 
 	// Write out mappings files if necessary.
 	for _, m := range mappings {
+		m := m // Remove aliasing lint
 		mpi := tfbridge.MarshalProviderInfo(&m.info)
 		bytes, err := json.Marshal(mpi)
 		if err != nil {


### PR DESCRIPTION
Attempting to do so results in a `panic`:

```
panic: fatal: An assertion has failed: Module token '' missing module delimiter

goroutine 1 [running]:
github.com/pulumi/pulumi/sdk/v3/go/common/util/contract.failfast(...)
	/Users/iwahbe/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.93.0/go/common/util/contract/failfast.go:23
github.com/pulumi/pulumi/sdk/v3/go/common/util/contract.Assertf(0x0?, {0x1038ec419?, 0x103e6fd10?}, {0x14000c9ef88?, 0x14000c9ef98?, 0x102bac1fc?})
	/Users/iwahbe/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.93.0/go/common/util/contract/assert.go:35 +0xe0
github.com/pulumi/pulumi/sdk/v3/go/common/tokens.Module.Name({0x0, 0x0})
	/Users/iwahbe/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.93.0/go/common/tokens/tokens.go:166 +0x7c
github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge.aliasOrRenameResource(0x14000c9f0a8?, 0x140005e3080, {0x1038b16ab, 0x18}, 0x14000a0ebc0, 0x0)
	/Users/iwahbe/go/pkg/mod/github.com/pulumi/pulumi-terraform-bridge/v3@v3.65.0/pkg/tfbridge/auto_aliasing.go:416 +0x320
github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge.aliasResource.func1()
	/Users/iwahbe/go/pkg/mod/github.com/pulumi/pulumi-terraform-bridge/v3@v3.65.0/pkg/tfbridge/auto_aliasing.go:201 +0x34
github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge.(*ProviderInfo).ApplyAutoAliases(0x14000943680)
	/Users/iwahbe/go/pkg/mod/github.com/pulumi/pulumi-terraform-bridge/v3@v3.65.0/pkg/tfbridge/auto_aliasing.go:152 +0x294
github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge.(*ProviderInfo).MustApplyAutoAliases(0x10388d21d?)
	/Users/iwahbe/go/pkg/mod/github.com/pulumi/pulumi-terraform-bridge/v3@v3.65.0/pkg/tfbridge/auto_aliasing.go:85 +0x1c
github.com/pulumi/pulumi-spotinst/provider/v3.Provider()
	/Users/iwahbe/go/src/github.com/pulumi/pulumi-spotinst/provider/resources.go:193 +0x1e34
main.main()
	/Users/iwahbe/go/src/github.com/pulumi/pulumi-spotinst/provider/cmd/pulumi-tfgen-spotinst/main.go:26 +0x24
make: *** [tfgen] Error
```

This issue made upgrading spotonist very confusing, since the new version deleted some resource and caused the bridge to panic.