### PR TITLE
Make pre configure callback errors into failures

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -94,7 +94,12 @@ type ProviderInfo struct {
 	TFProviderLicense        *TFProviderLicense // license that the TF provider is distributed under. Default `MPL 2.0`.
 	TFProviderModuleVersion  string             // the Go module version of the provider. Default is unversioned e.g. v1
 
-	PreConfigureCallback           PreConfigureCallback // a provider-specific callback to invoke prior to TF Configure
+	// a provider-specific callback to invoke prior to TF Configure
+	// Any CheckFailureErrors returned from PreConfigureCallback are converted to
+	// CheckFailures and returned as failures instead of errors in CheckConfig
+	PreConfigureCallback PreConfigureCallback
+	// Any CheckFailureErrors returned from PreConfigureCallbackWithLogger are
+	// converted to CheckFailures and returned as failures instead of errors in CheckConfig
 	PreConfigureCallbackWithLogger PreConfigureCallbackWithLogger
 
 	// Information for the embedded metadata file.

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -55,19 +55,19 @@ import (
 type Provider struct {
 	pulumirpc.UnimplementedResourceProviderServer
 
-	host            *provider.HostClient               // the RPC link back to the Pulumi engine.
-	module          string                             // the Terraform module name.
-	version         string                             // the plugin version number.
-	tf              shim.Provider                      // the Terraform resource provider to use.
-	info            ProviderInfo                       // overlaid info about this provider.
-	config          shim.SchemaMap                     // the Terraform config schema.
-	configValues    resource.PropertyMap               // this package's config values.
-	resources       map[tokens.Type]Resource           // a map of Pulumi type tokens to resource info.
-	dataSources     map[tokens.ModuleMember]DataSource // a map of Pulumi module tokens to data sources.
-	supportsSecrets bool                               // true if the engine supports secret property values
-	pulumiSchema    []byte                             // the JSON-encoded Pulumi schema.
-	memStats        memStatCollector
-	emittedCheckFailures []*pulumirpc.CheckFailure     // a list of check failures emitted by the provider
+	host                 *provider.HostClient               // the RPC link back to the Pulumi engine.
+	module               string                             // the Terraform module name.
+	version              string                             // the plugin version number.
+	tf                   shim.Provider                      // the Terraform resource provider to use.
+	info                 ProviderInfo                       // overlaid info about this provider.
+	config               shim.SchemaMap                     // the Terraform config schema.
+	configValues         resource.PropertyMap               // this package's config values.
+	resources            map[tokens.Type]Resource           // a map of Pulumi type tokens to resource info.
+	dataSources          map[tokens.ModuleMember]DataSource // a map of Pulumi module tokens to data sources.
+	supportsSecrets      bool                               // true if the engine supports secret property values
+	pulumiSchema         []byte                             // the JSON-encoded Pulumi schema.
+	memStats             memStatCollector
+	emittedCheckFailures []*pulumirpc.CheckFailure // a list of check failures emitted by the provider
 }
 
 // MuxProvider defines an interface which must be implemented by providers

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -215,8 +215,7 @@ func newMuxWithProvider(ctx context.Context, host *provider.HostClient,
 		servers = append(servers, muxer.Endpoint{
 			Server: func(hc *provider.HostClient) (pulumirpc.ResourceProviderServer, error) {
 				return f.GetInstance(ctx, module, version, hc)
-			},
-		})
+			}})
 	}
 
 	return muxer.Main{
@@ -1590,7 +1589,8 @@ func (p *ProviderInfo) SetAutonaming(maxLength int, separator string) {
 				sch.Type() == shim.TypeString { // has type string
 
 				if _, hasfield := res.Fields[nameProperty]; !hasfield {
-					ensureMap(&res.Fields)[nameProperty] = AutoName(nameProperty, maxLength, separator)
+					ensureMap(&res.Fields)[nameProperty] =
+						AutoName(nameProperty, maxLength, separator)
 				}
 			}
 		}

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -224,8 +224,7 @@ func newMuxWithProvider(ctx context.Context, host *provider.HostClient,
 		servers = append(servers, muxer.Endpoint{
 			Server: func(hc *provider.HostClient) (pulumirpc.ResourceProviderServer, error) {
 				return f.GetInstance(ctx, module, version, hc)
-			},
-		})
+			}})
 	}
 
 	return muxer.Main{
@@ -1615,7 +1614,8 @@ func (p *ProviderInfo) SetAutonaming(maxLength int, separator string) {
 				sch.Type() == shim.TypeString { // has type string
 
 				if _, hasfield := res.Fields[nameProperty]; !hasfield {
-					ensureMap(&res.Fields)[nameProperty] = AutoName(nameProperty, maxLength, separator)
+					ensureMap(&res.Fields)[nameProperty] =
+						AutoName(nameProperty, maxLength, separator)
 				}
 			}
 		}


### PR DESCRIPTION
Helps with https://github.com/pulumi/pulumi-aws/issues/2285

This removes the bad error message `error: rpc error: code = Unknown desc =` and makes it more comprehensible: `pulumi:providers:aws resource 'default_6_18_2' has a problem:`


The error message was this before:
```
Diagnostics:
  pulumi:providers:aws (default):
    error: rpc error: code = Unknown desc = unable to validate AWS credentials.
    Details: failed to get shared config profile, aws
    Make sure you have set your AWS region, e.g. `pulumi config set aws:region us-west-2`.
```


The distinction between an error and a failure seems to be if it was expected/unexpected IIUC. If that is true then this must be a failure instead of an error.