### PR TITLE
Create a fixupImports function as a docs replacement ruleset

### DIFF
--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -173,7 +173,7 @@ func fixupImports() tfbridge.DocsEdit {
 			content = blockImportRegexp.ReplaceAllLiteral(content, nil)
 			content = inlineImportRegexp.ReplaceAllFunc(content, func(match []byte) []byte {
 				match = bytes.ReplaceAll(match, []byte("terraform"), []byte("pulumi"))
-				match = bytes.ReplaceAll(match, []byte("Terraform"), []byte("pulumi"))
+				match = bytes.ReplaceAll(match, []byte("Terraform"), []byte("Pulumi"))
 				return match
 			})
 			content = quotedImportRegexp.ReplaceAllLiteral(content, []byte("`pulumi import`"))

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -157,13 +157,39 @@ func boundedReplace(from, to string) tfbridge.DocsEdit {
 	}
 }
 
+func fixupImports() tfbridge.DocsEdit {
+
+	var inlineImportRegexp = regexp.MustCompile("% [tT]erraform import.*")
+	var quotedImportRegexp = regexp.MustCompile("`[tT]erraform import`")
+
+	// (?s) makes the '.' match newlines (in addition to everything else).
+	var blockImportRegexp = regexp.MustCompile("(?s)In [tT]erraform v[0-9]+\\.[0-9]+\\.[0-9]+ and later," +
+		" use an `import` block.*?```.+?```\n")
+
+	return tfbridge.DocsEdit{
+		Path: "*",
+		Edit: func(_ string, content []byte) ([]byte, error) {
+			// Strip import blocks
+			content = blockImportRegexp.ReplaceAllLiteral(content, nil)
+			content = inlineImportRegexp.ReplaceAllFunc(content, func(match []byte) []byte {
+				match = bytes.ReplaceAll(match, []byte("terraform"), []byte("pulumi"))
+				match = bytes.ReplaceAll(match, []byte("Terraform"), []byte("pulumi"))
+				return match
+			})
+			content = quotedImportRegexp.ReplaceAllLiteral(content, []byte("`pulumi import`"))
+			return content, nil
+		},
+	}
+}
+
 var (
 	// Replace content such as "`terraform plan`" with "`pulumi preview`"
 	replaceTfPlan = boundedReplace("[tT]erraform [pP]lan", "pulumi preview")
 	// Replace content such as " Terraform Apply." with " pulumi up."
 	replaceTfApply = boundedReplace("[tT]erraform [aA]pply", "pulumi up")
+
 	// A markdown link that has terraform in the link component.
-	tfLink = regexp.MustCompile(`\[([^\]]*)\]\(.*\.terraform([^\)]*)\)`)
+	tfLink = regexp.MustCompile(`\[([^\]]*)\]\(.*terraform([^\)]*)\)`)
 )
 
 type editRules []tfbridge.DocsEdit
@@ -196,6 +222,7 @@ func getEditRules(info *tfbridge.DocRuleInfo) editRules {
 				return tfLink.ReplaceAll(content, []byte("$1")), nil
 			},
 		},
+		fixupImports(),
 	}
 	if info == nil || info.EditRules == nil {
 		return defaults

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -1326,7 +1326,7 @@ func TestFixupImports(t *testing.T) {
 		},
 		{
 			"% Terraform import thing",
-			"% pulumi import thing",
+			"% Pulumi import thing",
 		},
 		{
 			"% FOO import thing",

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -1345,7 +1345,7 @@ func TestFixupImports(t *testing.T) {
 			`% pulumi import has-pulumi-name`,
 		},
 		{
-			"In Terraform v1.5.0 and later, use an `import` block to import Transfer Workflows using the `id`. For example:\n" +
+			text: "In Terraform v1.5.0 and later, use an `import` block to import Transfer Workflows using the `id`. For example:\n" +
 				"\n" +
 				"```terraform" + `
 		import {
@@ -1355,7 +1355,7 @@ func TestFixupImports(t *testing.T) {
 		` + "```yaml" + `
 		foo: bar
 		` + "```\n",
-			`post text:
+			expected: `post text:
 		` + "```yaml" + `
 		foo: bar
 		` + "```\n",
@@ -1381,7 +1381,7 @@ func TestFixupImports(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.text, func(t *testing.T) {
-			//t.Parallel()
+			t.Parallel()
 			myRule := fixupImports()
 			actual, err := myRule.Edit("*", []byte(tt.text))
 			require.NoError(t, err)

--- a/pkg/tfgen/test_data/link/expected.json
+++ b/pkg/tfgen/test_data/link/expected.json
@@ -1,5 +1,5 @@
 {
-  "Description": "## \n\nThis is a test that we correctly strip TF doc links.",
+  "Description": "## \n\nThis is a test that we correctly strip TF doc links.\n\nThis is another test that we correctly strip TF import links.\n\nWe also make sure that we strip TF registry doc links.",
   "Arguments": {},
   "Attributes": {},
   "Import": ""

--- a/pkg/tfgen/test_data/link/input.md
+++ b/pkg/tfgen/test_data/link/input.md
@@ -1,2 +1,6 @@
 
 This is a test that we [correctly](https://www.terraform.io/docs/pkg/some-resource) strip TF doc links.
+
+This is another test that we [correctly](https://developer.hashicorp.com/terraform/cli/commands/import) strip TF import links.
+
+We also make sure that we strip [TF registry doc links](https://terraform.io/docs/providers/google/guides/provider_versions.html).


### PR DESCRIPTION
This pull request creates a new DocsEdit rule that categorically removes import blocks of the format,
"In Terraform v1.5.0 and later, use an `import` block to import..." which cleans up unusable import
sections such as [this one](https://www.pulumi.com/registry/packages/gcp/api-docs/compute/instancegroupmanager/#import).

Of note: prior to this change, the link stripping was not covering the import link due to it having 
the string `/terraform/` in it, not `.terraform`. This change removes the `.` from the regular expression,
looking instead for all links containing `terraform`. As an additional bonus, for the GCP provider
this results in a significant improvement of docs field descriptions, as all "Beta" resource field descriptions
contained a link that was not properly stripped and hence were omitted from the schema for containing the
`terraform` string.

[You can see the schema for pulumi-gcp here and compare](https://github.com/pulumi/pulumi-gcp/blob/guin/docs-gen-updates/provider/cmd/pulumi-resource-gcp/schema.json).

Fixes #1592.


Remove dot from terraform link expression to be able to catch import links with the same expression.
Add new link formats to link test.
