### PR TITLE
Fix example double-counting under PULUMI_CONVERT=1

### DIFF
--- a/pkg/tfgen/convert_cli.go
+++ b/pkg/tfgen/convert_cli.go
@@ -117,7 +117,7 @@ func (cc *cliConverter) StartConvertingExamples(
 	stripSubsectionsWithErrors bool,
 ) string {
 	// Record inner HCL conversions and discard the result.
-	cov := true // report examples to CoverageTracker
+	cov := false // do not use coverage tracker yet, it will be used in the second pass.
 	cc.generator.convertExamplesInner(docs, path, stripSubsectionsWithErrors, cc.recordHCL, cov)
 	// Record the convertExamples job for later.
 	e := struct {
@@ -153,10 +153,8 @@ func (cc *cliConverter) FinishConvertingExamples(p pschema.PackageSpec) pschema.
 		contract.AssertNoErrorf(err, "strconv.Atoi")
 		ex := cc.convertExamplesList[i]
 
-		// Set useCoverageTracker to false to avoid double-counting the examples. Presumably
-		// we already reported the examples to CoverageTracker during
-		// StartConvertingExamples, so no need do it again here.
-		useCoverageTracker := false
+		// Use coverage tracker here on the second pass.
+		useCoverageTracker := true
 		source := cc.generator.convertExamplesInner(ex.docs, ex.path,
 			ex.stripSubsectionsWithErrors, cc.generator.convertHCL, useCoverageTracker)
 		// JSON-escaping to splice into JSON string literals.

--- a/pkg/tfgen/convert_cli.go
+++ b/pkg/tfgen/convert_cli.go
@@ -62,13 +62,16 @@ type cliConverter struct {
 	hcls map[string]struct{} // set of observed HCL snippets
 
 	generator interface {
-		convertHCL(hcl, path, exampleTitle string, languages []string) (string, error)
+		convertHCL(
+			e *Example, hcl, path, exampleTitle string, languages []string,
+		) (string, error)
 		convertExamplesInner(
 			docs string,
 			path examplePath,
 			stripSubsectionsWithErrors bool,
-			convertHCL func(hcl, path, exampleTitle string,
-				languages []string) (string, error),
+			convertHCL func(
+				e *Example, hcl, path, exampleTitle string, languages []string,
+			) (string, error),
 			useCoverageTracker bool,
 		) string
 	}
@@ -448,7 +451,7 @@ func (cc *cliConverter) convertPCL(
 
 // Act as a convertHCL stub that does not actually convert but spies on the literals involved.
 func (cc *cliConverter) recordHCL(
-	hcl, path, exampleTitle string, languages []string,
+	e *Example, hcl, path, exampleTitle string, languages []string,
 ) (string, error) {
 	h := cc.hcls
 	h[hcl] = struct{}{}

--- a/pkg/tfgen/convert_cli_test.go
+++ b/pkg/tfgen/convert_cli_test.go
@@ -64,11 +64,11 @@ output "some_output" {
 			ResourcesMap: map[string]*schema.Resource{
 				"simple_resource": {
 					Schema: map[string]*schema.Schema{
-						"input_one": &schema.Schema{
+						"input_one": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
-						"input_two": &schema.Schema{
+						"input_two": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},

--- a/pkg/tfgen/convert_cli_test.go
+++ b/pkg/tfgen/convert_cli_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 
 	"encoding/json"
+
+	"github.com/hexops/autogold/v2"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -61,7 +63,16 @@ output "some_output" {
 		P: sdkv2.NewProvider(&schema.Provider{
 			ResourcesMap: map[string]*schema.Resource{
 				"simple_resource": {
-					Schema: map[string]*schema.Schema{},
+					Schema: map[string]*schema.Schema{
+						"input_one": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"input_two": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
 				},
 			},
 			DataSourcesMap: map[string]*schema.Resource{
@@ -147,6 +158,8 @@ output "someOutput" {
 		tempdir := t.TempDir()
 		fs := afero.NewBasePathFs(afero.NewOsFs(), tempdir)
 
+		ct := newCoverageTracker(info.Name, info.Version)
+
 		g, err := NewGenerator(GeneratorOptions{
 			Package:      info.Name,
 			Version:      info.Version,
@@ -156,6 +169,7 @@ output "someOutput" {
 			Sink: diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{
 				Color: colors.Never,
 			}),
+			CoverageTracker: ct,
 		})
 		assert.NoError(t, err)
 
@@ -171,6 +185,25 @@ output "someOutput" {
 
 		bridgetesting.AssertEqualsJSONFile(t,
 			"test_data/TestConvertViaPulumiCLI/schema.json", schema)
+
+		autogold.Expect(`
+Provider:     simple
+Success rate: 100.00% (6/6)
+
+Converted 100.00% of csharp examples (1/1)
+Converted 100.00% of go examples (1/1)
+Converted 100.00% of java examples (1/1)
+Converted 100.00% of python examples (1/1)
+Converted 100.00% of typescript examples (1/1)
+Converted 100.00% of yaml examples (1/1)
+`).Equal(t, ct.getShortResultSummary())
+
+		require.Equalf(t, 1, len(ct.EncounteredPages), "expected 1 page")
+		var page *DocumentationPage
+		for _, p := range ct.EncounteredPages {
+			page = p
+		}
+		require.Equal(t, 1, len(page.Examples), "expected 1 example")
 	})
 
 	t.Run("mappingsFile", func(t *testing.T) {

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -1329,7 +1329,9 @@ func (g *Generator) convertExamples(docs string, path examplePath, stripSubsecti
 			stripSubsectionsWithErrors)
 	}
 
-	return g.convertExamplesInner(docs, path, stripSubsectionsWithErrors, g.convertHCL)
+	// Use coverage tracker: on by default.
+	cov := true
+	return g.convertExamplesInner(docs, path, stripSubsectionsWithErrors, g.convertHCL, cov)
 }
 
 // The inner implementation of examples conversion is parameterized by convertHCL so that it can be
@@ -1339,6 +1341,7 @@ func (g *Generator) convertExamplesInner(
 	path examplePath,
 	stripSubsectionsWithErrors bool,
 	convertHCL func(hcl, path, exampleTitle string, languages []string) (string, error),
+	useCoverageTracker bool,
 ) (result string) {
 	output := &bytes.Buffer{}
 
@@ -1393,8 +1396,12 @@ func (g *Generator) convertExamplesInner(
 					if g.language.shouldConvertExamples() {
 						hcl := strings.Join(subsection[codeBlockStart+1:i], "\n")
 
-						// We've got some code -- assume it's HCL and try to convert it.
-						g.coverageTracker.foundExample(path.String(), hcl)
+						// We've got some code -- assume it's HCL and try to
+						// convert it.
+						if useCoverageTracker {
+							g.coverageTracker.foundExample(
+								path.String(), hcl)
+						}
 
 						exampleTitle := ""
 						if strings.Contains(subsection[0], "###") {

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -1404,9 +1404,6 @@ func (g *Generator) convertExamplesInner(
 						if useCoverageTracker {
 							e = g.coverageTracker.getOrCreateExample(
 								path.String(), hcl)
-						} else {
-							e = g.coverageTracker.getExample(
-								path.String(), hcl)
 						}
 
 						exampleTitle := ""

--- a/pkg/tfgen/examples_coverage_tracker.go
+++ b/pkg/tfgen/examples_coverage_tracker.go
@@ -124,13 +124,12 @@ func (ct *CoverageTracker) getOrCreateExample(pageName string, hcl string) *Exam
 		example := Example{hcl, make(map[string]*LanguageConversionResult)}
 		existingPage.Examples = append(existingPage.Examples, example)
 		return &example
-	} else {
-		// Initializing a page for this example.
-		example := Example{hcl, make(map[string]*LanguageConversionResult)}
-		examples := []Example{example}
-		ct.EncounteredPages[pageName] = &DocumentationPage{pageName, examples}
-		return &example
 	}
+	// Initializing a page for this example.
+	example := Example{hcl, make(map[string]*LanguageConversionResult)}
+	examples := []Example{example}
+	ct.EncounteredPages[pageName] = &DocumentationPage{pageName, examples}
+	return &example
 }
 
 // Used when: current example has been successfully converted to a certain language

--- a/pkg/tfgen/examples_coverage_tracker.go
+++ b/pkg/tfgen/examples_coverage_tracker.go
@@ -116,6 +116,7 @@ func (ct *CoverageTracker) getOrCreateExample(pageName string, hcl string) *Exam
 	if ct == nil {
 		return nil
 	}
+	// If the example with this HCL already exists, return it right away.
 	if e := ct.getExample(pageName, hcl); e != nil {
 		return e
 	}

--- a/pkg/tfgen/examples_coverage_tracker.go
+++ b/pkg/tfgen/examples_coverage_tracker.go
@@ -245,11 +245,6 @@ func formatDiagnostics(diagnostics hcl.Diagnostics) string {
 	return strings.Join(results[:], "; ")
 }
 
-// Returning the page's last example, to which conversion results will be added.
-func (Page *DocumentationPage) lastExample() *Example {
-	return &Page.Examples[len(Page.Examples)-1]
-}
-
 // Exporting the coverage results
 func (ct *CoverageTracker) exportResults(outputDirectory string) error {
 	coverageExportUtil := newCoverageExportUtil(ct)

--- a/pkg/tfgen/test_data/TestConvertViaPulumiCLI/schema.json
+++ b/pkg/tfgen/test_data/TestConvertViaPulumiCLI/schema.json
@@ -22,9 +22,33 @@
   },
   "resources": {
     "simple:index:resource": {
-      "description": "{{% examples %}}\n## Example Usage\n{{% example %}}\n\n```java\npackage generated_program;\n\nimport com.pulumi.Context;\nimport com.pulumi.Pulumi;\nimport com.pulumi.core.Output;\nimport com.pulumi.simple.resource;\nimport com.pulumi.simple.ResourceArgs;\nimport java.util.List;\nimport java.util.ArrayList;\nimport java.util.Map;\nimport java.io.File;\nimport java.nio.file.Files;\nimport java.nio.file.Paths;\n\npublic class App {\n    public static void main(String[] args) {\n        Pulumi.run(App::stack);\n    }\n\n    public static void stack(Context ctx) {\n        var aResource = new Resource(\"aResource\", ResourceArgs.builder()        \n            .renamedInput1(\"hello\")\n            .inputTwo(true)\n            .build());\n\n        ctx.export(\"someOutput\", aResource.result());\n    }\n}\n```\n```yaml\nresources:\n  aResource:\n    type: simple:resource\n    name: a_resource\n    properties:\n      renamedInput1: hello\n      inputTwo: true\noutputs:\n  someOutput: ${aResource.result}\n```\n\n##Extras\n{{% /example %}}\n{{% /examples %}}",
+      "description": "{{% examples %}}\n## Example Usage\n{{% example %}}\n\n```typescript\nimport * as pulumi from \"@pulumi/pulumi\";\nimport * as simple from \"@pulumi/simple\";\n\nconst aResource = new simple.Resource(\"a_resource\", {\n    renamedInput1: \"hello\",\n    inputTwo: \"true\",\n});\nexport const someOutput = aResource.result;\n```\n```python\nimport pulumi\nimport pulumi_simple as simple\n\na_resource = simple.Resource(\"a_resource\",\n    renamed_input1=\"hello\",\n    input_two=\"true\")\npulumi.export(\"someOutput\", a_resource.result)\n```\n```csharp\nusing System.Collections.Generic;\nusing System.Linq;\nusing Pulumi;\nusing Simple = Pulumi.Simple;\n\nreturn await Deployment.RunAsync(() =\u003e \n{\n    var aResource = new Simple.Resource(\"a_resource\", new()\n    {\n        RenamedInput1 = \"hello\",\n        InputTwo = \"true\",\n    });\n\n    return new Dictionary\u003cstring, object?\u003e\n    {\n        [\"someOutput\"] = aResource.Result,\n    };\n});\n```\n```go\npackage main\n\nimport (\n\t\"github.com/pulumi/pulumi-simple/sdk/go/simple\"\n\t\"github.com/pulumi/pulumi/sdk/v3/go/pulumi\"\n)\n\nfunc main() {\n\tpulumi.Run(func(ctx *pulumi.Context) error {\n\t\taResource, err := simple.Newresource(ctx, \"a_resource\", \u0026simple.resourceArgs{\n\t\t\tRenamedInput1: pulumi.String(\"hello\"),\n\t\t\tInputTwo:      pulumi.String(\"true\"),\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\tctx.Export(\"someOutput\", aResource.Result)\n\t\treturn nil\n\t})\n}\n```\n```java\npackage generated_program;\n\nimport com.pulumi.Context;\nimport com.pulumi.Pulumi;\nimport com.pulumi.core.Output;\nimport com.pulumi.simple.resource;\nimport com.pulumi.simple.ResourceArgs;\nimport java.util.List;\nimport java.util.ArrayList;\nimport java.util.Map;\nimport java.io.File;\nimport java.nio.file.Files;\nimport java.nio.file.Paths;\n\npublic class App {\n    public static void main(String[] args) {\n        Pulumi.run(App::stack);\n    }\n\n    public static void stack(Context ctx) {\n        var aResource = new Resource(\"aResource\", ResourceArgs.builder()        \n            .renamedInput1(\"hello\")\n            .inputTwo(true)\n            .build());\n\n        ctx.export(\"someOutput\", aResource.result());\n    }\n}\n```\n```yaml\nresources:\n  aResource:\n    type: simple:resource\n    name: a_resource\n    properties:\n      renamedInput1: hello\n      inputTwo: true\noutputs:\n  someOutput: ${aResource.result}\n```\n\n##Extras\n{{% /example %}}\n{{% /examples %}}",
+      "properties": {
+        "inputTwo": {
+          "type": "string"
+        },
+        "renamedInput1": {
+          "type": "string"
+        }
+      },
+      "inputProperties": {
+        "inputTwo": {
+          "type": "string"
+        },
+        "renamedInput1": {
+          "type": "string"
+        }
+      },
       "stateInputs": {
         "description": "Input properties used for looking up and filtering resource resources.\n",
+        "properties": {
+          "inputTwo": {
+            "type": "string"
+          },
+          "renamedInput1": {
+            "type": "string"
+          }
+        },
         "type": "object"
       }
     }
@@ -35,14 +59,14 @@
         "description": "A collection of values returned by dataSource.\n",
         "properties": {
           "id": {
-            "type": "string",
-            "description": "The provider-assigned unique ID for this managed resource.\n"
+            "description": "The provider-assigned unique ID for this managed resource.\n",
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "id"
-        ]
+        ],
+        "type": "object"
       }
     }
   }


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/1572

Before the change examples were accidentally double-counted under PULUMI_CONVERT=1 skewing stats. This is now fixed. 

Also the interface to the coverage tracker assumed that the methods are called in a particular order. This confused the PULUMI_CONVERT because it shuffles the ordering of discovering and post-processing the examples. This is now made more explicit by passing *Example pointers in the interface to the converter.