### PR TITLE
Add title prefix to downstream test PRs

### DIFF
--- a/.github/workflows/update-providers-test.yml
+++ b/.github/workflows/update-providers-test.yml
@@ -54,7 +54,8 @@ jobs:
                "target-bridge-version": ${{ toJSON(github.event.inputs.bridgeVersion != '' && github.event.inputs.bridgeVersion || github.sha) }},
                "pr-reviewers": ${{ toJSON( github.triggering_actor || 't0yv0' ) }},
                "pr-description": "This PR was created to test a pulumi/pulumi-terraform-bridge feature.\n\n- pulumi/pulumi-terraform-bridge#${{ github.event.number }}\n\n- https://github.com/pulumi/pulumi-terraform-bridge/commit/${{github.sha}}\n\nDO NOT MERGE.",
-               "automerge": false
+               "automerge": false,
+               "pr-title-prefix": "[DOWNSTREAM TEST][BRIDGE]"
             }
     needs: generate-providers-list
     strategy:


### PR DESCRIPTION
This just adds a prefix to the tiles of created PRs so they are more obviously tests