### PR TITLE
Expose the schema info for a resource from VisitResourceRoot

### DIFF
--- a/pkg/tfbridge/walk.go
+++ b/pkg/tfbridge/walk.go
@@ -350,7 +350,8 @@ var (
 type VisitResourceRoot struct {
 	token tokens.Type
 
-	Info *ResourceInfo
+	Info   *ResourceInfo
+	Schema shim.Resource
 
 	TfToken string
 }
@@ -562,6 +563,7 @@ func traverseResourceOrDataSource(
 			token:   info.Tok,
 			Info:    info,
 			TfToken: tfToken,
+			Schema:  schema,
 		}
 		if info.Fields == nil {
 			info.Fields = map[string]*SchemaInfo{}


### PR DESCRIPTION
This is necessary to correctly use `.Info` on the resource. I need this information to fix a bug in gcp labels: https://github.com/pulumi/pulumi-gcp/issues/1387.