### PR TITLE
Fix error handling in flattened encoder

### DIFF
--- a/pf/internal/convert/flattened.go
+++ b/pf/internal/convert/flattened.go
@@ -29,7 +29,7 @@ type flattenedEncoder struct {
 func (enc *flattenedEncoder) fromPropertyValue(v resource.PropertyValue) (tftypes.Value, error) {
 	encoded, err := enc.elementEncoder.fromPropertyValue(v)
 	if err != nil {
-		return tftypes.Value{}, nil
+		return tftypes.Value{}, err
 	}
 
 	list := []tftypes.Value{}
@@ -47,7 +47,7 @@ type flattenedDecoder struct {
 func (dec *flattenedDecoder) toPropertyValue(v tftypes.Value) (resource.PropertyValue, error) {
 	var list []tftypes.Value
 	if err := v.As(&list); err != nil {
-		return resource.PropertyValue{}, nil
+		return resource.PropertyValue{}, err
 	}
 	switch len(list) {
 	case 0:

--- a/pf/internal/convert/flattened_test.go
+++ b/pf/internal/convert/flattened_test.go
@@ -72,6 +72,11 @@ func TestFlattenedEncoder(t *testing.T) {
 		expected := tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, []tftypes.Value{})
 		assert.Equal(t, expected, actual)
 	})
+
+	t.Run("error-propagation", func(t *testing.T) {
+		_, err := listEncoder.fromPropertyValue(resource.NewObjectProperty(resource.PropertyMap{}))
+		require.Error(t, err)
+	})
 }
 
 func TestFlattenedDecoder(t *testing.T) {
@@ -121,6 +126,12 @@ func TestFlattenedDecoder(t *testing.T) {
 		require.NoError(t, err)
 		expected := resource.NewNullProperty()
 		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("error-propagation", func(t *testing.T) {
+		tfValue := tftypes.NewValue(tftypes.String, "mistyped")
+		_, err := listDecoder.toPropertyValue(tfValue)
+		require.Error(t, err)
 	})
 }
 


### PR DESCRIPTION
Looks like there was a small omission that resulted in swallowing errors. Possibly a typo. Fixing and adding coverage. 