### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -55,7 +55,7 @@ jobs:
         git update-index -q --refresh
 
         if ! git diff-files --quiet; then
-          echo ::set-output name=changes::1
+          echo changes=1 >> "$GITHUB_OUTPUT"
         fi
     - name: Bridge Pulumi Upgrade
       if: steps.gomod.outputs.changes != 0


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter