### PR TITLE
Implement DiffConfig

### DIFF
--- a/pf/internal/plugin/provider_context.go
+++ b/pf/internal/plugin/provider_context.go
@@ -37,7 +37,7 @@ type ProviderWithContext interface {
 	CheckConfigWithContext(ctx context.Context, urn resource.URN, olds, news resource.PropertyMap,
 		allowUnknowns bool) (resource.PropertyMap, []p.CheckFailure, error)
 
-	DiffConfigWithContext(ctx context.Context, urn resource.URN, olds, news resource.PropertyMap,
+	DiffConfigWithContext(ctx context.Context, urn resource.URN, oldInputs, olds, news resource.PropertyMap,
 		allowUnknowns bool, ignoreChanges []string) (p.DiffResult, error)
 
 	ConfigureWithContext(ctx context.Context, inputs resource.PropertyMap) error

--- a/pf/internal/plugin/provider_context.go
+++ b/pf/internal/plugin/provider_context.go
@@ -111,7 +111,7 @@ func (prov *provider) CheckConfig(urn resource.URN, olds, news resource.Property
 func (prov *provider) DiffConfig(urn resource.URN, oldInputs, oldOutputs, newInputs resource.PropertyMap,
 	allowUnknowns bool, ignoreChanges []string) (plugin.DiffResult, error) {
 	return prov.ProviderWithContext.DiffConfigWithContext(
-		prov.ctx, urn, oldOutputs, newInputs, allowUnknowns, ignoreChanges)
+		prov.ctx, urn, oldInputs, oldOutputs, newInputs, allowUnknowns, ignoreChanges)
 }
 
 func (prov *provider) Configure(inputs resource.PropertyMap) error {

--- a/pf/tests/testdata/genrandom/random-empty-preview.json
+++ b/pf/tests/testdata/genrandom/random-empty-preview.json
@@ -149,7 +149,7 @@
         "version": "4.8.2"
       }
     },
-    "response": {},
+    "errors": ["rpc error: code = Unimplemented desc = DiffConfig is not yet implemented"],
     "metadata": {
       "kind": "resource",
       "mode": "client",

--- a/pf/tests/testdata/genrandom/random-empty-preview.json
+++ b/pf/tests/testdata/genrandom/random-empty-preview.json
@@ -142,6 +142,9 @@
     "method": "/pulumirpc.ResourceProvider/DiffConfig",
     "request": {
       "urn": "urn:pulumi:generate::genradom::pulumi:providers:random::default",
+      "oldInputs": {
+        "version": "4.8.2"
+      },
       "olds": {
         "version": "4.8.2"
       },
@@ -149,7 +152,7 @@
         "version": "4.8.2"
       }
     },
-    "errors": ["rpc error: code = Unimplemented desc = DiffConfig is not yet implemented"],
+    "response": {},
     "metadata": {
       "kind": "resource",
       "mode": "client",

--- a/pf/tests/testdata/genrandom/random-empty-update.json
+++ b/pf/tests/testdata/genrandom/random-empty-update.json
@@ -149,7 +149,7 @@
         "version": "4.8.2"
       }
     },
-    "response": {},
+    "errors": ["rpc error: code = Unimplemented desc = DiffConfig is not yet implemented"],
     "metadata": {
       "kind": "resource",
       "mode": "client",

--- a/pf/tests/testdata/genrandom/random-empty-update.json
+++ b/pf/tests/testdata/genrandom/random-empty-update.json
@@ -142,6 +142,9 @@
     "method": "/pulumirpc.ResourceProvider/DiffConfig",
     "request": {
       "urn": "urn:pulumi:generate::genradom::pulumi:providers:random::default",
+      "oldInputs": {
+        "version": "4.8.2"
+      },
       "olds": {
         "version": "4.8.2"
       },
@@ -149,7 +152,7 @@
         "version": "4.8.2"
       }
     },
-    "errors": ["rpc error: code = Unimplemented desc = DiffConfig is not yet implemented"],
+    "response": {},
     "metadata": {
       "kind": "resource",
       "mode": "client",

--- a/pf/tests/testdata/genrandom/random-replace-preview.json
+++ b/pf/tests/testdata/genrandom/random-replace-preview.json
@@ -149,7 +149,7 @@
         "version": "4.8.2"
       }
     },
-    "response": {},
+    "errors": ["rpc error: code = Unimplemented desc = DiffConfig is not yet implemented"],
     "metadata": {
       "kind": "resource",
       "mode": "client",

--- a/pf/tests/testdata/genrandom/random-replace-preview.json
+++ b/pf/tests/testdata/genrandom/random-replace-preview.json
@@ -142,6 +142,9 @@
     "method": "/pulumirpc.ResourceProvider/DiffConfig",
     "request": {
       "urn": "urn:pulumi:generate::genradom::pulumi:providers:random::default",
+      "oldInputs": {
+        "version": "4.8.2"
+      },
       "olds": {
         "version": "4.8.2"
       },
@@ -149,7 +152,7 @@
         "version": "4.8.2"
       }
     },
-    "errors": ["rpc error: code = Unimplemented desc = DiffConfig is not yet implemented"],
+    "response": {},
     "metadata": {
       "kind": "resource",
       "mode": "client",

--- a/pf/tests/testdata/genrandom/random-replace-update.json
+++ b/pf/tests/testdata/genrandom/random-replace-update.json
@@ -149,7 +149,7 @@
         "version": "4.8.2"
       }
     },
-    "response": {},
+    "errors": ["rpc error: code = Unimplemented desc = DiffConfig is not yet implemented"],
     "metadata": {
       "kind": "resource",
       "mode": "client",

--- a/pf/tests/testdata/genrandom/random-replace-update.json
+++ b/pf/tests/testdata/genrandom/random-replace-update.json
@@ -142,6 +142,9 @@
     "method": "/pulumirpc.ResourceProvider/DiffConfig",
     "request": {
       "urn": "urn:pulumi:generate::genradom::pulumi:providers:random::default",
+      "oldInputs": {
+        "version": "4.8.2"
+      },
       "olds": {
         "version": "4.8.2"
       },
@@ -149,7 +152,7 @@
         "version": "4.8.2"
       }
     },
-    "errors": ["rpc error: code = Unimplemented desc = DiffConfig is not yet implemented"],
+    "response": {},
     "metadata": {
       "kind": "resource",
       "mode": "client",

--- a/pf/tests/testdata/updateprogram.json
+++ b/pf/tests/testdata/updateprogram.json
@@ -658,7 +658,7 @@
       "olds": {},
       "news": {}
     },
-    "errors": ["rpc error: code = Unimplemented desc = DiffConfig is not yet implemented"],
+    "response": {},
     "metadata": {
       "kind": "resource",
       "mode": "client",
@@ -944,7 +944,7 @@
       "olds": {},
       "news": {}
     },
-    "errors": ["rpc error: code = Unimplemented desc = DiffConfig is not yet implemented"],
+    "response": {},
     "metadata": {
       "kind": "resource",
       "mode": "client",
@@ -1300,7 +1300,7 @@
       "olds": {},
       "news": {}
     },
-    "errors": ["rpc error: code = Unimplemented desc = DiffConfig is not yet implemented"],
+    "response": {},
     "metadata": {
       "kind": "resource",
       "mode": "client",
@@ -1627,7 +1627,7 @@
       "olds": {},
       "news": {}
     },
-    "errors": ["rpc error: code = Unimplemented desc = DiffConfig is not yet implemented"],
+    "response": {},
     "metadata": {
       "kind": "resource",
       "mode": "client",

--- a/pf/tests/testdata/updateprogram.json
+++ b/pf/tests/testdata/updateprogram.json
@@ -658,7 +658,7 @@
       "olds": {},
       "news": {}
     },
-    "response": {},
+    "errors": ["rpc error: code = Unimplemented desc = DiffConfig is not yet implemented"],
     "metadata": {
       "kind": "resource",
       "mode": "client",
@@ -944,7 +944,7 @@
       "olds": {},
       "news": {}
     },
-    "response": {},
+    "errors": ["rpc error: code = Unimplemented desc = DiffConfig is not yet implemented"],
     "metadata": {
       "kind": "resource",
       "mode": "client",
@@ -1300,7 +1300,7 @@
       "olds": {},
       "news": {}
     },
-    "response": {},
+    "errors": ["rpc error: code = Unimplemented desc = DiffConfig is not yet implemented"],
     "metadata": {
       "kind": "resource",
       "mode": "client",
@@ -1627,7 +1627,7 @@
       "olds": {},
       "news": {}
     },
-    "response": {},
+    "errors": ["rpc error: code = Unimplemented desc = DiffConfig is not yet implemented"],
     "metadata": {
       "kind": "resource",
       "mode": "client",

--- a/pf/tfbridge/provider_diff.go
+++ b/pf/tfbridge/provider_diff.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 
 	"github.com/pulumi/pulumi-terraform-bridge/pf/internal/convert"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/propertyvalue"
 )
 
 // Diff checks what impacts a hypothetical update will have on the resource's properties. Receives checkedInputs from
@@ -54,7 +55,7 @@ func (p *provider) DiffWithContext(
 		return plugin.DiffResult{}, err
 	}
 
-	checkedInputs, err = applyIgnoreChanges(priorStateMap, checkedInputs, ignoreChanges)
+	checkedInputs, err = propertyvalue.ApplyIgnoreChanges(priorStateMap, checkedInputs, ignoreChanges)
 	if err != nil {
 		return plugin.DiffResult{}, fmt.Errorf("failed to apply ignore changes: %w", err)
 	}

--- a/pf/tfbridge/provider_diffconfig.go
+++ b/pf/tfbridge/provider_diffconfig.go
@@ -22,19 +22,12 @@ import (
 )
 
 // DiffConfig checks what impacts a hypothetical change to this provider's configuration will have on the provider.
-func (p *provider) DiffConfigWithContext(ctx context.Context,
-	urn resource.URN, olds, news resource.PropertyMap,
-	allowUnknowns bool, ignoredChanges []string) (plugin.DiffResult, error) {
-
-	// ctx = p.initLogging(ctx, p.logSink, urn)
-
-	// TODO[pulumi/pulumi-terraform-bridge#825] implement properly.
-
-	// This needs to include ignoredChanges:
-	// checkedInputs, err := applyIgnoreChanges(olds, news, ignoredChanges)
-	// if err != nil {
-	// 	return plugin.DiffResult{}, fmt.Errorf("failed to apply ignore changes: %w", err)
-	// }
-
-	return plugin.DiffResult{}, nil
+func (p *provider) DiffConfigWithContext(
+	_ context.Context,
+	_ resource.URN,
+	_, _ resource.PropertyMap,
+	_ bool,
+	_ []string,
+) (plugin.DiffResult, error) {
+	return plugin.DiffResult{}, plugin.ErrNotYetImplemented
 }

--- a/pf/tfbridge/provider_diffconfig.go
+++ b/pf/tfbridge/provider_diffconfig.go
@@ -17,17 +17,21 @@ package tfbridge
 import (
 	"context"
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 )
 
-// DiffConfig checks what impacts a hypothetical change to this provider's configuration will have on the provider.
+// DiffConfig checks what impacts a hypothetical change to this provider's configuration will have
+// on the provider.
 func (p *provider) DiffConfigWithContext(
-	_ context.Context,
-	_ resource.URN,
-	_, _ resource.PropertyMap,
-	_ bool,
-	_ []string,
+	ctx context.Context,
+	urn resource.URN,
+	oldInputs, state, inputs resource.PropertyMap,
+	allowUnknowns bool,
+	ignoreChanges []string,
 ) (plugin.DiffResult, error) {
-	return plugin.DiffResult{}, plugin.ErrNotYetImplemented
+	ctx = p.initLogging(ctx, p.logSink, urn)
+	diffConfig := tfbridge.DiffConfig(p.info.P.Schema(), p.info.Config)
+	return diffConfig(urn, oldInputs, state, inputs, allowUnknowns, ignoreChanges)
 }

--- a/pf/tfbridge/provider_diffconfig.go
+++ b/pf/tfbridge/provider_diffconfig.go
@@ -31,7 +31,6 @@ func (p *provider) DiffConfigWithContext(
 	allowUnknowns bool,
 	ignoreChanges []string,
 ) (plugin.DiffResult, error) {
-	ctx = p.initLogging(ctx, p.logSink, urn)
 	diffConfig := tfbridge.DiffConfig(p.info.P.Schema(), p.info.Config)
 	return diffConfig(urn, oldInputs, state, inputs, allowUnknowns, ignoreChanges)
 }

--- a/pf/tfbridge/provider_update.go
+++ b/pf/tfbridge/provider_update.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 
 	"github.com/pulumi/pulumi-terraform-bridge/pf/internal/convert"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/propertyvalue"
 )
 
 // Update updates an existing resource with new values.
@@ -49,7 +50,7 @@ func (p *provider) UpdateWithContext(
 		return nil, 0, err
 	}
 
-	checkedInputs, err = applyIgnoreChanges(priorStateMap, checkedInputs, ignoreChanges)
+	checkedInputs, err = propertyvalue.ApplyIgnoreChanges(priorStateMap, checkedInputs, ignoreChanges)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to apply ignore changes: %w", err)
 	}

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -154,6 +154,14 @@ type ProviderInfo struct {
 	//
 	// See also pulumi/pulumi-terraform-bridge#1524
 	GenerateRuntimeMetadata bool
+
+	// This feature enables the Pulumi provider to detect when provider configuration is
+	// changing and suggest a replacement plans when some properties require a replace.
+	// Replacing a provider then replaces all resources provisioned against this provider. See
+	// also the section on Explicit Provider Configuration in the docs:
+	//
+	// https://www.pulumi.com/docs/concepts/resources/providers/
+	EnableDiffConfig bool
 }
 
 // Send logs or status logs to the user.

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -154,14 +154,6 @@ type ProviderInfo struct {
 	//
 	// See also pulumi/pulumi-terraform-bridge#1524
 	GenerateRuntimeMetadata bool
-
-	// This feature enables the Pulumi provider to detect when provider configuration is
-	// changing and suggest a replacement plans when some properties require a replace.
-	// Replacing a provider then replaces all resources provisioned against this provider. See
-	// also the section on Explicit Provider Configuration in the docs:
-	//
-	// https://www.pulumi.com/docs/concepts/resources/providers/
-	EnableDiffConfig bool
 }
 
 // Send logs or status logs to the user.
@@ -493,6 +485,14 @@ type SchemaInfo struct {
 
 	// whether a change in the configuration would force a new resource
 	ForceNew *bool
+
+	// Controls whether a change in the provider configuration should trigger a provider
+	// replacement. While there is no matching concept in TF, Pulumi supports replacing explicit
+	// providers and cascading the replacement to all resources provisioned with the given
+	// provider configuration.
+	//
+	// This property is only relevant for [ProviderInfo.Config] properties.
+	ForcesProviderReplace *bool
 
 	// whether or not this property has been removed from the Terraform schema
 	Removed bool

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -587,7 +587,10 @@ func (p *Provider) DiffConfig(
 	label := fmt.Sprintf("%s.DiffConfig(%s)", p.label(), urn)
 	glog.V(9).Infof("%s executing", label)
 
-	return plugin.NewProviderServer(&configDiffer{}).DiffConfig(ctx, req)
+	return plugin.NewProviderServer(&configDiffer{
+		schemaMap:   p.config,
+		schemaInfos: p.info.Config,
+	}).DiffConfig(ctx, req)
 }
 
 type configDiffer struct {

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -609,10 +609,8 @@ type configDiffer struct {
 	schemaInfos map[string]*SchemaInfo
 }
 
-// Schema may specify that changing a property requires a replacement. This honors overrides to
-// ProviderInfo.Schema[x].ForceNew as well as raw schema.ForceNew(), although at the moment
-// realistic TF Providers do not use ForceNew for provider-level properties.
-func (p *configDiffer) isForceNew(path resource.PropertyPath) bool {
+// Schema may specify that changing a property requires a replacement.
+func (p *configDiffer) forcesProviderReplace(path resource.PropertyPath) bool {
 	schemaPath := PropertyPathToSchemaPath(path, p.schemaMap, p.schemaInfos)
 	_, info, err := LookupSchemas(schemaPath, p.schemaMap, p.schemaInfos)
 	if err != nil {
@@ -648,7 +646,7 @@ func (p *configDiffer) DiffConfig(
 	for key, change := range detailedDiff {
 		keyPath, err := resource.ParsePropertyPath(key)
 		contract.AssertNoErrorf(err, "Unexpected failed parse of PropertyPath %q", key)
-		if p.isForceNew(keyPath) {
+		if p.forcesProviderReplace(keyPath) {
 			detailedDiff[key] = change.ToReplace()
 		}
 	}

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -568,88 +568,87 @@ func validateProviderConfig(
 	return p.adaptCheckFailures(ctx, urn, true /*isProvider*/, p.config, p.info.GetConfig(), errs)
 }
 
-// DiffConfig diffs the configuration for this Terraform provider.
-func (p *Provider) DiffConfig(ctx context.Context, req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "DiffConfig is not yet implemented")
+// A DiffConfig implementation enables the Pulumi provider to detect when provider configuration is
+// changing and suggest a replacement plans when some properties require a replace. Replacing a
+// provider then replaces all resources provisioned against this provider. See also the section on
+// Explicit Provider Configuration in the docs:
+//
+// https://www.pulumi.com/docs/concepts/resources/providers/
+//
+// There is no matching context in Terraform so this remains a Pulumi-level feature.
+func (p *Provider) DiffConfig(
+	ctx context.Context, req *pulumirpc.DiffRequest,
+) (*pulumirpc.DiffResponse, error) {
+	if !p.info.EnableDiffConfig {
+		msg := "DiffConfig is disabled, set ProviderInfo.EnableDiffConfig to enable"
+		return nil, status.Error(codes.Unimplemented, msg)
+	}
+	urn := resource.URN(req.GetUrn())
+	label := fmt.Sprintf("%s.DiffConfig(%s)", p.label(), urn)
+	glog.V(9).Infof("%s executing", label)
 
-	// TO_DO - revert this comment!!
-	//urn := resource.URN(req.GetUrn())
-	//label := fmt.Sprintf("%s.DiffConfig(%s)", p.label(), urn)
-	//glog.V(9).Infof("%s executing", label)
-	//
-	//// There is no logic in the TF provider that suggests that provider level config
-	//// should force a new provider. Therefore, we are going to do this based on our
-	//// own schema overrides. We should use ForceNew as part of the SchemaInfo to do this
-	//
-	//// Create a Resource Schema from the config
-	//r := &schema.Resource{Schema: p.tf.Schema}
-	//
-	//var olds resource.PropertyMap
-	//var err error
-	//if req.GetOlds() != nil {
-	//	olds, err = plugin.UnmarshalProperties(req.GetOlds(), plugin.MarshalOptions{
-	//		Label: fmt.Sprintf("%s.olds", label), KeepUnknowns: true})
-	//	if err != nil {
-	//		return nil, err
-	//	}
-	//}
-	//
-	//attrs, meta, err := MakeTerraformAttributes(r, olds, r.Schema, p.info.Config, p.configValues, false)
-	//if err != nil {
-	//	return nil, errors.Wrapf(err, "preparing %s's old property state", urn)
-	//}
-	//state := &terraform.InstanceState{ID: req.GetId(), Attributes: attrs, Meta: meta}
-	//
-	//// Create a resource Config for the new configuration
-	//news, err := plugin.UnmarshalProperties(req.GetNews(), plugin.MarshalOptions{
-	//	Label: fmt.Sprintf("%s.news", label), KeepUnknowns: true, SkipNulls: true})
-	//if err != nil {
-	//	return nil, err
-	//}
-	//config, err := MakeTerraformConfig(nil, news, r.Schema, p.info.Config, nil, p.configValues, false)
-	//if err != nil {
-	//	return nil, errors.Wrapf(err, "preparing %s's new property state", urn)
-	//}
-	//diff, err := r.Diff(state, config, nil)
-	//if err != nil {
-	//	return nil, errors.Wrapf(err, "diffing %s", urn)
-	//}
-	//
-	//detailedDiff := makeDetailedDiff(r.Schema, p.info.Config, olds, news, diff)
-	//
-	//var replaces []string
-	//var changes pulumirpc.DiffResponse_DiffChanges
-	//var properties []string
-	//hasChanges := len(detailedDiff) > 0
-	//if hasChanges {
-	//	changes = pulumirpc.DiffResponse_DIFF_SOME
-	//	for k := range detailedDiff {
-	//		// Turn the attribute name into a top-level property name by trimming everything after the first dot.
-	//		if firstSep := strings.IndexAny(k, ".["); firstSep != -1 {
-	//			k = k[:firstSep]
-	//		}
-	//		properties = append(properties, k)
-	//		if p.info.Config != nil && p.info.Config[k] != nil {
-	//			config := p.info.Config[k]
-	//			// now is it a ForceNew or not
-	//			if config.ForceNew != nil && *config.ForceNew {
-	//				replaces = append(replaces, k)
-	//			} else {
-	//				properties = append(properties, k)
-	//			}
-	//		}
-	//	}
-	//} else {
-	//	changes = pulumirpc.DiffResponse_DIFF_NONE
-	//}
-	//
-	//return &pulumirpc.DiffResponse{
-	//	Changes:         changes,
-	//	Replaces:        replaces,
-	//	Diffs:           properties,
-	//	DetailedDiff:    detailedDiff,
-	//	HasDetailedDiff: true,
-	//}, nil
+	return plugin.NewProviderServer(&configDiffer{}).DiffConfig(ctx, req)
+}
+
+type configDiffer struct {
+	plugin.UnimplementedProvider
+	schemaMap   shim.SchemaMap
+	schemaInfos map[string]*SchemaInfo
+}
+
+// Schema may specify that changing a property requires a replacement. This honors overrides to
+// ProviderInfo.Schema[x].ForceNew as well as raw schema.ForceNew(), although at the moment
+// realistic TF Providers do not use ForceNew for provider-level properties.
+func (p *configDiffer) isForceNew(path resource.PropertyPath) bool {
+	schemaPath := PropertyPathToSchemaPath(path, p.schemaMap, p.schemaInfos)
+	schema, info, err := LookupSchemas(schemaPath, p.schemaMap, p.schemaInfos)
+	if err != nil {
+		contract.IgnoreError(err)
+		return false
+	}
+	if info != nil && info.ForceNew != nil {
+		return *info.ForceNew
+	}
+	if schema != nil {
+		return schema.ForceNew()
+	}
+	return false
+}
+
+func (p *configDiffer) DiffConfig(
+	urn resource.URN, oldInputs, oldOutputs, newInputs resource.PropertyMap,
+	allowUnknowns bool, ignoreChanges []string,
+) (plugin.DiffResult, error) {
+	contract.Assertf(allowUnknowns, "Expected allowUnknowns to always be true for DiffConfig")
+
+	// Seems that DiffIncludeUnknowns only accepts func (PropertyKey) bool to support ignoring
+	// changes which is awkward for recursive changes, would be better if it supported
+	// func(PropertyPath) bool. Instead of doing this, support IgnoreChanges by copying old
+	// values to new values to disable the diff.
+	newInputsIC, err := propertyvalue.ApplyIgnoreChanges(oldInputs, newInputs, ignoreChanges)
+	if err != nil {
+		return plugin.DiffResult{}, fmt.Errorf("Error applying ignoreChanges: %v", err)
+	}
+
+	objDiff := oldInputs.DiffIncludeUnknowns(newInputsIC)
+	inputDiff := true
+	detailedDiff := plugin.NewDetailedDiffFromObjectDiff(objDiff, inputDiff)
+
+	// Ensure that if schema specifies ForceNew, a change becomes a replacement.
+	for key, change := range detailedDiff {
+		keyPath, err := resource.ParsePropertyPath(key)
+		contract.AssertNoErrorf(err, "Unexpected failed parse of PropertyPath %q", key)
+		if p.isForceNew(keyPath) {
+			detailedDiff[key] = change.ToReplace()
+		}
+	}
+
+	return plugin.DiffResult{
+		// This is never true for DiffConfig at the provider level, making this explicit.
+		DeleteBeforeReplace: false,
+		// Everything else will be inferred from DetailedDiff by plugin.NewProviderServer.
+		DetailedDiff: detailedDiff,
+	}, nil
 }
 
 // Configure configures the underlying Terraform provider with the live Pulumi variable state.

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -589,6 +589,20 @@ func (p *Provider) DiffConfig(
 	}).DiffConfig(ctx, req)
 }
 
+// Re-exported to reuse for Plugin Framework based providers.
+func DiffConfig(
+	config shim.SchemaMap, configInfos map[string]*SchemaInfo,
+) func(
+	urn resource.URN, oldInputs, oldOutputs, newInputs resource.PropertyMap,
+	allowUnknowns bool, ignoreChanges []string,
+) (plugin.DiffResult, error) {
+	differ := &configDiffer{
+		schemaMap:   config,
+		schemaInfos: configInfos,
+	}
+	return differ.DiffConfig
+}
+
 type configDiffer struct {
 	plugin.UnimplementedProvider
 	schemaMap   shim.SchemaMap

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -307,36 +307,6 @@ func TestDiffConfig(t *testing.T) {
 		}`)
 	})
 
-	t.Run("changing region forces a cascading replace", func(t *testing.T) {
-		testutils.Replay(t, provider, `
-		{
-		  "method": "/pulumirpc.ResourceProvider/DiffConfig",
-		  "request": {
-		    "urn": "urn:pulumi:dev2::bridge-244::pulumi:providers:aws::name1",
-		    "olds": {
-		      "region": "us-east-1",
-		      "version": "6.22.0"
-		    },
-		    "news": {
-		      "region": "us-west-1",
-		      "version": "6.22.0"
-		    },
-		    "oldInputs": {
-		      "region": "us-east-1",
-		      "version": "6.22.0"
-		    }
-		  },
-		  "response": {
-                    "diffs": ["region"],
-		    "replaces": ["region"],
-		    "changes": "DIFF_SOME",
-                    "detailedDiff": {
-                      "region": {"inputDiff": true, "kind": "UPDATE_REPLACE"}
-                    }
-		  }
-		}`)
-	})
-
 	t.Run("changing region can be ignored", func(t *testing.T) {
 		testutils.Replay(t, provider, `
 		{

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -196,10 +196,9 @@ func TestDiffConfig(t *testing.T) {
 		tf:     tfProvider,
 		config: tfProvider.Schema(),
 		info: ProviderInfo{
-			EnableDiffConfig: true,
 			Config: map[string]*SchemaInfo{
 				"region": {
-					ForceNew: &yes,
+					ForcesProviderReplace: &yes,
 				},
 			},
 		},

--- a/unstable/propertyvalue/ignore_changes.go
+++ b/unstable/propertyvalue/ignore_changes.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tfbridge
+package propertyvalue
 
 import (
 	"fmt"
@@ -21,7 +21,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
-func applyIgnoreChanges(old, new resource.PropertyMap, ignoreChanges []string) (resource.PropertyMap, error) {
+func ApplyIgnoreChanges(old, new resource.PropertyMap, ignoreChanges []string) (resource.PropertyMap, error) {
 	var paths []resource.PropertyPath
 	var errs []error
 	for i, p := range ignoreChanges {

--- a/unstable/propertyvalue/ignore_changes_test.go
+++ b/unstable/propertyvalue/ignore_changes_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tfbridge
+package propertyvalue
 
 import (
 	"testing"
@@ -131,7 +131,7 @@ func TestIgnoreChanges(t *testing.T) {
 			path, err := resource.ParsePropertyPath(c.path)
 			require.NoError(t, err)
 
-			new, err = applyIgnoreChanges(old, new, c.ignoreChanges)
+			new, err = ApplyIgnoreChanges(old, new, c.ignoreChanges)
 			require.NoError(t, err)
 
 			prev, _ := path.Get(resource.NewObjectProperty(old))
@@ -155,7 +155,7 @@ func TestIgnoreChangesCopiesEntries(t *testing.T) {
 	news := resource.PropertyMap{"k": resource.NewObjectProperty(resource.PropertyMap{
 		"a": resource.NewStringProperty("A"),
 	})}
-	news2, err := applyIgnoreChanges(olds, news, []string{"k[*]"})
+	news2, err := ApplyIgnoreChanges(olds, news, []string{"k[*]"})
 	assert.NoError(t, err)
 	assert.Equal(t, olds, news2)
 }
@@ -165,7 +165,7 @@ func TestIgnoreChangesRemovesEntries(t *testing.T) {
 	news := resource.PropertyMap{"k": resource.NewObjectProperty(resource.PropertyMap{
 		"a": resource.NewStringProperty("A"),
 	})}
-	news2, err := applyIgnoreChanges(olds, news, []string{"k.a"})
+	news2, err := ApplyIgnoreChanges(olds, news, []string{"k.a"})
 	assert.NoError(t, err)
 	assert.Equal(t, olds, news2)
 }
@@ -250,7 +250,7 @@ func TestIgnoreChangesNestedGlob(t *testing.T) {
 
 	path := `["*"]["not-glob"][1].m5`
 
-	news, err := applyIgnoreChanges(olds, news, []string{path})
+	news, err := ApplyIgnoreChanges(olds, news, []string{path})
 	assert.NoError(t, err)
 	assert.Equal(t, resource.PropertyMap{
 		"k1": resource.NewObjectProperty(resource.PropertyMap{

--- a/x/muxer/muxer.go
+++ b/x/muxer/muxer.go
@@ -216,11 +216,13 @@ func (m *muxer) DiffConfig(ctx context.Context, req *rpc.DiffRequest) (*rpc.Diff
 	}
 
 	var (
-		deleteBeforeReplace bool                         // The OR of each server
-		replaces            set[string]                  // The AND of each server
-		diffs               set[string]                  // The AND of each server, sans replaces
-		stables             set[string]                  // The AND of each server, sans replaces and diffs
-		changes             rpc.DiffResponse_DiffChanges = rpc.DiffResponse_DIFF_NONE
+		deleteBeforeReplace bool // The OR of each server
+
+		replaces = make(set[string]) // The AND of each server
+		diffs    = make(set[string]) // The AND of each server, sans replaces
+		stables  = make(set[string]) // The AND of each server, sans replaces and diffs
+
+		changes rpc.DiffResponse_DiffChanges = rpc.DiffResponse_DIFF_NONE
 
 		errs = new(multierror.Error)
 	)

--- a/x/muxer/muxer.go
+++ b/x/muxer/muxer.go
@@ -259,7 +259,12 @@ func (m *muxer) DiffConfig(ctx context.Context, req *rpc.DiffRequest) (*rpc.Diff
 
 		// If any provider is lacking a detailed diff, we don't attempt to combine
 		// a detailed and non-detailed diff.
-		if !resp.HasDetailedDiff || !hasDetailedDiff {
+		//
+		// Simply checking HasDetailedDiff is not enough since marshalDiff from below
+		// forgets to set it:
+		//
+		// https://github.com/pulumi/pulumi/blob/master/sdk/go/common/resource/plugin/provider_server.go#L70
+		if (!resp.HasDetailedDiff && len(resp.DetailedDiff) == 0) || !hasDetailedDiff {
 			hasDetailedDiff = false
 			detailedDiff = nil
 		} else {

--- a/x/muxer/muxer_test.go
+++ b/x/muxer/muxer_test.go
@@ -127,6 +127,20 @@ func TestDiffConfig(t *testing.T) {
 		},
 	}
 
+	changeAwsRegionResponseCorrected := &pulumirpc.DiffResponse{
+		Diffs:           []string{}, // looks like muxer normalizes this to not include replaces
+		Stables:         []string{}, // looks like nils got normalized to empty list, no problem
+		Replaces:        []string{"region"},
+		Changes:         pulumirpc.DiffResponse_DIFF_SOME,
+		HasDetailedDiff: true, // this got populated by muxer even if upstream forgets it
+		DetailedDiff: map[string]*pulumirpc.PropertyDiff{
+			"region": {
+				InputDiff: true,
+				Kind:      pulumirpc.PropertyDiff_UPDATE_REPLACE,
+			},
+		},
+	}
+
 	testCases := []testCase{
 		{
 			name:           "unimplemented server2 respects the implemented server1",
@@ -139,6 +153,13 @@ func TestDiffConfig(t *testing.T) {
 			request:        changeAwsRegionReq,
 			response2:      changeAwsRegionResponse,
 			mergedResponse: changeAwsRegionResponse,
+		},
+		{
+			name:           "identical servers are treated as each of them",
+			request:        changeAwsRegionReq,
+			response1:      changeAwsRegionResponse,
+			response2:      changeAwsRegionResponse,
+			mergedResponse: changeAwsRegionResponseCorrected,
 		},
 	}
 

--- a/x/muxer/muxer_test.go
+++ b/x/muxer/muxer_test.go
@@ -23,7 +23,9 @@ import (
 	urn "github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	emptypb "google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func TestAttach(t *testing.T) {
@@ -86,4 +88,91 @@ func (h *host) Log(context.Context, diag.Severity, urn.URN, string) error {
 		return fmt.Errorf("cannot log against a closed host")
 	}
 	return nil
+}
+
+func TestDiffConfig(t *testing.T) {
+	type testCase struct {
+		name           string
+		request        *pulumirpc.DiffRequest
+		response1      *pulumirpc.DiffResponse
+		response2      *pulumirpc.DiffResponse
+		mergedResponse *pulumirpc.DiffResponse
+	}
+
+	changeAwsRegionReq := &pulumirpc.DiffRequest{
+		Urn: "urn:pulumi:dev2::bridge-244::pulumi:providers:aws::name1",
+		Olds: &structpb.Struct{Fields: map[string]*structpb.Value{
+			"region":  structpb.NewStringValue("us-east-1"),
+			"version": structpb.NewStringValue("6.22.0"),
+		}},
+		News: &structpb.Struct{Fields: map[string]*structpb.Value{
+			"region":  structpb.NewStringValue("us-east-1"),
+			"version": structpb.NewStringValue("6.22.0"),
+		}},
+		OldInputs: &structpb.Struct{Fields: map[string]*structpb.Value{
+			"region":  structpb.NewStringValue("us-east-1"),
+			"version": structpb.NewStringValue("6.22.0"),
+		}},
+	}
+
+	changeAwsRegionResponse := &pulumirpc.DiffResponse{
+		Diffs:    []string{"region"},
+		Replaces: []string{"region"},
+		Changes:  pulumirpc.DiffResponse_DIFF_SOME,
+		DetailedDiff: map[string]*pulumirpc.PropertyDiff{
+			"region": {
+				InputDiff: true,
+				Kind:      pulumirpc.PropertyDiff_UPDATE_REPLACE,
+			},
+		},
+	}
+
+	testCases := []testCase{
+		{
+			name:           "unimplemented server2 respects the implemented server1",
+			request:        changeAwsRegionReq,
+			response1:      changeAwsRegionResponse,
+			mergedResponse: changeAwsRegionResponse,
+		},
+		{
+			name:           "unimplemented server1 respects the implemented server2",
+			request:        changeAwsRegionReq,
+			response2:      changeAwsRegionResponse,
+			mergedResponse: changeAwsRegionResponse,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			m := &muxer{
+				servers: []pulumirpc.ResourceProviderServer{
+					&diffConfigServer{resp: tc.response1},
+					&diffConfigServer{resp: tc.response2},
+				},
+			}
+
+			actualResponse, err := m.DiffConfig(ctx, tc.request)
+			require.NoError(t, err)
+
+			require.Equal(t, tc.mergedResponse, actualResponse)
+		})
+	}
+}
+
+type diffConfigServer struct {
+	pulumirpc.UnimplementedResourceProviderServer
+	resp *pulumirpc.DiffResponse
+}
+
+func (s diffConfigServer) DiffConfig(
+	ctx context.Context, req *pulumirpc.DiffRequest,
+) (*pulumirpc.DiffResponse, error) {
+	if s.resp != nil {
+		return s.resp, nil
+	}
+	return s.UnimplementedResourceProviderServer.DiffConfig(ctx, req)
 }


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/244

Upon re-investigation DiffConfig appears to be a Pulumi-only feature as the notion of provider replacements, and especially cascading replacement plan from explicit provider to every resource managed by that provider, seems to be a Pulumi-only concept. The implementation is done accordingly at Pulumi-only level, not turning around through any TF internals. Path translation helpers are used to join in ForcesProviderReplace information from SchemaInfo overrides to changing property paths, and indicate replacement when a change is happening to such a property. Pulumi-level ignoreChanges is lifted from the Plugin Framework implementation and reused here. 

Outside of the checked in tests, I have verified that the scenario outlined by @EvanBoyle in https://github.com/pulumi/pulumi-terraform-bridge/issues/244#issuecomment-878683259 is now made to work with AWS with this change. Getting there required taking some fixes to the muxer around DiffConfig muxing. 


