### PR TITLE
Efficient schema traversal

### DIFF
--- a/pkg/tfbridge/metadata.go
+++ b/pkg/tfbridge/metadata.go
@@ -62,16 +62,19 @@ func (info *MetadataInfo) assertValid() {
 
 }
 
+var declaredRuntimeMetadata = map[string]struct{}{
+	autoSettingsKey: {},
+	"mux":           {},
+}
+
+func declareRuntimeMetadata(label string) { declaredRuntimeMetadata[label] = struct{}{} }
+
 // trim the metadata to just the keys required for the runtime phase
 // in the future this method might also substitute compressed contents within some keys
 func (info *MetadataInfo) ExtractRuntimeMetadata() *MetadataInfo {
 	data, _ := metadata.New(nil)
 
-	for _, k := range []string{
-		autoSettingsKey,
-		"mux",
-		"traverse-effects",
-	} {
+	for k := range declaredRuntimeMetadata {
 		metadata.CloneKey(k, info.Data, data)
 	}
 

--- a/pkg/tfbridge/metadata.go
+++ b/pkg/tfbridge/metadata.go
@@ -66,7 +66,14 @@ func (info *MetadataInfo) assertValid() {
 // in the future this method might also substitute compressed contents within some keys
 func (info *MetadataInfo) ExtractRuntimeMetadata() *MetadataInfo {
 	data, _ := metadata.New(nil)
-	metadata.CloneKey(autoSettingsKey, info.Data, data)
-	metadata.CloneKey("mux", info.Data, data)
+
+	for _, k := range []string{
+		autoSettingsKey,
+		"mux",
+		"traverse-effects",
+	} {
+		metadata.CloneKey(k, info.Data, data)
+	}
+
 	return &MetadataInfo{"runtime-bridge-metadata.json", ProviderMetadata(data)}
 }

--- a/pkg/tfbridge/walk.go
+++ b/pkg/tfbridge/walk.go
@@ -15,11 +15,17 @@
 package tfbridge
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/util"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/walk"
+	md "github.com/pulumi/pulumi-terraform-bridge/v3/unstable/metadata"
 )
 
 type SchemaPath = walk.SchemaPath
@@ -280,4 +286,395 @@ func LookupSchemaInfoPath(schemaPath SchemaPath, schemaInfo *SchemaInfo) *Schema
 	default:
 		return nil
 	}
+}
+
+// Drill down a path from a SchemaInfo object and find a matching SchemaInfo. If no
+// SchemaInfo exists, it will be created.
+func getOrCreateSchemaInfoPath(schemaPath SchemaPath, schemaInfo *SchemaInfo) *SchemaInfo {
+	if len(schemaPath) == 0 {
+		return schemaInfo
+	}
+
+	switch first := schemaPath[0].(type) {
+	case walk.ElementStep:
+		return getOrCreateSchemaInfoPath(schemaPath[1:], ensureField(&schemaInfo.Elem))
+	case walk.GetAttrStep:
+		return getOrCreateSchemaInfoPath(schemaPath[1:], ensureMapKey(&schemaInfo.Fields, first.Name))
+	default:
+		contract.Failf("Unable to walk SchemaPath segment of type %T", schemaPath[0])
+		return nil
+	}
+}
+
+type VisitInfo struct {
+	Root VisitRoot
+
+	schemaPath SchemaPath
+
+	shimSchema    shim.Schema
+	getSchemaInfo func() *SchemaInfo
+
+	getShimSchemaMap func() shim.SchemaMap
+	getSchemaInfoMap func() map[string]*SchemaInfo
+}
+
+type VisitResult struct {
+	// If the visitor has done something.
+	//
+	// Visits will only be replayed during runtime startup if `HasEffect: true`.
+	HasEffect bool
+}
+
+func (v *VisitInfo) SchemaPath() SchemaPath                         { return v.schemaPath }
+func (v *VisitInfo) ShimSchema() shim.Schema                        { return v.shimSchema }
+func (v *VisitInfo) SchemaInfo() *SchemaInfo                        { return v.getSchemaInfo() }
+func (v *VisitInfo) EnclosingSchemaInfoMap() map[string]*SchemaInfo { return v.getSchemaInfoMap() }
+func (v *VisitInfo) EnclosingSchemaShimMap() shim.SchemaMap         { return v.getShimSchemaMap() }
+
+type VisitRoot interface {
+	PulumiToken() tokens.Type
+
+	isVisitRoot()
+}
+
+// This ensures that we can peform casts from VisitRoot to T for each valid root. Changing
+// this from T to *T is a breaking change.
+var (
+	_ VisitRoot = VisitResourceRoot{}
+	_ VisitRoot = VisitDataSourceRoot{}
+	_ VisitRoot = VisitConfigRoot{}
+)
+
+type VisitResourceRoot struct {
+	token tokens.Type
+
+	Info *ResourceInfo
+
+	TfToken string
+}
+
+func (r VisitResourceRoot) PulumiToken() tokens.Type { return r.token }
+func (r VisitResourceRoot) isVisitRoot()             {}
+
+type VisitDataSourceRoot struct {
+	token tokens.Type
+
+	Info *DataSourceInfo
+
+	TfToken string
+}
+
+func (r VisitDataSourceRoot) PulumiToken() tokens.Type { return r.token }
+func (r VisitDataSourceRoot) isVisitRoot()             {}
+
+type VisitConfigRoot struct{ token tokens.Type }
+
+func (r VisitConfigRoot) PulumiToken() tokens.Type { return r.token }
+func (r VisitConfigRoot) isVisitRoot()             {}
+
+type Visitor = func(VisitInfo) (VisitResult, error)
+
+// A wrapper around [TraverseSchemas] that panics on error. See [TraverseSchemas] for
+// documentation.
+func MustTraverseSchemas(prov *ProviderInfo, traversalID string, visitor Visitor) {
+	err := TraverseSchemas(prov, traversalID, visitor)
+	contract.AssertNoErrorf(err, "failed to traverse provider schemas")
+}
+
+// _Efficiently_ traverse all schemas in a provider.
+//
+// TraverseSchemas operates in two stages:
+//
+//   - During `make tfgen` time, all fields in the provider are visited. TraverseSchemas
+//     builds a list of fields where `VisitResult{ HasEffect: true }` is returned.
+//
+//   - During the provider's normal runtime, only "effectful" fields are visited.
+//
+// traversalId must be unique for each traversal within a `make tfgen`, but the same
+// between `make tfgen` and the provider runtime. A simple descriptive string like `"apply
+// labels"` works great here.
+func TraverseSchemas(prov *ProviderInfo, traversalID string, visitor Visitor, opts ...TraversalOption) error {
+	prov.MetadataInfo.assertValid() // We must have metadata info for an efficient (sparse) traversal.
+
+	var errs []error
+
+	var traverseOptions traversalOptions
+	for _, opt := range opts {
+		opt(&traverseOptions)
+	}
+
+	// forEffect indicates that the traversal is being run for side effects only, so
+	// we can visit only "effectful" nodes.
+	forEffect := currentRuntimeStage == runningProviderStage
+	if b := traverseOptions.forEffect; b != nil {
+		forEffect = *b
+	}
+
+	var effects traversalRecord
+
+	// We are in forEffect mode, so we need to load in the list of paths where we need
+	// to replay effects.
+	if forEffect {
+		var ok bool
+		var err error
+		effects, ok, err = md.Get[traversalRecord](prov.GetMetadata(), traversalID)
+		contract.Assertf(ok, "could not find traversalID %q in metadata, are you missing a `make tfgen`?", traversalID)
+		if err != nil {
+			return fmt.Errorf("unable to find effect list: %w", err)
+		}
+	}
+
+	rMap := prov.P.ResourcesMap()
+	for tfName, rInfo := range prov.Resources {
+		rShim, ok := rMap.GetOk(tfName)
+		if !ok {
+			continue
+		}
+
+		var err error
+
+		effect := ensureMap(&effects.Resources)[tfName]
+
+		effect, err = traverseResourceOrDataSource(tfName, rShim, rInfo,
+			visitor, forEffect, effect)
+		if err != nil {
+			errs = append(errs, err)
+		}
+		effects.Resources[tfName] = effect
+	}
+
+	dMap := prov.P.DataSourcesMap()
+	for tfName, dInfo := range prov.DataSources {
+		rShim, ok := dMap.GetOk(tfName)
+		if !ok {
+			continue
+		}
+
+		var err error
+		effect := ensureMap(&effects.DataSources)[tfName]
+
+		effect, err = traverseResourceOrDataSource(tfName, rShim, dInfo,
+			visitor, forEffect, effect)
+		if err != nil {
+			errs = append(errs, err)
+		}
+		effects.DataSources[tfName] = effect
+	}
+
+	{
+		var err error
+		effects.Config, err = traverseSchemaMap(prov.P.Schema(), ensureMap(&prov.Config),
+			VisitConfigRoot{tokens.Type("pulumi:providers" + prov.Name)}, visitor, forEffect, effects.Config)
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	// We are in !forEffect mode, so we need to save the list of effects to generate.
+	if !forEffect {
+		effects.clean()
+		err := md.Set(prov.GetMetadata(), traversalID, effects)
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+type traversalOptions struct {
+	forEffect *bool
+}
+
+type TraversalOption func(*traversalOptions)
+
+// Set [TraverseSchemas] to run in a specific mode.
+//
+// If forEffect is `false`, then [TraverseSchemas] will always touch every field,
+// regardless of runtime.
+//
+// If forEffect is `true`, then [TraverseSchemas] will only touch fields based off of the
+// "effectful" list contained in [prov.MetadataInfo].
+func TraverseForEffect(forEffect bool) func(*traversalOptions) {
+	return func(opts *traversalOptions) {
+		opts.forEffect = &forEffect
+	}
+}
+
+// traversalRecord is the record of "effectful" traversals generated by [TraverseSchemas]
+// during `make tfgen`. It is used to replay _only_ "effectful" changes during provider
+// startup.
+type traversalRecord struct {
+	Resources   map[string][]SchemaPath `json:"resources,omitempty"`
+	DataSources map[string][]SchemaPath `json:"dataSources,omitempty"`
+	Config      []SchemaPath            `json:"config,omitempty"`
+}
+
+// clean removes unnecessary records and makes the result deterministic.
+//
+// It should be called before marshalling.
+func (r *traversalRecord) clean() {
+	cleanList := func(l []SchemaPath) []SchemaPath {
+		walk.SortSchemaPaths(l)
+		return l
+	}
+
+	clean := func(m map[string][]SchemaPath) {
+		for k, v := range m {
+			if len(v) == 0 {
+				delete(m, k)
+				continue
+			}
+			m[k] = cleanList(v)
+		}
+	}
+
+	clean(r.Resources)
+	clean(r.DataSources)
+	r.Config = cleanList(r.Config)
+}
+
+// traverseResourceOrDataSource traverses a single resource or datasource.
+//
+// During the provider runtime, visitor is only replayed on paths where there was an effect.
+func traverseResourceOrDataSource(
+	tfToken string, schema shim.Resource, info ResourceOrDataSourceInfo,
+	visitor Visitor, forEffect bool, effects []SchemaPath,
+) ([]SchemaPath, error) {
+	// If we are gathering effects for this resource, we don't want to observe any
+	// previously gathered effects.
+	if !forEffect {
+		effects = []SchemaPath{}
+	}
+
+	var root VisitRoot
+	switch info := info.(type) {
+	case *ResourceInfo:
+		root = VisitResourceRoot{
+			token:   info.Tok,
+			Info:    info,
+			TfToken: tfToken,
+		}
+		if info.Fields == nil {
+			info.Fields = map[string]*SchemaInfo{}
+		}
+	case *DataSourceInfo:
+		root = VisitDataSourceRoot{
+			token:   tokens.Type(info.GetTok()),
+			Info:    info,
+			TfToken: tfToken,
+		}
+		if info.Fields == nil {
+			info.Fields = map[string]*SchemaInfo{}
+		}
+	default:
+		contract.Failf("info must be a *ResourceInfo or *DataSourceInfo, found %T", info)
+	}
+	return traverseSchemaMap(schema.Schema(), info.GetFields(), root, visitor, forEffect, effects)
+}
+
+func traverseSchemaMap(
+	schema shim.SchemaMap, info map[string]*SchemaInfo, root VisitRoot,
+	visitor Visitor, forEffect bool, effects []SchemaPath,
+) ([]SchemaPath, error) {
+	var errs []error
+
+	f := func(p SchemaPath, s shim.Schema) {
+		getSchemaInfo := func() *SchemaInfo {
+			r := getSchemaInfoRoot(p, info)
+			contract.Assertf(r != nil, "failed to get non-nil resource info")
+			return r
+		}
+		getSchemaInfoMap := func() map[string]*SchemaInfo {
+			return getSchemaInfoRoot(p[:len(p)-1], info).Fields
+		}
+		getShimSchemaMap := func() shim.SchemaMap {
+			m, err := walk.LookupSchemaMapPath(p[:len(p)-1], schema)
+			if err != nil {
+				errs = append(errs, err)
+			}
+			if m == nil {
+				return nil
+			}
+			elem, ok := m.Elem().(shim.Resource)
+			if !ok {
+				return nil
+			}
+			return elem.Schema()
+		}
+		result, err := visitor(VisitInfo{
+			Root:             root,
+			schemaPath:       p,
+			shimSchema:       s,
+			getShimSchemaMap: getShimSchemaMap,
+			getSchemaInfo:    getSchemaInfo,
+			getSchemaInfoMap: getSchemaInfoMap,
+		})
+		if err != nil {
+			errs = append(errs, err)
+			return
+		}
+		if result.HasEffect && !forEffect {
+			effects = append(effects, p)
+		}
+		contract.Assertf(!(forEffect && !result.HasEffect),
+			"A runtime traversal did not request an effect. This indicates a provider bug.")
+	}
+
+	if forEffect {
+		for _, effect := range effects {
+			s, err := walk.LookupSchemaMapPath(effect, schema)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			f(effect, s)
+		}
+		return effects, errors.Join(errs...)
+	}
+
+	walk.VisitSchemaMap(schema, f)
+
+	return effects, errors.Join(errs...)
+}
+
+func getSchemaInfoRoot(p SchemaPath, info map[string]*SchemaInfo) *SchemaInfo {
+	if len(p) == 0 { // This must be the root of a resource or datasource, so we mock the root.
+		return &SchemaInfo{Fields: info}
+	}
+	contract.Assertf(info != nil, "info cannot be nil")
+	contract.Assertf(len(p) > 0, "p cannot point to the resource or datasource")
+
+	switch root := p[0].(type) {
+	case walk.GetAttrStep:
+		return getOrCreateSchemaInfoPath(p[1:], ensureMapKey(&info, root.Name))
+	default:
+		contract.Failf("The first step of a resource or datasource must be a attr")
+		return nil
+	}
+}
+
+func ensureField[T any](t **T) *T {
+	if *t == nil {
+		*t = new(T)
+	}
+	return *t
+}
+
+func ensureMap[K comparable, V any](m *map[K]V) map[K]V {
+	if *m == nil {
+		*m = map[K]V{}
+	}
+	return *m
+}
+
+func ensureMapKey[K comparable, V any](m *map[K]*V, key K) *V {
+	ensureMap(m)
+	v, ok := (*m)[key]
+	if ok {
+		return v
+	}
+	v = new(V)
+	(*m)[key] = v
+	return v
 }

--- a/pkg/tfbridge/walk.go
+++ b/pkg/tfbridge/walk.go
@@ -378,8 +378,9 @@ type PropertyVisitor = func(PropertyVisitInfo) (PropertyVisitResult, error)
 
 // A wrapper around [TraverseProperties] that panics on error. See [TraverseProperties] for
 // documentation.
-func MustTraverseProperties(prov *ProviderInfo, traversalID string, visitor PropertyVisitor) {
-	err := TraverseProperties(prov, traversalID, visitor)
+func (prov *ProviderInfo) MustTraverseProperties(traversalID string, visitor PropertyVisitor,
+	opts ...TraversalOption) {
+	err := prov.TraverseProperties(traversalID, visitor, opts...)
 	contract.AssertNoErrorf(err, "failed to traverse provider schemas")
 }
 
@@ -398,8 +399,8 @@ func MustTraverseProperties(prov *ProviderInfo, traversalID string, visitor Prop
 // traversalId must be unique for each traversal within a `make tfgen`, but the same
 // between `make tfgen` and the provider runtime. A simple descriptive string like `"apply
 // labels"` works great here.
-func TraverseProperties(
-	prov *ProviderInfo, traversalID string, visitor PropertyVisitor,
+func (prov *ProviderInfo) TraverseProperties(
+	traversalID string, visitor PropertyVisitor,
 	opts ...TraversalOption,
 ) error {
 	prov.MetadataInfo.assertValid() // We must have metadata info for an efficient (sparse) traversal.

--- a/pkg/tfbridge/walk.go
+++ b/pkg/tfbridge/walk.go
@@ -432,11 +432,15 @@ func TraverseProperties(
 		}
 	}
 
+	ignoredTokens := ignoredTokens(prov)
+
 	prov.P.ResourcesMap().Range(func(tfName string, rShim shim.Resource) bool {
+		if ignoredTokens[tfName] {
+			return true
+		}
+
 		var err error
-
 		effectPaths := ensureMap(&traversalEffects.Resources)[tfName]
-
 		effectPaths, err = traverseResourceOrDataSource(tfName, rShim, ensureMapKey(&prov.Resources, tfName),
 			visitor, forEffect, effectPaths)
 		if err != nil {
@@ -448,9 +452,12 @@ func TraverseProperties(
 	})
 
 	prov.P.DataSourcesMap().Range(func(tfName string, dShim shim.Resource) bool {
+		if ignoredTokens[tfName] {
+			return true
+		}
+
 		var err error
 		effectPaths := ensureMap(&traversalEffects.DataSources)[tfName]
-
 		effectPaths, err = traverseResourceOrDataSource(tfName, dShim, ensureMapKey(&prov.DataSources, tfName),
 			visitor, forEffect, effectPaths)
 		if err != nil {

--- a/pkg/tfbridge/walk_test.go
+++ b/pkg/tfbridge/walk_test.go
@@ -290,7 +290,7 @@ func TestTraverseProperties(t *testing.T) {
 	}
 
 	seenPaths := map[string][]SchemaPath{}
-	err := TraverseProperties(prov, t.Name(), func(i PropertyVisitInfo) (PropertyVisitResult, error) {
+	err := prov.TraverseProperties(t.Name(), func(i PropertyVisitInfo) (PropertyVisitResult, error) {
 		paths := seenPaths[tfToken(i)]
 		seenPaths[tfToken(i)] = append(paths, i.SchemaPath())
 		return hasEffect(i)
@@ -355,7 +355,7 @@ func TestTraverseProperties(t *testing.T) {
 	}, seenPaths)
 
 	seenPaths = map[string][]SchemaPath{}
-	err = TraverseProperties(prov, t.Name(), func(i PropertyVisitInfo) (PropertyVisitResult, error) {
+	err = prov.TraverseProperties(t.Name(), func(i PropertyVisitInfo) (PropertyVisitResult, error) {
 		paths := seenPaths[tfToken(i)]
 		seenPaths[tfToken(i)] = append(paths, i.SchemaPath())
 		return hasEffect(i)
@@ -409,7 +409,7 @@ func TestTraversePropertiesSchemaInfo(t *testing.T) {
 			Fields["bool_property_value"].ForceNew)
 	}
 
-	err := TraverseProperties(prov, t.Name(), visitor, TraverseForEffect(false))
+	err := prov.TraverseProperties(t.Name(), visitor, TraverseForEffect(false))
 	require.NoError(t, err)
 
 	assert.NotNil(t, prov.Resources["example_resource"].
@@ -423,7 +423,7 @@ func TestTraversePropertiesSchemaInfo(t *testing.T) {
 		P:            shimv2.NewProvider(testTFProviderV2),
 		MetadataInfo: md.ExtractRuntimeMetadata(),
 	}
-	err = TraverseProperties(prov, t.Name(), visitor, TraverseForEffect(true))
+	err = prov.TraverseProperties(t.Name(), visitor, TraverseForEffect(true))
 	require.NoError(t, err)
 	verify(prov)
 

--- a/pkg/tfbridge/walk_test.go
+++ b/pkg/tfbridge/walk_test.go
@@ -303,9 +303,9 @@ func TestTraverseProperties(t *testing.T) {
 	}
 
 	assert.Equal(t, map[string][]walk.SchemaPath{
-		"": []walk.SchemaPath{
+		"": {
 			walk.NewSchemaPath().GetAttr("config_value")},
-		"example_resource": []walk.SchemaPath{
+		"example_resource": {
 			walk.NewSchemaPath().GetAttr("array_property_value"),
 			walk.NewSchemaPath().GetAttr("array_property_value"),
 			walk.NewSchemaPath().GetAttr("array_property_value").Element(),
@@ -335,7 +335,7 @@ func TestTraverseProperties(t *testing.T) {
 			walk.NewSchemaPath().GetAttr("string_property_value"),
 			walk.NewSchemaPath().GetAttr("string_with_bad_interpolation"),
 			walk.NewSchemaPath().GetAttr("string_with_bad_interpolation")},
-		"second_resource": []walk.SchemaPath{
+		"second_resource": {
 			walk.NewSchemaPath().GetAttr("array_property_value"),
 			walk.NewSchemaPath().GetAttr("array_property_value").Element(),
 			walk.NewSchemaPath().GetAttr("bool_property_value"),
@@ -368,11 +368,11 @@ func TestTraverseProperties(t *testing.T) {
 	}
 
 	assert.Equal(t, map[string][]walk.SchemaPath{
-		"example_resource": []walk.SchemaPath{
+		"example_resource": {
 			walk.NewSchemaPath().GetAttr("bool_property_value"),
 			walk.NewSchemaPath().GetAttr("bool_property_value"),
 			walk.NewSchemaPath().GetAttr("nested_resources").Element().GetAttr("opt_bool")},
-		"second_resource": []walk.SchemaPath{
+		"second_resource": {
 			walk.NewSchemaPath().GetAttr("bool_property_value")},
 	}, seenPaths)
 }

--- a/pkg/tfbridge/walk_test.go
+++ b/pkg/tfbridge/walk_test.go
@@ -266,8 +266,20 @@ func TestLookupSchemaInfoMapPath(t *testing.T) {
 
 func TestTraverseProperties(t *testing.T) {
 	prov := &ProviderInfo{
-		P:            shimv2.NewProvider(testTFProviderV2),
-		MetadataInfo: NewProviderMetadata(nil),
+		P:              shimv2.NewProvider(testTFProviderV2),
+		IgnoreMappings: []string{"nested_secret_resource"},
+		MetadataInfo:   NewProviderMetadata(nil),
+	}
+
+	tfToken := func(i PropertyVisitInfo) string {
+		switch root := i.Root.(type) {
+		case VisitResourceRoot:
+			return root.TfToken
+		case VisitDataSourceRoot:
+			return root.TfToken
+		default:
+			return ""
+		}
 	}
 
 	hasEffect := func(i PropertyVisitInfo) (PropertyVisitResult, error) {
@@ -277,79 +289,91 @@ func TestTraverseProperties(t *testing.T) {
 		}, nil
 	}
 
-	seenPaths := []SchemaPath{}
+	seenPaths := map[string][]SchemaPath{}
 	err := TraverseProperties(prov, t.Name(), func(i PropertyVisitInfo) (PropertyVisitResult, error) {
-		seenPaths = append(seenPaths, i.SchemaPath())
+		paths := seenPaths[tfToken(i)]
+		seenPaths[tfToken(i)] = append(paths, i.SchemaPath())
 		return hasEffect(i)
 	}, TraverseForEffect(false))
 	require.NoError(t, err)
 
-	walk.SortSchemaPaths(seenPaths)
+	for k, v := range seenPaths {
+		walk.SortSchemaPaths(v)
+		seenPaths[k] = v
+	}
 
-	assert.Equal(t, []walk.SchemaPath{
-		walk.NewSchemaPath().GetAttr("array_property_value"),
-		walk.NewSchemaPath().GetAttr("array_property_value"),
-		walk.NewSchemaPath().GetAttr("array_property_value"),
-		walk.NewSchemaPath().GetAttr("array_property_value").Element(),
-		walk.NewSchemaPath().GetAttr("array_property_value").Element(),
-		walk.NewSchemaPath().GetAttr("array_property_value").Element(),
-		walk.NewSchemaPath().GetAttr("bool_property_value"),
-		walk.NewSchemaPath().GetAttr("bool_property_value"),
-		walk.NewSchemaPath().GetAttr("bool_property_value"),
-		walk.NewSchemaPath().GetAttr("config_value"),
-		walk.NewSchemaPath().GetAttr("conflicting_property"),
-		walk.NewSchemaPath().GetAttr("conflicting_property2"),
-		walk.NewSchemaPath().GetAttr("conflicting_property_unidirectional"),
-		walk.NewSchemaPath().GetAttr("float_property_value"),
-		walk.NewSchemaPath().GetAttr("float_property_value"),
-		walk.NewSchemaPath().GetAttr("float_property_value"),
-		walk.NewSchemaPath().GetAttr("map_property_value"),
-		walk.NewSchemaPath().GetAttr("nested"),
-		walk.NewSchemaPath().GetAttr("nested").Element().GetAttr("a_secret"),
-		walk.NewSchemaPath().GetAttr("nested_resources"),
-		walk.NewSchemaPath().GetAttr("nested_resources"),
-		walk.NewSchemaPath().GetAttr("nested_resources"),
-		walk.NewSchemaPath().GetAttr("nested_resources").Element().GetAttr("configuration"),
-		walk.NewSchemaPath().GetAttr("nested_resources").Element().GetAttr("configuration"),
-		walk.NewSchemaPath().GetAttr("nested_resources").Element().GetAttr("configuration"),
-		walk.NewSchemaPath().GetAttr("nested_resources").Element().GetAttr("kind"),
-		walk.NewSchemaPath().GetAttr("nested_resources").Element().GetAttr("opt_bool"),
-		walk.NewSchemaPath().GetAttr("nil_property_value"),
-		walk.NewSchemaPath().GetAttr("nil_property_value"),
-		walk.NewSchemaPath().GetAttr("nil_property_value"),
-		walk.NewSchemaPath().GetAttr("number_property_value"),
-		walk.NewSchemaPath().GetAttr("number_property_value"),
-		walk.NewSchemaPath().GetAttr("number_property_value"),
-		walk.NewSchemaPath().GetAttr("object_property_value"),
-		walk.NewSchemaPath().GetAttr("object_property_value"),
-		walk.NewSchemaPath().GetAttr("object_property_value"),
-		walk.NewSchemaPath().GetAttr("set_property_value"),
-		walk.NewSchemaPath().GetAttr("set_property_value"),
-		walk.NewSchemaPath().GetAttr("set_property_value"),
-		walk.NewSchemaPath().GetAttr("set_property_value").Element(),
-		walk.NewSchemaPath().GetAttr("set_property_value").Element(),
-		walk.NewSchemaPath().GetAttr("set_property_value").Element(),
-		walk.NewSchemaPath().GetAttr("string_property_value"),
-		walk.NewSchemaPath().GetAttr("string_property_value"),
-		walk.NewSchemaPath().GetAttr("string_property_value"),
-		walk.NewSchemaPath().GetAttr("string_with_bad_interpolation"),
-		walk.NewSchemaPath().GetAttr("string_with_bad_interpolation"),
-		walk.NewSchemaPath().GetAttr("string_with_bad_interpolation"),
+	assert.Equal(t, map[string][]walk.SchemaPath{
+		"": []walk.SchemaPath{
+			walk.NewSchemaPath().GetAttr("config_value")},
+		"example_resource": []walk.SchemaPath{
+			walk.NewSchemaPath().GetAttr("array_property_value"),
+			walk.NewSchemaPath().GetAttr("array_property_value"),
+			walk.NewSchemaPath().GetAttr("array_property_value").Element(),
+			walk.NewSchemaPath().GetAttr("array_property_value").Element(),
+			walk.NewSchemaPath().GetAttr("bool_property_value"),
+			walk.NewSchemaPath().GetAttr("bool_property_value"),
+			walk.NewSchemaPath().GetAttr("float_property_value"),
+			walk.NewSchemaPath().GetAttr("float_property_value"),
+			walk.NewSchemaPath().GetAttr("map_property_value"),
+			walk.NewSchemaPath().GetAttr("nested_resources"),
+			walk.NewSchemaPath().GetAttr("nested_resources"),
+			walk.NewSchemaPath().GetAttr("nested_resources").Element().GetAttr("configuration"),
+			walk.NewSchemaPath().GetAttr("nested_resources").Element().GetAttr("configuration"),
+			walk.NewSchemaPath().GetAttr("nested_resources").Element().GetAttr("kind"),
+			walk.NewSchemaPath().GetAttr("nested_resources").Element().GetAttr("opt_bool"),
+			walk.NewSchemaPath().GetAttr("nil_property_value"),
+			walk.NewSchemaPath().GetAttr("nil_property_value"),
+			walk.NewSchemaPath().GetAttr("number_property_value"),
+			walk.NewSchemaPath().GetAttr("number_property_value"),
+			walk.NewSchemaPath().GetAttr("object_property_value"),
+			walk.NewSchemaPath().GetAttr("object_property_value"),
+			walk.NewSchemaPath().GetAttr("set_property_value"),
+			walk.NewSchemaPath().GetAttr("set_property_value"),
+			walk.NewSchemaPath().GetAttr("set_property_value").Element(),
+			walk.NewSchemaPath().GetAttr("set_property_value").Element(),
+			walk.NewSchemaPath().GetAttr("string_property_value"),
+			walk.NewSchemaPath().GetAttr("string_property_value"),
+			walk.NewSchemaPath().GetAttr("string_with_bad_interpolation"),
+			walk.NewSchemaPath().GetAttr("string_with_bad_interpolation")},
+		"second_resource": []walk.SchemaPath{
+			walk.NewSchemaPath().GetAttr("array_property_value"),
+			walk.NewSchemaPath().GetAttr("array_property_value").Element(),
+			walk.NewSchemaPath().GetAttr("bool_property_value"),
+			walk.NewSchemaPath().GetAttr("conflicting_property"),
+			walk.NewSchemaPath().GetAttr("conflicting_property2"),
+			walk.NewSchemaPath().GetAttr("conflicting_property_unidirectional"),
+			walk.NewSchemaPath().GetAttr("float_property_value"),
+			walk.NewSchemaPath().GetAttr("nested_resources"),
+			walk.NewSchemaPath().GetAttr("nested_resources").Element().GetAttr("configuration"),
+			walk.NewSchemaPath().GetAttr("nil_property_value"),
+			walk.NewSchemaPath().GetAttr("number_property_value"),
+			walk.NewSchemaPath().GetAttr("object_property_value"),
+			walk.NewSchemaPath().GetAttr("set_property_value"),
+			walk.NewSchemaPath().GetAttr("set_property_value").Element(),
+			walk.NewSchemaPath().GetAttr("string_property_value"),
+			walk.NewSchemaPath().GetAttr("string_with_bad_interpolation")},
 	}, seenPaths)
 
-	seenPaths = []SchemaPath{}
+	seenPaths = map[string][]SchemaPath{}
 	err = TraverseProperties(prov, t.Name(), func(i PropertyVisitInfo) (PropertyVisitResult, error) {
-		seenPaths = append(seenPaths, i.SchemaPath())
+		paths := seenPaths[tfToken(i)]
+		seenPaths[tfToken(i)] = append(paths, i.SchemaPath())
 		return hasEffect(i)
 	}, TraverseForEffect(true))
 	require.NoError(t, err)
 
-	walk.SortSchemaPaths(seenPaths)
-	assert.Equal(t, []walk.SchemaPath{
-		walk.NewSchemaPath().GetAttr("bool_property_value"),
-		walk.NewSchemaPath().GetAttr("bool_property_value"),
-		walk.NewSchemaPath().GetAttr("bool_property_value"),
-		walk.NewSchemaPath().GetAttr("nested_resources").Element().GetAttr("opt_bool"),
+	for k, v := range seenPaths {
+		walk.SortSchemaPaths(v)
+		seenPaths[k] = v
+	}
+
+	assert.Equal(t, map[string][]walk.SchemaPath{
+		"example_resource": []walk.SchemaPath{
+			walk.NewSchemaPath().GetAttr("bool_property_value"),
+			walk.NewSchemaPath().GetAttr("bool_property_value"),
+			walk.NewSchemaPath().GetAttr("nested_resources").Element().GetAttr("opt_bool")},
+		"second_resource": []walk.SchemaPath{
+			walk.NewSchemaPath().GetAttr("bool_property_value")},
 	}, seenPaths)
 }
 

--- a/pkg/tfbridge/walk_test.go
+++ b/pkg/tfbridge/walk_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 
@@ -277,10 +278,11 @@ func TestTraverseProperties(t *testing.T) {
 	}
 
 	seenPaths := []SchemaPath{}
-	TraverseProperties(prov, t.Name(), func(i PropertyVisitInfo) (PropertyVisitResult, error) {
+	err := TraverseProperties(prov, t.Name(), func(i PropertyVisitInfo) (PropertyVisitResult, error) {
 		seenPaths = append(seenPaths, i.SchemaPath())
 		return hasEffect(i)
 	}, TraverseForEffect(false))
+	require.NoError(t, err)
 
 	walk.SortSchemaPaths(seenPaths)
 
@@ -336,10 +338,11 @@ func TestTraverseProperties(t *testing.T) {
 	}, seenPaths)
 
 	seenPaths = []SchemaPath{}
-	TraverseProperties(prov, t.Name(), func(i PropertyVisitInfo) (PropertyVisitResult, error) {
+	err = TraverseProperties(prov, t.Name(), func(i PropertyVisitInfo) (PropertyVisitResult, error) {
 		seenPaths = append(seenPaths, i.SchemaPath())
 		return hasEffect(i)
 	}, TraverseForEffect(true))
+	require.NoError(t, err)
 
 	walk.SortSchemaPaths(seenPaths)
 	assert.Equal(t, []walk.SchemaPath{
@@ -382,7 +385,8 @@ func TestTraversePropertiesSchemaInfo(t *testing.T) {
 			Fields["bool_property_value"].ForceNew)
 	}
 
-	TraverseProperties(prov, t.Name(), visitor, TraverseForEffect(false))
+	err := TraverseProperties(prov, t.Name(), visitor, TraverseForEffect(false))
+	require.NoError(t, err)
 
 	assert.NotNil(t, prov.Resources["example_resource"].
 		Fields["nested_resources"].Elem.
@@ -395,7 +399,8 @@ func TestTraversePropertiesSchemaInfo(t *testing.T) {
 		P:            shimv2.NewProvider(testTFProviderV2),
 		MetadataInfo: md.ExtractRuntimeMetadata(),
 	}
-	TraverseProperties(prov, t.Name(), visitor, TraverseForEffect(true))
+	err = TraverseProperties(prov, t.Name(), visitor, TraverseForEffect(true))
+	require.NoError(t, err)
 	verify(prov)
 
 	// This property did not have an effect, so it should not have been visited.


### PR DESCRIPTION
The goal is a general solution that abstracts traversing each SchemaInfo in a provider and applying some action. To prevent the provider from bogging down during startup, the API needs to do a full search during tfgen time, and then visit only impactful fields during the providers runtime.

This implementation will replace gcp's labels traversal, aws's tags traversal and will be used in akamai to unify types.

The implementation takes after https://github.com/pulumi/pulumi-terraform-bridge/pull/1544. Visitors return if they had an "effect". During `make tfgen`, every path is visited and a list of "effectful" `SchemaPath`s is built. During the provider's normal runtime, this list is deserialized and only these paths are visited.