### PR TITLE
Allow the `Type` override to effect downstream types

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -416,6 +416,10 @@ type SchemaInfo struct {
 	CSharpName string
 
 	// a type to override the default; "" uses the default.
+	//
+	// If the type overriden is an object type, `Type: newName` is interpreted as a
+	// move operation, pointing the property to a type called `newName` and creating
+	// `newName` with the schema described by this type.
 	Type tokens.Type
 
 	// alternative types that can be used instead of the override.

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -417,7 +417,7 @@ type SchemaInfo struct {
 
 	// a type to override the default; "" uses the default.
 	//
-	// If the type overriden is an object type, `Type: newName` is interpreted as a
+	// If the type overridden is an object type, `Type: newName` is interpreted as a
 	// move operation, pointing the property to a type called `newName` and creating
 	// `newName` with the schema described by this type.
 	Type tokens.Type
@@ -428,7 +428,7 @@ type SchemaInfo struct {
 	// a type to override when the property is a nested structure.
 	NestedType tokens.Type
 
-	// an optional idemponent transformation, applied before passing to TF.
+	// an optional idempotent transformation, applied before passing to TF.
 	Transform Transformer
 
 	// a schema override for elements for arrays, maps, and sets.

--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -180,8 +180,12 @@ func (nt *schemaNestedTypes) gatherFromProperties(pathContext paths.TypePath,
 			name = inflector.Singularize(name)
 		}
 
-		nt.gatherFromPropertyType(paths.NewProperyPath(pathContext, p.propertyName),
-			declarer, namePrefix, name, p.typ, isInput)
+		var path paths.TypePath = paths.NewProperyPath(pathContext, p.propertyName)
+		if t := p.typ.typ; t != "" && p.typ.kind == kindObject {
+			namePrefix = ""
+		}
+
+		nt.gatherFromPropertyType(path, declarer, namePrefix, name, p.typ, isInput)
 	}
 }
 
@@ -195,6 +199,9 @@ func (nt *schemaNestedTypes) gatherFromPropertyType(typePath paths.TypePath, dec
 				declarer, namePrefix, name, typ.element, isInput)
 		}
 	case kindObject:
+		if typ.typ != "" {
+			namePrefix = ""
+		}
 		baseName := nt.declareType(typePath, declarer, namePrefix, name, typ, isInput)
 		nt.gatherFromProperties(typePath, declarer, baseName, typ.properties, isInput)
 	}

--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -67,17 +67,19 @@ type schemaNestedType struct {
 }
 
 type schemaNestedTypes struct {
-	nameToType map[string]*schemaNestedType
+	nameToType      map[string]*schemaNestedType
+	pathCorrections map[string]paths.TypePath
 }
 
-func gatherSchemaNestedTypesForModule(mod *module) map[string]*schemaNestedType {
+func gatherSchemaNestedTypesForModule(mod *module) (map[string]*schemaNestedType, map[string]paths.TypePath) {
 	nt := &schemaNestedTypes{
-		nameToType: make(map[string]*schemaNestedType),
+		nameToType:      make(map[string]*schemaNestedType),
+		pathCorrections: make(map[string]paths.TypePath),
 	}
 	for _, member := range mod.members {
 		nt.gatherFromMember(member)
 	}
-	return nt.nameToType
+	return nt.nameToType, nt.pathCorrections
 }
 
 func gatherSchemaNestedTypesForMember(member moduleMember) map[string]*schemaNestedType {
@@ -187,10 +189,18 @@ func (nt *schemaNestedTypes) gatherFromProperties(pathContext paths.TypePath,
 		var path paths.TypePath = paths.NewProperyPath(pathContext, p.propertyName)
 		if t := p.typ.typ; t != "" && p.typ.kind == kindObject {
 			namePrefix = ""
+			newPath := paths.NewRawPath(t, path)
+			nt.correctPath(path, newPath)
+			path = newPath
 		}
 
 		nt.gatherFromPropertyType(path, declarer, namePrefix, name, p.typ, isInput)
 	}
+}
+
+// Insert a type path redirect, setting src to point to dst.
+func (nt *schemaNestedTypes) correctPath(src, dst paths.TypePath) {
+	nt.pathCorrections[src.UniqueKey()] = dst
 }
 
 func (nt *schemaNestedTypes) gatherFromPropertyType(typePath paths.TypePath, declarer declarer, namePrefix,
@@ -205,6 +215,7 @@ func (nt *schemaNestedTypes) gatherFromPropertyType(typePath paths.TypePath, dec
 	case kindObject:
 		if typ.typ != "" {
 			namePrefix = ""
+			typePath = paths.NewRawPath(typ.typ, typePath)
 		}
 		baseName := nt.declareType(typePath, declarer, namePrefix, name, typ, isInput)
 		nt.gatherFromProperties(typePath, declarer, baseName, typ.properties, isInput)
@@ -261,7 +272,17 @@ func (g *schemaGenerator) genPackageSpec(pack *pkg) (pschema.PackageSpec, error)
 	declaredTypes := map[string]*schemaNestedType{}
 	for _, mod := range pack.modules.values() {
 		// Generate nested types.
-		for _, t := range gatherSchemaNestedTypesForModule(mod) {
+		nestedTypes, pathCorrections := gatherSchemaNestedTypesForModule(mod)
+		if b := g.renamesBuilder; b != nil {
+			if b.pathCorrections == nil {
+				b.pathCorrections = pathCorrections
+			} else {
+				for k, v := range pathCorrections {
+					b.pathCorrections[k] = v
+				}
+			}
+		}
+		for _, t := range nestedTypes {
 			tok := g.genObjectTypeToken(t)
 			ts := g.genObjectType(t, false)
 

--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -114,9 +114,7 @@ type declarer interface {
 	Name() string
 }
 
-func (nt *schemaNestedTypes) declareType(typePath paths.TypePath, declarer declarer, namePrefix, name string,
-	typ *propertyType, isInput bool) string {
-
+func (nt *schemaNestedTypes) typeName(namePrefix, name string, typ *propertyType) string {
 	// Generate a name for this nested type.
 	typeName := namePrefix + cases.Title(language.Und, cases.NoLower).String(name)
 
@@ -130,6 +128,16 @@ func (nt *schemaNestedTypes) declareType(typePath paths.TypePath, declarer decla
 	}
 
 	typ.name = typeName
+	return typ.name
+}
+
+// declareType emits the declared type into nt.
+//
+// declareType requires that:
+// 1. nt.typeName(..., typ) has been called previously on this type.
+// 2. All nested types have already been declare.
+func (nt *schemaNestedTypes) declareType(typePath paths.TypePath, declarer declarer,
+	typ *propertyType, isInput bool) {
 
 	required := codegen.StringSet{}
 	for _, p := range typ.properties {
@@ -146,8 +154,9 @@ func (nt *schemaNestedTypes) declareType(typePath paths.TypePath, declarer decla
 	}
 
 	// Merging makes sure that structurally identical types are shared and not generated more than once.
-	if existing, ok := nt.nameToType[typeName]; ok {
-		contract.Assertf(existing.declarer == declarer || existing.typ.equals(typ), "duplicate type %v", typeName)
+	if existing, ok := nt.nameToType[typ.name]; ok {
+		contract.Assertf(existing.declarer == declarer || existing.typ.equals(typ),
+			"%s declared twice with different values", typ.name)
 
 		// Remember that existing type is now also seen at the current typePath.
 		existing.typePaths.Add(typePath)
@@ -162,10 +171,10 @@ func (nt *schemaNestedTypes) declareType(typePath paths.TypePath, declarer decla
 		}
 
 		existing.typ, existing.required = typ, required
-		return typeName
+		return
 	}
 
-	nt.nameToType[typeName] = &schemaNestedType{
+	nt.nameToType[typ.name] = &schemaNestedType{
 		typ:             typ,
 		declarer:        declarer,
 		required:        required,
@@ -173,7 +182,6 @@ func (nt *schemaNestedTypes) declareType(typePath paths.TypePath, declarer decla
 		requiredOutputs: requiredOutputs,
 		typePaths:       paths.SingletonTypePathSet(typePath),
 	}
-	return typeName
 }
 
 func (nt *schemaNestedTypes) gatherFromProperties(pathContext paths.TypePath,
@@ -217,8 +225,15 @@ func (nt *schemaNestedTypes) gatherFromPropertyType(typePath paths.TypePath, dec
 			namePrefix = ""
 			typePath = paths.NewRawPath(typ.typ, typePath)
 		}
-		baseName := nt.declareType(typePath, declarer, namePrefix, name, typ, isInput)
+
+		// Because nt.declareType expects the declared type to be fully formed (to
+		// allow an equality comparison against other fully formed types), all
+		// nested types must themselves be fully formed.
+		//
+		// gatherFromProperties must be called before declareType.
+		baseName := nt.typeName(namePrefix, name, typ)
 		nt.gatherFromProperties(typePath, declarer, baseName, typ.properties, isInput)
+		nt.declareType(typePath, declarer, typ, isInput)
 	}
 }
 
@@ -812,7 +827,6 @@ func (g *schemaGenerator) genObjectTypeToken(typInfo *schemaNestedType) string {
 	}
 
 	g.renamesBuilder.registerNamedObjectType(typInfo.typePaths, token)
-	fmt.Printf("Generated token %s (mod = %s, name = %s)\n", token, mod, name)
 	return token.String()
 }
 

--- a/pkg/tfgen/generate_test.go
+++ b/pkg/tfgen/generate_test.go
@@ -409,7 +409,7 @@ func Test_ProviderWithMovedTypes(t *testing.T) {
 		assert.Len(t, spec.Resources, 1)
 		assert.Len(t, spec.Types, 2)
 		if assert.Contains(t, spec.Types, "test:moved:Top") {
-			assert.Contains(t, spec.Types, "test:moved:TopNested")
+			assert.Contains(t, spec.Types, "test:moved/TopNested:TopNested")
 		}
 	})
 

--- a/pkg/tfgen/internal/paths/paths.go
+++ b/pkg/tfgen/internal/paths/paths.go
@@ -336,3 +336,20 @@ func (s TypePathSet) Paths() []TypePath {
 	})
 	return res
 }
+
+// RawTypePath represents a type anchored from an opaque user provided type.
+type RawTypePath struct{ t tokens.Type }
+
+func NewRawPath(typ tokens.Type) *RawTypePath { return &RawTypePath{typ} }
+
+var _ TypePath = (*RawTypePath)(nil)
+
+func (p *RawTypePath) Parent() TypePath { return nil }
+
+// Useful for comparing paths.
+func (p *RawTypePath) UniqueKey() string { return p.t.String() }
+
+// Human friendly representation.
+func (p *RawTypePath) String() string { return p.t.Name().String() }
+
+func (p *RawTypePath) Raw() tokens.Type { return tokens.Type(p.t) }

--- a/pkg/tfgen/internal/paths/paths.go
+++ b/pkg/tfgen/internal/paths/paths.go
@@ -338,9 +338,14 @@ func (s TypePathSet) Paths() []TypePath {
 }
 
 // RawTypePath represents a type anchored from an opaque user provided type.
-type RawTypePath struct{ t tokens.Type }
+type RawTypePath struct {
+	t              tokens.Type
+	structuralPath TypePath
+}
 
-func NewRawPath(typ tokens.Type) *RawTypePath { return &RawTypePath{typ} }
+func NewRawPath(typ tokens.Type, structuralPath TypePath) *RawTypePath {
+	return &RawTypePath{typ, structuralPath}
+}
 
 var _ TypePath = (*RawTypePath)(nil)
 
@@ -353,3 +358,5 @@ func (p *RawTypePath) UniqueKey() string { return p.t.String() }
 func (p *RawTypePath) String() string { return p.t.Name().String() }
 
 func (p *RawTypePath) Raw() tokens.Type { return tokens.Type(p.t) }
+
+func (p *RawTypePath) StructuralPath() TypePath { return p.structuralPath }

--- a/pkg/tfgen/internal/paths/paths.go
+++ b/pkg/tfgen/internal/paths/paths.go
@@ -357,6 +357,6 @@ func (p *RawTypePath) UniqueKey() string { return p.t.String() }
 // Human friendly representation.
 func (p *RawTypePath) String() string { return p.t.Name().String() }
 
-func (p *RawTypePath) Raw() tokens.Type { return tokens.Type(p.t) }
+func (p *RawTypePath) Raw() tokens.Type { return p.t }
 
 func (p *RawTypePath) StructuralPath() TypePath { return p.structuralPath }

--- a/pkg/tfgen/namecheck.go
+++ b/pkg/tfgen/namecheck.go
@@ -383,6 +383,8 @@ func locateTypByTypePath(prov tfbridge.ProviderInfo, path paths.TypePath) (typ, 
 			return nil, err
 		}
 		return t.Element()
+	case *paths.RawTypePath:
+		return locateTypByTypePath(prov, p.StructuralPath())
 	default:
 		panic("impossible match in locateTypByTypePath")
 	}


### PR DESCRIPTION
This PR changes how `tfbridge.SchemaInfo.Type` is interpreted when applied to object properties.

Previously, type changed the `schema.TypeSpec.{Type,Ref}` fields on the generated resource. It did not effect any nested types.

With this PR, `Type` is interpreted as a command to rename the relevant object and its entire nested structure. This allows multiple fields or objects to share a type definition when specified, and will allow us to reduce the size of our SDKs.

---

This is technically a breaking change. Bridge users who have specified `Type: someNewType` on object types will see different behavior. In practice, setting `Type` on an object would generate an invalid schema without a careful fix-up. I suspect that no-one does this.

I have tested this change on `pulumi-ns1`, `pulumi-aws`, `pulumi-gcp` and `pulumi-azure`. None of these providers are effected by this change.

### Implementers Notes

`paths.TypePath` is used to determine the module of derived types. Since we want subtypes of a moved type to themselves move to the module of their parent, we need to track that in the paths used. To allow inserting a type at an arbitrary module, it was necessary to create a new `paths.TypePath`; `paths.RawTypePath` projects a `tokens.Type` into `paths.TypePath` so it can be used for module discovery.