### PR TITLE
Revert "Allow the `Type` override to effect downstream types"

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -426,10 +426,6 @@ type SchemaInfo struct {
 	CSharpName string
 
 	// a type to override the default; "" uses the default.
-	//
-	// If the type overridden is an object type, `Type: newName` is interpreted as a
-	// move operation, pointing the property to a type called `newName` and creating
-	// `newName` with the schema described by this type.
 	Type tokens.Type
 
 	// alternative types that can be used instead of the override.
@@ -438,7 +434,7 @@ type SchemaInfo struct {
 	// a type to override when the property is a nested structure.
 	NestedType tokens.Type
 
-	// an optional idempotent transformation, applied before passing to TF.
+	// an optional idemponent transformation, applied before passing to TF.
 	Transform Transformer
 
 	// a schema override for elements for arrays, maps, and sets.

--- a/pkg/tfgen/generate_test.go
+++ b/pkg/tfgen/generate_test.go
@@ -285,73 +285,74 @@ func Test_ProviderWithObjectTypesInConfigCanGenerateRenames(t *testing.T) {
 	assert.Equal(t, "foo_bar", r.Renames.RenamedProperties["test:index/ProviderProp:ProviderProp"]["fooBar"])
 }
 
-func generateNestedSchema(t *testing.T, f func(*tfbridge.ResourceInfo)) pschema.PackageSpec {
-	strType := (&shimschema.Schema{Type: shim.TypeString}).Shim()
-	mkObj := func(m shim.SchemaMap) shim.Schema {
-		return (&shimschema.Schema{
+func Test_ProviderWithOmittedTypes(t *testing.T) {
+
+	gen := func(t *testing.T, f func(*tfbridge.ResourceInfo)) pschema.PackageSpec {
+		strType := (&shimschema.Schema{Type: shim.TypeString}).Shim()
+		nestedObj := (&shimschema.Schema{
 			Type:     shim.TypeMap,
 			Optional: true,
-			Elem:     (&shimschema.Resource{Schema: m}).Shim(),
-		}).Shim()
-	}
-
-	nestedObj := mkObj(shimschema.SchemaMap{
-		"fizz_buzz": strType,
-	})
-	objType := mkObj(shimschema.SchemaMap{
-		"foo_bar": strType,
-		"nested":  nestedObj,
-	})
-
-	p := (&shimschema.Provider{
-		ResourcesMap: shimschema.ResourceMap{
-			"test_res": (&shimschema.Resource{
+			Elem: (&shimschema.Resource{
 				Schema: shimschema.SchemaMap{
-					"obj": objType,
+					"fizz_buzz": strType,
 				},
 			}).Shim(),
-		},
-	}).Shim()
+		}).Shim()
+		objType := (&shimschema.Schema{
+			Type:     shim.TypeMap,
+			Optional: true,
+			Elem: (&shimschema.Resource{
+				Schema: shimschema.SchemaMap{
+					"foo_bar": strType,
+					"nested":  nestedObj,
+				},
+			}).Shim(),
+		}).Shim()
 
-	nilSink := diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{
-		Color: colors.Never,
-	})
-
-	res := &tfbridge.ResourceInfo{
-		Tok: "test:index:Bar",
-	}
-	if f != nil {
-		f(res)
-	}
-
-	r, err := GenerateSchemaWithOptions(GenerateSchemaOptions{
-		DiagnosticsSink: nilSink,
-		ProviderInfo: tfbridge.ProviderInfo{
-			Name: "test",
-			P:    p,
-			Resources: map[string]*tfbridge.ResourceInfo{
-				"test_res": res,
+		p := (&shimschema.Provider{
+			ResourcesMap: shimschema.ResourceMap{
+				"test_res": (&shimschema.Resource{
+					Schema: shimschema.SchemaMap{
+						"obj": objType,
+					},
+				}).Shim(),
 			},
-		},
-	})
-	require.NoError(t, err)
-	return r.PackageSpec
-}
+		}).Shim()
 
-func Test_ProviderWithOmittedTypes(t *testing.T) {
-	t.Parallel()
+		nilSink := diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{
+			Color: colors.Never,
+		})
+
+		res := &tfbridge.ResourceInfo{
+			Tok: "test:index:Bar",
+		}
+		if f != nil {
+			f(res)
+		}
+
+		r, err := GenerateSchemaWithOptions(GenerateSchemaOptions{
+			DiagnosticsSink: nilSink,
+			ProviderInfo: tfbridge.ProviderInfo{
+				Name: "test",
+				P:    p,
+				Resources: map[string]*tfbridge.ResourceInfo{
+					"test_res": res,
+				},
+			},
+		})
+		require.NoError(t, err)
+		return r.PackageSpec
+	}
 
 	t.Run("no-omit", func(t *testing.T) {
-		t.Parallel()
-		spec := generateNestedSchema(t, nil)
+		spec := gen(t, nil)
 		assert.Len(t, spec.Resources, 1)
 		assert.Len(t, spec.Resources["test:index:Bar"].InputProperties, 1)
 		assert.Len(t, spec.Types, 2)
 	})
 
 	t.Run("omit-top-level-prop", func(t *testing.T) {
-		t.Parallel()
-		spec := generateNestedSchema(t, func(info *tfbridge.ResourceInfo) {
+		spec := gen(t, func(info *tfbridge.ResourceInfo) {
 			info.Fields = map[string]*tfbridge.SchemaInfo{
 				"obj": {Omit: true},
 			}
@@ -362,8 +363,7 @@ func Test_ProviderWithOmittedTypes(t *testing.T) {
 	})
 
 	t.Run("omit-nested-prop", func(t *testing.T) {
-		t.Parallel()
-		spec := generateNestedSchema(t, func(info *tfbridge.ResourceInfo) {
+		spec := gen(t, func(info *tfbridge.ResourceInfo) {
 			info.Fields = map[string]*tfbridge.SchemaInfo{
 				"obj": {
 					Elem: &tfbridge.SchemaInfo{
@@ -377,195 +377,6 @@ func Test_ProviderWithOmittedTypes(t *testing.T) {
 		assert.Len(t, spec.Resources, 1)
 		assert.Len(t, spec.Resources["test:index:Bar"].InputProperties, 1)
 		assert.Len(t, spec.Types, 1)
-	})
-
-}
-
-func Test_ProviderWithMovedTypes(t *testing.T) {
-	t.Parallel()
-
-	t.Run("none", func(t *testing.T) {
-		t.Parallel()
-		spec := generateNestedSchema(t, nil)
-		assert.Len(t, spec.Resources, 1)
-		assert.Len(t, spec.Resources["test:index:Bar"].InputProperties, 1)
-		assert.Len(t, spec.Types, 2)
-		assert.Contains(t, spec.Types, "test:index/BarObj:BarObj")
-		assert.Contains(t, spec.Types, "test:index/BarObjNested:BarObjNested")
-	})
-
-	t.Run("top-level", func(t *testing.T) {
-		t.Parallel()
-		spec := generateNestedSchema(t, func(info *tfbridge.ResourceInfo) {
-			info.Fields = map[string]*tfbridge.SchemaInfo{
-				"obj": {
-					Elem: &tfbridge.SchemaInfo{
-						Type: "test:moved:Top",
-					},
-				},
-			}
-		})
-
-		assert.Len(t, spec.Resources, 1)
-		assert.Len(t, spec.Types, 2)
-		if assert.Contains(t, spec.Types, "test:moved:Top") {
-			assert.Contains(t, spec.Types, "test:moved/TopNested:TopNested")
-		}
-	})
-
-	t.Run("nested-prop", func(t *testing.T) {
-		t.Parallel()
-		spec := generateNestedSchema(t, func(info *tfbridge.ResourceInfo) {
-			info.Fields = map[string]*tfbridge.SchemaInfo{
-				"obj": {
-					Elem: &tfbridge.SchemaInfo{
-						Fields: map[string]*tfbridge.SchemaInfo{
-							"nested": {
-								Elem: &tfbridge.SchemaInfo{
-									Type: "test:moved:Nested",
-								},
-							},
-						},
-					},
-				},
-			}
-		})
-		assert.Len(t, spec.Resources, 1)
-		assert.Len(t, spec.Types, 2)
-		assert.Contains(t, spec.Types, "test:index/BarObj:BarObj")
-		assert.Contains(t, spec.Types, "test:moved:Nested")
-	})
-
-	strType := (&shimschema.Schema{Type: shim.TypeString}).Shim()
-	mkObj := func(m shim.SchemaMap) shim.Schema {
-		return (&shimschema.Schema{
-			Type:     shim.TypeMap,
-			Optional: true,
-			Elem:     (&shimschema.Resource{Schema: m}).Shim(),
-		}).Shim()
-	}
-	nilSink := diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{
-		Color: colors.Never,
-	})
-
-	t.Run("conflict", func(t *testing.T) {
-		t.Parallel()
-
-		nestedObj := mkObj(shimschema.SchemaMap{
-			"fizz_buzz": strType,
-		})
-		objType := mkObj(shimschema.SchemaMap{
-			"foo_bar": strType,
-			"nested":  nestedObj,
-		})
-
-		p := (&shimschema.Provider{
-			ResourcesMap: shimschema.ResourceMap{
-				"test_res": (&shimschema.Resource{
-					Schema: shimschema.SchemaMap{
-						"obj": objType,
-					},
-				}).Shim(),
-				"test_other": (&shimschema.Resource{
-					Schema: shimschema.SchemaMap{
-						"obj": nestedObj,
-					},
-				}).Shim(),
-			},
-		}).Shim()
-
-		nameObj := map[string]*tfbridge.SchemaInfo{
-			"obj": {
-				Elem: &tfbridge.SchemaInfo{
-					Type: "test:index:Obj",
-				},
-			},
-		}
-
-		// GenerateSchemaWithOptions should return an error when we force distinct
-		// types to have the same type token. Instead, it panics. We capture this
-		// behavior for now, since we want to assert that it doesn't return
-		// garbage.
-		err := "fatal: An assertion has failed: Obj declared twice with different values"
-		assert.PanicsWithValue(t, err, func() {
-			_, _ = GenerateSchemaWithOptions(GenerateSchemaOptions{
-				DiagnosticsSink: nilSink,
-				ProviderInfo: tfbridge.ProviderInfo{
-					Name: "test",
-					P:    p,
-					Resources: map[string]*tfbridge.ResourceInfo{
-						"test_res": {
-							Tok:    "test:index:Res",
-							Fields: nameObj,
-						},
-						"test_other": {
-							Tok:    "test:index:Other",
-							Fields: nameObj,
-						},
-					},
-				},
-			})
-		})
-	})
-
-	t.Run("no-conflict", func(t *testing.T) {
-		t.Parallel()
-
-		nestedObj := mkObj(shimschema.SchemaMap{
-			"fizz_buzz": strType,
-		})
-		objType := mkObj(shimschema.SchemaMap{
-			"foo_bar": strType,
-			"nested":  nestedObj,
-		})
-
-		p := (&shimschema.Provider{
-			ResourcesMap: shimschema.ResourceMap{
-				"test_res": (&shimschema.Resource{
-					Schema: shimschema.SchemaMap{
-						"field1": objType,
-					},
-				}).Shim(),
-				"test_other": (&shimschema.Resource{
-					Schema: shimschema.SchemaMap{
-						"field2": objType,
-					},
-				}).Shim(),
-			},
-		}).Shim()
-
-		nameObj := func(i int) map[string]*tfbridge.SchemaInfo {
-			return map[string]*tfbridge.SchemaInfo{
-				fmt.Sprintf("field%d", i): {
-					Elem: &tfbridge.SchemaInfo{
-						Type: "test:index:Obj",
-					},
-				},
-			}
-		}
-
-		r, err := GenerateSchemaWithOptions(GenerateSchemaOptions{
-			DiagnosticsSink: nilSink,
-			ProviderInfo: tfbridge.ProviderInfo{
-				Name: "test",
-				P:    p,
-				Resources: map[string]*tfbridge.ResourceInfo{
-					"test_res": {
-						Tok:    "test:index:Res",
-						Fields: nameObj(1),
-					},
-					"test_other": {
-						Tok:    "test:index:Other",
-						Fields: nameObj(2),
-					},
-				},
-			},
-		})
-		require.NoError(t, err)
-
-		assert.Len(t, r.PackageSpec.Resources, 2)
-		assert.Len(t, r.PackageSpec.Types, 2,
-			"Since nested types were declared to have the same name, they should only show up once.")
 	})
 
 }

--- a/pkg/tfgen/internal/paths/paths.go
+++ b/pkg/tfgen/internal/paths/paths.go
@@ -336,27 +336,3 @@ func (s TypePathSet) Paths() []TypePath {
 	})
 	return res
 }
-
-// RawTypePath represents a type anchored from an opaque user provided type.
-type RawTypePath struct {
-	t              tokens.Type
-	structuralPath TypePath
-}
-
-func NewRawPath(typ tokens.Type, structuralPath TypePath) *RawTypePath {
-	return &RawTypePath{typ, structuralPath}
-}
-
-var _ TypePath = (*RawTypePath)(nil)
-
-func (p *RawTypePath) Parent() TypePath { return nil }
-
-// Useful for comparing paths.
-func (p *RawTypePath) UniqueKey() string { return p.t.String() }
-
-// Human friendly representation.
-func (p *RawTypePath) String() string { return p.t.Name().String() }
-
-func (p *RawTypePath) Raw() tokens.Type { return p.t }
-
-func (p *RawTypePath) StructuralPath() TypePath { return p.structuralPath }

--- a/pkg/tfgen/namecheck.go
+++ b/pkg/tfgen/namecheck.go
@@ -383,8 +383,6 @@ func locateTypByTypePath(prov tfbridge.ProviderInfo, path paths.TypePath) (typ, 
 			return nil, err
 		}
 		return t.Element()
-	case *paths.RawTypePath:
-		return locateTypByTypePath(prov, p.StructuralPath())
 	default:
 		panic("impossible match in locateTypByTypePath")
 	}


### PR DESCRIPTION
Reverts pulumi/pulumi-terraform-bridge#1550

Discovered that ExtraTypes support is broken by this change per https://github.com/pulumi/pulumi-terraform-bridge/issues/1626 