### PR TITLE
Fixes unknown handling in makeResourceRawConfig

### DIFF
--- a/pkg/tfshim/sdk-v2/cty.go
+++ b/pkg/tfshim/sdk-v2/cty.go
@@ -19,9 +19,12 @@ import (
 	"math/big"
 
 	"github.com/golang/glog"
+
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 const (
@@ -159,9 +162,7 @@ func recoverCtyValue(dT cty.Type, value interface{}) (cty.Value, error) {
 }
 
 func recoverCtyValueOfMapType(dT cty.Type, value map[string]interface{}) (cty.Value, error) {
-	if !dT.IsMapType() {
-		return cty.NilVal, fmt.Errorf("recoverCtyValueOfMapType expected a Map, got %v", dT)
-	}
+	contract.Assertf(dT.IsMapType(), "recoverCtyValueOfMapType expected a Map, got %v", dT)
 	eT := dT.ElementType()
 	attrs := map[string]cty.Value{}
 	for k, v := range value {
@@ -178,10 +179,7 @@ func recoverCtyValueOfMapType(dT cty.Type, value map[string]interface{}) (cty.Va
 }
 
 func recoverCtyValueOfObjectType(dT cty.Type, value map[string]interface{}) (cty.Value, error) {
-	if !dT.IsObjectType() {
-		return cty.NilVal,
-			fmt.Errorf("recoverCtyValueOfObjectType expected an Object, got %v", dT)
-	}
+	contract.Assertf(dT.IsObjectType(), "recoverCtyValueOfObjectType expected an Object, got %v", dT)
 	aT := dT.AttributeTypes()
 	if len(aT) == 0 {
 		return cty.EmptyObjectVal, nil
@@ -202,10 +200,7 @@ func recoverCtyValueOfObjectType(dT cty.Type, value map[string]interface{}) (cty
 }
 
 func recoverCtyValueOfListType(dT cty.Type, values []interface{}) (cty.Value, error) {
-	if !dT.IsListType() {
-		return cty.NilVal,
-			fmt.Errorf("recoverCtyValueOfListType expected a List, got %v", dT)
-	}
+	contract.Assertf(dT.IsListType(), "recoverCtyValueOfListType expected a List, got %v", dT)
 	eT := dT.ElementType()
 	vals := []cty.Value{}
 	for _, v := range values {
@@ -222,9 +217,7 @@ func recoverCtyValueOfListType(dT cty.Type, values []interface{}) (cty.Value, er
 }
 
 func recoverCtyValueOfSetType(dT cty.Type, values []interface{}) (cty.Value, error) {
-	if !dT.IsSetType() {
-		return cty.NilVal, fmt.Errorf("recoverCtyValueOfSetType expected a Set, got %v", dT)
-	}
+	contract.Assertf(dT.IsSetType(), "recoverCtyValueOfSetType expected a Set, got %v", dT)
 	eT := dT.ElementType()
 	vals := []cty.Value{}
 	for _, v := range values {
@@ -241,10 +234,7 @@ func recoverCtyValueOfSetType(dT cty.Type, values []interface{}) (cty.Value, err
 }
 
 func recoverCtyValueOfTupleType(dT cty.Type, values []interface{}) (cty.Value, error) {
-	if !dT.IsTupleType() {
-		return cty.NilVal, fmt.Errorf(
-			"recoverCtyValueOfTulpeType expected a Tuple, got %v", dT)
-	}
+	contract.Assertf(dT.IsTupleType(), "recoverCtyValueOfTulpeType expected a Tuple, got %v", dT)
 	vals := []cty.Value{}
 	for i, v := range values {
 		rv, err := recoverCtyValue(dT.TupleElementType(i), v)

--- a/pkg/tfshim/sdk-v2/cty.go
+++ b/pkg/tfshim/sdk-v2/cty.go
@@ -15,10 +15,17 @@
 package sdkv2
 
 import (
+	"fmt"
+	"math/big"
+
 	"github.com/golang/glog"
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+const (
+	terraformUnknownVariableValue = "74D93920-ED26-11E3-AC10-0800200C9A66"
 )
 
 // makeResourceRawConfig converts the decoded Go values in a terraform.ResourceConfig into a cty.Value that is
@@ -32,10 +39,7 @@ func makeResourceRawConfig(
 		return makeResourceRawConfigClassic(config, resource)
 	}
 
-	// The method JSONMapToStateValue has State in its name but the implementation is generic, and fits the use case
-	// here. What it does is simply parsing raw map[string]interface{} data into a Object value with a schema that
-	// corresponds to the Resource schema.
-	value, err := schema.JSONMapToStateValue(config.Raw, resource.CoreConfigSchema())
+	value, err := recoverAndCoerceCtyValue(resource, config.Raw)
 	if err == nil {
 		return value
 	}
@@ -60,4 +64,194 @@ func makeResourceRawConfigClassic(config *terraform.ResourceConfig, resource *sc
 		return original
 	}
 	return coerced
+}
+
+// This method started off calling [schema.JSONMapToStateValue], but it turns out that it is not
+// suitable for processing unknown values encoded as [terraformUnknownVariableValue]. The latest
+// implementation retains CoerceValue call from the JSONMapToStateValue, but does an explicit
+// type-driven recursive recovery pass from any to cty.Value first, instead of doing this
+// transformation via an intermediate JSON form. The pass is made aware of
+// terraformUnknownVariableValue.
+//
+// One possibility to refactor this code is to have MakeTerraformInput return cty.Value directly
+// instead of implicit any encoding.
+func recoverAndCoerceCtyValue(resource *schema.Resource, value any) (cty.Value, error) {
+	c, err := recoverCtyValue(resource.CoreConfigSchema().ImpliedType(), value)
+	if err != nil {
+		return cty.NilVal, fmt.Errorf("recoverCtyValue failed: %w", err)
+	}
+	cv, err := resource.CoreConfigSchema().CoerceValue(c)
+	if err != nil {
+		return cty.NilVal, fmt.Errorf("CoerceValue failed: %w", err)
+	}
+	return cv, nil
+}
+
+// See [recoverAndCoerceCtyValue] as the main use case. Takes a value produced by
+// tfbridge.MakeTerraformInput and converts it to a cty.Value of the desired type dT. This recursive
+// method tracks desired type dT through containers such as objects, maps and lists. For scalars, it
+// recognizes unknowns encoded as terraformUnknownVariableValue. Missing values for object maps are
+// populated with nulls (important to avoid panics in TF internal code), and extraneous values
+// discarded. No type conversions such as string to bool are attempted, as the code calls
+// CoerceValue on the result of this method and that traversal takes care of that.
+func recoverCtyValue(dT cty.Type, value interface{}) (cty.Value, error) {
+	switch value := value.(type) {
+	case nil:
+		return cty.NullVal(dT), nil
+	case map[string]interface{}:
+		switch {
+		case dT.IsMapType():
+			return recoverCtyValueOfMapType(dT, value)
+		case dT.IsObjectType():
+			return recoverCtyValueOfObjectType(dT, value)
+		default:
+			return cty.NilVal, fmt.Errorf("Cannot reconcile map %v to %v", value, dT)
+		}
+	case []interface{}:
+		switch {
+		case dT.IsTupleType():
+			return recoverCtyValueOfTupleType(dT, value)
+		case dT.IsSetType():
+			return recoverCtyValueOfSetType(dT, value)
+		case dT.IsListType():
+			return recoverCtyValueOfListType(dT, value)
+		default:
+			return cty.NilVal, fmt.Errorf("Cannot reconcile slice %v to %v", value, dT)
+		}
+	case string:
+		if value == terraformUnknownVariableValue {
+			return cty.UnknownVal(dT), nil
+		}
+		return cty.StringVal(value), nil
+	case bool:
+		return cty.BoolVal(value), nil
+	case int:
+		return cty.NumberIntVal(int64(value)), nil
+	case int64:
+		return cty.NumberIntVal(value), nil
+	case uint64:
+		return cty.NumberUIntVal(value), nil
+	case float64:
+		return cty.NumberFloatVal(value), nil
+	case *big.Float:
+		return cty.NumberVal(value), nil
+	case uint8:
+		return cty.NumberIntVal(int64(value)), nil
+	case uint16:
+		return cty.NumberIntVal(int64(value)), nil
+	case uint32:
+		return cty.NumberIntVal(int64(value)), nil
+	case int8:
+		return cty.NumberIntVal(int64(value)), nil
+	case int16:
+		return cty.NumberIntVal(int64(value)), nil
+	case int32:
+		return cty.NumberIntVal(int64(value)), nil
+	case float32:
+		return cty.NumberFloatVal(float64(value)), nil
+	default:
+		return cty.NilVal, fmt.Errorf("Cannot recover cty.Value\n"+
+			"  Desired type: %v\n"+
+			"  Value: %v\n"+
+			"  Actual type: %#T\n",
+			dT.GoString(), value, value)
+	}
+}
+
+func recoverCtyValueOfMapType(dT cty.Type, value map[string]interface{}) (cty.Value, error) {
+	if !dT.IsMapType() {
+		return cty.NilVal, fmt.Errorf("recoverCtyValueOfMapType expected a Map, got %v", dT)
+	}
+	eT := dT.ElementType()
+	attrs := map[string]cty.Value{}
+	for k, v := range value {
+		var err error
+		attrs[k], err = recoverCtyValue(eT, v)
+		if err != nil {
+			return cty.NilVal, err
+		}
+	}
+	return cty.ObjectVal(attrs), nil
+}
+
+func recoverCtyValueOfObjectType(dT cty.Type, value map[string]interface{}) (cty.Value, error) {
+	if !dT.IsObjectType() {
+		return cty.NilVal,
+			fmt.Errorf("recoverCtyValueOfObjectType expected an Object, got %v", dT)
+	}
+	aT := dT.AttributeTypes()
+	if len(aT) == 0 {
+		return cty.EmptyObjectVal, nil
+	}
+	attrs := map[string]cty.Value{}
+	for attrName, attrType := range aT {
+		if v, ok := value[attrName]; ok {
+			var err error
+			attrs[attrName], err = recoverCtyValue(attrType, v)
+			if err != nil {
+				return cty.NilVal, err
+			}
+		} else {
+			attrs[attrName] = cty.NullVal(attrType)
+		}
+	}
+	return cty.ObjectVal(attrs), nil
+}
+
+func recoverCtyValueOfListType(dT cty.Type, values []interface{}) (cty.Value, error) {
+	if !dT.IsListType() {
+		return cty.NilVal,
+			fmt.Errorf("recoverCtyValueOfListType expected a List, got %v", dT)
+	}
+	eT := dT.ElementType()
+	vals := []cty.Value{}
+	for _, v := range values {
+		rv, err := recoverCtyValue(eT, v)
+		if err != nil {
+			return cty.NilVal, err
+		}
+		vals = append(vals, rv)
+	}
+	if len(vals) == 0 {
+		return cty.ListValEmpty(dT), nil
+	}
+	return cty.ListVal(vals), nil
+}
+
+func recoverCtyValueOfSetType(dT cty.Type, values []interface{}) (cty.Value, error) {
+	if !dT.IsSetType() {
+		return cty.NilVal, fmt.Errorf("recoverCtyValueOfSetType expected a Set, got %v", dT)
+	}
+	eT := dT.ElementType()
+	vals := []cty.Value{}
+	for _, v := range values {
+		rv, err := recoverCtyValue(eT, v)
+		if err != nil {
+			return cty.NilVal, err
+		}
+		vals = append(vals, rv)
+	}
+	if len(vals) == 0 {
+		return cty.SetValEmpty(dT), nil
+	}
+	return cty.SetVal(vals), nil
+}
+
+func recoverCtyValueOfTupleType(dT cty.Type, values []interface{}) (cty.Value, error) {
+	if !dT.IsTupleType() {
+		return cty.NilVal, fmt.Errorf(
+			"recoverCtyValueOfTulpeType expected a Tuple, got %v", dT)
+	}
+	vals := []cty.Value{}
+	for i, v := range values {
+		rv, err := recoverCtyValue(dT.TupleElementType(i), v)
+		if err != nil {
+			return cty.NilVal, err
+		}
+		vals = append(vals, rv)
+	}
+	if len(vals) == 0 {
+		return cty.EmptyTupleVal, nil
+	}
+	return cty.TupleVal(vals), nil
 }

--- a/pkg/tfshim/sdk-v2/cty.go
+++ b/pkg/tfshim/sdk-v2/cty.go
@@ -211,7 +211,7 @@ func recoverCtyValueOfListType(dT cty.Type, values []interface{}) (cty.Value, er
 		vals = append(vals, rv)
 	}
 	if len(vals) == 0 {
-		return cty.ListValEmpty(dT), nil
+		return cty.ListValEmpty(eT), nil
 	}
 	return cty.ListVal(vals), nil
 }

--- a/pkg/tfshim/sdk-v2/cty.go
+++ b/pkg/tfshim/sdk-v2/cty.go
@@ -171,7 +171,10 @@ func recoverCtyValueOfMapType(dT cty.Type, value map[string]interface{}) (cty.Va
 			return cty.NilVal, err
 		}
 	}
-	return cty.ObjectVal(attrs), nil
+	if len(attrs) == 0 {
+		return cty.MapValEmpty(eT), nil
+	}
+	return cty.MapVal(attrs), nil
 }
 
 func recoverCtyValueOfObjectType(dT cty.Type, value map[string]interface{}) (cty.Value, error) {
@@ -232,7 +235,7 @@ func recoverCtyValueOfSetType(dT cty.Type, values []interface{}) (cty.Value, err
 		vals = append(vals, rv)
 	}
 	if len(vals) == 0 {
-		return cty.SetValEmpty(dT), nil
+		return cty.SetValEmpty(eT), nil
 	}
 	return cty.SetVal(vals), nil
 }

--- a/pkg/tfshim/sdk-v2/cty_test.go
+++ b/pkg/tfshim/sdk-v2/cty_test.go
@@ -4,12 +4,13 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/internal/testprovider"
-	"github.com/stretchr/testify/require"
 )
 
 var awsSSMParameterSchema = &schema.Resource{
@@ -750,6 +751,12 @@ func TestRecoverCtyValue(t *testing.T) {
 			cty.Map(cty.String),
 			map[string]interface{}{},
 			cty.MapValEmpty(cty.String),
+		},
+		{
+			"empty list",
+			cty.List(cty.String),
+			[]any{},
+			cty.ListValEmpty(cty.String),
 		},
 		{
 			"empty set",


### PR DESCRIPTION
AWS opts into PlanState DiffStrategy but it appears that under certain conditions involving unknowns this may cause panics in objchange.ProposedNew. This fix takes apart schema.JSONMapToStateValue that we used to employ for the purpose of massaging config values to the desired form. The original method does not handle unknowns properly translating them to strings of the unknown sentinel value as part of the any->json->cty.Value conversion. The replacement method does a more explicit any->cty.Value conversion taking the unknown sentinels into account, but retains CoerceValue method from schema.JSONMapToStateValue that can help to continue to be permissive and automatically recognize values of a slightly different type (auto converting bool to string etc). 

See also pulumi/pulumi-aws#3094