### PR TITLE
Add tfgen time validation for ProviderInfo.Resources

### DIFF
--- a/pkg/tfbridge/validate.go
+++ b/pkg/tfbridge/validate.go
@@ -1,0 +1,213 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfbridge
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/util"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/walk"
+)
+
+// Validate ProviderInfo.
+//
+// Validate is automatically called as part of `make tfgen`.
+func (p *ProviderInfo) Validate(context.Context) error {
+	c := new(infoCheck)
+
+	res := p.P.ResourcesMap()
+	for tk, schema := range p.Resources {
+		tf, ok := res.GetOk(tk)
+		if !ok {
+			// This is checked elsewhere.
+			continue
+		}
+		c.checkResource(&Resource{
+			Schema: schema,
+			TF:     tf,
+			TFName: tk,
+		})
+	}
+
+	return c.errorOrNil()
+}
+
+func (c *infoCheck) errorOrNil() error {
+	errs := make([]error, len(c.errors))
+	for i, e := range c.errors {
+		errs[i] = e
+	}
+	return errors.Join(errs...)
+}
+
+// During tfgen time, we validate that providers are correctly configured.
+//
+// That means that we error if non-existent fields are specified or if overrides have no effect.
+
+type checkError struct {
+	tfToken string
+	path    walk.SchemaPath
+	err     error
+}
+
+func (e checkError) Unwrap() error { return e.err }
+
+func (e checkError) Error() string {
+	return fmt.Sprintf("%s: %s: %s", e.tfToken, e.path, e.err.Error())
+}
+
+type infoCheck struct {
+	errors []checkError
+
+	finishError func(e *checkError)
+}
+
+func (c *infoCheck) error(path walk.SchemaPath, err error) {
+	e := checkError{
+		path: path,
+		err:  err,
+	}
+	c.finishError(&e)
+	c.errors = append(c.errors, e)
+}
+
+var (
+	errNoCorrespondingField           = fmt.Errorf("overriding non-existent field")
+	errNoElemToOverride               = fmt.Errorf("overriding non-existent elem")
+	errCannotSpecifyFieldsOnListOrSet = fmt.Errorf("cannot specify .Fields on a List[T] or Set[T] type")
+	errCannotSpecifyNameOnElem        = fmt.Errorf("cannot specify .Name on a List[T], Map[T] or Set[T] type")
+	errCannotSetMaxItemsOne           = fmt.Errorf("cannot specify .MaxItemsOne on a scalar type")
+	errElemForObject                  = fmt.Errorf("cannot set .Elem on a singly nested object block")
+)
+
+func (c *infoCheck) checkResource(res *Resource) {
+	c.finishError = func(e *checkError) {
+		e.tfToken = res.TFName
+	}
+	defer func() {
+		c.finishError = nil
+	}()
+	c.checkFields(walk.NewSchemaPath(), res.TF.Schema(), res.Schema.Fields)
+}
+
+func (c *infoCheck) checkProperty(path walk.SchemaPath, tfs shim.Schema, ps *SchemaInfo) {
+	// If there is no override, then there were no mistakes.
+	if ps == nil {
+		return
+	}
+
+	// s.Elem() case 2
+	//
+	// `path` represents a singly-nested Terraform block.
+	//
+	// Conceptually `path` and `path.Elem` represent the same object.
+	//
+	// To prevent confusion, users are barred from specifying information on
+	// the associated Elem. All information should be specified directly on
+	// this SchemaInfo.
+	if obj, ok := util.CastToTypeObject(tfs); ok {
+		if ps.Elem != nil {
+			c.error(path, errElemForObject)
+		}
+
+		if ps.MaxItemsOne != nil {
+			c.error(path.Element(), errCannotSetMaxItemsOne)
+		}
+
+		// Now check sub-fields
+		c.checkFields(path, obj, ps.Fields)
+
+		return
+	}
+
+	if len(ps.Fields) > 0 {
+		c.error(path, errCannotSpecifyFieldsOnListOrSet)
+	}
+
+	switch elem := tfs.Elem().(type) {
+
+	// s.Elem() case 1
+	//
+	// There is a simple element type here, so we just recursively validate that.
+	case shim.Schema:
+		c.checkElem(path.Element(), elem, ps.Elem)
+
+	// Either `path` represents an object nested under a list or set, or `path` is
+	// itself an object, depending on the .Type() property.
+	case shim.Resource:
+		// s.Elem() case 3
+		//
+		// `path` represents a List[elem] or Set[elem].
+
+		// Check the nested fields
+		if ps.Elem != nil {
+			c.checkFields(path.Element(), elem.Schema(), ps.Elem.Fields)
+		}
+
+	// There is no element for this shim.Schema shape.
+	//
+	// The only thing the user can do wrong here is to customize the element.
+	case nil:
+		switch tfs.Type() {
+		// s.Elem() case 5
+		case shim.TypeMap, shim.TypeList, shim.TypeSet:
+			// The type is unknown, but specifying overrides is invalid.
+			//
+			// We can't check any deeper, so return
+			return
+		}
+
+		// s.Elem() case 4
+		//
+		// It is not valid to specify .Elem
+		if ps.Elem != nil {
+			c.error(path.Element(), errNoElemToOverride)
+		}
+
+		if ps.MaxItemsOne != nil {
+			c.error(path.Element(), errCannotSetMaxItemsOne)
+		}
+	}
+}
+
+// Check a nested element.
+func (c *infoCheck) checkElem(path walk.SchemaPath, tfs shim.Schema, ps *SchemaInfo) {
+	if ps == nil {
+		return
+	}
+	if ps.Name != "" {
+		// If we are an element type, and we are not an object (which has a name),
+		// then it doesn't make sense to provide a name since the elem will be
+		// accessed by an index.
+		c.error(path, errCannotSpecifyNameOnElem)
+	}
+
+	c.checkProperty(path, tfs, ps)
+}
+
+func (c *infoCheck) checkFields(path walk.SchemaPath, tfs shim.SchemaMap, ps map[string]*SchemaInfo) {
+	for k, p := range ps {
+		elemPath := path.GetAttr(k)
+		elemTfs, ok := tfs.GetOk(k)
+		if !ok {
+			c.error(elemPath, errNoCorrespondingField)
+			continue
+		}
+		c.checkProperty(elemPath, elemTfs, p)
+	}
+}

--- a/pkg/tfbridge/validate_test.go
+++ b/pkg/tfbridge/validate_test.go
@@ -1,0 +1,225 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfbridge
+
+import (
+	"context"
+	"testing"
+
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateNameOverride(t *testing.T) {
+	r := func() shim.Resource {
+		return (&schema.Resource{
+			Schema: schema.SchemaMap{
+				"scalar1": (&schema.Schema{
+					Type: shim.TypeString,
+				}).Shim(),
+				"list_of_scalar": (&schema.Schema{
+					Type: shim.TypeList,
+					Elem: (&schema.Schema{
+						Type: shim.TypeInt,
+					}).Shim(),
+				}).Shim(),
+				"object1": (&schema.Schema{
+					Type: shim.TypeMap,
+					Elem: (&schema.Resource{
+						Schema: schema.SchemaMap{
+							"nest1": (&schema.Schema{
+								Type: shim.TypeString,
+							}).Shim(),
+							"nest2": (&schema.Schema{
+								Type: shim.TypeList,
+								Elem: (&schema.Schema{
+									Type: shim.TypeInt,
+								}).Shim(),
+							}).Shim(),
+						},
+					}).Shim(),
+				}).Shim(),
+			},
+		}).Shim()
+	}
+
+	tests := []struct {
+		name        string
+		info        *ResourceInfo
+		expectedErr error
+	}{
+		{
+			name:        "no override",
+			info:        nil,
+			expectedErr: nil,
+		},
+		{
+			name: "valid field, name override",
+			info: &ResourceInfo{
+				Fields: map[string]*SchemaInfo{
+					"scalar1": {Name: "foo"},
+				},
+			},
+		},
+		{
+			name: "invalid field, name override",
+			info: &ResourceInfo{
+				Fields: map[string]*SchemaInfo{
+					"scalar_missing": {Name: "foo"},
+				},
+			},
+			expectedErr: errNoCorrespondingField,
+		},
+		{
+			name: "invalid elem on scalar",
+			info: &ResourceInfo{
+				Fields: map[string]*SchemaInfo{
+					"scalar1": {Elem: &SchemaInfo{}},
+				},
+			},
+			expectedErr: errNoElemToOverride,
+		},
+		{
+			name: "invalid name override on scalar list elem",
+			info: &ResourceInfo{
+				Fields: map[string]*SchemaInfo{
+					"list_of_scalar": {
+						Elem: &SchemaInfo{
+							Name: "foo",
+						},
+					},
+				},
+			},
+			expectedErr: errCannotSpecifyNameOnElem,
+		},
+		{
+			name: "valid object field overrides",
+			info: &ResourceInfo{
+				Fields: map[string]*SchemaInfo{
+					"object1": {
+						Fields: map[string]*SchemaInfo{
+							"nest1": {Name: "Foo"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "invalid object field overrides",
+			info: &ResourceInfo{
+				Fields: map[string]*SchemaInfo{
+					"object1": {
+						Elem: &SchemaInfo{
+							Fields: map[string]*SchemaInfo{
+								"nest1": {Name: "Foo"},
+							},
+						},
+					},
+				},
+			},
+			expectedErr: errElemForObject,
+		},
+		{
+			name: "invalid fields on list",
+			info: &ResourceInfo{
+				Fields: map[string]*SchemaInfo{
+					"list_of_scalar": {
+						Fields: map[string]*SchemaInfo{
+							"invalid": {},
+						},
+					},
+				},
+			},
+			expectedErr: errCannotSpecifyFieldsOnListOrSet,
+		},
+		{
+			name: "valid max items 1",
+			info: &ResourceInfo{
+				Fields: map[string]*SchemaInfo{
+					"list_of_scalar": {MaxItemsOne: True()},
+				},
+			},
+		},
+		{
+			name: "invalid max items 1 (nested)",
+			info: &ResourceInfo{
+				Fields: map[string]*SchemaInfo{
+					"list_of_scalar": {
+						Elem: &SchemaInfo{MaxItemsOne: True()},
+					},
+				},
+			},
+			expectedErr: errCannotSetMaxItemsOne,
+		},
+		{
+			name: "invalid max items 1 (scalar)",
+			info: &ResourceInfo{
+				Fields: map[string]*SchemaInfo{
+					"scalar1": {MaxItemsOne: True()},
+				},
+			},
+			expectedErr: errCannotSetMaxItemsOne,
+		},
+		{
+			name: "invalid max items 1 (object)",
+			info: &ResourceInfo{
+				Fields: map[string]*SchemaInfo{
+					"object1": {MaxItemsOne: True()},
+				},
+			},
+			expectedErr: errCannotSetMaxItemsOne,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := withResource(tt.info, r()).Validate(context.Background())
+			if tt.expectedErr == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorIs(t, err, tt.expectedErr)
+			}
+		})
+	}
+}
+
+func withResource(info *ResourceInfo, r shim.Resource) *ProviderInfo {
+	token := "test_r"
+
+	if info == nil {
+		info = &ResourceInfo{}
+	}
+
+	p := &ProviderInfo{
+		Name: "test",
+		P: (&schema.Provider{
+			ResourcesMap: schema.ResourceMap{
+				token: r,
+			},
+		}).Shim(),
+		Resources: map[string]*ResourceInfo{
+			token: info,
+		},
+	}
+
+	if p.Resources[token].Tok == "" {
+		p.Resources[token].Tok = "test:index/r:R"
+	}
+
+	return p
+}

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -15,6 +15,7 @@
 package tfgen
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -860,6 +861,10 @@ type GenerateOptions struct {
 
 // Generate creates Pulumi packages from the information it was initialized with.
 func (g *Generator) Generate() error {
+	err := g.info.Validate(context.Background())
+	if err != nil {
+		return err
+	}
 	// First gather up the entire package contents. This structure is complete and sufficient to hand off to the
 	// language-specific generators to create the full output.
 	pack, err := g.gatherPackage()


### PR DESCRIPTION
While discussing #1757, there was some uncertainty on how to align `*SchemaInfo` with the underlying `shim.Schema`. This PR clarifies by introducing a user error during `make tfgen` time if the user provides a misaligned or nonsensical `*SchemaInfo`.