### PR TITLE
Restrict Autonaming to String types

### DIFF
--- a/internal/testprovider/autonaming.go
+++ b/internal/testprovider/autonaming.go
@@ -1,0 +1,68 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testprovider
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func AutonamingProvider() *schema.Provider {
+	r := func(r func() map[string]*schema.Schema) *schema.Resource {
+		return &schema.Resource{
+			Schema: r(),
+		}
+	}
+
+	return &schema.Provider{
+		Schema: map[string]*schema.Schema{},
+		ResourcesMap: map[string]*schema.Resource{
+			"auto_v1": r(resourceAutoNamedV1),
+			"auto_v2": r(resourceAutoNamedV2),
+		},
+	}
+}
+
+func resourceAutoNamedV1() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:        schema.TypeString,
+			Required:    true,
+			ForceNew:    true,
+			Description: "Name of the ruleset.",
+		},
+		"description": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Brief summary of the ruleset and its intended use.",
+		},
+	}
+}
+
+func resourceAutoNamedV2() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:        schema.TypeList,
+			Elem:        schema.TypeString,
+			Required:    true,
+			ForceNew:    true,
+			Description: "Name of the ruleset.",
+		},
+		"description": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Brief summary of the ruleset and its intended use.",
+		},
+	}
+}

--- a/pkg/tfbridge/names_test.go
+++ b/pkg/tfbridge/names_test.go
@@ -52,8 +52,6 @@ func TestTerraformToPulumiName(t *testing.T) {
 	assert.Equal(t, "TESTNAME", TerraformToPulumiName("t_e_s_t_n_a_m_e", nil, nil, true))
 }
 
-func ref[T any](value T) *T { return &value }
-
 func TestTerraformToPulumiNameWithSchemaInfoOverride(t *testing.T) {
 	tfs := map[string]*schema.Schema{
 		"list_property": {

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -2553,3 +2553,20 @@ func TestDefaultsAndRequiredWithValidationInteraction(t *testing.T) {
 			}`, "$", "`"))
 	})
 }
+
+func TestSetAutoNaming(t *testing.T) {
+	tok := func(name string) tokens.Type { return MakeResource("auto", "index", name) }
+	prov := &ProviderInfo{
+		Name: "auto",
+		P:    shimv2.NewProvider(testprovider.AutonamingProvider()),
+		Resources: map[string]*ResourceInfo{
+			"auto_v1": {Tok: tok("v1")},
+			"auto_v2": {Tok: tok("v2")},
+		},
+	}
+
+	prov.SetAutonaming(10, "-")
+
+	assert.True(t, prov.Resources["auto_v1"].Fields["name"].Default.AutoNamed) // Of type string - so applied
+	assert.Nil(t, prov.Resources["auto_v2"].Fields["name"])                    // Of type list - so not applied
+}


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-aws/issues/3199

`ProviderInfo.SetAutonaming` applies to all top level fields called "name". This works great... unless there is such a field of a type besides String. This PR removes AutoName from fields of the wrong type.

While this change is breaking at the schema level (since it moves fields from optional to required), it will not cause user programs to break since any "name" field from optional to required with the change would have invalid auto-names and thus be effectively required anyway.