### PR TITLE
Improve docs for bridged provider authors

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you want to wrap a _new_ Terraform provider as a Pulumi provider, check out [
 
 ## Developing a New Provider
 
-The recommended way to start developing a new TF provider is with https://github.com/pulumi/pulumi-tf-provider-boilerplate/issues.
+The recommended way to start developing a new TF provider is with [pulumi-tf-provider-boilerplate](https://github.com/pulumi/pulumi-tf-provider-boilerplate).
 
 If you want details on how provider development works, please see [our docs](./docs/new-provider.md).
 

--- a/README.md
+++ b/README.md
@@ -11,12 +11,13 @@ of infrastructure providers and types.  In principle, any of them can be program
 
 If you want to wrap a _new_ Terraform provider as a Pulumi provider, check out [pulumi/pulumi-tf-provider-boilerplate](https://github.com/pulumi/pulumi-tf-provider-boilerplate).
 
-## Overview
+## Developing a New Provider
 
-Although the Terraform schema is used as a starting point, the concept of "overlays" enables customization, including
-classification into modules, stronger typing, better documentation, and more.  Pulumi can also augment providers with
-non-CRUD operations like queries, metrics, and logs -- while not having to repeat all of the considerable and quality
-work that has already gone into building reliable CRUD operations against the major cloud providers' platforms.
+The recommended way to start developing a new TF provider is with https://github.com/pulumi/pulumi-tf-provider-boilerplate/issues.
+
+If you want details on how provider development works, please see [our docs](./docs/new-provider.md).
+
+## Overview
 
 Most users of Pulumi don't need to know how this bridge works.  Many will find it interesting, and, if you'd like to
 bring up a new provider that is available in Terraform but not yet Pulumi, we would love to hear from you.
@@ -62,39 +63,7 @@ This repo on its own isn't particularly interesting, until it is used to create 
 
 See [playbook](https://github.com/pulumi/platform-providers-team/blob/main/playbooks/Release%3A%20Terraform%20Bridge.md).
 
-### Adapting a New Terraform Provider
-
-It is relatively easy to adapt a Terraform Provider, X, for use with Pulumi.  The
-[AWS provider](https://github.com/pulumi/pulumi-aws) offers a good blueprint for how to go about this.
-
-You will create two Go binaries -- one purely for design-time usage to act as X's code-generator and the other for
-runtime usage to serve as its dynamic resource plugin -- and link with the Terraform Provider repo and this one.
-There is then typically a `resources.go` file that maps all of the Terraform Provider metadata available at runtime
-to types and concepts that the bridge will use to generate well-typed programmatic abstractions.
-
-The AWS provider provides a standard blueprint to follow for this.  There are three major elements:
-
-* [`cmd/pulumi-tfgen-aws/`](https://github.com/pulumi/pulumi-aws/tree/master/provider/cmd/pulumi-tfgen-aws)
-* [`cmd/pulumi-resource-aws/`](https://github.com/pulumi/pulumi-aws/tree/master/provider/cmd/pulumi-resource-aws)
-* [`resources.go`](https://github.com/pulumi/pulumi-aws/blob/master/provider/resources.go)
-
-The [`Makefile`](https://github.com/pulumi/pulumi-aws/blob/master/Makefile) compiles these programs, and notably, uses
-the resulting `pulumi-tfgen-aws` binary to generate code for many different languages.  The resulting generated code is
-stored in the [`sdk` directory](https://github.com/pulumi/pulumi-aws/tree/master/sdk).
-
-### Augmenting Auto-Generated Code w/ Overlays
-
-An overlay is a set of additional directives that the code generator obeys when creating the final packages.
-
-These may specify additional types, functions, or entire modules in this directory may be merged into the resulting
-package.  This can be useful for helper modules and functions, in addition to gradual typing, such as using strongly
-typed enums in places where the underlying provider may only have weakly typed strings.
-
-To do this, first add the files in the appropriate package sub-directory of the sdk, and then add the requisite directives to the
-provider file.  See the [AWS overlays section in resources.go](https://github.com/pulumi/pulumi-aws/blob/master/provider/resources.go#L4486) for
-an example of this in action.
-
-# tfgen options
+## Design Time Options
 
 tfgen, the command that generates Pulumi schema/code for a bridged provider supports the following environment variables:
 

--- a/docs/automatic-token-mapping.md
+++ b/docs/automatic-token-mapping.md
@@ -1,0 +1,48 @@
+# Automatic Token Mapping
+
+Automatic token mappings provide a programmatic way to map Terraform tokens to Pulumi tokens.
+
+## `tfbridge.ProviderInfo.ComputeTokens`
+
+`tfbridge.ProviderInfo.ComputeTokens` (or `tfbridge.ProviderInfo.MustComputeTokens` to panic on errors) is the entry point for automatic token mapping. `ComputeTokens` takes a strategy, which dictates how each Terraform token maps to Pulumi tokens. There are 4 built-in strategies, which cover most use cases. The interface is open, so you may write a custom strategy.
+
+## Mapping Strategies
+
+[Mapping strategies](https://github.com/pulumi/pulumi-terraform-bridge/blob/5e17c6c7e2d877db7e1d9c0b953a06d3ecabbaea/pkg/tfbridge/tokens.go#L32-L38) dictate the mapping from Terraform to Pulumi tokens. There are 4 Pulumi maintained strategies in the bridge. They live in "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/tokens".
+
+Each built-in strategy decides how to assign Terraform tokens to Pulumi modules, then delegates token construction to a passed in mint function: `func(module, name string) (string, error)`. The standard mint function is `tokens.MakeStandard`.
+
+### `tokens.SingleModule`
+
+`tokens.SingleModule` is a strategy that assigns all tokens to a specific module. 
+
+### `tokens.KnownModules`
+
+`tokens.KnownModules` is a strategy that assigns tokens to a hand-authored set of modules based on prefix in the Terraform token. 
+
+Consider the following example:
+
+```go
+strategy := tokens.KnownModules("pkg_", "index", []string{"mod1", "mod2"}, tokens.MakeStandard("pkg"))
+```
+
+`strategy` will map `pkg_mod1_resource` to `pkg:mod1/resource:Resource` and `pkg_mod2_datasource` to `pkg:mod2/datasource:getDatasource`. It will map `pkg_mod3_resource` to `pkg:index/mod3Resource:Mod3Resource`, since `mod3` is not in the list of known packages and `"index"` is supplied as a default. If we replace `"index"` with `""`, then `strategy` will error on `pkg:index/mod3Resource:Mod3Resource` instead.
+
+### `tokens.MappedModules`
+
+`tokens.MappedModules` is similar to `tokens.KnownModules`, except it takes a `map[string]string` instead of a `[]string` for it's module set. This allows users to specify a mapping between Terraform prefixes and arbitrary Pulumi modules.
+
+Consider the following example:
+
+```go
+m := map[string]string{"mod1": "foo", "mod2": "bar"}
+strategy := tokens.KnownModules("pkg_", "index", m, tokens.MakeStandard("pkg"))
+```
+
+`strategy` will map `pkg_mod1_resource` to `pkg:foo/resource:Resource` and `pkg_mod2_datasource` to `pkg:bar/datasource:getDatasource`. `tokens.MappedModules` has the same behavior as `tokens.KnownModules` for Terraform tokens that don't have a matching prefix.
+
+### `tokens.InferredModules`
+
+`tokens.InferredModules` attempts to infer which Terraform resources should go into the same module, and then applies that mapping.
+
+> **Warning** `tokens.InferredModules` may decide to move an existing resource when a new resource is added. It should be used with [`tfbridge.ProviderInfo.ApplyAutoAliases`](../pkg/tfbridge/README.md) to prevent breaking changes.

--- a/docs/muxwith.md
+++ b/docs/muxwith.md
@@ -1,0 +1,7 @@
+# `tfbridge.ProviderInfo.MuxWith`
+
+[`tfbridge.ProviderInfo.MuxWith`](https://github.com/pulumi/pulumi-terraform-bridge/blob/5e17c6c7e2d877db7e1d9c0b953a06d3ecabbaea/pkg/tfbridge/info.go#L126-L133)
+allows the mixin (muxing) of other providers to the bridged upstream Terraform
+provider. With a provider mixin it's possible to add or replace resources and/or functions
+(data sources) in the wrapped Terraform provider without having to change the upstream
+code itself.

--- a/docs/new-provider.md
+++ b/docs/new-provider.md
@@ -1,0 +1,53 @@
+# Developing a New Provider
+
+It is relatively easy to adapt a Terraform Provider, X, for use with Pulumi.  The
+[Cloudflare provider](https://github.com/pulumi/pulumi-cloudflare) offers a good blueprint for how to go about this.
+
+You will create two Go binaries -- one purely for design-time usage to act as X's code-generator and the other for
+runtime usage to serve as its dynamic resource plugin -- and link with the Terraform Provider repo and this one.
+There is then typically a `resources.go` file that maps all of the Terraform Provider metadata available at runtime
+to types and concepts that the bridge will use to generate well-typed programmatic abstractions.
+
+The Cloudflare provider provides a standard blueprint to follow for this.  There are three major elements:
+
+* [`cmd/pulumi-tfgen-cloudflare/`](https://github.com/pulumi/pulumi-cloudflare/tree/master/provider/cmd/pulumi-tfgen-cloudflare)
+* [`cmd/pulumi-resource-cloudflare/`](https://github.com/pulumi/pulumi-cloudflare/tree/master/provider/cmd/pulumi-resource-cloudflare)
+* [`resources.go`](https://github.com/pulumi/pulumi-cloudflare/blob/master/provider/resources.go)
+
+The [`Makefile`](https://github.com/pulumi/pulumi-cloudflare/blob/master/Makefile) compiles these programs, and notably, uses
+the resulting `pulumi-tfgen-cloudflare` binary to generate code for many different languages.  The resulting generated code is
+stored in the [`sdk` directory](https://github.com/pulumi/pulumi-cloudflare/tree/master/sdk).
+
+
+## Building `tfbridge.ProviderInfo`
+
+The main interaction point between the bridged provider authors and the bridge itself if via [tfbridge.ProviderInfo](https://github.com/pulumi/pulumi-terraform-bridge/blob/5e17c6c7e2d877db7e1d9c0b953a06d3ecabbaea/pkg/tfbridge/info.go#L48). 
+
+
+## Token Mapping
+
+Each upstream Terraform resource needs to be given a Pulumi appropriate name, called a token. We call this process token mapping. A simple mapping looks like this:
+
+```go
+			"aws_s3_bucket": {
+				Tok: tfbridge.MakeResource(awsPackage, s3Mod, "Bucket"),
+			},
+```
+### Automatic Token Mapping
+
+Mapping a couple of resources is fine, but it quickly becomes tiresome to provide a manual mapping for each resource and datasource in a large provider, especially since new updates to the provider introduce new resources and remove old resources. The solution is *automatic token mappings*. 
+
+For example:
+
+```go
+prov.MustComputeTokens(tokens.SingleModule("docker_", "index",
+	tokens.MakeStandard(dockerPkg)))
+```
+
+[source](https://github.com/pulumi/pulumi-docker/blob/014b3fa8b3d9369d4108e71006cf8d429c19bc13/provider/resources.go#L369-L371)
+
+See [automatic token mapping](./automatic-token-mapping.md) for more information.
+
+## Augmenting a Terraform Provider
+
+To add new resources/datasoruces or replace existing resources/datasoruces to the bridge Terraform provider, see [MuxWith](./muxwith.md).

--- a/docs/new-provider.md
+++ b/docs/new-provider.md
@@ -50,4 +50,11 @@ See [automatic token mapping](./automatic-token-mapping.md) for more information
 
 ## Augmenting a Terraform Provider
 
-To add new resources/datasoruces or replace existing resources/datasoruces to the bridge Terraform provider, see [MuxWith](./muxwith.md).
+To add new resources/datasoruces or replace existing resources/datasoruces to the bridge
+Terraform provider, see [MuxWith](./muxwith.md).
+
+## Pulumi Bridge for Terraform Plugin Framework
+
+For instructions on bridging a Terraform provider built using the [Terraform Plugin
+Framework](https://developer.hashicorp.com/terraform/plugin/framework), please see
+[pf/README.md](../pf/README.md).

--- a/docs/overlays.md
+++ b/docs/overlays.md
@@ -1,0 +1,15 @@
+# Augmenting Auto-Generated Code w/ Overlays (Legacy Feature)
+
+> **Warning** Overlays are a legacy feature and support may be removed in a future version of the bridge.
+>             We do not recommend using overlays for a new provider. To augment a terraform provider,
+>             please use [tfbridge.ProviderInfo.MuxWith](./muxwith.md).
+
+An overlay is a set of additional directives that the code generator obeys when creating the final packages.
+
+These may specify additional types, functions, or entire modules in this directory may be merged into the resulting
+package.  This can be useful for helper modules and functions, in addition to gradual typing, such as using strongly
+typed enums in places where the underlying provider may only have weakly typed strings.
+
+To do this, first add the files in the appropriate package sub-directory of the sdk, and then add the requisite directives to the
+provider file.  See the [AWS overlays section in resources.go](https://github.com/pulumi/pulumi-aws/blob/master/provider/resources.go#L4486) for
+an example of this in action.

--- a/docs/overlays.md
+++ b/docs/overlays.md
@@ -4,9 +4,9 @@
 >             We do not recommend using overlays for a new provider. To augment a terraform provider,
 >             please use [tfbridge.ProviderInfo.MuxWith](./muxwith.md).
 
-An overlay is a set of additional directives that the code generator obeys when creating the final packages.
+An overlay is a set of additional (per language files) that the code generator injects when creating the final packages.
 
-These may specify additional types, functions, or entire modules in this directory may be merged into the resulting
+These may add additional types, functions, or entire modules in this directory may be merged into the resulting
 package.  This can be useful for helper modules and functions, in addition to gradual typing, such as using strongly
 typed enums in places where the underlying provider may only have weakly typed strings.
 

--- a/docs/overlays.md
+++ b/docs/overlays.md
@@ -4,7 +4,7 @@
 >             We do not recommend using overlays for a new provider. To augment a terraform provider,
 >             please use [tfbridge.ProviderInfo.MuxWith](./muxwith.md).
 
-An overlay is a set of additional (per language files) that the code generator injects when creating the final packages.
+An overlay is a set of additional (per language) files that the code generator injects when creating the final packages.
 
 These may add additional types, functions, or entire modules in this directory may be merged into the resulting
 package.  This can be useful for helper modules and functions, in addition to gradual typing, such as using strongly

--- a/pf/README.md
+++ b/pf/README.md
@@ -6,7 +6,7 @@ Providers](https://github.com/terraform-providers) built using the [Terraform Pl
 Framework](https://developer.hashicorp.com/terraform/plugin/framework).
 
 If you need to adapt [Terraform Plugin SDK](https://github.com/hashicorp/terraform-plugin-sdk) based providers, see
-[Pulumi Terraform Bridge](https://github.com/pulumi/pulumi-terraform-bridge).
+[the documentation for bridging a new SDK based provider](../docs/new-provider.md).
 
 ## How to Bridge a Provider
 

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -126,7 +126,7 @@ type ProviderInfo struct {
 	// The MuxWith array allows the mixin (muxing) of other providers to the wrapped upstream Terraform provider.
 	// With a provider mixin it's possible to add or replace resources and/or functions (data sources) in the wrapped
 	// Terraform provider without having to change the upstream code itself. If multiple provider mixins are specified
-	// the schema generator in pkg/tfgen will call the GetSpec() method of muxer.Provider in sequenece. Thus, if more or two
+	// the schema generator in pkg/tfgen will call the GetSpec() method of muxer.Provider in sequence. Thus, if more or two
 	// of the mixins define the same resource/function, the last definition will end up in the combined schema of the
 	// compiled provider.
 	MuxWith []MuxProvider


### PR DESCRIPTION
This includes starting a `docs` folder and moving some of our documentation there.

This PR also de-emphasizes overlays (marking it as legacy) and points users to MuxWith
to extend TF providers.
