### PR TITLE
Breaking: require context.Context in shim.Provider

### DIFF
--- a/pf/internal/schemashim/provider.go
+++ b/pf/internal/schemashim/provider.go
@@ -59,67 +59,82 @@ func (p *SchemaOnlyProvider) DataSourcesMap() shim.ResourceMap {
 	return &schemaOnlyDataSourceMap{dataSources}
 }
 
-func (p *SchemaOnlyProvider) Validate(c shim.ResourceConfig) ([]string, []error) {
+func (p *SchemaOnlyProvider) Validate(ctx context.Context, c shim.ResourceConfig) ([]string, []error) {
 	panic("schemaOnlyProvider does not implement runtime operation Validate")
 }
 
-func (p *SchemaOnlyProvider) ValidateResource(t string, c shim.ResourceConfig) ([]string, []error) {
+func (p *SchemaOnlyProvider) ValidateResource(
+	ctx context.Context, t string, c shim.ResourceConfig,
+) ([]string, []error) {
 	panic("schemaOnlyProvider does not implement runtime operation ValidateResource")
 }
 
 func (p *SchemaOnlyProvider) ValidateDataSource(
-	t string, c shim.ResourceConfig) ([]string, []error) {
+	ctx context.Context, t string, c shim.ResourceConfig) ([]string, []error) {
 	panic("schemaOnlyProvider does not implement runtime operation ValidateDataSource")
 }
 
-func (p *SchemaOnlyProvider) Configure(c shim.ResourceConfig) error {
+func (p *SchemaOnlyProvider) Configure(ctx context.Context, c shim.ResourceConfig) error {
 	panic("schemaOnlyProvider does not implement runtime operation Configure")
 }
 
-func (p *SchemaOnlyProvider) Diff(t string, s shim.InstanceState,
-	c shim.ResourceConfig) (shim.InstanceDiff, error) {
+func (p *SchemaOnlyProvider) Diff(
+	ctx context.Context, t string, s shim.InstanceState, c shim.ResourceConfig,
+) (shim.InstanceDiff, error) {
 	panic("schemaOnlyProvider does not implement runtime operation Diff")
 }
 
-func (p *SchemaOnlyProvider) Apply(t string, s shim.InstanceState,
-	d shim.InstanceDiff) (shim.InstanceState, error) {
+func (p *SchemaOnlyProvider) Apply(
+	ctx context.Context,
+	t string,
+	s shim.InstanceState,
+	d shim.InstanceDiff,
+) (shim.InstanceState, error) {
 	panic("schemaOnlyProvider does not implement runtime operation Apply")
 }
 
-func (p *SchemaOnlyProvider) Refresh(string, shim.InstanceState, shim.ResourceConfig) (shim.InstanceState, error) {
+func (p *SchemaOnlyProvider) Refresh(
+	context.Context, string, shim.InstanceState, shim.ResourceConfig,
+) (shim.InstanceState, error) {
 	panic("schemaOnlyProvider does not implement runtime operation Refresh")
 }
 
-func (p *SchemaOnlyProvider) ReadDataDiff(t string,
-	c shim.ResourceConfig) (shim.InstanceDiff, error) {
+func (p *SchemaOnlyProvider) ReadDataDiff(
+	ctx context.Context,
+	t string,
+	c shim.ResourceConfig,
+) (shim.InstanceDiff, error) {
 	panic("schemaOnlyProvider does not implement runtime operation ReadDataDiff")
 }
 
-func (p *SchemaOnlyProvider) ReadDataApply(t string,
-	d shim.InstanceDiff) (shim.InstanceState, error) {
+func (p *SchemaOnlyProvider) ReadDataApply(
+	ctx context.Context,
+	t string,
+	d shim.InstanceDiff,
+) (shim.InstanceState, error) {
 	panic("schemaOnlyProvider does not implement runtime operation ReadDataApply")
 }
 
-func (p *SchemaOnlyProvider) Meta() interface{} {
+func (p *SchemaOnlyProvider) Meta(ctx context.Context) interface{} {
 	panic("schemaOnlyProvider does not implement runtime operation Meta")
 }
 
-func (p *SchemaOnlyProvider) Stop() error {
+func (p *SchemaOnlyProvider) Stop(ctx context.Context) error {
 	panic("schemaOnlyProvider does not implement runtime operation Stop")
 }
 
-func (p *SchemaOnlyProvider) InitLogging() {
+func (p *SchemaOnlyProvider) InitLogging(ctx context.Context) {
 	panic("schemaOnlyProvider does not implement runtime operation InitLogging")
 }
 
-func (p *SchemaOnlyProvider) NewDestroyDiff() shim.InstanceDiff {
+func (p *SchemaOnlyProvider) NewDestroyDiff(ctx context.Context, t string) shim.InstanceDiff {
 	panic("schemaOnlyProvider does not implement runtime operation NewDestroyDiff")
 }
 
-func (p *SchemaOnlyProvider) NewResourceConfig(object map[string]interface{}) shim.ResourceConfig {
+func (p *SchemaOnlyProvider) NewResourceConfig(ctx context.Context, object map[string]interface{}) shim.ResourceConfig {
 	panic("schemaOnlyProvider does not implement runtime operation ReourceConfig")
 }
 
-func (p *SchemaOnlyProvider) IsSet(v interface{}) ([]interface{}, bool) {
+func (p *SchemaOnlyProvider) IsSet(ctx context.Context, v interface{}) ([]interface{}, bool) {
 	panic("schemaOnlyProvider does not implement runtime operation IsSet")
 }

--- a/pkg/tfbridge/diff_test.go
+++ b/pkg/tfbridge/diff_test.go
@@ -89,7 +89,7 @@ func TestCustomizeDiff(t *testing.T) {
 		config, _, err := MakeTerraformConfig(ctx, &Provider{tf: provider}, inputsMap, sch, info)
 		assert.NoError(t, err)
 
-		tfDiff, err := provider.Diff("resource", tfState, config)
+		tfDiff, err := provider.Diff(ctx, "resource", tfState, config)
 		assert.NoError(t, err)
 
 		// ProcessIgnoreChanges
@@ -131,7 +131,7 @@ func TestCustomizeDiff(t *testing.T) {
 		config, _, err := MakeTerraformConfig(ctx, &Provider{tf: provider}, inputsMap, sch, info)
 		assert.NoError(t, err)
 
-		tfDiff, err := provider.Diff("resource", tfState, config)
+		tfDiff, err := provider.Diff(ctx, "resource", tfState, config)
 		assert.NoError(t, err)
 
 		// ProcessIgnoreChanges
@@ -187,7 +187,7 @@ func TestCustomizeDiff(t *testing.T) {
 				assert.NoError(t, err)
 
 				// Calling Diff with the given CustomizeDiff used to panic, no more asserts needed.
-				_, err = provider.Diff("resource", tfState, config)
+				_, err = provider.Diff(ctx, "resource", tfState, config)
 				assert.NoError(t, err)
 			})
 		}
@@ -229,7 +229,7 @@ func diffTest(t *testing.T, tfs map[string]*schema.Schema, info map[string]*Sche
 	config, _, err := MakeTerraformConfig(ctx, &Provider{tf: provider}, inputsMap, sch, info)
 	assert.NoError(t, err)
 
-	tfDiff, err := provider.Diff("resource", tfState, config)
+	tfDiff, err := provider.Diff(ctx, "resource", tfState, config)
 	assert.NoError(t, err)
 
 	// ProcessIgnoreChanges

--- a/pkg/tfbridge/main.go
+++ b/pkg/tfbridge/main.go
@@ -15,6 +15,7 @@
 package tfbridge
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -27,6 +28,8 @@ import (
 
 // Main launches the tfbridge plugin for a given package pkg and provider prov.
 func Main(pkg string, version string, prov ProviderInfo, pulumiSchema []byte) {
+	ctx := context.Background()
+
 	// Look for a request to dump the provider info to stdout.
 	flags := flag.NewFlagSet("tf-provider-flags", flag.ContinueOnError)
 
@@ -65,7 +68,7 @@ func Main(pkg string, version string, prov ProviderInfo, pulumiSchema []byte) {
 	}
 
 	// Initialize Terraform logging.
-	prov.P.InitLogging()
+	prov.P.InitLogging(ctx)
 
 	if err := Serve(pkg, version, prov, pulumiSchema); err != nil {
 		cmdutil.ExitError(err.Error())

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -90,11 +90,13 @@ type Resource struct {
 // resource ID, and returns a replacement input map if any resources are matched. A nil map
 // with no error should be interpreted by the caller as meaning the resource does not exist,
 // but there were no errors in determining this.
-func (res *Resource) runTerraformImporter(id string, provider *Provider) (shim.InstanceState, error) {
+func (res *Resource) runTerraformImporter(
+	ctx context.Context, id string, provider *Provider,
+) (shim.InstanceState, error) {
 	contract.Assertf(res.TF.Importer() != nil, "res.TF.Importer() != nil")
 
 	// Run the importer defined in the Terraform resource schema
-	states, err := res.TF.Importer()(res.TFName, id, provider.tf.Meta())
+	states, err := res.TF.Importer()(res.TFName, id, provider.tf.Meta(ctx))
 	if err != nil {
 		return nil, errors.Wrapf(err, "importing %s", id)
 	}
@@ -184,7 +186,7 @@ func newProvider(ctx context.Context, host *provider.HostClient,
 		host:         host,
 		module:       module,
 		version:      version,
-		tf:           shim.NewProviderWithContext(tf),
+		tf:           tf,
 		info:         info,
 		config:       tf.Schema(),
 		pulumiSchema: pulumiSchema,
@@ -482,7 +484,7 @@ func buildTerraformConfig(ctx context.Context, p *Provider, vars resource.Proper
 		return nil, err
 	}
 
-	return MakeTerraformConfigFromInputs(p.tf, inputs), nil
+	return MakeTerraformConfigFromInputs(ctx, p.tf, inputs), nil
 }
 
 func validateProviderConfig(
@@ -517,7 +519,7 @@ func validateProviderConfig(
 	}
 
 	// Perform validation of the config state so we can offer nice errors.
-	warns, errs := p.tf.Validate(config)
+	warns, errs := p.tf.Validate(ctx, config)
 	for _, warn := range warns {
 		logErr := p.host.Log(ctx, diag.Warning, "", fmt.Sprintf("provider config warning: %v", warn))
 		if logErr != nil {
@@ -651,7 +653,7 @@ func (p *Provider) Configure(ctx context.Context,
 	}
 
 	// Now actually attempt to do the configuring and return its resulting error (if any).
-	if err = p.tfc().ConfigureWithContext(ctx, config); err != nil {
+	if err = p.tf.Configure(ctx, config); err != nil {
 		replacedErr, replacementError := ReplaceConfigProperties(err.Error(), p.info.Config, p.config)
 		if replacementError != nil {
 			wrappedErr := errors.Wrapf(
@@ -729,8 +731,8 @@ func (p *Provider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (*pul
 	}
 
 	// Now check with the resource provider to see if the values pass muster.
-	rescfg := MakeTerraformConfigFromInputs(p.tf, inputs)
-	warns, errs := p.tf.ValidateResource(tfname, rescfg)
+	rescfg := MakeTerraformConfigFromInputs(ctx, p.tf, inputs)
+	warns, errs := p.tf.ValidateResource(ctx, tfname, rescfg)
 	for _, warn := range warns {
 		if err = p.host.Log(ctx, diag.Warning, urn, fmt.Sprintf("%v verification warning: %v", urn, warn)); err != nil {
 			return nil, err
@@ -749,7 +751,9 @@ func (p *Provider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (*pul
 	}
 
 	// After all is said and done, we need to go back and return only what got populated as a diff from the origin.
-	pinputs := MakeTerraformOutputs(p.tf, inputs, res.TF.Schema(), res.Schema.Fields, assets, false, p.supportsSecrets)
+	pinputs := MakeTerraformOutputs(
+		ctx, p.tf, inputs, res.TF.Schema(), res.Schema.Fields, assets, false, p.supportsSecrets,
+	)
 
 	pinputsWithSecrets := MarkSchemaSecrets(ctx, res.TF.Schema(), res.Schema.Fields,
 		resource.NewObjectProperty(pinputs)).ObjectValue()
@@ -834,7 +838,7 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 		return nil, errors.Wrapf(err, "preparing %s's new property state", urn)
 	}
 
-	diff, err := p.tfc().DiffWithContext(ctx, res.TFName, state, config)
+	diff, err := p.tf.Diff(ctx, res.TFName, state, config)
 	if err != nil {
 		return nil, errors.Wrapf(err, "diffing %s", urn)
 	}
@@ -956,7 +960,7 @@ func (p *Provider) Create(ctx context.Context, req *pulumirpc.CreateRequest) (*p
 		return nil, errors.Wrapf(err, "preparing %s's new property state", urn)
 	}
 
-	diff, err := p.tfc().DiffWithContext(ctx, res.TFName, nil, config)
+	diff, err := p.tf.Diff(ctx, res.TFName, nil, config)
 	if err != nil {
 		return nil, errors.Wrapf(err, "diffing %s", urn)
 	}
@@ -978,7 +982,7 @@ func (p *Provider) Create(ctx context.Context, req *pulumirpc.CreateRequest) (*p
 	var newstate shim.InstanceState
 	var reasons []string
 	if !req.GetPreview() {
-		newstate, err = p.tfc().ApplyWithContext(ctx, res.TFName, nil, diff)
+		newstate, err = p.tf.Apply(ctx, res.TFName, nil, diff)
 		if newstate == nil {
 			if err == nil {
 				return nil, fmt.Errorf("expected non-nil error with nil state during Create of %s", urn)
@@ -1000,7 +1004,7 @@ func (p *Provider) Create(ctx context.Context, req *pulumirpc.CreateRequest) (*p
 	}
 
 	// Create the ID and property maps and return them.
-	props, err := MakeTerraformResult(p.tf, newstate, res.TF.Schema(), res.Schema.Fields, assets, p.supportsSecrets)
+	props, err := MakeTerraformResult(ctx, p.tf, newstate, res.TF.Schema(), res.Schema.Fields, assets, p.supportsSecrets)
 	if err != nil {
 		reasons = append(reasons, errors.Wrapf(err, "converting result for %s", urn).Error())
 	}
@@ -1067,7 +1071,7 @@ func (p *Provider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*pulum
 	if !isRefresh && res.TF.Importer() != nil {
 		glog.V(9).Infof("%s has TF Importer", res.TFName)
 
-		state, err = res.runTerraformImporter(id, p)
+		state, err = res.runTerraformImporter(ctx, id, p)
 		if err != nil {
 			// Pass through any error running the importer
 			return nil, err
@@ -1084,7 +1088,7 @@ func (p *Provider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*pulum
 		return nil, errors.Wrapf(err, "preparing %s's new property state", urn)
 	}
 
-	newstate, err := p.tfc().RefreshWithContext(ctx, res.TFName, state, config)
+	newstate, err := p.tf.Refresh(ctx, res.TFName, state, config)
 	if err != nil {
 		return nil, errors.Wrapf(err, "refreshing %s", urn)
 	}
@@ -1092,7 +1096,7 @@ func (p *Provider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*pulum
 	// Store the ID and properties in the output.  The ID *should* be the same as the input ID, but in the case
 	// that the resource no longer exists, we will simply return the empty string and an empty property map.
 	if newstate != nil {
-		props, err := MakeTerraformResult(p.tf, newstate, res.TF.Schema(), res.Schema.Fields, nil, p.supportsSecrets)
+		props, err := MakeTerraformResult(ctx, p.tf, newstate, res.TF.Schema(), res.Schema.Fields, nil, p.supportsSecrets)
 		if err != nil {
 			return nil, err
 		}
@@ -1178,7 +1182,7 @@ func (p *Provider) Update(ctx context.Context, req *pulumirpc.UpdateRequest) (*p
 		return nil, errors.Wrapf(err, "preparing %s's new property state", urn)
 	}
 
-	diff, err := p.tfc().DiffWithContext(ctx, res.TFName, state, config)
+	diff, err := p.tf.Diff(ctx, res.TFName, state, config)
 	if err != nil {
 		return nil, errors.Wrapf(err, "diffing %s", urn)
 	}
@@ -1207,7 +1211,7 @@ func (p *Provider) Update(ctx context.Context, req *pulumirpc.UpdateRequest) (*p
 	var newstate shim.InstanceState
 	var reasons []string
 	if !req.GetPreview() {
-		newstate, err = p.tfc().ApplyWithContext(ctx, res.TFName, state, diff)
+		newstate, err = p.tf.Apply(ctx, res.TFName, state, diff)
 		if newstate == nil {
 			if err != nil {
 				return nil, err
@@ -1230,7 +1234,7 @@ func (p *Provider) Update(ctx context.Context, req *pulumirpc.UpdateRequest) (*p
 		}
 	}
 
-	props, err := MakeTerraformResult(p.tf, newstate, res.TF.Schema(), res.Schema.Fields, assets, p.supportsSecrets)
+	props, err := MakeTerraformResult(ctx, p.tf, newstate, res.TF.Schema(), res.Schema.Fields, assets, p.supportsSecrets)
 	if err != nil {
 		reasons = append(reasons, errors.Wrapf(err, "converting result for %s", urn).Error())
 	}
@@ -1284,12 +1288,12 @@ func (p *Provider) Delete(ctx context.Context, req *pulumirpc.DeleteRequest) (*p
 	}
 
 	// Create a new destroy diff.
-	diff := p.tf.NewDestroyDiff()
+	diff := p.tf.NewDestroyDiff(ctx, string(t))
 	if req.Timeout != 0 {
 		diff.SetTimeout(req.Timeout, shim.TimeoutDelete)
 	}
 
-	if _, err := p.tfc().ApplyWithContext(ctx, res.TFName, state, diff); err != nil {
+	if _, err := p.tf.Apply(ctx, res.TFName, state, diff); err != nil {
 		return nil, errors.Wrapf(err, "deleting %s", urn)
 	}
 	return &pbempty.Empty{}, nil
@@ -1345,8 +1349,8 @@ func (p *Provider) Invoke(ctx context.Context, req *pulumirpc.InvokeRequest) (*p
 	}
 
 	// Next, ensure the inputs are valid before actually performing the invoaction.
-	rescfg := MakeTerraformConfigFromInputs(p.tf, inputs)
-	warns, errs := p.tf.ValidateDataSource(tfname, rescfg)
+	rescfg := MakeTerraformConfigFromInputs(ctx, p.tf, inputs)
+	warns, errs := p.tf.ValidateDataSource(ctx, tfname, rescfg)
 	for _, warn := range warns {
 		if err = p.host.Log(ctx, diag.Warning, "", fmt.Sprintf("%v verification warning: %v", tok, warn)); err != nil {
 			return nil, err
@@ -1364,18 +1368,18 @@ func (p *Provider) Invoke(ctx context.Context, req *pulumirpc.InvokeRequest) (*p
 	// If there are no failures in verification, go ahead and perform the invocation.
 	var ret *pbstruct.Struct
 	if len(failures) == 0 {
-		diff, err := p.tfc().ReadDataDiffWithContext(ctx, tfname, rescfg)
+		diff, err := p.tf.ReadDataDiff(ctx, tfname, rescfg)
 		if err != nil {
 			return nil, errors.Wrapf(err, "reading data source diff for %s", tok)
 		}
 
-		invoke, err := p.tfc().ReadDataApplyWithContext(ctx, tfname, diff)
+		invoke, err := p.tf.ReadDataApply(ctx, tfname, diff)
 		if err != nil {
 			return nil, errors.Wrapf(err, "invoking %s", tok)
 		}
 
 		// Add the special "id" attribute if it wasn't listed in the schema
-		props, err := MakeTerraformResult(p.tf, invoke, ds.TF.Schema(), ds.Schema.Fields, nil, p.supportsSecrets)
+		props, err := MakeTerraformResult(ctx, p.tf, invoke, ds.TF.Schema(), ds.Schema.Fields, nil, p.supportsSecrets)
 		if err != nil {
 			return nil, err
 		}
@@ -1450,10 +1454,6 @@ func (p *Provider) GetMapping(
 
 	// An empty response is valid for GetMapping, it means we don't have a mapping for the given key
 	return &pulumirpc.GetMappingResponse{}, nil
-}
-
-func (p *Provider) tfc() shim.ProviderWithContext {
-	return shim.NewProviderWithContext(p.tf)
 }
 
 func initializationError(id string, props *pbstruct.Struct, reasons []string) error {

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -218,7 +218,7 @@ func TestBuildConfig(t *testing.T) {
 	configOut, err := buildTerraformConfig(ctx, provider, configIn)
 	assert.NoError(t, err)
 
-	expected := provider.tf.NewResourceConfig(map[string]interface{}{
+	expected := provider.tf.NewResourceConfig(ctx, map[string]interface{}{
 		"config_value": "foo",
 	})
 	assert.Equal(t, expected, configOut)

--- a/pkg/tfshim/schema/provider.go
+++ b/pkg/tfshim/schema/provider.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"context"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
@@ -40,62 +41,80 @@ func (s ProviderShim) DataSourcesMap() shim.ResourceMap {
 	return s.V.DataSourcesMap
 }
 
-func (ProviderShim) Validate(c shim.ResourceConfig) ([]string, []error) {
+func (ProviderShim) Validate(ctx context.Context, c shim.ResourceConfig) ([]string, []error) {
 	panic("this provider is schema-only and does not support runtime operations")
 }
 
-func (ProviderShim) ValidateResource(t string, c shim.ResourceConfig) ([]string, []error) {
+func (ProviderShim) ValidateResource(
+	ctx context.Context, t string, c shim.ResourceConfig,
+) ([]string, []error) {
 	panic("this provider is schema-only and does not support runtime operations")
 }
 
-func (ProviderShim) ValidateDataSource(t string, c shim.ResourceConfig) ([]string, []error) {
+func (ProviderShim) ValidateDataSource(
+	ctx context.Context, t string, c shim.ResourceConfig,
+) ([]string, []error) {
 	panic("this provider is schema-only and does not support runtime operations")
 }
 
-func (ProviderShim) Configure(c shim.ResourceConfig) error {
+func (ProviderShim) Configure(
+	ctx context.Context, c shim.ResourceConfig,
+) error {
 	panic("this provider is schema-only and does not support runtime operations")
 }
 
-func (ProviderShim) Diff(t string, s shim.InstanceState, c shim.ResourceConfig) (shim.InstanceDiff, error) {
+func (ProviderShim) Diff(
+	ctx context.Context, t string, s shim.InstanceState, c shim.ResourceConfig,
+) (shim.InstanceDiff, error) {
 	panic("this provider is schema-only and does not support runtime operations")
 }
 
-func (ProviderShim) Apply(t string, s shim.InstanceState, d shim.InstanceDiff) (shim.InstanceState, error) {
+func (ProviderShim) Apply(
+	ctx context.Context, t string, s shim.InstanceState, d shim.InstanceDiff,
+) (shim.InstanceState, error) {
 	panic("this provider is schema-only and does not support runtime operations")
 }
 
-func (ProviderShim) Refresh(t string, s shim.InstanceState, c shim.ResourceConfig) (shim.InstanceState, error) {
+func (ProviderShim) Refresh(
+	ctx context.Context, t string, s shim.InstanceState, c shim.ResourceConfig,
+) (shim.InstanceState, error) {
 	panic("this provider is schema-only and does not support runtime operations")
 }
 
-func (ProviderShim) ReadDataDiff(t string, c shim.ResourceConfig) (shim.InstanceDiff, error) {
+func (ProviderShim) ReadDataDiff(
+	ctx context.Context, t string, c shim.ResourceConfig,
+) (shim.InstanceDiff, error) {
 	panic("this provider is schema-only and does not support runtime operations")
 }
 
-func (ProviderShim) ReadDataApply(t string, d shim.InstanceDiff) (shim.InstanceState, error) {
+func (ProviderShim) ReadDataApply(
+	ctx context.Context, t string, d shim.InstanceDiff,
+) (shim.InstanceState, error) {
 	panic("this provider is schema-only and does not support runtime operations")
 }
 
-func (ProviderShim) Meta() interface{} {
+func (ProviderShim) Meta(ctx context.Context) interface{} {
 	panic("this provider is schema-only and does not support runtime operations")
 }
 
-func (ProviderShim) Stop() error {
+func (ProviderShim) Stop(ctx context.Context) error {
 	panic("this provider is schema-only and does not support runtime operations")
 }
 
-func (ProviderShim) InitLogging() {
+func (ProviderShim) InitLogging(ctx context.Context) {
 	panic("this provider is schema-only and does not support runtime operations")
 }
 
-func (ProviderShim) NewDestroyDiff() shim.InstanceDiff {
+func (ProviderShim) NewDestroyDiff(ctx context.Context, t string) shim.InstanceDiff {
 	panic("this provider is schema-only and does not support runtime operations")
 }
 
-func (ProviderShim) NewResourceConfig(object map[string]interface{}) shim.ResourceConfig {
+func (ProviderShim) NewResourceConfig(
+	ctx context.Context, object map[string]interface{},
+) shim.ResourceConfig {
 	panic("this provider is schema-only and does not support runtime operations")
 }
 
-func (ProviderShim) IsSet(v interface{}) ([]interface{}, bool) {
+func (ProviderShim) IsSet(ctx context.Context, v interface{}) ([]interface{}, bool) {
 	panic("this provider is schema-only and does not support runtime operations")
 }

--- a/pkg/tfshim/sdk-v1/provider.go
+++ b/pkg/tfshim/sdk-v1/provider.go
@@ -1,6 +1,8 @@
 package sdkv1
 
 import (
+	"context"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
@@ -68,23 +70,25 @@ func (p v1Provider) DataSourcesMap() shim.ResourceMap {
 	return v1ResourceMap(p.tf.DataSourcesMap)
 }
 
-func (p v1Provider) Validate(c shim.ResourceConfig) ([]string, []error) {
+func (p v1Provider) Validate(_ context.Context, c shim.ResourceConfig) ([]string, []error) {
 	return p.tf.Validate(configFromShim(c))
 }
 
-func (p v1Provider) ValidateResource(t string, c shim.ResourceConfig) ([]string, []error) {
+func (p v1Provider) ValidateResource(_ context.Context, t string, c shim.ResourceConfig) ([]string, []error) {
 	return p.tf.ValidateResource(t, configFromShim(c))
 }
 
-func (p v1Provider) ValidateDataSource(t string, c shim.ResourceConfig) ([]string, []error) {
+func (p v1Provider) ValidateDataSource(_ context.Context, t string, c shim.ResourceConfig) ([]string, []error) {
 	return p.tf.ValidateDataSource(t, configFromShim(c))
 }
 
-func (p v1Provider) Configure(c shim.ResourceConfig) error {
+func (p v1Provider) Configure(_ context.Context, c shim.ResourceConfig) error {
 	return p.tf.Configure(configFromShim(c))
 }
 
-func (p v1Provider) Diff(t string, s shim.InstanceState, c shim.ResourceConfig) (shim.InstanceDiff, error) {
+func (p v1Provider) Diff(
+	_ context.Context, t string, s shim.InstanceState, c shim.ResourceConfig,
+) (shim.InstanceDiff, error) {
 	if c == nil {
 		return diffToShim(&terraform.InstanceDiff{Destroy: true}), nil
 	}
@@ -93,50 +97,60 @@ func (p v1Provider) Diff(t string, s shim.InstanceState, c shim.ResourceConfig) 
 	return diffToShim(diff), err
 }
 
-func (p v1Provider) Apply(t string, s shim.InstanceState, d shim.InstanceDiff) (shim.InstanceState, error) {
+func (p v1Provider) Apply(
+	_ context.Context, t string, s shim.InstanceState, d shim.InstanceDiff,
+) (shim.InstanceState, error) {
 	state, err := p.tf.Apply(instanceInfo(t), stateFromShim(s), diffFromShim(d))
 	return stateToShim(state), err
 }
 
-func (p v1Provider) Refresh(t string, s shim.InstanceState, _ shim.ResourceConfig) (shim.InstanceState, error) {
+func (p v1Provider) Refresh(
+	_ context.Context, t string, s shim.InstanceState, _ shim.ResourceConfig,
+) (shim.InstanceState, error) {
 	state, err := p.tf.Refresh(instanceInfo(t), stateFromShim(s))
 	return stateToShim(state), err
 }
 
-func (p v1Provider) ReadDataDiff(t string, c shim.ResourceConfig) (shim.InstanceDiff, error) {
+func (p v1Provider) ReadDataDiff(
+	_ context.Context, t string, c shim.ResourceConfig,
+) (shim.InstanceDiff, error) {
 	diff, err := p.tf.ReadDataDiff(instanceInfo(t), configFromShim(c))
 	return diffToShim(diff), err
 }
 
-func (p v1Provider) ReadDataApply(t string, d shim.InstanceDiff) (shim.InstanceState, error) {
+func (p v1Provider) ReadDataApply(
+	_ context.Context, t string, d shim.InstanceDiff,
+) (shim.InstanceState, error) {
 	state, err := p.tf.ReadDataApply(instanceInfo(t), diffFromShim(d))
 	return stateToShim(state), err
 }
 
-func (p v1Provider) Meta() interface{} {
+func (p v1Provider) Meta(_ context.Context) interface{} {
 	return p.tf.Meta()
 }
 
-func (p v1Provider) Stop() error {
+func (p v1Provider) Stop(_ context.Context) error {
 	return p.tf.Stop()
 }
 
-func (p v1Provider) InitLogging() {
+func (p v1Provider) InitLogging(_ context.Context) {
 	logging.SetOutput()
 }
 
-func (p v1Provider) NewDestroyDiff() shim.InstanceDiff {
+func (p v1Provider) NewDestroyDiff(_ context.Context, t string) shim.InstanceDiff {
 	return v1InstanceDiff{&terraform.InstanceDiff{Destroy: true}}
 }
 
-func (p v1Provider) NewResourceConfig(object map[string]interface{}) shim.ResourceConfig {
+func (p v1Provider) NewResourceConfig(
+	_ context.Context, object map[string]interface{},
+) shim.ResourceConfig {
 	return v1ResourceConfig{&terraform.ResourceConfig{
 		Raw:    object,
 		Config: object,
 	}}
 }
 
-func (p v1Provider) IsSet(v interface{}) ([]interface{}, bool) {
+func (p v1Provider) IsSet(_ context.Context, v interface{}) ([]interface{}, bool) {
 	if set, ok := v.(*schema.Set); ok {
 		return set.List(), true
 	}

--- a/pkg/tfshim/sdk-v2/provider_diff.go
+++ b/pkg/tfshim/sdk-v2/provider_diff.go
@@ -27,14 +27,6 @@ import (
 )
 
 func (p v2Provider) Diff(
-	t string,
-	s shim.InstanceState,
-	c shim.ResourceConfig,
-) (shim.InstanceDiff, error) {
-	return p.DiffWithContext(context.Background(), t, s, c)
-}
-
-func (p v2Provider) DiffWithContext(
 	ctx context.Context,
 	t string,
 	s shim.InstanceState,

--- a/pkg/tfshim/sdk-v2/provider_diff_test.go
+++ b/pkg/tfshim/sdk-v2/provider_diff_test.go
@@ -15,6 +15,7 @@
 package sdkv2
 
 import (
+	"context"
 	"testing"
 
 	"github.com/hashicorp/go-cty/cty"
@@ -25,6 +26,7 @@ import (
 )
 
 func TestRawPlanSet(t *testing.T) {
+	ctx := context.Background()
 	r := &schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"tags": {
@@ -58,7 +60,7 @@ func TestRawPlanSet(t *testing.T) {
 		tf:       instanceState,
 	}
 
-	id, err := wp.Diff("myres", ss, v2ResourceConfig{
+	id, err := wp.Diff(ctx, "myres", ss, v2ResourceConfig{
 		tf: resourceConfig,
 	})
 	require.NoError(t, err)

--- a/pkg/tfshim/shim.go
+++ b/pkg/tfshim/shim.go
@@ -188,93 +188,38 @@ type Provider interface {
 	ResourcesMap() ResourceMap
 	DataSourcesMap() ResourceMap
 
-	Validate(c ResourceConfig) ([]string, []error)
-	ValidateResource(t string, c ResourceConfig) ([]string, []error)
-	ValidateDataSource(t string, c ResourceConfig) ([]string, []error)
+	Validate(ctx context.Context, c ResourceConfig) ([]string, []error)
+	ValidateResource(ctx context.Context, t string, c ResourceConfig) ([]string, []error)
+	ValidateDataSource(ctx context.Context, t string, c ResourceConfig) ([]string, []error)
 
-	Configure(c ResourceConfig) error
-	Diff(t string, s InstanceState, c ResourceConfig) (InstanceDiff, error)
-	Apply(t string, s InstanceState, d InstanceDiff) (InstanceState, error)
-	Refresh(t string, s InstanceState, c ResourceConfig) (InstanceState, error)
+	Configure(ctx context.Context, c ResourceConfig) error
 
-	ReadDataDiff(t string, c ResourceConfig) (InstanceDiff, error)
-	ReadDataApply(t string, d InstanceDiff) (InstanceState, error)
+	Diff(
+		ctx context.Context,
+		t string,
+		s InstanceState,
+		c ResourceConfig,
+	) (InstanceDiff, error)
 
-	Meta() interface{}
-	Stop() error
+	Apply(ctx context.Context, t string, s InstanceState, d InstanceDiff) (InstanceState, error)
 
-	InitLogging()
-	NewDestroyDiff() InstanceDiff
-	NewResourceConfig(object map[string]interface{}) ResourceConfig
-	IsSet(v interface{}) ([]interface{}, bool)
-}
+	Refresh(
+		ctx context.Context, t string, s InstanceState, c ResourceConfig,
+	) (InstanceState, error)
 
-type ProviderWithContext interface {
-	Provider
+	ReadDataDiff(ctx context.Context, t string, c ResourceConfig) (InstanceDiff, error)
+	ReadDataApply(ctx context.Context, t string, d InstanceDiff) (InstanceState, error)
 
-	ConfigureWithContext(ctx context.Context, c ResourceConfig) error
-	DiffWithContext(ctx context.Context, t string, s InstanceState, c ResourceConfig) (InstanceDiff, error)
-	ApplyWithContext(ctx context.Context, t string, s InstanceState, d InstanceDiff) (InstanceState, error)
-	RefreshWithContext(ctx context.Context, t string, s InstanceState, c ResourceConfig) (InstanceState, error)
+	Meta(ctx context.Context) interface{}
+	Stop(ctx context.Context) error
 
-	ReadDataDiffWithContext(ctx context.Context, t string, c ResourceConfig) (InstanceDiff, error)
-	ReadDataApplyWithContext(ctx context.Context, t string, d InstanceDiff) (InstanceState, error)
-}
+	InitLogging(ctx context.Context)
 
-func NewProviderWithContext(p Provider) ProviderWithContext {
-	if pwc, ok := p.(ProviderWithContext); ok {
-		return pwc
-	}
-	return &providerWithIgnoredContext{p}
-}
+	// Create a Destroy diff for a resource identified by the TF token t.
+	NewDestroyDiff(ctx context.Context, t string) InstanceDiff
 
-type providerWithIgnoredContext struct {
-	Provider
-}
+	NewResourceConfig(ctx context.Context, object map[string]interface{}) ResourceConfig
 
-func (p *providerWithIgnoredContext) ConfigureWithContext(_ context.Context, c ResourceConfig) error {
-	return p.Provider.Configure(c)
-}
-
-func (p *providerWithIgnoredContext) DiffWithContext(
-	_ context.Context,
-	t string,
-	s InstanceState,
-	c ResourceConfig,
-) (InstanceDiff, error) {
-	return p.Provider.Diff(t, s, c)
-}
-
-func (p *providerWithIgnoredContext) ApplyWithContext(
-	_ context.Context,
-	t string,
-	s InstanceState,
-	d InstanceDiff,
-) (InstanceState, error) {
-	return p.Provider.Apply(t, s, d)
-}
-
-func (p *providerWithIgnoredContext) RefreshWithContext(
-	_ context.Context,
-	t string,
-	s InstanceState,
-	c ResourceConfig,
-) (InstanceState, error) {
-	return p.Provider.Refresh(t, s, c)
-}
-
-func (p *providerWithIgnoredContext) ReadDataDiffWithContext(
-	_ context.Context,
-	t string,
-	c ResourceConfig,
-) (InstanceDiff, error) {
-	return p.Provider.ReadDataDiff(t, c)
-}
-
-func (p *providerWithIgnoredContext) ReadDataApplyWithContext(
-	ctx context.Context,
-	t string,
-	d InstanceDiff,
-) (InstanceState, error) {
-	return p.Provider.ReadDataApply(t, d)
+	// Checks if a value is representing a Set, and unpacks its elements on success.
+	IsSet(ctx context.Context, v interface{}) ([]interface{}, bool)
 }

--- a/pkg/tfshim/util/filter.go
+++ b/pkg/tfshim/util/filter.go
@@ -15,6 +15,7 @@
 package util
 
 import (
+	"context"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
@@ -57,64 +58,80 @@ func (p *FilteringProvider) DataSourcesMap() shim.ResourceMap {
 	return &filteringMap{p.Provider.DataSourcesMap(), p.DataSourceFilter}
 }
 
-func (p *FilteringProvider) Validate(c shim.ResourceConfig) ([]string, []error) {
-	return p.Provider.Validate(c)
+func (p *FilteringProvider) Validate(ctx context.Context, c shim.ResourceConfig) ([]string, []error) {
+	return p.Provider.Validate(ctx, c)
 }
 
-func (p *FilteringProvider) ValidateResource(t string, c shim.ResourceConfig) ([]string, []error) {
-	return p.Provider.ValidateResource(t, c)
+func (p *FilteringProvider) ValidateResource(
+	ctx context.Context, t string, c shim.ResourceConfig,
+) ([]string, []error) {
+	return p.Provider.ValidateResource(ctx, t, c)
 }
 
-func (p *FilteringProvider) ValidateDataSource(t string, c shim.ResourceConfig) ([]string, []error) {
-	return p.Provider.ValidateDataSource(t, c)
+func (p *FilteringProvider) ValidateDataSource(
+	ctx context.Context, t string, c shim.ResourceConfig,
+) ([]string, []error) {
+	return p.Provider.ValidateDataSource(ctx, t, c)
 }
 
-func (p *FilteringProvider) Configure(c shim.ResourceConfig) error {
-	return p.Provider.Configure(c)
+func (p *FilteringProvider) Configure(ctx context.Context, c shim.ResourceConfig) error {
+	return p.Provider.Configure(ctx, c)
 }
 
-func (p *FilteringProvider) Diff(t string, s shim.InstanceState, c shim.ResourceConfig) (shim.InstanceDiff, error) {
-	return p.Provider.Diff(t, s, c)
+func (p *FilteringProvider) Diff(
+	ctx context.Context, t string, s shim.InstanceState, c shim.ResourceConfig,
+) (shim.InstanceDiff, error) {
+	return p.Provider.Diff(ctx, t, s, c)
 }
 
-func (p *FilteringProvider) Apply(t string, s shim.InstanceState, d shim.InstanceDiff) (shim.InstanceState, error) {
-	return p.Provider.Apply(t, s, d)
+func (p *FilteringProvider) Apply(
+	ctx context.Context, t string, s shim.InstanceState, d shim.InstanceDiff,
+) (shim.InstanceState, error) {
+	return p.Provider.Apply(ctx, t, s, d)
 }
 
-func (p *FilteringProvider) Refresh(t string, s shim.InstanceState, c shim.ResourceConfig) (shim.InstanceState, error) {
-	return p.Provider.Refresh(t, s, c)
+func (p *FilteringProvider) Refresh(
+	ctx context.Context, t string, s shim.InstanceState, c shim.ResourceConfig,
+) (shim.InstanceState, error) {
+	return p.Provider.Refresh(ctx, t, s, c)
 }
 
-func (p *FilteringProvider) ReadDataDiff(t string, c shim.ResourceConfig) (shim.InstanceDiff, error) {
-	return p.Provider.ReadDataDiff(t, c)
+func (p *FilteringProvider) ReadDataDiff(
+	ctx context.Context, t string, c shim.ResourceConfig,
+) (shim.InstanceDiff, error) {
+	return p.Provider.ReadDataDiff(ctx, t, c)
 }
 
-func (p *FilteringProvider) ReadDataApply(t string, d shim.InstanceDiff) (shim.InstanceState, error) {
-	return p.Provider.ReadDataApply(t, d)
+func (p *FilteringProvider) ReadDataApply(
+	ctx context.Context, t string, d shim.InstanceDiff,
+) (shim.InstanceState, error) {
+	return p.Provider.ReadDataApply(ctx, t, d)
 }
 
-func (p *FilteringProvider) Meta() interface{} {
-	return p.Provider.Meta()
+func (p *FilteringProvider) Meta(ctx context.Context) interface{} {
+	return p.Provider.Meta(ctx)
 }
 
-func (p *FilteringProvider) Stop() error {
-	return p.Provider.Stop()
+func (p *FilteringProvider) Stop(ctx context.Context) error {
+	return p.Provider.Stop(ctx)
 }
 
-func (p *FilteringProvider) InitLogging() {
-	p.Provider.InitLogging()
+func (p *FilteringProvider) InitLogging(ctx context.Context) {
+	p.Provider.InitLogging(ctx)
 }
 
-func (p *FilteringProvider) NewDestroyDiff() shim.InstanceDiff {
-	return p.Provider.NewDestroyDiff()
+func (p *FilteringProvider) NewDestroyDiff(ctx context.Context, t string) shim.InstanceDiff {
+	return p.Provider.NewDestroyDiff(ctx, t)
 }
 
-func (p *FilteringProvider) NewResourceConfig(object map[string]interface{}) shim.ResourceConfig {
-	return p.Provider.NewResourceConfig(object)
+func (p *FilteringProvider) NewResourceConfig(
+	ctx context.Context, object map[string]interface{},
+) shim.ResourceConfig {
+	return p.Provider.NewResourceConfig(ctx, object)
 }
 
-func (p *FilteringProvider) IsSet(v interface{}) ([]interface{}, bool) {
-	return p.Provider.IsSet(v)
+func (p *FilteringProvider) IsSet(ctx context.Context, v interface{}) ([]interface{}, bool) {
+	return p.Provider.IsSet(ctx, v)
 }
 
 type filteringMap struct {

--- a/pkg/tfshim/util/util.go
+++ b/pkg/tfshim/util/util.go
@@ -15,6 +15,7 @@
 package util
 
 import (
+	"context"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
@@ -27,40 +28,73 @@ func (UnimplementedProvider) Schema() shim.SchemaMap           { panic("unimplem
 func (UnimplementedProvider) ResourcesMap() shim.ResourceMap   { panic("unimplemented") }
 func (UnimplementedProvider) DataSourcesMap() shim.ResourceMap { panic("unimplemented") }
 
-func (UnimplementedProvider) Validate(c shim.ResourceConfig) ([]string, []error) {
-	panic("unimplemented")
-}
-func (UnimplementedProvider) ValidateResource(t string, c shim.ResourceConfig) ([]string, []error) {
-	panic("unimplemented")
-}
-func (UnimplementedProvider) ValidateDataSource(t string, c shim.ResourceConfig) ([]string, []error) {
+func (UnimplementedProvider) Validate(
+	ctx context.Context, c shim.ResourceConfig,
+) ([]string, []error) {
 	panic("unimplemented")
 }
 
-func (UnimplementedProvider) Configure(c shim.ResourceConfig) error { panic("unimplemented") }
-func (UnimplementedProvider) Diff(t string, s shim.InstanceState, c shim.ResourceConfig) (shim.InstanceDiff, error) {
-	panic("unimplemented")
-}
-func (UnimplementedProvider) Apply(t string, s shim.InstanceState, d shim.InstanceDiff) (shim.InstanceState, error) {
-	panic("unimplemented")
-}
-func (UnimplementedProvider) Refresh(string, shim.InstanceState, shim.ResourceConfig) (shim.InstanceState, error) {
+func (UnimplementedProvider) ValidateResource(
+	ctx context.Context, t string, c shim.ResourceConfig,
+) ([]string, []error) {
 	panic("unimplemented")
 }
 
-func (UnimplementedProvider) ReadDataDiff(t string, c shim.ResourceConfig) (shim.InstanceDiff, error) {
-	panic("unimplemented")
-}
-func (UnimplementedProvider) ReadDataApply(t string, d shim.InstanceDiff) (shim.InstanceState, error) {
+func (UnimplementedProvider) ValidateDataSource(
+	ctx context.Context, t string, c shim.ResourceConfig,
+) ([]string, []error) {
 	panic("unimplemented")
 }
 
-func (UnimplementedProvider) Meta() interface{} { panic("unimplemented") }
-func (UnimplementedProvider) Stop() error       { panic("unimplemented") }
-
-func (UnimplementedProvider) InitLogging()                      { panic("unimplemented") }
-func (UnimplementedProvider) NewDestroyDiff() shim.InstanceDiff { panic("unimplemented") }
-func (UnimplementedProvider) NewResourceConfig(object map[string]interface{}) shim.ResourceConfig {
+func (UnimplementedProvider) Configure(ctx context.Context, c shim.ResourceConfig) error {
 	panic("unimplemented")
 }
-func (UnimplementedProvider) IsSet(v interface{}) ([]interface{}, bool) { panic("unimplemented") }
+
+func (UnimplementedProvider) Diff(
+	ctx context.Context, t string, s shim.InstanceState, c shim.ResourceConfig,
+) (shim.InstanceDiff, error) {
+	panic("unimplemented")
+}
+
+func (UnimplementedProvider) Apply(
+	ctx context.Context, t string, s shim.InstanceState, d shim.InstanceDiff,
+) (shim.InstanceState, error) {
+	panic("unimplemented")
+}
+
+func (UnimplementedProvider) Refresh(
+	ctx context.Context, t string, s shim.InstanceState, c shim.ResourceConfig,
+) (shim.InstanceState, error) {
+	panic("unimplemented")
+}
+
+func (UnimplementedProvider) ReadDataDiff(
+	ctx context.Context, t string, c shim.ResourceConfig,
+) (shim.InstanceDiff, error) {
+	panic("unimplemented")
+}
+
+func (UnimplementedProvider) ReadDataApply(
+	ctx context.Context, t string, d shim.InstanceDiff,
+) (shim.InstanceState, error) {
+	panic("unimplemented")
+}
+
+func (UnimplementedProvider) Meta(ctx context.Context) interface{} { panic("unimplemented") }
+func (UnimplementedProvider) Stop(ctx context.Context) error       { panic("unimplemented") }
+
+func (UnimplementedProvider) InitLogging(ctx context.Context) { panic("unimplemented") }
+
+func (UnimplementedProvider) NewDestroyDiff(ctx context.Context, t string) shim.InstanceDiff {
+	panic("unimplemented")
+}
+
+func (UnimplementedProvider) NewResourceConfig(
+	ctx context.Context, object map[string]interface{},
+) shim.ResourceConfig {
+	panic("unimplemented")
+}
+
+func (UnimplementedProvider) IsSet(ctx context.Context, v interface{}) ([]interface{}, bool) {
+	panic("unimplemented")
+}


### PR DESCRIPTION
This change should not break bridged provider users or authors, but is technically a small breaking change in the pkg/tfshim module.

The shim.Provider interface methods now requires a context.Context as the first argument.

The shim.ProviderWithContext compatibility interface is now removed. Use shim.Provider.

The shim.Provider NewDestroyDiff method now additionally accepts the resource token:

        // Create a Destroy diff for a resource identified by the TF token t.
        NewDestroyDiff(ctx context.Context, t string) InstanceDiff


Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/1541