### PR TITLE
Add a SchemaPathToPropertyPath

### DIFF
--- a/pkg/tfshim/util/types.go
+++ b/pkg/tfshim/util/types.go
@@ -18,7 +18,7 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
-// isOfTypeMap detects schemas indicating a map[string,X] type. Due to a quirky encoding of
+// IsOfTypeMap detects schemas indicating a map[string,X] type. Due to a quirky encoding of
 // single-nested Terraform blocks, it is insufficient to just check for tfs.Type() == shim.TypeMap.
 // See [shim.Schema.Elem()] comment for all the details of the encoding.
 func IsOfTypeMap(tfs shim.Schema) bool {
@@ -27,4 +27,19 @@ func IsOfTypeMap(tfs shim.Schema) bool {
 	}
 	_, hasResourceElem := tfs.Elem().(shim.Resource)
 	return !hasResourceElem
+}
+
+// CastToTypeObject performs a checked cast from shim.Schema to a TF object (a collection
+// of fields).
+//
+// See [shim.Schema.Elem()] comment for all the details of the encoding.
+func CastToTypeObject(tfs shim.Schema) (shim.SchemaMap, bool) {
+	if tfs == nil {
+		return nil, false
+	}
+	res, isRes := tfs.Elem().(shim.Resource)
+	if isRes && tfs.Type() == shim.TypeMap {
+		return res.Schema(), true
+	}
+	return nil, false
 }


### PR DESCRIPTION
This function is currently unused in the bridge itself. It is expected that the function will be used by providers.

See https://github.com/pulumi/pulumi-gcp/pull/1474 for an example.

---

Some tests had PP names that didn't make sense with the given schema. I corrected them to allow round-tripability:

```patch
-			pp:       []any{"objSet", 0},
+			pp:       []any{"objSets", 0},
```

I added a test with name overrides to confirm that it still worked as expected.  Put simply, the property path []any{"listStr"} would have never been generated by the bridge from it's schema, since TerraformToPulumiName would have pluralized listStr to listStrs. This worked in the context of the previous test, but lost information in the translation.