### PR TITLE
[PF] Call `Read` after `ImportState` when importing a resource

### DIFF
--- a/pf/internal/convert/convert.go
+++ b/pf/internal/convert/convert.go
@@ -70,6 +70,9 @@ func DecodePropertyMap(dec Decoder, v tftypes.Value) (resource.PropertyMap, erro
 	if err != nil {
 		return nil, err
 	}
+	if pv.IsNull() {
+		return nil, nil
+	}
 	if !pv.IsObject() {
 		return nil, fmt.Errorf("Expected an Object, got: %v", pv.String())
 	}

--- a/pf/internal/convert/convert.go
+++ b/pf/internal/convert/convert.go
@@ -70,15 +70,6 @@ func DecodePropertyMap(dec Decoder, v tftypes.Value) (resource.PropertyMap, erro
 	if err != nil {
 		return nil, err
 	}
-
-	// Pulumi's property value representation doesn't do a good job distinguishing
-	// between the empty property map (PropertyMap{}) and a nil value
-	// (resource.NullProperty).
-	//
-	// We allow converting a null property into a nil map.
-	if pv.IsNull() {
-		return nil, nil
-	}
 	if !pv.IsObject() {
 		return nil, fmt.Errorf("Expected an Object, got: %v", pv.String())
 	}

--- a/pf/internal/convert/convert.go
+++ b/pf/internal/convert/convert.go
@@ -70,6 +70,12 @@ func DecodePropertyMap(dec Decoder, v tftypes.Value) (resource.PropertyMap, erro
 	if err != nil {
 		return nil, err
 	}
+
+	// Pulumi's property value representation doesn't do a good job distinguishing
+	// between the empty property map (PropertyMap{}) and a nil value
+	// (resource.NullProperty).
+	//
+	// We allow converting a null property into a nil map.
 	if pv.IsNull() {
 		return nil, nil
 	}

--- a/pf/tests/internal/testprovider/cmd/pulumi-resource-testbridge/schema.json
+++ b/pf/tests/internal/testprovider/cmd/pulumi-resource-testbridge/schema.json
@@ -46,6 +46,9 @@
             "properties": {
                 "actionParameters": {
                     "$ref": "#/types/testbridge:index/TestnestRuleActionParameters:TestnestRuleActionParameters"
+                },
+                "protocol": {
+                    "type": "string"
                 }
             },
             "type": "object"

--- a/pf/tests/internal/testprovider/testbridge_resource_testcompres.go
+++ b/pf/tests/internal/testprovider/testbridge_resource_testcompres.go
@@ -87,7 +87,7 @@ func (e *testCompRes) Create(ctx context.Context, req resource.CreateRequest, re
 }
 
 func (e *testCompRes) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	panic("TODO Read")
+	// Accept the inputs of ImportState as is.
 }
 
 func (e *testCompRes) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {

--- a/pf/tests/internal/testprovider/testbridge_resource_testnest.go
+++ b/pf/tests/internal/testprovider/testbridge_resource_testnest.go
@@ -17,6 +17,7 @@ package testprovider
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -84,6 +85,12 @@ func (*testnest) schema() rschema.Schema {
 			"rules": schema.ListNestedBlock{
 				MarkdownDescription: "List of rules to apply to the ruleset.",
 				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"protocol": schema.StringAttribute{
+							MarkdownDescription: "network protocol",
+							Optional:            true,
+						},
+					},
 					Blocks: map[string]schema.Block{
 						"action_parameters": schema.ListNestedBlock{
 							MarkdownDescription: "List of parameters that configure the behavior of the ruleset rule action.",
@@ -136,7 +143,17 @@ func (e *testnest) Create(ctx context.Context, req resource.CreateRequest, resp 
 }
 
 func (e *testnest) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	panic("unimplemented")
+	type ruleModel struct {
+		Protocol         string     `tfsdk:"protocol"`
+		ActionParameters []struct{} `tfsdk:"action_parameters"`
+	}
+	path := path.Root("rules")
+	err := resp.State.SetAttribute(ctx, path, []ruleModel{
+		{Protocol: "some-string"},
+	})
+	if err != nil {
+		resp.Diagnostics.Append(err...)
+	}
 }
 
 func (e *testnest) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {

--- a/pf/tests/internal/testprovider/testbridge_resource_testnest.go
+++ b/pf/tests/internal/testprovider/testbridge_resource_testnest.go
@@ -147,12 +147,24 @@ func (e *testnest) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		Protocol         string     `tfsdk:"protocol"`
 		ActionParameters []struct{} `tfsdk:"action_parameters"`
 	}
+
+	var id string
+	diag := req.State.GetAttribute(ctx, path.Root("id"), &id)
+	if diag != nil {
+		resp.Diagnostics.Append(diag...)
+	}
+
+	if id == "missing" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	path := path.Root("rules")
-	err := resp.State.SetAttribute(ctx, path, []ruleModel{
+	diag = resp.State.SetAttribute(ctx, path, []ruleModel{
 		{Protocol: "some-string"},
 	})
-	if err != nil {
-		resp.Diagnostics.Append(err...)
+	if diag != nil {
+		resp.Diagnostics.Append(diag...)
 	}
 }
 

--- a/pf/tests/internal/testprovider/testbridge_resource_testnestattr.go
+++ b/pf/tests/internal/testprovider/testbridge_resource_testnestattr.go
@@ -100,7 +100,7 @@ func (e *testnestattr) Create(ctx context.Context, req resource.CreateRequest, r
 }
 
 func (e *testnestattr) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	panic("unimplemented")
+	// Do nothing, accepting the result from ImportState as-is
 }
 
 func (e *testnestattr) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {

--- a/pf/tests/provider_read_test.go
+++ b/pf/tests/provider_read_test.go
@@ -188,22 +188,26 @@ func TestImportingResourcesWithBlocks(t *testing.T) {
 	server := newProviderServer(t, testprovider.SyntheticTestBridgeProvider())
 	testCase := `
 	{
-	  "method": "/pulumirpc.ResourceProvider/Read",
-	  "request": {
-	    "id": "zone/929e99f1a4152bfe415bbb3b29d1a227/my-ruleset-id",
-	    "urn": "urn:pulumi:testing::testing::testbridge:index/testnest:Testnest::myresource",
-	    "properties": {}
-	  },
-	  "response": {
+          "method": "/pulumirpc.ResourceProvider/Read",
+          "request": {
+            "id": "zone/929e99f1a4152bfe415bbb3b29d1a227/my-ruleset-id",
+            "urn": "urn:pulumi:testing::testing::testbridge:index/testnest:Testnest::myresource",
+            "properties": {}
+          },
+          "response": {
             "id": "*",
             "inputs": "*",
             "properties": {
-               	"id": "*",
-               	"rules": [],
-				"services": []
+              "id": "*",
+              "rules": [
+                {
+                  "protocol": "some-string"
+                }
+              ],
+              "services": []
             }
           }
-	}`
+        }`
 	testutils.Replay(t, server, testCase)
 }
 
@@ -213,21 +217,21 @@ func TestImportingResourcesWithNestedAttributes(t *testing.T) {
 	server := newProviderServer(t, testprovider.SyntheticTestBridgeProvider())
 	testCase := `
 	{
-	  "method": "/pulumirpc.ResourceProvider/Read",
-	  "request": {
-	    "id": "zone/929e99f1a4152bfe415bbb3b29d1a227/my-ruleset-id",
-	    "urn": "urn:pulumi:testing::testing::testbridge:index/testnestattr:Testnestattr::someresource",
-	    "properties": {}
-	  },
-	  "response": {
-		"id": "*",
-		"inputs": "*",
-		"properties": {
-			"id": "zone/929e99f1a4152bfe415bbb3b29d1a227/my-ruleset-id",
-			"services": []
-		}
-      }
-	}`
+          "method": "/pulumirpc.ResourceProvider/Read",
+          "request": {
+            "id": "zone/929e99f1a4152bfe415bbb3b29d1a227/my-ruleset-id",
+            "urn": "urn:pulumi:testing::testing::testbridge:index/testnestattr:Testnestattr::someresource",
+            "properties": {}
+          },
+          "response": {
+            "id": "*",
+            "inputs": "*",
+            "properties": {
+              "id": "zone/929e99f1a4152bfe415bbb3b29d1a227/my-ruleset-id",
+              "services": []
+            }
+          }
+        }`
 	testutils.Replay(t, server, testCase)
 }
 

--- a/pf/tests/provider_read_test.go
+++ b/pf/tests/provider_read_test.go
@@ -211,6 +211,26 @@ func TestImportingResourcesWithBlocks(t *testing.T) {
 	testutils.Replay(t, server, testCase)
 }
 
+// Check that importing a resource that does not exist returns an empty property bag and
+// no ID.
+func TestImportingMissingResources(t *testing.T) {
+	server := newProviderServer(t, testprovider.SyntheticTestBridgeProvider())
+	testCase := `
+	{
+          "method": "/pulumirpc.ResourceProvider/Read",
+          "request": {
+            "id": "missing",
+            "urn": "urn:pulumi:testing::testing::testbridge:index/testnest:Testnest::myresource",
+            "properties": {}
+          },
+          "response": {
+            "inputs": {},
+            "properties": {}
+          }
+        }`
+	testutils.Replay(t, server, testCase)
+}
+
 func TestImportingResourcesWithNestedAttributes(t *testing.T) {
 	// Importing a resource that has attribute blocks such as Testnest resource used to panic. Ensure that it minimally
 	// succeeds.
@@ -230,6 +250,34 @@ func TestImportingResourcesWithNestedAttributes(t *testing.T) {
               "id": "zone/929e99f1a4152bfe415bbb3b29d1a227/my-ruleset-id",
               "services": []
             }
+          }
+        }`
+	testutils.Replay(t, server, testCase)
+}
+
+// Check that refreshing a resource that does not exist returns an empty property bag and
+// no ID.
+func TestRefreshMissingResources(t *testing.T) {
+	server := newProviderServer(t, testprovider.SyntheticTestBridgeProvider())
+	testCase := `
+	{
+          "method": "/pulumirpc.ResourceProvider/Read",
+          "request": {
+            "id": "missing",
+            "urn": "urn:pulumi:testing::testing::testbridge:index/testnest:Testnest::myresource",
+            "properties": {
+              "id": "missing",
+              "rules": [
+                {
+                  "protocol": "some-string"
+                }
+              ],
+              "services": []
+            }
+          },
+          "response": {
+            "inputs": {},
+            "properties": {}
           }
         }`
 	testutils.Replay(t, server, testCase)

--- a/pf/tfbridge/provider_read.go
+++ b/pf/tfbridge/provider_read.go
@@ -130,11 +130,11 @@ func (p *provider) readResource(
 
 	resp, err := p.tfServer.ReadResource(ctx, &req)
 	if err != nil {
-		return plugin.ReadResult{}, fmt.Errorf("ReadResource call: %w", err)
+		return plugin.ReadResult{}, err
 	}
 
 	if err := p.processDiagnostics(resp.Diagnostics); err != nil {
-		return plugin.ReadResult{}, fmt.Errorf("ReadResource call (diagnostics): %w", err)
+		return plugin.ReadResult{}, err
 	}
 
 	if resp.NewState == nil {
@@ -145,7 +145,7 @@ func (p *provider) readResource(
 	// exist in the cloud provider.
 	newStateNull, err := resp.NewState.IsNull()
 	if err != nil {
-		return plugin.ReadResult{}, fmt.Errorf("Checking null state: %w", err)
+		return plugin.ReadResult{}, fmt.Errorf("checking null state: %w", err)
 	}
 	if newStateNull {
 		return plugin.ReadResult{}, nil


### PR DESCRIPTION
This PR makes two changes to PF's import semantics:
1. It calls `ReadResource` after `ImportResourceState`.
2. It checks for an empty state (TF's signal that a `Read` found no resource) and returns appropriately.

Fixes #1655 
Fixes https://github.com/pulumi/pulumi-aws/issues/3308
Fixes #793 