### PR TITLE
Adjust CI go versions to 1.21 and 1.22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         #
         # When we decide to bump our minimum go version, we need to remember to bump the
         # go version in our go.mod files.
-        go-version: [1.20.x, 1.21.x]
+        go-version: [1.21.x, 1.22.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
go 1.20 was deprecated and the new pu/pu depends on features from 1.21