### PR TITLE
Refactor IgnoreChanges

### DIFF
--- a/pf/internal/schemashim/provider.go
+++ b/pf/internal/schemashim/provider.go
@@ -79,7 +79,7 @@ func (p *SchemaOnlyProvider) Configure(ctx context.Context, c shim.ResourceConfi
 }
 
 func (p *SchemaOnlyProvider) Diff(
-	ctx context.Context, t string, s shim.InstanceState, c shim.ResourceConfig, opts ...shim.DiffOption,
+	ctx context.Context, t string, s shim.InstanceState, c shim.ResourceConfig, opts shim.DiffOptions,
 ) (shim.InstanceDiff, error) {
 	panic("schemaOnlyProvider does not implement runtime operation Diff")
 }

--- a/pf/internal/schemashim/provider.go
+++ b/pf/internal/schemashim/provider.go
@@ -79,7 +79,7 @@ func (p *SchemaOnlyProvider) Configure(ctx context.Context, c shim.ResourceConfi
 }
 
 func (p *SchemaOnlyProvider) Diff(
-	ctx context.Context, t string, s shim.InstanceState, c shim.ResourceConfig,
+	ctx context.Context, t string, s shim.InstanceState, c shim.ResourceConfig, opts ...shim.DiffOption,
 ) (shim.InstanceDiff, error) {
 	panic("schemaOnlyProvider does not implement runtime operation Diff")
 }

--- a/pkg/tfbridge/diff.go
+++ b/pkg/tfbridge/diff.go
@@ -252,12 +252,12 @@ func newIgnoreChanges(
 		return nil
 	}
 	return func() map[string]struct{} {
-		return doIgnoreChanges(ctx, tfs, ps, olds, news, ignoredPaths)
+		return computeIgnoreChanges(ctx, tfs, ps, olds, news, ignoredPaths)
 	}
 }
 
 // Computes the ignored key set.
-func doIgnoreChanges(
+func computeIgnoreChanges(
 	ctx context.Context,
 	tfs shim.SchemaMap,
 	ps map[string]*SchemaInfo,
@@ -284,6 +284,25 @@ func doIgnoreChanges(
 		visitPropertyValue(ctx, en, string(k), v, etf, eps, shimutil.IsOfTypeMap(etf), visitor)
 	}
 	return ignoredKeySet
+}
+
+func doIgnoreChanges(
+	ctx context.Context,
+	tfs shim.SchemaMap,
+	ps map[string]*SchemaInfo,
+	olds, news resource.PropertyMap,
+	ignoredPaths []string,
+	diff shim.InstanceDiff,
+) {
+	if diff == nil {
+		return
+	}
+	ignored := computeIgnoreChanges(ctx, tfs, ps, olds, news, ignoredPaths)
+	m := map[string]bool{}
+	for k := range ignored {
+		m[k] = true
+	}
+	diff.IgnoreChanges(m)
 }
 
 // makeDetailedDiff converts the given state (olds), config (news), and InstanceDiff to a Pulumi property diff.

--- a/pkg/tfbridge/diff.go
+++ b/pkg/tfbridge/diff.go
@@ -241,22 +241,37 @@ func makePropertyDiff(ctx context.Context, name, path string, v resource.Propert
 	visitPropertyValue(ctx, name, path, v, tfs, ps, rawNames, visitor)
 }
 
-func doIgnoreChanges(ctx context.Context, tfs shim.SchemaMap, ps map[string]*SchemaInfo,
-	olds, news resource.PropertyMap, ignoredPaths []string, tfDiff shim.InstanceDiff) {
-
-	if tfDiff == nil {
-		return
+func newIgnoreChanges(
+	ctx context.Context,
+	tfs shim.SchemaMap,
+	ps map[string]*SchemaInfo,
+	olds, news resource.PropertyMap,
+	ignoredPaths []string,
+) shim.IgnoreChanges {
+	if len(ignoredPaths) == 0 {
+		return nil
 	}
+	return func() map[string]struct{} {
+		return doIgnoreChanges(ctx, tfs, ps, olds, news, ignoredPaths)
+	}
+}
 
+// Computes the ignored key set.
+func doIgnoreChanges(
+	ctx context.Context,
+	tfs shim.SchemaMap,
+	ps map[string]*SchemaInfo,
+	olds, news resource.PropertyMap,
+	ignoredPaths []string,
+) map[string]struct{} {
 	ignoredPathSet := map[string]bool{}
 	for _, p := range ignoredPaths {
 		ignoredPathSet[p] = true
 	}
-
-	ignoredKeySet := map[string]bool{}
+	ignoredKeySet := map[string]struct{}{}
 	visitor := func(attributeKey, propertyPath string, _ resource.PropertyValue) bool {
 		if ignoredPathSet[propertyPath] {
-			ignoredKeySet[attributeKey] = true
+			ignoredKeySet[attributeKey] = struct{}{}
 		}
 		return true
 	}
@@ -268,8 +283,7 @@ func doIgnoreChanges(ctx context.Context, tfs shim.SchemaMap, ps map[string]*Sch
 		en, etf, eps := getInfoFromPulumiName(k, tfs, ps, false)
 		visitPropertyValue(ctx, en, string(k), v, etf, eps, shimutil.IsOfTypeMap(etf), visitor)
 	}
-
-	tfDiff.IgnoreChanges(ignoredKeySet)
+	return ignoredKeySet
 }
 
 // makeDetailedDiff converts the given state (olds), config (news), and InstanceDiff to a Pulumi property diff.

--- a/pkg/tfbridge/diff.go
+++ b/pkg/tfbridge/diff.go
@@ -286,25 +286,6 @@ func computeIgnoreChanges(
 	return ignoredKeySet
 }
 
-func doIgnoreChanges(
-	ctx context.Context,
-	tfs shim.SchemaMap,
-	ps map[string]*SchemaInfo,
-	olds, news resource.PropertyMap,
-	ignoredPaths []string,
-	diff shim.InstanceDiff,
-) {
-	if diff == nil {
-		return
-	}
-	ignored := computeIgnoreChanges(ctx, tfs, ps, olds, news, ignoredPaths)
-	m := map[string]bool{}
-	for k := range ignored {
-		m[k] = true
-	}
-	diff.IgnoreChanges(m)
-}
-
 // makeDetailedDiff converts the given state (olds), config (news), and InstanceDiff to a Pulumi property diff.
 //
 // See makePropertyDiff for more details.

--- a/pkg/tfbridge/diff_test.go
+++ b/pkg/tfbridge/diff_test.go
@@ -90,7 +90,7 @@ func TestCustomizeDiff(t *testing.T) {
 		config, _, err := MakeTerraformConfig(ctx, &Provider{tf: provider}, inputsMap, sch, info)
 		assert.NoError(t, err)
 
-		tfDiff, err := provider.Diff(ctx, "resource", tfState, config)
+		tfDiff, err := provider.Diff(ctx, "resource", tfState, config, shim.DiffOptions{})
 		assert.NoError(t, err)
 
 		// ProcessIgnoreChanges
@@ -132,7 +132,7 @@ func TestCustomizeDiff(t *testing.T) {
 		config, _, err := MakeTerraformConfig(ctx, &Provider{tf: provider}, inputsMap, sch, info)
 		assert.NoError(t, err)
 
-		tfDiff, err := provider.Diff(ctx, "resource", tfState, config)
+		tfDiff, err := provider.Diff(ctx, "resource", tfState, config, shim.DiffOptions{})
 		assert.NoError(t, err)
 
 		// ProcessIgnoreChanges
@@ -188,7 +188,7 @@ func TestCustomizeDiff(t *testing.T) {
 				assert.NoError(t, err)
 
 				// Calling Diff with the given CustomizeDiff used to panic, no more asserts needed.
-				_, err = provider.Diff(ctx, "resource", tfState, config)
+				_, err = provider.Diff(ctx, "resource", tfState, config, shim.DiffOptions{})
 				assert.NoError(t, err)
 			})
 		}
@@ -230,7 +230,7 @@ func diffTest(t *testing.T, tfs map[string]*schema.Schema, info map[string]*Sche
 	config, _, err := MakeTerraformConfig(ctx, &Provider{tf: provider}, inputsMap, sch, info)
 	assert.NoError(t, err)
 
-	tfDiff, err := provider.Diff(ctx, "resource", tfState, config)
+	tfDiff, err := provider.Diff(ctx, "resource", tfState, config, shim.DiffOptions{})
 	assert.NoError(t, err)
 
 	// ProcessIgnoreChanges

--- a/pkg/tfbridge/diff_test.go
+++ b/pkg/tfbridge/diff_test.go
@@ -11,6 +11,7 @@ import (
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/assert"
 
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	shimv1 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v1"
 	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
 )
@@ -2059,4 +2060,23 @@ func TestListNestedAddMaxItemsOne(t *testing.T) {
 			"prop.nest": AR,
 		},
 		pulumirpc.DiffResponse_DIFF_SOME)
+}
+
+func doIgnoreChanges(
+	ctx context.Context,
+	tfs shim.SchemaMap,
+	ps map[string]*SchemaInfo,
+	olds, news resource.PropertyMap,
+	ignoredPaths []string,
+	diff shim.InstanceDiff,
+) {
+	if diff == nil {
+		return
+	}
+	ignored := computeIgnoreChanges(ctx, tfs, ps, olds, news, ignoredPaths)
+	m := map[string]bool{}
+	for k := range ignored {
+		m[k] = true
+	}
+	diff.IgnoreChanges(m)
 }

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -869,18 +869,23 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 	if err != nil {
 		return nil, err
 	}
-	config, _, err := MakeTerraformConfig(ctx, p, news, res.TF.Schema(), res.Schema.Fields)
+
+	schema, fields := res.TF.Schema(), res.Schema.Fields
+
+	config, _, err := MakeTerraformConfig(ctx, p, news, schema, fields)
 	if err != nil {
 		return nil, errors.Wrapf(err, "preparing %s's new property state", urn)
 	}
 
-	diff, err := p.tf.Diff(ctx, res.TFName, state, config)
+	ic := newIgnoreChanges(ctx, schema, fields, olds, news, req.GetIgnoreChanges())
+
+	diff, err := p.tf.Diff(ctx, res.TFName, state, config, shim.WithIgnored(ic))
+
 	if err != nil {
 		return nil, errors.Wrapf(err, "diffing %s", urn)
 	}
 
-	doIgnoreChanges(ctx, res.TF.Schema(), res.Schema.Fields, olds, news, req.GetIgnoreChanges(), diff)
-	detailedDiff, changes := makeDetailedDiff(ctx, res.TF.Schema(), res.Schema.Fields, olds, news, diff)
+	detailedDiff, changes := makeDetailedDiff(ctx, schema, fields, olds, news, diff)
 
 	// There are some providers/situations which `makeDetailedDiff` distorts the expected changes, leading
 	// to changes being dropped by Pulumi.
@@ -923,8 +928,8 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 	// For all properties that are ForceNew, but didn't change, assume they are stable.  Also recognize
 	// overlays that have requested that we treat specific properties as stable.
 	var stables []string
-	res.TF.Schema().Range(func(k string, sch shim.Schema) bool {
-		name, _, cust := getInfoFromTerraformName(k, res.TF.Schema(), res.Schema.Fields, false)
+	schema.Range(func(k string, sch shim.Schema) bool {
+		name, _, cust := getInfoFromTerraformName(k, schema, fields, false)
 		if !replaced[string(name)] &&
 			(sch.ForceNew() || (cust != nil && cust.Stable != nil && *cust.Stable)) {
 			stables = append(stables, string(name))
@@ -933,7 +938,7 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 	})
 
 	deleteBeforeReplace := len(replaces) > 0 &&
-		(res.Schema.DeleteBeforeReplace || nameRequiresDeleteBeforeReplace(news, olds, res.TF.Schema(), res.Schema))
+		(res.Schema.DeleteBeforeReplace || nameRequiresDeleteBeforeReplace(news, olds, schema, res.Schema))
 
 	// If the upstream diff object indicates a replace is necessary and we have not
 	// recorded any replaces, that means that `makeDetailedDiff` failed to translate a
@@ -951,7 +956,7 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 	}
 
 	if changes == pulumirpc.DiffResponse_DIFF_NONE &&
-		markWronglyTypedMaxItemsOneStateDiff(res.TF.Schema(), res.Schema.Fields, olds) {
+		markWronglyTypedMaxItemsOneStateDiff(schema, fields, olds) {
 
 		changes = pulumirpc.DiffResponse_DIFF_SOME
 	}
@@ -1213,12 +1218,17 @@ func (p *Provider) Update(ctx context.Context, req *pulumirpc.UpdateRequest) (*p
 	if err != nil {
 		return nil, err
 	}
-	config, assets, err := MakeTerraformConfig(ctx, p, news, res.TF.Schema(), res.Schema.Fields)
+
+	schema, fields := res.TF.Schema(), res.Schema.Fields
+
+	config, assets, err := MakeTerraformConfig(ctx, p, news, schema, fields)
 	if err != nil {
 		return nil, errors.Wrapf(err, "preparing %s's new property state", urn)
 	}
 
-	diff, err := p.tf.Diff(ctx, res.TFName, state, config)
+	ic := newIgnoreChanges(ctx, schema, fields, olds, news, req.GetIgnoreChanges())
+	diff, err := p.tf.Diff(ctx, res.TFName, state, config, shim.WithIgnored(ic))
+
 	if err != nil {
 		return nil, errors.Wrapf(err, "diffing %s", urn)
 	}
@@ -1229,10 +1239,6 @@ func (p *Provider) Update(ctx context.Context, req *pulumirpc.UpdateRequest) (*p
 		// moment.
 		return &pulumirpc.UpdateResponse{Properties: req.GetOlds()}, nil
 	}
-
-	// Apply any ignoreChanges before we check that the diff doesn't require replacement or deletion since we may be
-	// ignoring changes to the keys that would result in replacement/deletion.
-	doIgnoreChanges(ctx, res.TF.Schema(), res.Schema.Fields, olds, news, req.GetIgnoreChanges(), diff)
 
 	if diff.Destroy() || diff.RequiresNew() {
 		return nil, fmt.Errorf("internal: expected diff to not require deletion or replacement"+

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -880,7 +880,6 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 	ic := newIgnoreChanges(ctx, schema, fields, olds, news, req.GetIgnoreChanges())
 
 	diff, err := p.tf.Diff(ctx, res.TFName, state, config, shim.WithIgnored(ic))
-
 	if err != nil {
 		return nil, errors.Wrapf(err, "diffing %s", urn)
 	}
@@ -1228,7 +1227,6 @@ func (p *Provider) Update(ctx context.Context, req *pulumirpc.UpdateRequest) (*p
 
 	ic := newIgnoreChanges(ctx, schema, fields, olds, news, req.GetIgnoreChanges())
 	diff, err := p.tf.Diff(ctx, res.TFName, state, config, shim.WithIgnored(ic))
-
 	if err != nil {
 		return nil, errors.Wrapf(err, "diffing %s", urn)
 	}

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -879,7 +879,9 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 
 	ic := newIgnoreChanges(ctx, schema, fields, olds, news, req.GetIgnoreChanges())
 
-	diff, err := p.tf.Diff(ctx, res.TFName, state, config, shim.WithIgnored(ic))
+	diff, err := p.tf.Diff(ctx, res.TFName, state, config, shim.DiffOptions{
+		IgnoreChanges: ic,
+	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "diffing %s", urn)
 	}
@@ -1000,7 +1002,7 @@ func (p *Provider) Create(ctx context.Context, req *pulumirpc.CreateRequest) (*p
 		return nil, errors.Wrapf(err, "preparing %s's new property state", urn)
 	}
 
-	diff, err := p.tf.Diff(ctx, res.TFName, nil, config)
+	diff, err := p.tf.Diff(ctx, res.TFName, nil, config, shim.DiffOptions{})
 	if err != nil {
 		return nil, errors.Wrapf(err, "diffing %s", urn)
 	}
@@ -1226,7 +1228,9 @@ func (p *Provider) Update(ctx context.Context, req *pulumirpc.UpdateRequest) (*p
 	}
 
 	ic := newIgnoreChanges(ctx, schema, fields, olds, news, req.GetIgnoreChanges())
-	diff, err := p.tf.Diff(ctx, res.TFName, state, config, shim.WithIgnored(ic))
+	diff, err := p.tf.Diff(ctx, res.TFName, state, config, shim.DiffOptions{
+		IgnoreChanges: ic,
+	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "diffing %s", urn)
 	}

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -689,7 +689,7 @@ func TestMetaProperties(t *testing.T) {
 			ok = clearID(state)
 			assert.True(t, ok)
 			cfg := prov.NewResourceConfig(ctx, map[string]interface{}{})
-			diff, err := prov.Diff(ctx, resName, state, cfg)
+			diff, err := prov.Diff(ctx, resName, state, cfg, shim.DiffOptions{})
 			assert.NoError(t, err)
 
 			// To populate default timeouts, we take the timeouts from the resource schema and insert them into the diff
@@ -765,7 +765,7 @@ func TestInjectingCustomTimeouts(t *testing.T) {
 			ok = clearID(state)
 			assert.True(t, ok)
 			cfg := prov.NewResourceConfig(ctx, map[string]interface{}{})
-			diff, err := prov.Diff(ctx, resName, state, cfg)
+			diff, err := prov.Diff(ctx, resName, state, cfg, shim.DiffOptions{})
 			assert.NoError(t, err)
 
 			// To populate default timeouts, we take the timeouts from the resource schema and insert them into the diff

--- a/pkg/tfshim/schema/provider.go
+++ b/pkg/tfshim/schema/provider.go
@@ -64,7 +64,7 @@ func (ProviderShim) Configure(
 }
 
 func (ProviderShim) Diff(
-	ctx context.Context, t string, s shim.InstanceState, c shim.ResourceConfig, opts ...shim.DiffOption,
+	ctx context.Context, t string, s shim.InstanceState, c shim.ResourceConfig, opts shim.DiffOptions,
 ) (shim.InstanceDiff, error) {
 	panic("this provider is schema-only and does not support runtime operations")
 }

--- a/pkg/tfshim/schema/provider.go
+++ b/pkg/tfshim/schema/provider.go
@@ -64,7 +64,7 @@ func (ProviderShim) Configure(
 }
 
 func (ProviderShim) Diff(
-	ctx context.Context, t string, s shim.InstanceState, c shim.ResourceConfig,
+	ctx context.Context, t string, s shim.InstanceState, c shim.ResourceConfig, opts ...shim.DiffOption,
 ) (shim.InstanceDiff, error) {
 	panic("this provider is schema-only and does not support runtime operations")
 }

--- a/pkg/tfshim/sdk-v1/instance_diff.go
+++ b/pkg/tfshim/sdk-v1/instance_diff.go
@@ -92,6 +92,22 @@ func (d v1InstanceDiff) IgnoreChanges(ignored map[string]bool) {
 	}
 }
 
+func (d v1InstanceDiff) processIgnoreChanges(ignored shim.IgnoreChanges) {
+	i := ignored()
+	for k := range d.tf.Attributes {
+		if _, ok := i[k]; ok {
+			delete(d.tf.Attributes, k)
+		} else {
+			for attr := range i {
+				if strings.HasPrefix(k, attr+".") {
+					delete(d.tf.Attributes, k)
+					break
+				}
+			}
+		}
+	}
+}
+
 func (d v1InstanceDiff) EncodeTimeouts(timeouts *shim.ResourceTimeout) error {
 	v1Timeouts := &schema.ResourceTimeout{}
 	if timeouts != nil {

--- a/pkg/tfshim/sdk-v1/instance_diff.go
+++ b/pkg/tfshim/sdk-v1/instance_diff.go
@@ -77,21 +77,6 @@ func (d v1InstanceDiff) RequiresNew() bool {
 	return d.tf.RequiresNew()
 }
 
-func (d v1InstanceDiff) IgnoreChanges(ignored map[string]bool) {
-	for k := range d.tf.Attributes {
-		if ignored[k] {
-			delete(d.tf.Attributes, k)
-		} else {
-			for attr := range ignored {
-				if strings.HasPrefix(k, attr+".") {
-					delete(d.tf.Attributes, k)
-					break
-				}
-			}
-		}
-	}
-}
-
 func (d v1InstanceDiff) processIgnoreChanges(ignored shim.IgnoreChanges) {
 	i := ignored()
 	for k := range d.tf.Attributes {

--- a/pkg/tfshim/sdk-v1/provider.go
+++ b/pkg/tfshim/sdk-v1/provider.go
@@ -87,7 +87,7 @@ func (p v1Provider) Configure(_ context.Context, c shim.ResourceConfig) error {
 }
 
 func (p v1Provider) Diff(
-	_ context.Context, t string, s shim.InstanceState, c shim.ResourceConfig, opts ...shim.DiffOption,
+	_ context.Context, t string, s shim.InstanceState, c shim.ResourceConfig, opts shim.DiffOptions,
 ) (shim.InstanceDiff, error) {
 	if c == nil {
 		return diffToShim(&terraform.InstanceDiff{Destroy: true}), nil
@@ -95,11 +95,10 @@ func (p v1Provider) Diff(
 
 	diff, err := p.tf.SimpleDiff(instanceInfo(t), stateFromShim(s), configFromShim(c))
 
-	options := shim.NewDiffOptions(opts...)
 	d := diffToShim(diff)
 
-	if dd, ok := d.(v1InstanceDiff); ok && options.IgnoreChanges != nil {
-		dd.processIgnoreChanges(options.IgnoreChanges)
+	if dd, ok := d.(v1InstanceDiff); ok && opts.IgnoreChanges != nil {
+		dd.processIgnoreChanges(opts.IgnoreChanges)
 	}
 
 	return d, err

--- a/pkg/tfshim/sdk-v2/instance_diff.go
+++ b/pkg/tfshim/sdk-v2/instance_diff.go
@@ -70,21 +70,6 @@ func (d v2InstanceDiff) RequiresNew() bool {
 	return d.tf.RequiresNew()
 }
 
-func (d v2InstanceDiff) IgnoreChanges(ignored map[string]bool) {
-	for k := range d.tf.Attributes {
-		if ignored[k] {
-			delete(d.tf.Attributes, k)
-		} else {
-			for attr := range ignored {
-				if strings.HasPrefix(k, attr+".") {
-					delete(d.tf.Attributes, k)
-					break
-				}
-			}
-		}
-	}
-}
-
 func (d v2InstanceDiff) processIgnoreChanges(ignored shim.IgnoreChanges) {
 	i := ignored()
 	for k := range d.tf.Attributes {

--- a/pkg/tfshim/sdk-v2/instance_diff.go
+++ b/pkg/tfshim/sdk-v2/instance_diff.go
@@ -85,6 +85,22 @@ func (d v2InstanceDiff) IgnoreChanges(ignored map[string]bool) {
 	}
 }
 
+func (d v2InstanceDiff) processIgnoreChanges(ignored shim.IgnoreChanges) {
+	i := ignored()
+	for k := range d.tf.Attributes {
+		if _, ok := i[k]; ok {
+			delete(d.tf.Attributes, k)
+		} else {
+			for attr := range i {
+				if strings.HasPrefix(k, attr+".") {
+					delete(d.tf.Attributes, k)
+					break
+				}
+			}
+		}
+	}
+}
+
 func (d v2InstanceDiff) EncodeTimeouts(timeouts *shim.ResourceTimeout) error {
 	v2Timeouts := &schema.ResourceTimeout{}
 	if timeouts != nil {

--- a/pkg/tfshim/sdk-v2/provider_diff.go
+++ b/pkg/tfshim/sdk-v2/provider_diff.go
@@ -31,7 +31,7 @@ func (p v2Provider) Diff(
 	t string,
 	s shim.InstanceState,
 	c shim.ResourceConfig,
-	opts ...shim.DiffOption,
+	opts shim.DiffOptions,
 ) (shim.InstanceDiff, error) {
 	if c == nil {
 		return diffToShim(&terraform.InstanceDiff{Destroy: true}), nil
@@ -76,9 +76,8 @@ func (p v2Provider) Diff(
 
 	resultingDiff := diffToShim(diff)
 
-	options := shim.NewDiffOptions(opts...)
-	if dd, ok := resultingDiff.(v2InstanceDiff); ok && options.IgnoreChanges != nil {
-		dd.processIgnoreChanges(options.IgnoreChanges)
+	if dd, ok := resultingDiff.(v2InstanceDiff); ok && opts.IgnoreChanges != nil {
+		dd.processIgnoreChanges(opts.IgnoreChanges)
 	}
 
 	return resultingDiff, err

--- a/pkg/tfshim/sdk-v2/provider_diff_test.go
+++ b/pkg/tfshim/sdk-v2/provider_diff_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -62,7 +63,7 @@ func TestRawPlanSet(t *testing.T) {
 
 	id, err := wp.Diff(ctx, "myres", ss, v2ResourceConfig{
 		tf: resourceConfig,
-	})
+	}, shim.DiffOptions{})
 	require.NoError(t, err)
 
 	assert.False(t, id.(v2InstanceDiff).tf.RawPlan.IsNull(), "RawPlan should not be Null")

--- a/pkg/tfshim/shim.go
+++ b/pkg/tfshim/shim.go
@@ -41,12 +41,6 @@ type InstanceDiff interface {
 	ProposedState(res Resource, priorState InstanceState) (InstanceState, error)
 	Destroy() bool
 	RequiresNew() bool
-
-	// Deprecated. Instead of constructing an InstanceDiff object and then calling IgnoreChanges
-	// on it, please pass IgnoreChanges option to Diff so that the ignores are processed as part
-	// of constructing InstanceDiff.
-	IgnoreChanges(ignored map[string]bool)
-
 	EncodeTimeouts(timeouts *ResourceTimeout) error
 	SetTimeout(timeout float64, timeoutKey string)
 }

--- a/pkg/tfshim/shim.go
+++ b/pkg/tfshim/shim.go
@@ -202,6 +202,7 @@ type Provider interface {
 		t string,
 		s InstanceState,
 		c ResourceConfig,
+		opts ...DiffOption,
 	) (InstanceDiff, error)
 
 	Apply(ctx context.Context, t string, s InstanceState, d InstanceDiff) (InstanceState, error)

--- a/pkg/tfshim/shim.go
+++ b/pkg/tfshim/shim.go
@@ -202,7 +202,7 @@ type Provider interface {
 		t string,
 		s InstanceState,
 		c ResourceConfig,
-		opts ...DiffOption,
+		opts DiffOptions,
 	) (InstanceDiff, error)
 
 	Apply(ctx context.Context, t string, s InstanceState, d InstanceDiff) (InstanceState, error)
@@ -232,16 +232,6 @@ type DiffOptions struct {
 	IgnoreChanges IgnoreChanges
 }
 
-func NewDiffOptions(opts ...DiffOption) DiffOptions {
-	options := DiffOptions{}
-	for _, o := range opts {
-		o(&options)
-	}
-	return options
-}
-
-type DiffOption func(*DiffOptions)
-
 // Supports the ignoreChanges Pulumi option.
 //
 // The bridge needs to be able to suppress diffs computed by the underlying provider.
@@ -254,7 +244,3 @@ type DiffOption func(*DiffOptions)
 //
 // https://www.pulumi.com/docs/concepts/options/ignorechanges/
 type IgnoreChanges = func() map[string]struct{}
-
-func WithIgnored(i IgnoreChanges) DiffOption {
-	return func(opts *DiffOptions) { opts.IgnoreChanges = i }
-}

--- a/pkg/tfshim/tfplugin5/instance_diff.go
+++ b/pkg/tfshim/tfplugin5/instance_diff.go
@@ -80,21 +80,6 @@ func (d *instanceDiff) RequiresNew() bool {
 	return d.requiresNew
 }
 
-func (d *instanceDiff) IgnoreChanges(ignored map[string]bool) {
-	for k := range d.attributes {
-		if ignored[k] {
-			delete(d.attributes, k)
-		} else {
-			for attr := range ignored {
-				if strings.HasPrefix(k, attr+".") {
-					delete(d.attributes, k)
-					break
-				}
-			}
-		}
-	}
-}
-
 func (d *instanceDiff) EncodeTimeouts(timeouts *shim.ResourceTimeout) error {
 	if timeouts == nil {
 		return nil

--- a/pkg/tfshim/tfplugin5/provider.go
+++ b/pkg/tfshim/tfplugin5/provider.go
@@ -277,8 +277,13 @@ func (p *provider) Configure(ctx context.Context, c shim.ResourceConfig) error {
 }
 
 func (p *provider) Diff(
-	ctx context.Context, t string, s shim.InstanceState, c shim.ResourceConfig,
+	ctx context.Context, t string, s shim.InstanceState, c shim.ResourceConfig, opts ...shim.DiffOption,
 ) (shim.InstanceDiff, error) {
+
+	if shim.NewDiffOptions(opts...).IgnoreChanges != nil {
+		return nil, fmt.Errorf("IgnoreChanges option is not yet supported")
+	}
+
 	state, ok := s.(*instanceState)
 	if s != nil && !ok {
 		return nil, fmt.Errorf("internal error: foreign resource state")

--- a/pkg/tfshim/tfplugin5/provider.go
+++ b/pkg/tfshim/tfplugin5/provider.go
@@ -277,10 +277,10 @@ func (p *provider) Configure(ctx context.Context, c shim.ResourceConfig) error {
 }
 
 func (p *provider) Diff(
-	ctx context.Context, t string, s shim.InstanceState, c shim.ResourceConfig, opts ...shim.DiffOption,
+	ctx context.Context, t string, s shim.InstanceState, c shim.ResourceConfig, opts shim.DiffOptions,
 ) (shim.InstanceDiff, error) {
 
-	if shim.NewDiffOptions(opts...).IgnoreChanges != nil {
+	if opts.IgnoreChanges != nil {
 		return nil, fmt.Errorf("IgnoreChanges option is not yet supported")
 	}
 

--- a/pkg/tfshim/tfplugin5/provider_test.go
+++ b/pkg/tfshim/tfplugin5/provider_test.go
@@ -1042,7 +1042,7 @@ func TestDiff(t *testing.T) {
 			configVal, err := goToCty(config, res.(*resource).ctyType)
 			require.NoError(t, err)
 
-			diff, err := p.Diff(ctx, "example_resource", state, config)
+			diff, err := p.Diff(ctx, "example_resource", state, config, shim.DiffOptions{})
 			require.NoError(t, err)
 
 			var meta map[string]interface{}
@@ -1177,7 +1177,7 @@ func TestApply(t *testing.T) {
 
 			config := p.NewResourceConfig(ctx, c.config)
 
-			diff, err := p.Diff(ctx, "example_resource", state, config)
+			diff, err := p.Diff(ctx, "example_resource", state, config, shim.DiffOptions{})
 			require.NoError(t, err)
 
 			if len(diff.Attributes()) == 0 {
@@ -1223,7 +1223,7 @@ func TestApply(t *testing.T) {
 				state, err = resource.InstanceState("", map[string]interface{}{}, nil)
 				require.NoError(t, err)
 
-				diff, err = p.Diff(ctx, "example_resource", state, config)
+				diff, err = p.Diff(ctx, "example_resource", state, config, shim.DiffOptions{})
 				require.NoError(t, err)
 			}
 

--- a/pkg/tfshim/util/filter.go
+++ b/pkg/tfshim/util/filter.go
@@ -79,9 +79,9 @@ func (p *FilteringProvider) Configure(ctx context.Context, c shim.ResourceConfig
 }
 
 func (p *FilteringProvider) Diff(
-	ctx context.Context, t string, s shim.InstanceState, c shim.ResourceConfig,
+	ctx context.Context, t string, s shim.InstanceState, c shim.ResourceConfig, opts ...shim.DiffOption,
 ) (shim.InstanceDiff, error) {
-	return p.Provider.Diff(ctx, t, s, c)
+	return p.Provider.Diff(t, s, c, opts...)
 }
 
 func (p *FilteringProvider) Apply(

--- a/pkg/tfshim/util/filter.go
+++ b/pkg/tfshim/util/filter.go
@@ -79,9 +79,9 @@ func (p *FilteringProvider) Configure(ctx context.Context, c shim.ResourceConfig
 }
 
 func (p *FilteringProvider) Diff(
-	ctx context.Context, t string, s shim.InstanceState, c shim.ResourceConfig, opts ...shim.DiffOption,
+	ctx context.Context, t string, s shim.InstanceState, c shim.ResourceConfig, opts shim.DiffOptions,
 ) (shim.InstanceDiff, error) {
-	return p.Provider.Diff(ctx, t, s, c, opts...)
+	return p.Provider.Diff(ctx, t, s, c, opts)
 }
 
 func (p *FilteringProvider) Apply(

--- a/pkg/tfshim/util/filter.go
+++ b/pkg/tfshim/util/filter.go
@@ -81,7 +81,7 @@ func (p *FilteringProvider) Configure(ctx context.Context, c shim.ResourceConfig
 func (p *FilteringProvider) Diff(
 	ctx context.Context, t string, s shim.InstanceState, c shim.ResourceConfig, opts ...shim.DiffOption,
 ) (shim.InstanceDiff, error) {
-	return p.Provider.Diff(t, s, c, opts...)
+	return p.Provider.Diff(ctx, t, s, c, opts...)
 }
 
 func (p *FilteringProvider) Apply(

--- a/pkg/tfshim/util/util.go
+++ b/pkg/tfshim/util/util.go
@@ -51,7 +51,7 @@ func (UnimplementedProvider) Configure(ctx context.Context, c shim.ResourceConfi
 }
 
 func (UnimplementedProvider) Diff(
-	ctx context.Context, t string, s shim.InstanceState, c shim.ResourceConfig, opts ...shim.DiffOption,
+	ctx context.Context, t string, s shim.InstanceState, c shim.ResourceConfig, opts shim.DiffOptions,
 ) (shim.InstanceDiff, error) {
 	panic("unimplemented")
 }

--- a/pkg/tfshim/util/util.go
+++ b/pkg/tfshim/util/util.go
@@ -37,21 +37,6 @@ func (UnimplementedProvider) Validate(
 func (UnimplementedProvider) ValidateResource(
 	ctx context.Context, t string, c shim.ResourceConfig,
 ) ([]string, []error) {
-	panic("Unimplemented")
-}
-
-func (UnimplementedProvider) Configure(c shim.ResourceConfig) error { panic("unimplemented") }
-
-func (UnimplementedProvider) Diff(
-	t string, s shim.InstanceState, c shim.ResourceConfig, opts ...shim.DiffOption,
-) (shim.InstanceDiff, error) {
-	panic("unimplemented")
-}
-
-func (UnimplementedProvider) Apply(t string, s shim.InstanceState, d shim.InstanceDiff) (shim.InstanceState, error) {
-	panic("unimplemented")
-}
-func (UnimplementedProvider) Refresh(string, shim.InstanceState, shim.ResourceConfig) (shim.InstanceState, error) {
 	panic("unimplemented")
 }
 
@@ -66,7 +51,7 @@ func (UnimplementedProvider) Configure(ctx context.Context, c shim.ResourceConfi
 }
 
 func (UnimplementedProvider) Diff(
-	ctx context.Context, t string, s shim.InstanceState, c shim.ResourceConfig,
+	ctx context.Context, t string, s shim.InstanceState, c shim.ResourceConfig, opts ...shim.DiffOption,
 ) (shim.InstanceDiff, error) {
 	panic("unimplemented")
 }

--- a/pkg/tfshim/util/util.go
+++ b/pkg/tfshim/util/util.go
@@ -37,6 +37,21 @@ func (UnimplementedProvider) Validate(
 func (UnimplementedProvider) ValidateResource(
 	ctx context.Context, t string, c shim.ResourceConfig,
 ) ([]string, []error) {
+	panic("Unimplemented")
+}
+
+func (UnimplementedProvider) Configure(c shim.ResourceConfig) error { panic("unimplemented") }
+
+func (UnimplementedProvider) Diff(
+	t string, s shim.InstanceState, c shim.ResourceConfig, opts ...shim.DiffOption,
+) (shim.InstanceDiff, error) {
+	panic("unimplemented")
+}
+
+func (UnimplementedProvider) Apply(t string, s shim.InstanceState, d shim.InstanceDiff) (shim.InstanceState, error) {
+	panic("unimplemented")
+}
+func (UnimplementedProvider) Refresh(string, shim.InstanceState, shim.ResourceConfig) (shim.InstanceState, error) {
 	panic("unimplemented")
 }
 


### PR DESCRIPTION
The intent here is to refactor the code without any observable changes to make possible further extensions such as https://github.com/pulumi/pulumi-terraform-bridge/pull/1614 .

Specifically, before this PR:

```go

type Provider interface {
        ...
	Diff(t string, s InstanceState, c ResourceConfig) (InstanceDiff, error)
}

type InstanceDiff interface {
        ...
	IgnoreChanges(ignored map[string]bool)
}

```

That is the interface is to compute a diff first, and then side-effect to ignore changes. 

After this PR we have this instead:

```go
type Provider interface {
        ...
	Diff(t string, s InstanceState, c ResourceConfig, opts DiffOptions) (InstanceDiff, error)
}
type IgnoreChanges = func() map[string]struct{}
type DiffOptions struct {
  IgnoreChanges IgnoreChanges
}
```

So the algorithm to ignore changes is specified upfront when constructing the diff. This seems to be useful to un-constrain the implementation of shim.Provider a little bit, specifically in #1614 that is trying to change the internal representation of InstanceDiff implementation in such a way that it is inconvenient to process IgnoreChanges after the InstanceDiff is constructed already. 


 