### PR TITLE
Update go 1.20 references

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -18,7 +18,7 @@ jobs:
     name: Build and Test Bridge
     strategy:
       matrix:
-        go-version: [1.20.x]
+        go-version: [1.21.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.20.x
+        - 1.21.x
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3


### PR DESCRIPTION
https://github.com/pulumi/pulumi-terraform-bridge/pull/1703 missed these.

go 1.20 is deprecated and the latest pu/pu requires 1.21