### PR TITLE
Fix custom timeout propagation for Update

### DIFF
--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -1684,7 +1684,7 @@ func transformFromState(
 func newTimeoutOverrides(key shim.TimeoutKey, maybeTimeoutSeconds float64) map[shim.TimeoutKey]time.Duration {
 	timeoutOverrides := map[shim.TimeoutKey]time.Duration{}
 	if maybeTimeoutSeconds != 0 {
-		timeoutOverrides[shim.TimeoutCreate] = time.Duration(maybeTimeoutSeconds * float64(time.Second))
+		timeoutOverrides[key] = time.Duration(maybeTimeoutSeconds * float64(time.Second))
 	}
 	return timeoutOverrides
 }

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -3260,7 +3260,7 @@ func TestSchemaFuncsNotCalledDuringRuntime(t *testing.T) {
 	})
 }
 
-// TOOD[pulumi/pulumi#15636] if/when Pulumi supports customizing Read timeouts these could be added here.
+// TODO[pulumi/pulumi#15636] if/when Pulumi supports customizing Read timeouts these could be added here.
 func TestCustomTimeouts(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -3260,7 +3260,7 @@ func TestSchemaFuncsNotCalledDuringRuntime(t *testing.T) {
 	})
 }
 
-// Does Pulumi support setting custom Read timeouts? Read is not yet tested here.
+// TOOD[pulumi/pulumi#15636] if/when Pulumi supports customizing Read timeouts these could be added here.
 func TestCustomTimeouts(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -3259,3 +3259,181 @@ func TestSchemaFuncsNotCalledDuringRuntime(t *testing.T) {
 		t.Errorf("The code did not panic!")
 	})
 }
+
+// Does Pulumi support setting custom Read timeouts? Read is not yet tested here.
+func TestCustomTimeouts(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		name                 string
+		cud                  string // Create, Update, or Delete
+		schemaTimeout        *time.Duration
+		userSpecifiedTimeout *time.Duration
+	}
+
+	testCases := []testCase{}
+
+	sec1 := 1 * time.Second
+	sec2 := 2 * time.Second
+	timeouts := []*time.Duration{nil, &sec1, &sec2}
+	cuds := []string{"Create", "Update", "Delete"}
+
+	for _, schemaTimeout := range timeouts {
+		for _, userSpecifiedTimeout := range timeouts {
+			for _, cud := range cuds {
+				n := fmt.Sprintf("%s-schema-%v-user-%v", cud, schemaTimeout, userSpecifiedTimeout)
+				testCases = append(testCases, testCase{
+					cud:                  cud,
+					name:                 n,
+					schemaTimeout:        schemaTimeout,
+					userSpecifiedTimeout: userSpecifiedTimeout,
+				})
+			}
+		}
+	}
+
+	seconds := func(d *time.Duration) float64 {
+		if d == nil {
+			return 0
+		}
+		return d.Seconds()
+	}
+
+	actualTimeout := func(tc testCase) *time.Duration {
+		var capturedTimeout *time.Duration
+
+		tok := "testprov:index:TestRes"
+		urn := fmt.Sprintf("urn:pulumi:dev::teststack::%s::testresource", tok)
+		id := "r1"
+
+		upstreamProvider := &schema.Provider{
+			ResourcesMap: map[string]*schema.Resource{
+				"testprov_testres": {
+					Schema: map[string]*schema.Schema{
+						"x": {
+							Type: schema.TypeMap,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{},
+							},
+							MaxItems: 1,
+						},
+					},
+					Timeouts: &schema.ResourceTimeout{
+						Default: tc.schemaTimeout,
+						Create:  tc.schemaTimeout,
+						Update:  tc.schemaTimeout,
+						Delete:  tc.schemaTimeout,
+					},
+					CreateContext: func(
+						ctx context.Context, rd *schema.ResourceData, i interface{},
+					) diag.Diagnostics {
+						t := rd.Timeout(schema.TimeoutCreate)
+						capturedTimeout = &t
+						rd.SetId(id)
+						return diag.Diagnostics{}
+					},
+					UpdateContext: func(
+						ctx context.Context, rd *schema.ResourceData, i interface{},
+					) diag.Diagnostics {
+						t := rd.Timeout(schema.TimeoutUpdate)
+						capturedTimeout = &t
+						return diag.Diagnostics{}
+					},
+					DeleteContext: func(
+						ctx context.Context, rd *schema.ResourceData, i interface{},
+					) diag.Diagnostics {
+						t := rd.Timeout(schema.TimeoutDelete)
+						capturedTimeout = &t
+						return diag.Diagnostics{}
+					},
+				},
+			},
+		}
+
+		providerInfo := ProviderInfo{
+			Name: "testprov",
+			Resources: map[string]*ResourceInfo{
+				"testprov_testres": {
+					Tok: tokens.Type(tok),
+				},
+			},
+		}
+
+		shimmedProvider := shimv2.NewProvider(upstreamProvider)
+
+		bridgedProvider := &Provider{
+			tf:   shimmedProvider,
+			info: providerInfo,
+		}
+
+		bridgedProvider.initResourceMaps()
+
+		switch tc.cud {
+		case "Create":
+			_, err := bridgedProvider.Create(context.Background(), &pulumirpc.CreateRequest{
+				Urn:        urn,
+				Properties: &structpb.Struct{},
+				Timeout:    seconds(tc.userSpecifiedTimeout),
+			})
+			require.NoError(t, err)
+		case "Update":
+			_, err := bridgedProvider.Update(context.Background(), &pulumirpc.UpdateRequest{
+				Id:      id,
+				Urn:     urn,
+				Olds:    &structpb.Struct{},
+				News:    &structpb.Struct{},
+				Timeout: seconds(tc.userSpecifiedTimeout),
+			})
+			require.NoError(t, err)
+		case "Delete":
+			_, err := bridgedProvider.Delete(context.Background(), &pulumirpc.DeleteRequest{
+				Id:         id,
+				Urn:        urn,
+				Properties: &structpb.Struct{},
+				Timeout:    seconds(tc.userSpecifiedTimeout),
+			})
+			require.NoError(t, err)
+		}
+
+		return capturedTimeout
+	}
+
+	expectedTimeout := func(tc testCase) time.Duration {
+		if tc.schemaTimeout == nil && tc.userSpecifiedTimeout == nil {
+			return 20 * time.Minute
+		}
+		if tc.userSpecifiedTimeout != nil {
+			return *tc.userSpecifiedTimeout
+		}
+		return *tc.schemaTimeout
+	}
+
+	skips := func(tc testCase) string {
+		if tc.userSpecifiedTimeout != nil {
+			return ""
+		}
+		if tc.schemaTimeout == nil {
+			return ""
+		}
+		switch tc.cud {
+		case "Update", "Delete":
+			return "TODO[pulumi/pulumi-terraform-bridge#1651] - schema-specified timeouts are not " +
+				"yet supported for Update and Delete"
+		default:
+			return ""
+		}
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			if reason := skips(tc); reason != "" {
+				t.Skip(reason)
+			}
+			a := actualTimeout(tc)
+			require.NotNil(t, a)
+			assert.Equal(t, expectedTimeout(tc), *a)
+		})
+	}
+}


### PR DESCRIPTION
Fixes a regression responsible for the https://github.com/pulumi/pulumi-aws/issues/3442 P1.

When refactoring timeout handling in https://github.com/pulumi/pulumi-terraform-bridge/pull/1648 the behavior of custom timeouts for Update and Delete was inadvertently broken, but passed the test suite. 

The regression was introduced in v3.72.0 of the bridge and affects all SDKv2 based resources. Custom timeouts were not respected for Update and Delete but were respected for Create. 

The fix is very self-contained but this PR also backfills test coverage with a matrix of tests for custom timeout propagation and respecting both schema-based and user-based timeouts.

