### PR TITLE
Reference v3.73.0 version of the bridge

### DIFF
--- a/pf/go.mod
+++ b/pf/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.10.0
 	github.com/hashicorp/terraform-plugin-go v0.19.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
-	github.com/pulumi/pulumi-terraform-bridge/v3 v3.72.0
+	github.com/pulumi/pulumi-terraform-bridge/v3 v3.73.0
 	github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.7
 	github.com/stretchr/testify v1.8.4
 	google.golang.org/grpc v1.59.0

--- a/pf/tests/go.mod
+++ b/pf/tests/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-provider-tls/shim v0.0.0-00010101000000-000000000000
 	github.com/pulumi/providertest v0.0.10
 	github.com/pulumi/pulumi-terraform-bridge/pf v0.0.0
-	github.com/pulumi/pulumi-terraform-bridge/v3 v3.72.0
+	github.com/pulumi/pulumi-terraform-bridge/v3 v3.73.0
 	github.com/stretchr/testify v1.8.4
 	github.com/terraform-providers/terraform-provider-random/randomshim v0.0.0
 )


### PR DESCRIPTION
A standard post-release follow-up action, ensure that pf module references v3.73.0 of the regular bridge module.