### PR TITLE
Refactor timeouts

### DIFF
--- a/pf/internal/schemashim/provider.go
+++ b/pf/internal/schemashim/provider.go
@@ -59,18 +59,18 @@ func (p *SchemaOnlyProvider) DataSourcesMap() shim.ResourceMap {
 	return &schemaOnlyDataSourceMap{dataSources}
 }
 
-func (p *SchemaOnlyProvider) Validate(ctx context.Context, c shim.ResourceConfig) ([]string, []error) {
+func (p *SchemaOnlyProvider) Validate(context.Context, shim.ResourceConfig) ([]string, []error) {
 	panic("schemaOnlyProvider does not implement runtime operation Validate")
 }
 
 func (p *SchemaOnlyProvider) ValidateResource(
-	ctx context.Context, t string, c shim.ResourceConfig,
+	context.Context, string, shim.ResourceConfig,
 ) ([]string, []error) {
 	panic("schemaOnlyProvider does not implement runtime operation ValidateResource")
 }
 
 func (p *SchemaOnlyProvider) ValidateDataSource(
-	ctx context.Context, t string, c shim.ResourceConfig) ([]string, []error) {
+	context.Context, string, shim.ResourceConfig) ([]string, []error) {
 	panic("schemaOnlyProvider does not implement runtime operation ValidateDataSource")
 }
 
@@ -79,16 +79,13 @@ func (p *SchemaOnlyProvider) Configure(ctx context.Context, c shim.ResourceConfi
 }
 
 func (p *SchemaOnlyProvider) Diff(
-	ctx context.Context, t string, s shim.InstanceState, c shim.ResourceConfig, opts shim.DiffOptions,
+	context.Context, string, shim.InstanceState, shim.ResourceConfig, shim.DiffOptions,
 ) (shim.InstanceDiff, error) {
 	panic("schemaOnlyProvider does not implement runtime operation Diff")
 }
 
 func (p *SchemaOnlyProvider) Apply(
-	ctx context.Context,
-	t string,
-	s shim.InstanceState,
-	d shim.InstanceDiff,
+	context.Context, string, shim.InstanceState, shim.InstanceDiff,
 ) (shim.InstanceState, error) {
 	panic("schemaOnlyProvider does not implement runtime operation Apply")
 }
@@ -100,41 +97,37 @@ func (p *SchemaOnlyProvider) Refresh(
 }
 
 func (p *SchemaOnlyProvider) ReadDataDiff(
-	ctx context.Context,
-	t string,
-	c shim.ResourceConfig,
+	context.Context, string, shim.ResourceConfig,
 ) (shim.InstanceDiff, error) {
 	panic("schemaOnlyProvider does not implement runtime operation ReadDataDiff")
 }
 
 func (p *SchemaOnlyProvider) ReadDataApply(
-	ctx context.Context,
-	t string,
-	d shim.InstanceDiff,
+	context.Context, string, shim.InstanceDiff,
 ) (shim.InstanceState, error) {
 	panic("schemaOnlyProvider does not implement runtime operation ReadDataApply")
 }
 
-func (p *SchemaOnlyProvider) Meta(ctx context.Context) interface{} {
+func (p *SchemaOnlyProvider) Meta(context.Context) interface{} {
 	panic("schemaOnlyProvider does not implement runtime operation Meta")
 }
 
-func (p *SchemaOnlyProvider) Stop(ctx context.Context) error {
+func (p *SchemaOnlyProvider) Stop(context.Context) error {
 	panic("schemaOnlyProvider does not implement runtime operation Stop")
 }
 
-func (p *SchemaOnlyProvider) InitLogging(ctx context.Context) {
+func (p *SchemaOnlyProvider) InitLogging(context.Context) {
 	panic("schemaOnlyProvider does not implement runtime operation InitLogging")
 }
 
-func (p *SchemaOnlyProvider) NewDestroyDiff(ctx context.Context, t string, _ shim.TimeoutOptions) shim.InstanceDiff {
+func (p *SchemaOnlyProvider) NewDestroyDiff(context.Context, string, shim.TimeoutOptions) shim.InstanceDiff {
 	panic("schemaOnlyProvider does not implement runtime operation NewDestroyDiff")
 }
 
-func (p *SchemaOnlyProvider) NewResourceConfig(ctx context.Context, object map[string]interface{}) shim.ResourceConfig {
-	panic("schemaOnlyProvider does not implement runtime operation ReourceConfig")
+func (p *SchemaOnlyProvider) NewResourceConfig(context.Context, map[string]interface{}) shim.ResourceConfig {
+	panic("schemaOnlyProvider does not implement runtime operation ResourceConfig")
 }
 
-func (p *SchemaOnlyProvider) IsSet(ctx context.Context, v interface{}) ([]interface{}, bool) {
+func (p *SchemaOnlyProvider) IsSet(context.Context, interface{}) ([]interface{}, bool) {
 	panic("schemaOnlyProvider does not implement runtime operation IsSet")
 }

--- a/pf/internal/schemashim/provider.go
+++ b/pf/internal/schemashim/provider.go
@@ -127,7 +127,7 @@ func (p *SchemaOnlyProvider) InitLogging(ctx context.Context) {
 	panic("schemaOnlyProvider does not implement runtime operation InitLogging")
 }
 
-func (p *SchemaOnlyProvider) NewDestroyDiff(ctx context.Context, t string) shim.InstanceDiff {
+func (p *SchemaOnlyProvider) NewDestroyDiff(ctx context.Context, t string, _ shim.TimeoutOptions) shim.InstanceDiff {
 	panic("schemaOnlyProvider does not implement runtime operation NewDestroyDiff")
 }
 

--- a/pkg/tfshim/schema/provider.go
+++ b/pkg/tfshim/schema/provider.go
@@ -105,7 +105,7 @@ func (ProviderShim) InitLogging(ctx context.Context) {
 	panic("this provider is schema-only and does not support runtime operations")
 }
 
-func (ProviderShim) NewDestroyDiff(ctx context.Context, t string) shim.InstanceDiff {
+func (ProviderShim) NewDestroyDiff(ctx context.Context, t string, _ shim.TimeoutOptions) shim.InstanceDiff {
 	panic("this provider is schema-only and does not support runtime operations")
 }
 

--- a/pkg/tfshim/sdk-v2/provider.go
+++ b/pkg/tfshim/sdk-v2/provider.go
@@ -186,8 +186,10 @@ func (p v2Provider) InitLogging(_ context.Context) {
 	logging.SetOutput(&testing.RuntimeT{})
 }
 
-func (p v2Provider) NewDestroyDiff(_ context.Context, t string) shim.InstanceDiff {
-	return v2InstanceDiff{&terraform.InstanceDiff{Destroy: true}}
+func (p v2Provider) NewDestroyDiff(_ context.Context, t string, opts shim.TimeoutOptions) shim.InstanceDiff {
+	d := v2InstanceDiff{&terraform.InstanceDiff{Destroy: true}}
+	d.applyTimeoutOptions(opts)
+	return d
 }
 
 func (p v2Provider) NewResourceConfig(

--- a/pkg/tfshim/sdk-v2/provider_diff.go
+++ b/pkg/tfshim/sdk-v2/provider_diff.go
@@ -32,7 +32,13 @@ func (p v2Provider) Diff(
 	s shim.InstanceState,
 	c shim.ResourceConfig,
 	opts shim.DiffOptions,
-) (shim.InstanceDiff, error) {
+) (theDiff shim.InstanceDiff, theError error) {
+	defer func() {
+		switch theDiff := theDiff.(type) {
+		case v2InstanceDiff:
+			theDiff.applyTimeoutOptions(opts.TimeoutOptions)
+		}
+	}()
 	if c == nil {
 		return diffToShim(&terraform.InstanceDiff{Destroy: true}), nil
 	}

--- a/pkg/tfshim/tfplugin5/provider.go
+++ b/pkg/tfshim/tfplugin5/provider.go
@@ -556,8 +556,10 @@ func (p *provider) InitLogging(ctx context.Context) {
 	// Nothing to do.
 }
 
-func (p *provider) NewDestroyDiff(ctx context.Context, t string) shim.InstanceDiff {
-	return &instanceDiff{destroy: true}
+func (p *provider) NewDestroyDiff(ctx context.Context, t string, opts shim.TimeoutOptions) shim.InstanceDiff {
+	d := &instanceDiff{destroy: true}
+	d.applyTimeoutOptions(opts)
+	return d
 }
 
 func (p *provider) NewResourceConfig(ctx context.Context, object map[string]interface{}) shim.ResourceConfig {

--- a/pkg/tfshim/util/filter.go
+++ b/pkg/tfshim/util/filter.go
@@ -120,8 +120,10 @@ func (p *FilteringProvider) InitLogging(ctx context.Context) {
 	p.Provider.InitLogging(ctx)
 }
 
-func (p *FilteringProvider) NewDestroyDiff(ctx context.Context, t string) shim.InstanceDiff {
-	return p.Provider.NewDestroyDiff(ctx, t)
+func (p *FilteringProvider) NewDestroyDiff(
+	ctx context.Context, t string, opts shim.TimeoutOptions,
+) shim.InstanceDiff {
+	return p.Provider.NewDestroyDiff(ctx, t, opts)
 }
 
 func (p *FilteringProvider) NewResourceConfig(

--- a/pkg/tfshim/util/util.go
+++ b/pkg/tfshim/util/util.go
@@ -85,7 +85,9 @@ func (UnimplementedProvider) Stop(ctx context.Context) error       { panic("unim
 
 func (UnimplementedProvider) InitLogging(ctx context.Context) { panic("unimplemented") }
 
-func (UnimplementedProvider) NewDestroyDiff(ctx context.Context, t string) shim.InstanceDiff {
+func (UnimplementedProvider) NewDestroyDiff(
+	ctx context.Context, t string, _ shim.TimeoutOptions,
+) shim.InstanceDiff {
 	panic("unimplemented")
 }
 


### PR DESCRIPTION
This refactor removes the imperative timeout setters:

```go
type InstanceDiff interface {
	EncodeTimeouts(timeouts *ResourceTimeout) error
        SetTimeout(float64, string)
}
```

In favor of having Diff and NewDestroyDiff accept TimeoutOptions:

```go
type TimeoutOptions struct {
	ResourceTimeout  *ResourceTimeout // optional
	TimeoutOverrides map[TimeoutKey]time.Duration
}
```

This enables a little more flexibility for the TF backend implementation in that it can encode timeouts as part of InstanceDiff construction rather than teach it how to modify them ex-post-facto.
