### PR TITLE
Fix unexplained detailed diffs

### DIFF
--- a/pkg/tfbridge/diff_test.go
+++ b/pkg/tfbridge/diff_test.go
@@ -2103,7 +2103,8 @@ func diffTest2(t *testing.T, tc diffTestCase) {
 			XSkipDetailedDiffForChanges: tc.XSkipDetailedDiffForChanges,
 			Resources: map[string]*ResourceInfo{
 				"p_resource": {
-					Tok: "pkg:index:PResource",
+					Tok:    "pkg:index:PResource",
+					Fields: tc.resourceFields,
 				},
 			},
 		},

--- a/pkg/tfbridge/diff_test.go
+++ b/pkg/tfbridge/diff_test.go
@@ -252,9 +252,6 @@ func diffTest(t *testing.T, tfs map[string]*schema.Schema, info map[string]*Sche
 	t.Run("withIgnoreAllExpected", func(t *testing.T) {
 		for k := range expected {
 			ignoreChanges = append(ignoreChanges, k)
-			if k == "prop.nest" {
-				ignoreChanges = append(ignoreChanges, "prop")
-			}
 		}
 		tfDiff, err := provider.Diff(ctx, "resource", tfState, config, shim.DiffOptions{
 			IgnoreChanges: newIgnoreChanges(ctx, sch, info, stateMap, inputsMap, ignoreChanges),


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-aws/issues/3439

makeDetailedDiff does not report collection changes. It instead hopes that elements of the collection will produce diff entries. When changes involve collections all the way down and there are no element entries, makeDetailedDiff produces no records. 

However we have some workarounds now that produce a DIFF_SOME even when there are no entries per
https://github.com/pulumi/pulumi-terraform-bridge/issues/1501

```
	if p.info.XSkipDetailedDiffForChanges && len(diff.Attributes()) > 0 {
		changes = pulumirpc.DiffResponse_DIFF_SOME
```

The change in this PR embellishes this case with collection-level diffs so there is at least something to show. 