### PR TITLE
Fix plugin framework encoding of MaxItems=1 fields

### DIFF
--- a/pf/internal/convert/object.go
+++ b/pf/internal/convert/object.go
@@ -74,16 +74,15 @@ func (enc *objectEncoder) fromPropertyValue(p resource.PropertyValue) (tftypes.V
 		t := enc.objectType.AttributeTypes[attr]
 		key := enc.propertyNames.PropertyKey(attr, t)
 		pv, gotPV := pulumiMap[key]
-		if gotPV {
-			v, err := attrEncoder.fromPropertyValue(pv)
-			if err != nil {
-				return tftypes.NewValue(enc.objectType, nil),
-					fmt.Errorf("objectEncoder failed on property %q: %w", attr, err)
-			}
-			values[attr] = v
-		} else {
-			values[attr] = tftypes.NewValue(t, nil)
+		if !gotPV {
+			pv = resource.NewNullProperty()
 		}
+		v, err := attrEncoder.fromPropertyValue(pv)
+		if err != nil {
+			return tftypes.NewValue(enc.objectType, nil),
+				fmt.Errorf("objectEncoder failed on property %q: %w", attr, err)
+		}
+		values[attr] = v
 	}
 	return tftypes.NewValue(enc.objectType, values), nil
 }

--- a/pf/internal/convert/object_test.go
+++ b/pf/internal/convert/object_test.go
@@ -1,0 +1,59 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package convert
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
+// When PropertyMap is missing an entry, do not assume that the result is null but instead call the
+// matching encoder. Some encoders like flattened would prefer to return empty lists.
+func TestObjectEncoderRecursesWhenMissing(t *testing.T) {
+	pn := &trivialLocalPropertyNames{}
+	innerType := tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{
+			"x": tftypes.String,
+		},
+	}
+	innerEncoders := map[string]Encoder{"x": &stringEncoder{}}
+	innerEnc, err := newObjectEncoder(innerType, innerEncoders, pn)
+	require.NoError(t, err)
+
+	collectionType := tftypes.List{ElementType: innerType}
+
+	ty := tftypes.Object{AttributeTypes: map[string]tftypes.Type{"prop": collectionType}}
+
+	encoders := map[string]Encoder{"prop": &flattenedEncoder{
+		collectionType: collectionType,
+		elementEncoder: innerEnc,
+	}}
+
+	encoder, err := newObjectEncoder(ty, encoders, &trivialLocalPropertyNames{})
+	require.NoError(t, err)
+
+	v, err := EncodePropertyMap(encoder, resource.PropertyMap{})
+	require.NoError(t, err)
+
+	expected := tftypes.NewValue(ty, map[string]tftypes.Value{
+		"prop": tftypes.NewValue(collectionType, []tftypes.Value{}),
+	})
+
+	require.Truef(t, expected.Equal(v), "exp: %s\n\ngot: %s\n\n", expected.String(), v.String())
+}


### PR DESCRIPTION
Fixes a bug where transforming PropertyValue to tftypes.Value incorrectly translated missing values as null where empty collections were expected because of MaxItems=1 flattened projection.

This change is needed to fix https://github.com/pulumi/pulumi-cloudflare/issues/444