### PR TITLE
Fixes refresh of resources with unchanged assets

### DIFF
--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -1123,7 +1123,7 @@ func (p *Provider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*pulum
 		}
 	}
 
-	config, _, err := MakeTerraformConfig(ctx, p, oldInputs, res.TF.Schema(), res.Schema.Fields)
+	config, assets, err := MakeTerraformConfig(ctx, p, oldInputs, res.TF.Schema(), res.Schema.Fields)
 	if err != nil {
 		return nil, errors.Wrapf(err, "preparing %s's new property state", urn)
 	}
@@ -1136,7 +1136,7 @@ func (p *Provider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*pulum
 	// Store the ID and properties in the output.  The ID *should* be the same as the input ID, but in the case
 	// that the resource no longer exists, we will simply return the empty string and an empty property map.
 	if newstate != nil {
-		props, err := MakeTerraformResult(ctx, p.tf, newstate, res.TF.Schema(), res.Schema.Fields, nil, p.supportsSecrets)
+		props, err := MakeTerraformResult(ctx, p.tf, newstate, res.TF.Schema(), res.Schema.Fields, assets, p.supportsSecrets)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -2929,6 +2929,59 @@ func testRefresh(t *testing.T, newProvider func(*schema.Provider) shim.Provider)
 		  "response": {}
 		}`)
 	})
+
+	t.Run("refresh-read-unchanged-archive", func(t *testing.T) {
+		provider := init(func(
+			ctx context.Context, rd *schema.ResourceData, i interface{},
+		) diag.Diagnostics {
+			return diag.Diagnostics{}
+		})
+		provider.info.Resources["example_resource"].Fields = map[string]*SchemaInfo{
+			"string_property_value": {
+				Asset: &AssetTranslation{
+					Kind: FileAsset,
+				},
+			},
+		}
+
+		testutils.Replay(t, provider, `
+		{
+		  "method": "/pulumirpc.ResourceProvider/Read",
+		  "request": {
+		    "id": "someres",
+		    "urn": "urn:pulumi:dev::teststack::ExampleResource::exres",
+		    "properties": {
+		      "stringPropertyValue": {
+			"4dabf18193072939515e22adb298388d": "c44067f5952c0a294b673a41bacd8c17",
+			"hash": "a72e573d8c91ec1c6bb0dfdf641bc2de1e2417c0d980ecfcdf039c2a9bcbbf67"
+		      }
+		    },
+		    "inputs": {
+		      "stringPropertyValue": {
+			"4dabf18193072939515e22adb298388d": "c44067f5952c0a294b673a41bacd8c17",
+			"hash": "a72e573d8c91ec1c6bb0dfdf641bc2de1e2417c0d980ecfcdf039c2a9bcbbf67"
+		      }
+		    }
+		  },
+		  "response": {
+		    "id": "someres",
+		    "properties": {
+                      "id": "someres",
+                      "__meta": "*",
+		      "stringPropertyValue": {
+			"4dabf18193072939515e22adb298388d": "c44067f5952c0a294b673a41bacd8c17",
+			"hash": "a72e573d8c91ec1c6bb0dfdf641bc2de1e2417c0d980ecfcdf039c2a9bcbbf67"
+		      }
+		    },
+		    "inputs": {
+		      "stringPropertyValue": {
+			"4dabf18193072939515e22adb298388d": "c44067f5952c0a294b673a41bacd8c17",
+			"hash": "a72e573d8c91ec1c6bb0dfdf641bc2de1e2417c0d980ecfcdf039c2a9bcbbf67"
+		      }
+		    }
+		  }
+		}`)
+	})
 }
 
 func TestDestroy(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/1595, https://github.com/pulumi/pulumi/issues/6235

Before this change, refreshing an unchanged resource which used an Asset or an Archive resulted in polluting Pulumi state with a machine-local filename.

The simplest example this is tested on is:

```typescript
    const exampleBucketObject = new aws.s3.BucketObject("exampleBucketObject", {
        key: "someobject",
        bucket: bucket.id,
        source: new pulumi.asset.FileAsset(inFile),
    });
```

After this change this example refreshes correctly with no changes detected.

Unfortunately this change by itself is insufficient to guarantee that these resources refresh correctly when Pulumi-tracked state is out of date with respect to the cloud state, and further work is required to make this correct for individual resources in each provider. For the example above, the upstream provider for BucketObject does not implement fetching contents of the object upon Read into a temporary file. Therefore refreshing the object in this situation updates the "etag" property but does not guide the user to the need of reconciling the FileAsset with the updated cloud state.