### PR TITLE
Dont apply defaults to properties which have requiredWith

### DIFF
--- a/pf/internal/schemashim/attr_schema.go
+++ b/pf/internal/schemashim/attr_schema.go
@@ -16,6 +16,7 @@ package schemashim
 
 import (
 	"fmt"
+
 	bridge "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 
 	pfattr "github.com/hashicorp/terraform-plugin-framework/attr"
@@ -53,9 +54,11 @@ func (s *attrSchema) Required() bool {
 func (*attrSchema) Default() interface{} {
 	panic("Default() should not be called during schema generation")
 }
+
 func (*attrSchema) DefaultFunc() shim.SchemaDefaultFunc {
 	panic("DefaultFunc() should not be called during schema generation")
 }
+
 func (*attrSchema) DefaultValue() (interface{}, error) {
 	// DefaultValue() should not be called by tfgen, but it currently may be called by ExtractInputsFromOutputs, so
 	// returning nil is better than a panic.
@@ -135,10 +138,14 @@ func (*attrSchema) MinItems() int {
 
 func (*attrSchema) ConflictsWith() []string {
 	panic("ConflictsWith() should not be called during schema generation")
-
 }
+
 func (*attrSchema) ExactlyOneOf() []string {
 	panic("ExactlyOneOf() should not be called during schema generation")
+}
+
+func (*attrSchema) RequiredWith() []string {
+	panic("RequiredWith() should not be called during schema generation")
 }
 
 func (s *attrSchema) Deprecated() string {

--- a/pf/internal/schemashim/block_schema.go
+++ b/pf/internal/schemashim/block_schema.go
@@ -55,7 +55,6 @@ func (s *blockSchema) Description() string {
 
 // Needs to return a shim.Schema, a shim.Resource, or nil. See docstring on shim.Schema.Elem().
 func (s *blockSchema) Elem() interface{} {
-
 	asObjectType := func(typ any) (shim.Resource, bool) {
 		if tt, ok := typ.(basetypes.ObjectTypable); ok {
 			var res shim.Resource = newObjectPseudoResource(tt,
@@ -138,6 +137,10 @@ func (*blockSchema) DefaultValue() (interface{}, error) {
 
 func (*blockSchema) ExactlyOneOf() []string {
 	panic("ExactlyOneOf() should not be called during schema generation")
+}
+
+func (*blockSchema) RequiredWith() []string {
+	panic("RequiredWith() should not be called during schema generation")
 }
 
 func (*blockSchema) SetElement(config interface{}) (interface{}, error) {

--- a/pf/internal/schemashim/type_schema.go
+++ b/pf/internal/schemashim/type_schema.go
@@ -115,6 +115,10 @@ func (*typeSchema) ExactlyOneOf() []string {
 	panic("ExactlyOneOf() should not be called during schema generation")
 }
 
+func (*typeSchema) RequiredWith() []string {
+	panic("RequiredWith() should not be called during schema generation")
+}
+
 func (*typeSchema) Removed() string { panic("Removed() should not be called during schema generation") }
 
 func (*typeSchema) UnknownValue() interface{} {

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -1247,7 +1247,7 @@ func (p *Provider) Invoke(ctx context.Context, req *pulumirpc.InvokeRequest) (*p
 		return nil, errors.Wrapf(err, "couldn't prepare resource %v input state", tfname)
 	}
 
-	// Next, ensure the inputs are valid before actually performing the invoaction.
+	// Next, ensure the inputs are valid before actually performing the invocation.
 	rescfg := MakeTerraformConfigFromInputs(p.tf, inputs)
 	warns, errs := p.tf.ValidateDataSource(tfname, rescfg)
 	for _, warn := range warns {
@@ -1499,13 +1499,13 @@ func SetProviderLicense(license TFProviderLicense) *TFProviderLicense {
 	return &license
 }
 
-// True is used for interations in the providers that require a pointer to true
+// True is used for interactions in the providers that require a pointer to true
 func True() *bool {
 	x := true
 	return &x
 }
 
-// False is used for interations in the providers that require a pointer to false
+// False is used for interactions in the providers that require a pointer to false
 func False() *bool {
 	x := false
 	return &x

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"q"
 	"reflect"
 	"sort"
 	"strconv"
@@ -667,8 +666,6 @@ func (ctx *conversionContext) applyDefaults(
 	conflictsWith := buildConflictsWith(result, tfs)
 	exactlyOneOf := buildExactlyOneOfsWith(result, tfs)
 	requiredWith := buildRequiredWith(result, tfs)
-
-	q.Q(requiredWith, tfs)
 
 	// First, attempt to use the overlays.
 	for name, info := range ps {

--- a/pkg/tfbridge/schema_provider_test.go
+++ b/pkg/tfbridge/schema_provider_test.go
@@ -21,8 +21,10 @@ func schemaMap(m map[string]*schema.Schema) shim.SchemaMap {
 	return mm
 }
 
-var testTFProvider = testprovider.ProviderV1()
-var testTFProviderV2 = testprovider.ProviderV2()
+var (
+	testTFProvider   = testprovider.ProviderV1()
+	testTFProviderV2 = testprovider.ProviderV2()
+)
 
 type shimFactory interface {
 	SDKVersion() string
@@ -134,7 +136,8 @@ func (f shimv1Factory) NewResource(r *schema.Resource) shim.Resource {
 
 func (f shimv1Factory) NewInstanceState(id string) shim.InstanceState {
 	return shimv1.NewInstanceState(&terraformv1.InstanceState{
-		ID: id, Attributes: map[string]string{}, Meta: map[string]interface{}{}})
+		ID: id, Attributes: map[string]string{}, Meta: map[string]interface{}{},
+	})
 }
 
 func (f shimv1Factory) NewTestProvider() shim.Provider {
@@ -188,6 +191,7 @@ func (f shimv2Factory) newSchema(m shim.Schema) *schemav2.Schema {
 		MaxItems:      m.MaxItems(),
 		MinItems:      m.MinItems(),
 		ConflictsWith: m.ConflictsWith(),
+		RequiredWith:  m.RequiredWith(),
 		Deprecated:    m.Deprecated(),
 		Sensitive:     m.Sensitive(),
 		ExactlyOneOf:  m.ExactlyOneOf(),
@@ -245,7 +249,8 @@ func (f shimv2Factory) NewResource(r *schema.Resource) shim.Resource {
 
 func (f shimv2Factory) NewInstanceState(id string) shim.InstanceState {
 	return shimv2.NewInstanceState(&terraformv2.InstanceState{
-		ID: id, Attributes: map[string]string{}, Meta: map[string]interface{}{}})
+		ID: id, Attributes: map[string]string{}, Meta: map[string]interface{}{},
+	})
 }
 
 func (f shimv2Factory) NewTestProvider() shim.Provider {

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -41,8 +41,8 @@ import (
 )
 
 func makeTerraformInputs(olds, news resource.PropertyMap,
-	tfs shim.SchemaMap, ps map[string]*SchemaInfo) (map[string]interface{}, AssetTable, error) {
-
+	tfs shim.SchemaMap, ps map[string]*SchemaInfo,
+) (map[string]interface{}, AssetTable, error) {
 	ctx := &conversionContext{Assets: AssetTable{}}
 	inputs, err := ctx.MakeTerraformInputs(olds, news, tfs, ps, false)
 	if err != nil {
@@ -52,8 +52,8 @@ func makeTerraformInputs(olds, news resource.PropertyMap,
 }
 
 func makeTerraformInputsWithDefaults(olds, news resource.PropertyMap,
-	tfs shim.SchemaMap, ps map[string]*SchemaInfo) (map[string]interface{}, AssetTable, error) {
-
+	tfs shim.SchemaMap, ps map[string]*SchemaInfo,
+) (map[string]interface{}, AssetTable, error) {
 	ctx := &conversionContext{
 		Assets:        AssetTable{},
 		ApplyDefaults: true,
@@ -362,7 +362,8 @@ func TestMakeTerraformInputMixedMaxItemsOne(t *testing.T) {
 			oldState: resource.NewArrayProperty([]resource.PropertyValue{
 				resource.NewArrayProperty([]resource.PropertyValue{
 					resource.NewStringProperty("sc"),
-				})}),
+				}),
+			}),
 			newState: resource.NewArrayProperty([]resource.PropertyValue{
 				resource.NewStringProperty("sc"),
 			}),
@@ -932,6 +933,10 @@ func TestDefaults(t *testing.T) {
 				"x1of2": {Type: shim.TypeString, ExactlyOneOf: x1ofN, DefaultFunc: fixedDefault(nil)},
 				"x1of3": {Type: shim.TypeString, ExactlyOneOf: x1ofN, DefaultFunc: fixedDefault(nil)},
 
+				// Test required with behavior: default should not be applied
+				"requiredWith1": {Type: shim.TypeString, RequiredWith: []string{"requiredWith2"}, Default: "", Optional: true},
+				"requiredWith2": {Type: shim.TypeString, RequiredWith: []string{"requiredWith1"}, Optional: true},
+
 				// Default value application across types
 				"x2stringxbool": {Type: shim.TypeString},
 				"x2stringxint":  {Type: shim.TypeString},
@@ -1040,7 +1045,7 @@ func TestDefaults(t *testing.T) {
 
 			outputs = MakeTerraformOutputs(f.NewTestProvider(), inputs, tfs, ps, assets, false, true)
 
-			//sort the defaults list before the equality test below.
+			// sort the defaults list before the equality test below.
 			sortDefaultsList(outputs)
 			assert.Equal(t, resource.NewPropertyMapFromMap(map[string]interface{}{
 				defaultsKey: []interface{}{
@@ -1127,7 +1132,6 @@ func TestInvalidAsset(t *testing.T) {
 }
 
 func TestOverridingTFSchema(t *testing.T) {
-
 	tfInputs := map[string]interface{}{
 		"pulumi_override_tf_string_to_boolean":    MyString("true"),
 		"pulumi_override_tf_string_to_bool":       MyString("true"),
@@ -1506,7 +1510,6 @@ func TestImporterWithMultipleNewIDs(t *testing.T) {
 }
 
 func TestImporterWithNoResource(t *testing.T) {
-
 	tfProvider := makeTestTFProvider(map[string]*schemav1.Schema{},
 		func(d *schemav1.ResourceData, meta interface{}) ([]*schemav1.ResourceData, error) {
 			// Return nothing
@@ -1877,7 +1880,6 @@ func TestExtractInputsFromOutputs(t *testing.T) {
 		"inputH": "Input_H_Default",
 		"inoutK": "",
 	}), ins)
-
 }
 
 // This schema replicates the panic behavior of

--- a/pkg/tfshim/schema/schema.go
+++ b/pkg/tfshim/schema/schema.go
@@ -27,6 +27,7 @@ type Schema struct {
 	MinItems      int
 	ConflictsWith []string
 	ExactlyOneOf  []string
+	RequiredWith  []string
 	Removed       string
 	Deprecated    string
 	Sensitive     bool
@@ -111,6 +112,10 @@ func (s SchemaShim) ConflictsWith() []string {
 
 func (s SchemaShim) ExactlyOneOf() []string {
 	return s.V.ExactlyOneOf
+}
+
+func (s SchemaShim) RequiredWith() []string {
+	return s.V.RequiredWith
 }
 
 func (s SchemaShim) Removed() string {

--- a/pkg/tfshim/sdk-v1/schema.go
+++ b/pkg/tfshim/sdk-v1/schema.go
@@ -6,8 +6,10 @@ import (
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
-var _ = shim.Schema(v1Schema{})
-var _ = shim.SchemaMap(v1SchemaMap{})
+var (
+	_ = shim.Schema(v1Schema{})
+	_ = shim.SchemaMap(v1SchemaMap{})
+)
 
 // UnknownVariableValue is the sentinal defined in github.com/hashicorp/terraform/configs/hcl2shim,
 // representing a variable whose value is not known at some particular time. The value is duplicated here in
@@ -105,6 +107,10 @@ func (s v1Schema) ConflictsWith() []string {
 
 func (s v1Schema) ExactlyOneOf() []string {
 	return s.tf.ExactlyOneOf
+}
+
+func (s v1Schema) RequiredWith() []string {
+	return []string{}
 }
 
 func (s v1Schema) Removed() string {

--- a/pkg/tfshim/sdk-v2/schema.go
+++ b/pkg/tfshim/sdk-v2/schema.go
@@ -6,8 +6,10 @@ import (
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
-var _ = shim.Schema(v2Schema{})
-var _ = shim.SchemaMap(v2SchemaMap{})
+var (
+	_ = shim.Schema(v2Schema{})
+	_ = shim.SchemaMap(v2SchemaMap{})
+)
 
 // UnknownVariableValue is the sentinal defined in github.com/hashicorp/terraform/configs/hcl2shim,
 // representing a variable whose value is not known at some particular time. The value is duplicated here in
@@ -105,6 +107,10 @@ func (s v2Schema) ConflictsWith() []string {
 
 func (s v2Schema) ExactlyOneOf() []string {
 	return s.tf.ExactlyOneOf
+}
+
+func (s v2Schema) RequiredWith() []string {
+	return s.tf.RequiredWith
 }
 
 func (s v2Schema) Removed() string {

--- a/pkg/tfshim/shim.go
+++ b/pkg/tfshim/shim.go
@@ -129,6 +129,7 @@ type Schema interface {
 	MinItems() int
 	ConflictsWith() []string
 	ExactlyOneOf() []string
+	RequiredWith() []string
 	Deprecated() string
 	Removed() string
 	Sensitive() bool

--- a/pkg/tfshim/tfplugin5/schema.go
+++ b/pkg/tfshim/tfplugin5/schema.go
@@ -88,6 +88,10 @@ func (s *attributeSchema) ExactlyOneOf() []string {
 	return nil
 }
 
+func (s *attributeSchema) RequiredWith() []string {
+	return nil
+}
+
 func (s *attributeSchema) AtLeastOneOf() []string {
 	return nil
 }


### PR DESCRIPTION
This should fix https://github.com/pulumi/pulumi-azuredevops/issues/66

This PR changes the behaviour of applying defaults to properties with `requiredWith` in the TF schema. We will no longer apply the defaults to them.

I'm wondering if we should limit this to "trivial" defaults, like the one in the issue above. 


The behaviour in the bridge here is slightly different to what TF does. We seem to apply the terraform defaults BEFORE validating the config, while terraform seems to apply the defaults AFTER applying defaults. I've got a longer discussion of this here https://github.com/pulumi/pulumi-azuredevops/issues/66#issuecomment-1829880996. 
We might want to look into that too, perhaps we can separate tf defaults from pulumi ones in `applyDefaults` and apply the tf ones after validating the config in `Check`.