### PR TITLE
Use latest muxer v0.0.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/pulumi/providertest v0.0.10
 	github.com/pulumi/pulumi-java/pkg v0.9.9
-	github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.7
+	github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.8
 	github.com/pulumi/pulumi-yaml v1.5.0
 	github.com/pulumi/schema-tools v0.1.2
 	github.com/pulumi/terraform-diff-reader v0.0.2

--- a/pf/go.mod
+++ b/pf/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.19.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.74.0
-	github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.7
+	github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.8
 	github.com/stretchr/testify v1.8.4
 	google.golang.org/grpc v1.59.0
 )

--- a/pf/tests/go.mod
+++ b/pf/tests/go.mod
@@ -202,7 +202,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/posener/complete v1.2.3 // indirect
 	github.com/pulumi/pulumi-java/pkg v0.9.9 // indirect
-	github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.7 // indirect
+	github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.8 // indirect
 	github.com/pulumi/pulumi-yaml v1.5.0 // indirect
 	github.com/pulumi/pulumi/pkg/v3 v3.105.0
 	github.com/pulumi/pulumi/sdk/v3 v3.105.0

--- a/pkg/tests/go.mod
+++ b/pkg/tests/go.mod
@@ -189,7 +189,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/term v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.7 // indirect
+	github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.8 // indirect
 	github.com/pulumi/pulumi/pkg/v3 v3.105.0
 	github.com/pulumi/pulumi/sdk/v3 v3.105.0
 	github.com/pulumi/terraform-diff-reader v0.0.2 // indirect

--- a/x/muxer/tests/go.mod
+++ b/x/muxer/tests/go.mod
@@ -6,7 +6,7 @@ replace github.com/pulumi/pulumi-terraform-bridge/x/muxer => ../
 
 require (
 	github.com/pulumi/providertest v0.0.10
-	github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.7
+	github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.8
 	github.com/stretchr/testify v1.8.4
 	google.golang.org/protobuf v1.31.0
 )


### PR DESCRIPTION
Routine update to ensure latest fixes propagate to the repos that use the bridge. 