### PR TITLE
Propagate name overrides for nested objects

### DIFF
--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -503,8 +503,8 @@ func (ctx *conversionContext) makeTerraformInput(
 				}
 			}
 			var psflds map[string]*SchemaInfo
-			if ps != nil {
-				psflds = ps.Fields
+			if ps != nil && ps.Elem != nil {
+				psflds = ps.Elem.Fields
 			}
 			var err error
 			input, err = ctx.makeObjectTerraformInputs(oldObject, v.ObjectValue(),

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -2584,11 +2584,13 @@ func TestMakeTerraformInputsOnMapNestedObjects(t *testing.T) {
 			},
 			ps: map[string]*SchemaInfo{
 				"map_prop": {
-					Elem: &SchemaInfo{
-						Elem: &SchemaInfo{
-							Fields: map[string]*SchemaInfo{
-								"x_prop": {
-									Name: "x",
+					Elem: &SchemaInfo{ // The element of the map
+						Elem: &SchemaInfo{ // The element of the array
+							Elem: &SchemaInfo{ // The underlying map of the resource
+								Fields: map[string]*SchemaInfo{
+									"x_prop": {
+										Name: "x",
+									},
 								},
 							},
 						},

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -1268,9 +1268,9 @@ func (g *Generator) convertExamples(docs string, path examplePath, stripSubsecti
 	}
 
 	// This function is very expensive for large providers. Permit experimental disk-based caching if the user
-	// specifies the PULUMI_CONVERT_EXAMPES_CACHE_DIR environment variable, pointing to a folder for the cache.
+	// specifies the PULUMI_CONVERT_EXAMPLES_CACHE_DIR environment variable, pointing to a folder for the cache.
 	{
-		dir, enableCache := os.LookupEnv("PULUMI_CONVERT_EXAMPES_CACHE_DIR")
+		dir, enableCache := os.LookupEnv("PULUMI_CONVERT_EXAMPLES_CACHE_DIR")
 		if enableCache && dir != "" {
 			path := path.String()
 			sep := string(rune(0))


### PR DESCRIPTION
This is a prerequisite for https://github.com/pulumi/pulumi-gcp/issues/1387.