### PR TITLE
Apply consistent traversal to `MakeTerraformOutput`

### DIFF
--- a/pkg/tfbridge/names_test.go
+++ b/pkg/tfbridge/names_test.go
@@ -174,10 +174,13 @@ func TestBijectiveNameConversion(t *testing.T) {
 		}
 	}
 
+	type PulumiName = string
+	type TFName = string
+
 	tests := []struct {
-		schema   map[string]*schemav2.Schema
-		info     map[string]*SchemaInfo
-		expected map[string]string
+		schema   map[TFName]*schemav2.Schema
+		info     map[TFName]*SchemaInfo
+		expected map[PulumiName]TFName
 	}{
 		{ // Conflicting plural types
 			schema: certSchema(),
@@ -283,6 +286,33 @@ func TestBijectiveNameConversion(t *testing.T) {
 			},
 			expected: map[string]string{
 				"values": "value",
+			},
+		},
+
+		{ // A Pulumi name that maps to a TF name of a different property
+			schema: map[string]*schemav2.Schema{
+				"role": {
+					Type:     schemav2.TypeList,
+					Required: true,
+					Elem: &schemav2.Schema{
+						Type: schemav2.TypeString,
+					},
+				},
+				"roles": {
+					Type:       schemav2.TypeString,
+					Optional:   true,
+					Deprecated: "Use role instead",
+				},
+			},
+			info: map[string]*SchemaInfo{
+				"roles": {
+					Name:       "rolesDeprecated",
+					CSharpName: "RolesDeprecated",
+				},
+			},
+			expected: map[string]string{
+				"rolesDeprecated": "roles",
+				"roles":           "role",
 			},
 		},
 	}

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -780,9 +780,7 @@ func (p *Provider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (*pul
 	rescfg := MakeTerraformConfigFromInputs(ctx, p.tf, inputs)
 	warns, errs := p.tf.ValidateResource(ctx, tfname, rescfg)
 	for _, warn := range warns {
-		if err = p.host.Log(ctx, diag.Warning, urn, fmt.Sprintf("%v verification warning: %v", urn, warn)); err != nil {
-			return nil, err
-		}
+		GetLogger(ctx).Warn(fmt.Sprintf("%v verification warning: %v", urn, warn))
 	}
 
 	// Now produce CheckFalures for any properties that failed verification.

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	schemav2 "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hexops/autogold/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -3262,17 +3261,16 @@ func TestSchemaFuncsNotCalledDuringRuntime(t *testing.T) {
 }
 
 func TestSingularAndPluralProp(t *testing.T) {
-	p := &schemav2.Provider{
-		Schema: map[string]*schemav2.Schema{},
-		ResourcesMap: map[string]*schemav2.Resource{
+	p := &schema.Provider{
+		Schema: map[string]*schema.Schema{},
+		ResourcesMap: map[string]*schema.Resource{
 			"res": {
-				Schema: map[string]*schemav2.Schema{
+				Schema: map[string]*schema.Schema{
 					"nodes": {
 						Type:     schema.TypeList,
-						MinItems: 1,
-						Optional: true,
+						Required: true,
 						Elem: &schema.Resource{
-							Schema: map[string]*schemav2.Schema{
+							Schema: map[string]*schema.Schema{
 								"role": {
 									Type:     schema.TypeList,
 									Required: true,
@@ -3323,48 +3321,58 @@ func TestSingularAndPluralProp(t *testing.T) {
 
 	t.Run("No error when plural specified", func(t *testing.T) {
 		testutils.ReplaySequence(t, provider, `[
-			{
-			  "method": "/pulumirpc.ResourceProvider/Configure",
-			  "request": {
-				"args": {},
-				"variables": {}
-			  },
-			  "response": {
-				"supportsPreview": true
-			  }
-			},
-			{
-			  "method": "/pulumirpc.ResourceProvider/Check",
-			  "request": {
-				"urn": "urn:pulumi:dev::teststack::Res::exres",
-				"olds": {},
-				"news": {
-					"nodes": [{
-                        "roles": ["role1", "role2"]
-                    }]
-				},
-				"randomSeed": "iYRxB6/8Mm7pwKIs+yK6IyMDmW9JSSTM6klzRUgZhRk="
-			  },
-			  "response": {
-				"inputs": {
-				  "__defaults": [],
-				  "nodes": [
-					{"__defaults": [], "roles": ["role1", "role2"]}
-				  ]
-				}
-			  }
-			}
-		  ]
-		  `)
+                {
+                    "method": "/pulumirpc.ResourceProvider/Configure",
+                    "request": {
+                        "args": {},
+                        "variables": {}
+                    },
+                    "response": {
+                        "supportsPreview": true
+                    }
+                },
+                {
+                    "method": "/pulumirpc.ResourceProvider/Check",
+                    "request": {
+                        "urn": "urn:pulumi:dev::teststack::Res::exres",
+                        "olds": {},
+                        "news": {
+                            "nodes": [
+                                {
+                                    "roles": [
+                                        "role1",
+                                        "role2"
+                                    ]
+                                }
+                            ]
+                        },
+                        "randomSeed": "iYRxB6/8Mm7pwKIs+yK6IyMDmW9JSSTM6klzRUgZhRk="
+                    },
+                    "response": {
+                        "inputs": {
+                            "__defaults": [],
+                            "nodes": [
+                                {
+                                    "__defaults": [],
+                                    "roles": [
+                                        "role1",
+                                        "role2"
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                }
+            ]`)
 	})
 }
 
 func TestSingularAndPluralPropTopLevel(t *testing.T) {
-	p := &schemav2.Provider{
-		Schema: map[string]*schemav2.Schema{},
-		ResourcesMap: map[string]*schemav2.Resource{
+	p := &schema.Provider{
+		Schema: map[string]*schema.Schema{},
+		ResourcesMap: map[string]*schema.Resource{
 			"res": {
-				Schema: map[string]*schemav2.Schema{
+				Schema: map[string]*schema.Schema{
 					"role": {
 						Type:     schema.TypeList,
 						Required: true,

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -3303,7 +3303,7 @@ func TestSingularAndPluralProp(t *testing.T) {
 				TFName: "res",
 				Schema: &ResourceInfo{
 					Fields: map[string]*SchemaInfo{
-						"nodes": {
+						"nodes": {Elem: &SchemaInfo{
 							Elem: &SchemaInfo{
 								Fields: map[string]*SchemaInfo{
 									"roles": {
@@ -3312,7 +3312,7 @@ func TestSingularAndPluralProp(t *testing.T) {
 									},
 								},
 							},
-						},
+						}},
 					},
 				},
 			},

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -1189,8 +1189,8 @@ func MakeTerraformOutput(
 				}
 			}
 			var psflds map[string]*SchemaInfo
-			if ps != nil {
-				psflds = ps.Fields
+			if ps != nil && ps.Elem != nil {
+				psflds = ps.Elem.Fields
 			}
 			obj := MakeTerraformOutputs(
 				ctx, p, outs, tfflds, psflds, assets, rawNames || shimutil.IsOfTypeMap(tfs), supportsSecrets,


### PR DESCRIPTION
Fixes #1729 

This matches #1710 for outputs.

This is a fork of https://github.com/pulumi/pulumi-terraform-bridge/pull/1738.