### PR TITLE
Make assert actionable

### DIFF
--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -273,7 +273,8 @@ func (m *module) config() bool {
 func (m *module) addMember(member moduleMember) {
 	name := member.Name()
 	for _, existing := range m.members {
-		contract.Assertf(existing.Name() != name, "unexpected duplicate module member %s", name)
+		contract.Assertf(existing.Name() != name, "unexpected duplicate module member %q in %q",
+			name, m.name.String())
 	}
 	m.members = append(m.members, member)
 }


### PR DESCRIPTION
I was triggering this assert as part of upgrading pulumi-alicloud. The message should include enough information to debug the issue, which means at least the *module name* and duplicate member name.