### PR TITLE
Fix schema path elem traversal

### DIFF
--- a/pkg/tfbridge/walk_test.go
+++ b/pkg/tfbridge/walk_test.go
@@ -70,6 +70,10 @@ func TestPropertyPathToSchemaPath(t *testing.T) {
 			Type: shim.TypeMap,
 			Elem: xySchema,
 		}).Shim(),
+		"list_obj": (&schema.Schema{
+			Type: shim.TypeList,
+			Elem: xySchema,
+		}).Shim(),
 	}
 
 	schemaInfos := map[string]*SchemaInfo{
@@ -78,6 +82,14 @@ func TestPropertyPathToSchemaPath(t *testing.T) {
 		},
 		"list_str_named": {
 			Name: "listStr",
+		},
+		"list_obj": {
+			Name: "listObj",
+			Elem: &SchemaInfo{
+				Fields: map[string]*SchemaInfo{
+					"x_prop": {Name: "xOverride"},
+				},
+			},
 		},
 	}
 
@@ -163,6 +175,11 @@ func TestPropertyPathToSchemaPath(t *testing.T) {
 			name:     "max-items-1 list 3 via schemainfo",
 			pp:       []any{"flatListViaSchemaInfo", "xProp"},
 			expected: walk.NewSchemaPath().GetAttr("flat_list_via_schema_info").Element().GetAttr("x_prop"),
+		},
+		{
+			name:     "override list nested object property",
+			pp:       resource.PropertyPath{"listObj", 0, "xOverride"},
+			expected: walk.NewSchemaPath().GetAttr("list_obj").Element().GetAttr("x_prop"),
 		},
 	}
 


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-gcp/issues/1794

This is the second attempt at fixing https://github.com/pulumi/pulumi-gcp/issues/1794, so strict scrutiny would be appreciated.

The core of the issue is correctly interpreting this block:

https://github.com/pulumi/pulumi-terraform-bridge/blob/07b2c1c9587009bc89eb554bddcd8e7bf72e2668/pkg/tfshim/shim.go#L102-L127

From what I can tell, both `propertyPathToSchemaPathInner` and `schemaPathToPropertyPathInner` confuse case 3 for case 2:

`propertyPathToSchemaPathInner` and `schemaPathToPropertyPathInner` correctly handle case 2 (`(schema, ps) ~ {x: T}`), traversing `(schema.Elem().(shim.Resource).Schema(), ps.Fields)`. This is correct, as the `.Elem()` in the `shim` path is a fiction of representation. `ps.Fields` correctly represents that `(schema, ps)` is the object (`{x: T}`) in question.

Currently, both functions incorrectly handle case 3 (`(schema, ps) ~ List[{x: T}], (schema.Elem(), ps.Elem) ~ {x: T}`), treating it identically to case 2. The correct traversal for the nested object is `(schema.Elem().(shim.Resource).Schema(), ps.Elem.Fields)` (note the additional `.Elem` after `ps`). This PR makes that change, and adds a test case to lock it in.