### PR TITLE
Fix azure loader issues

### DIFF
--- a/pkg/tfgen/convert_cli.go
+++ b/pkg/tfgen/convert_cli.go
@@ -370,13 +370,6 @@ func (cc *cliConverter) convertPCL(
 	source string,
 	languageName string,
 ) (string, hcl.Diagnostics, error) {
-	defer func() {
-		if e := recover(); e != nil {
-			msg := fmt.Sprintf("PANIC while converting pcl=%q: %v", source, e)
-			panic(msg)
-		}
-	}()
-
 	pulumiParser := syntax.NewParser()
 
 	err := pulumiParser.ParseFile(bytes.NewBufferString(source), "example.pp")
@@ -397,9 +390,6 @@ func (cc *cliConverter) convertPCL(
 		if cc.pluginHost != nil {
 			opts = append(opts, pcl.PluginHost(cc.pluginHost))
 			loader := newLoader(cc.pluginHost)
-			// This stanza helps the loader to recognize that for example "azurerm"
-			// needs to be loaded as "azure".
-			//loader.AliasPackage(cc.info.Name, spec.Name)
 			opts = append(opts, pcl.Loader(loader))
 		}
 		if cc.packageCache != nil {

--- a/pkg/tfgen/convert_cli.go
+++ b/pkg/tfgen/convert_cli.go
@@ -370,6 +370,13 @@ func (cc *cliConverter) convertPCL(
 	source string,
 	languageName string,
 ) (string, hcl.Diagnostics, error) {
+	defer func() {
+		if e := recover(); e != nil {
+			msg := fmt.Sprintf("PANIC while converting pcl=%q: %v", source, e)
+			panic(msg)
+		}
+	}()
+
 	pulumiParser := syntax.NewParser()
 
 	err := pulumiParser.ParseFile(bytes.NewBufferString(source), "example.pp")
@@ -390,6 +397,9 @@ func (cc *cliConverter) convertPCL(
 		if cc.pluginHost != nil {
 			opts = append(opts, pcl.PluginHost(cc.pluginHost))
 			loader := newLoader(cc.pluginHost)
+			// This stanza helps the loader to recognize that for example "azurerm"
+			// needs to be loaded as "azure".
+			//loader.AliasPackage(cc.info.Name, spec.Name)
 			opts = append(opts, pcl.Loader(loader))
 		}
 		if cc.packageCache != nil {

--- a/pkg/tfgen/convert_cli_test.go
+++ b/pkg/tfgen/convert_cli_test.go
@@ -59,8 +59,7 @@ output "some_output" {
 }`
 
 	p := tfbridge.ProviderInfo{
-		Name:           "simple",
-		ResourcePrefix: "simple",
+		Name: "simple",
 		P: sdkv2.NewProvider(&schema.Provider{
 			ResourcesMap: map[string]*schema.Resource{
 				"simple_resource": {
@@ -84,7 +83,7 @@ output "some_output" {
 		}),
 		Resources: map[string]*tfbridge.ResourceInfo{
 			"simple_resource": {
-				Tok: "simp:index:resource",
+				Tok: "simple:index:resource",
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"input_one": {
 						Name: "renamedInput1",
@@ -101,41 +100,41 @@ output "some_output" {
 		},
 		DataSources: map[string]*tfbridge.DataSourceInfo{
 			"simple_data_source": {
-				Tok: "simp:index:dataSource",
+				Tok: "simple:index:dataSource",
 			},
 		},
 	}
 
 	simpleDataSourceTF := `
-	data "simple_data_source" "a_data_source" {
-	    input_one = "hello"
-	    input_two = true
-	}
+data "simple_data_source" "a_data_source" {
+    input_one = "hello"
+    input_two = true
+}
 
-	output "some_output" {
-	    value = data.simple_data_source.a_data_source.result
-	}`
+output "some_output" {
+    value = data.simple_data_source.a_data_source.result
+}`
 
 	simpleResourceExpectPCL := `resource "aResource" "simple:index:resource" {
-	  __logicalName = "a_resource"
-	  renamedInput1 = "hello"
-	  inputTwo      = true
-	}
+  __logicalName = "a_resource"
+  renamedInput1 = "hello"
+  inputTwo      = true
+}
 
-	output "someOutput" {
-	  value = aResource.result
-	}
-	`
+output "someOutput" {
+  value = aResource.result
+}
+`
 
 	simpleDataSourceExpectPCL := `aDataSource = invoke("simple:index:dataSource", {
-	  inputOne = "hello"
-	  inputTwo = true
-	})
+  inputOne = "hello"
+  inputTwo = true
+})
 
-	output "someOutput" {
-	  value = aDataSource.result
-	}
-	`
+output "someOutput" {
+  value = aDataSource.result
+}
+`
 
 	t.Run("convertViaPulumiCLI", func(t *testing.T) {
 		cc := &cliConverter{}
@@ -162,7 +161,7 @@ output "some_output" {
 		ct := newCoverageTracker(info.Name, info.Version)
 
 		g, err := NewGenerator(GeneratorOptions{
-			Package:      "simp",
+			Package:      info.Name,
 			Version:      info.Version,
 			Language:     Schema,
 			ProviderInfo: info,
@@ -175,7 +174,7 @@ output "some_output" {
 		assert.NoError(t, err)
 
 		err = g.Generate()
-		require.NoError(t, err)
+		assert.NoError(t, err)
 
 		d, err := os.ReadFile(filepath.Join(tempdir, "schema.json"))
 		assert.NoError(t, err)
@@ -188,16 +187,16 @@ output "some_output" {
 			"test_data/TestConvertViaPulumiCLI/schema.json", schema)
 
 		autogold.Expect(`
-		Provider:     simple
-		Success rate: 100.00% (6/6)
+Provider:     simple
+Success rate: 100.00% (6/6)
 
-		Converted 100.00% of csharp examples (1/1)
-		Converted 100.00% of go examples (1/1)
-		Converted 100.00% of java examples (1/1)
-		Converted 100.00% of python examples (1/1)
-		Converted 100.00% of typescript examples (1/1)
-		Converted 100.00% of yaml examples (1/1)
-		`).Equal(t, ct.getShortResultSummary())
+Converted 100.00% of csharp examples (1/1)
+Converted 100.00% of go examples (1/1)
+Converted 100.00% of java examples (1/1)
+Converted 100.00% of python examples (1/1)
+Converted 100.00% of typescript examples (1/1)
+Converted 100.00% of yaml examples (1/1)
+`).Equal(t, ct.getShortResultSummary())
 
 		require.Equalf(t, 1, len(ct.EncounteredPages), "expected 1 page")
 		var page *DocumentationPage

--- a/pkg/tfgen/convert_cli_test.go
+++ b/pkg/tfgen/convert_cli_test.go
@@ -59,7 +59,8 @@ output "some_output" {
 }`
 
 	p := tfbridge.ProviderInfo{
-		Name: "simple",
+		Name:           "simple",
+		ResourcePrefix: "simple",
 		P: sdkv2.NewProvider(&schema.Provider{
 			ResourcesMap: map[string]*schema.Resource{
 				"simple_resource": {
@@ -83,7 +84,7 @@ output "some_output" {
 		}),
 		Resources: map[string]*tfbridge.ResourceInfo{
 			"simple_resource": {
-				Tok: "simple:index:resource",
+				Tok: "simp:index:resource",
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"input_one": {
 						Name: "renamedInput1",
@@ -100,41 +101,41 @@ output "some_output" {
 		},
 		DataSources: map[string]*tfbridge.DataSourceInfo{
 			"simple_data_source": {
-				Tok: "simple:index:dataSource",
+				Tok: "simp:index:dataSource",
 			},
 		},
 	}
 
 	simpleDataSourceTF := `
-data "simple_data_source" "a_data_source" {
-    input_one = "hello"
-    input_two = true
-}
+	data "simple_data_source" "a_data_source" {
+	    input_one = "hello"
+	    input_two = true
+	}
 
-output "some_output" {
-    value = data.simple_data_source.a_data_source.result
-}`
+	output "some_output" {
+	    value = data.simple_data_source.a_data_source.result
+	}`
 
 	simpleResourceExpectPCL := `resource "aResource" "simple:index:resource" {
-  __logicalName = "a_resource"
-  renamedInput1 = "hello"
-  inputTwo      = true
-}
+	  __logicalName = "a_resource"
+	  renamedInput1 = "hello"
+	  inputTwo      = true
+	}
 
-output "someOutput" {
-  value = aResource.result
-}
-`
+	output "someOutput" {
+	  value = aResource.result
+	}
+	`
 
 	simpleDataSourceExpectPCL := `aDataSource = invoke("simple:index:dataSource", {
-  inputOne = "hello"
-  inputTwo = true
-})
+	  inputOne = "hello"
+	  inputTwo = true
+	})
 
-output "someOutput" {
-  value = aDataSource.result
-}
-`
+	output "someOutput" {
+	  value = aDataSource.result
+	}
+	`
 
 	t.Run("convertViaPulumiCLI", func(t *testing.T) {
 		cc := &cliConverter{}
@@ -161,7 +162,7 @@ output "someOutput" {
 		ct := newCoverageTracker(info.Name, info.Version)
 
 		g, err := NewGenerator(GeneratorOptions{
-			Package:      info.Name,
+			Package:      "simp",
 			Version:      info.Version,
 			Language:     Schema,
 			ProviderInfo: info,
@@ -174,7 +175,7 @@ output "someOutput" {
 		assert.NoError(t, err)
 
 		err = g.Generate()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		d, err := os.ReadFile(filepath.Join(tempdir, "schema.json"))
 		assert.NoError(t, err)
@@ -187,16 +188,16 @@ output "someOutput" {
 			"test_data/TestConvertViaPulumiCLI/schema.json", schema)
 
 		autogold.Expect(`
-Provider:     simple
-Success rate: 100.00% (6/6)
+		Provider:     simple
+		Success rate: 100.00% (6/6)
 
-Converted 100.00% of csharp examples (1/1)
-Converted 100.00% of go examples (1/1)
-Converted 100.00% of java examples (1/1)
-Converted 100.00% of python examples (1/1)
-Converted 100.00% of typescript examples (1/1)
-Converted 100.00% of yaml examples (1/1)
-`).Equal(t, ct.getShortResultSummary())
+		Converted 100.00% of csharp examples (1/1)
+		Converted 100.00% of go examples (1/1)
+		Converted 100.00% of java examples (1/1)
+		Converted 100.00% of python examples (1/1)
+		Converted 100.00% of typescript examples (1/1)
+		Converted 100.00% of yaml examples (1/1)
+		`).Equal(t, ct.getShortResultSummary())
 
 		require.Equalf(t, 1, len(ct.EncounteredPages), "expected 1 page")
 		var page *DocumentationPage

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -1708,14 +1708,6 @@ func hclConversionsToString(hclConversions map[string]string) string {
 // If some languages fail to convert, the returned string contain any successful conversions and no error will be
 // returned, but conversion failures will be logged via the Generator.
 func (g *Generator) convertHCL(e *Example, hcl, path, exampleTitle string, languages []string) (string, error) {
-
-	defer func() {
-		if e := recover(); e != nil {
-			msg := fmt.Sprintf("PANIC while converting hcl=%q: %v", hcl, e)
-			panic(msg)
-		}
-	}()
-
 	g.debug("converting HCL for %s", path)
 
 	// Fixup the HCL as necessary.

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -1708,6 +1708,14 @@ func hclConversionsToString(hclConversions map[string]string) string {
 // If some languages fail to convert, the returned string contain any successful conversions and no error will be
 // returned, but conversion failures will be logged via the Generator.
 func (g *Generator) convertHCL(e *Example, hcl, path, exampleTitle string, languages []string) (string, error) {
+
+	defer func() {
+		if e := recover(); e != nil {
+			msg := fmt.Sprintf("PANIC while converting hcl=%q: %v", hcl, e)
+			panic(msg)
+		}
+	}()
+
 	g.debug("converting HCL for %s", path)
 
 	// Fixup the HCL as necessary.

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -871,7 +871,6 @@ type GenerateOptions struct {
 
 // Generate creates Pulumi packages from the information it was initialized with.
 func (g *Generator) Generate() error {
-
 	// First gather up the entire package contents. This structure is complete and sufficient to hand off to the
 	// language-specific generators to create the full output.
 	pack, err := g.gatherPackage()

--- a/pkg/tfgen/loaders.go
+++ b/pkg/tfgen/loaders.go
@@ -16,19 +16,36 @@ package tfgen
 
 import (
 	"github.com/blang/semver"
+	"fmt"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 )
 
 type loader struct {
-	innerLoader   schema.Loader
-	emptyPackages map[string]bool
+	innerLoader     schema.Loader
+	emptyPackages   map[string]bool
+	aliasedPackages map[string]string
 }
 
 var _ schema.Loader = &loader{}
 
+func (l *loader) AliasPackage(alias string, canonicalName string) {
+	if l.aliasedPackages == nil {
+		l.aliasedPackages = map[string]string{}
+	}
+	l.aliasedPackages[alias] = canonicalName
+}
+
 func (l *loader) LoadPackage(name string, ver *semver.Version) (*schema.Package, error) {
+	fmt.Println("^^LoadPackage", name, ver)
+	if name == "azurerm" {
+		panic("!")
+	}
+	if renamed, ok := l.aliasedPackages[name]; ok {
+		name = renamed
+	}
+
 	if l.emptyPackages[name] {
 		return &schema.Package{
 			Name:    name,

--- a/pkg/tfgen/loaders.go
+++ b/pkg/tfgen/loaders.go
@@ -16,8 +16,6 @@ package tfgen
 
 import (
 	"github.com/blang/semver"
-	"fmt"
-
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 )
@@ -30,7 +28,7 @@ type loader struct {
 
 var _ schema.Loader = &loader{}
 
-func (l *loader) AliasPackage(alias string, canonicalName string) {
+func (l *loader) aliasPackage(alias string, canonicalName string) {
 	if l.aliasedPackages == nil {
 		l.aliasedPackages = map[string]string{}
 	}
@@ -38,10 +36,6 @@ func (l *loader) AliasPackage(alias string, canonicalName string) {
 }
 
 func (l *loader) LoadPackage(name string, ver *semver.Version) (*schema.Package, error) {
-	fmt.Println("^^LoadPackage", name, ver)
-	if name == "azurerm" {
-		panic("!")
-	}
 	if renamed, ok := l.aliasedPackages[name]; ok {
 		name = renamed
 	}


### PR DESCRIPTION
Fixes #1681

For providers such as Azure Classic that have a discrepancy between "azure" and "azurerm", PULUMI_CONVERT=1 conversion no longer attempts to resolve and download the "azurerm" plugin from GitHub.