### PR TITLE
Continue configuring in the normal way

### DIFF
--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -369,7 +369,13 @@ func (p *Provider) CheckConfig(ctx context.Context, req *pulumirpc.CheckRequest)
 	secretNews := MarkSchemaSecrets(ctx, p.config, p.info.Config, resource.NewObjectProperty(news)).ObjectValue()
 
 	// In case news was modified by pre-configure callbacks, marshal it again to send out the modified value.
-	newsStruct, err := configEnc.MarshalProperties(secretNews)
+	newsStruct, err := plugin.MarshalProperties(secretNews, plugin.MarshalOptions{
+		Label:        "config",
+		KeepUnknowns: true,
+		SkipNulls:    true,
+		KeepSecrets:  true,
+		RejectAssets: true,
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
@blampe points out in https://github.com/pulumi/pulumi-go-provider/pull/172 it's might not be necessary to marshal with configencoding once we get past CheckConfig.  Interesting idea. This works fine for a simple program on custom AWS build:

```
name: aws-yaml-configs
runtime: yaml
description: A minimal AWS Pulumi YAML program
outputs:
  # Export the name of the bucket
  bucketName: ${my-bucket.id}
resources:
  provider:
    type: pulumi:providers:aws
    properties:
      defaultTags:
        tags:
          foo: bar
    options:
      version: 6.17.0
  my-bucket:
    type: aws:s3:Bucket
    options:
      provider: ${provider}
``` 

Let me think of further testing. This can improve granularity of secret tracking. 