### PR TITLE
fix: fixes are not applied to property deprecation messages

### DIFF
--- a/internal/testprovider/schema_mini_aws.go
+++ b/internal/testprovider/schema_mini_aws.go
@@ -45,13 +45,8 @@ func resourceMiniAwsBucket() map[string]*schema.Schema {
 			Required: true,
 		},
 		"acl": {
-			Type:     schema.TypeString,
-			Optional: true,
-			// // NOTE: In the real provider this field is not populated in the terraform schema so we pull it from the
-			// // markdown docs. This is the value of the description after being pulled from the markdown docs and after
-			// // the doc edits have been applied.
-			// Description: "The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`. " +
-			// 	"Conflicts with `grant`. The provider will only perform drift detection if a configuration value is provided. Use the resource `aws_s3_bucket_acl` instead.",
+			Type:          schema.TypeString,
+			Optional:      true,
 			ConflictsWith: []string{"grant"},
 			Deprecated:    "Use the aws_s3_bucket_acl resource instead",
 		},

--- a/internal/testprovider/schema_mini_aws.go
+++ b/internal/testprovider/schema_mini_aws.go
@@ -1,0 +1,59 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testprovider
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func ProviderMiniAws() *schema.Provider {
+	resourceBucket := func() *schema.Resource {
+		return &schema.Resource{
+			Schema:      resourceMiniAwsBucket(),
+			Description: "Provides a S3 bucket resource.",
+		}
+	}
+
+	return &schema.Provider{
+		Schema: map[string]*schema.Schema{},
+		ResourcesMap: map[string]*schema.Resource{
+			"aws_s3_bucket": resourceBucket(),
+			"aws_s3_bucket_acl": {
+				Description: "Provides a S3 bucket ACL resource.",
+				Schema:      map[string]*schema.Schema{},
+			},
+		},
+	}
+}
+
+func resourceMiniAwsBucket() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"bucket": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		"acl": {
+			Type:     schema.TypeString,
+			Optional: true,
+			// // NOTE: In the real provider this field is not populated in the terraform schema so we pull it from the
+			// // markdown docs. This is the value of the description after being pulled from the markdown docs and after
+			// // the doc edits have been applied.
+			// Description: "The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`. " +
+			// 	"Conflicts with `grant`. The provider will only perform drift detection if a configuration value is provided. Use the resource `aws_s3_bucket_acl` instead.",
+			ConflictsWith: []string{"grant"},
+			Deprecated:    "Use the aws_s3_bucket_acl resource instead",
+		},
+	}
+}

--- a/pkg/tfgen/generate_schema_test.go
+++ b/pkg/tfgen/generate_schema_test.go
@@ -113,6 +113,32 @@ func TestCSharpMiniRandom(t *testing.T) {
 	bridgetesting.AssertEqualsJSONFile(t, "test_data/minirandom-schema-csharp.json", schema)
 }
 
+// TestPropertyDocumentationEdits tests that documentation edits are applied to individual properties.
+// This includes both the property description and deprecation message. This tests the following workflow
+//  1. The generator finds markdown documentation for the `aws_s3_bucket` resource
+//  2. The generator applies `DocsEdit` rules to the markdown documentation
+//  3. The generator parses the markdown documentation and pulls out the `acl` argument description and merges that into the schema
+//  3. The generator cleans up the `acl` description and deprecation message, replacing terraform references with pulumi references
+//     e.g. `aws_s3_bucket_acl` -> `aws.s3.BucketAclV2`
+func TestPropertyDocumentationEdits(t *testing.T) {
+	provider := testprovider.ProviderMiniAws()
+	provider.MetadataInfo = tfbridge.NewProviderMetadata(nil)
+	schema, err := GenerateSchema(provider, diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{
+		Color: colors.Never,
+	}))
+	assert.NoError(t, err)
+
+	// asserts that `aws_s3_bucket_acl` has been changed to `aws.s3.BucketAclV2`
+	assert.Equal(t,
+		"The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`. The provider will only perform drift detection if a configuration value is provided. Use the resource `aws.s3.BucketAclV2` instead.\n",
+		schema.Resources["aws:s3/bucketV2:BucketV2"].InputProperties["acl"].Description,
+	)
+	assert.Equal(t,
+		"Use the aws.s3.BucketAclV2 resource instead",
+		schema.Resources["aws:s3/bucketV2:BucketV2"].InputProperties["acl"].DeprecationMessage,
+	)
+}
+
 func TestNestedMaxItemsOne(t *testing.T) {
 	provider := testprovider.ProviderMiniCloudflare()
 	meta, err := metadata.New(nil)

--- a/pkg/tfgen/internal/testprovider/miniaws.go
+++ b/pkg/tfgen/internal/testprovider/miniaws.go
@@ -1,0 +1,72 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testprovider
+
+import (
+	"bytes"
+
+	testproviderdata "github.com/pulumi/pulumi-terraform-bridge/v3/internal/testprovider"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+)
+
+func ProviderMiniAws() tfbridge.ProviderInfo {
+
+	return tfbridge.ProviderInfo{
+		P:           shimv2.NewProvider(testproviderdata.ProviderMiniAws()),
+		Name:        "aws",
+		Description: "A Pulumi package to safely use aws in Pulumi programs.",
+		Keywords:    []string{"pulumi", "aws"},
+		License:     "Apache-2.0",
+		Homepage:    "https://pulumi.io",
+		Repository:  "https://github.com/pulumi/pulumi-aws",
+		DocRules: &tfbridge.DocRuleInfo{EditRules: func(defaults []tfbridge.DocsEdit) []tfbridge.DocsEdit {
+			return []tfbridge.DocsEdit{
+				{
+					Path: "*",
+					Edit: func(_ string, content []byte) ([]byte, error) {
+						content = bytes.ReplaceAll(
+							content,
+							// This replacement is done in the aws provider here. This replacement is necessary because the bridge will drop any docs that
+							// contain the work 'Terraform'
+							// https://github.com/pulumi/pulumi-aws/blob/df5d52299c72b936df9c9289d83d10225dc1dce7/provider/replacements.json#L1688
+							[]byte(" Terraform will only perform drift detection if a configuration value is provided."),
+							[]byte(" The provider will only perform drift detection if a configuration value is provided."),
+						)
+						return content, nil
+
+					},
+				},
+			}
+		}},
+		UpstreamRepoPath: "./test_data",
+		Resources: map[string]*tfbridge.ResourceInfo{
+			"aws_s3_bucket_acl": {
+				Tok: tokens.Type(tokens.ModuleMember("aws:s3/bucketAclV2:BucketAclV2")),
+			},
+			"aws_s3_bucket": {
+				Tok: tokens.Type(tokens.ModuleMember("aws:s3/bucketV2:BucketV2")),
+				Aliases: []tfbridge.AliasInfo{
+					{
+						Type: ref("aws:s3/bucket:Bucket"),
+					},
+				},
+			},
+		},
+	}
+}
+
+func ref[T any](value T) *T { return &value }

--- a/pkg/tfgen/test_data/website/docs/r/s3_bucket.html.markdown
+++ b/pkg/tfgen/test_data/website/docs/r/s3_bucket.html.markdown
@@ -1,0 +1,21 @@
+---
+subcategory: "S3 (Simple Storage)"
+layout: "aws"
+page_title: "AWS: aws_s3_bucket"
+description: |-
+  Provides a S3 bucket resource.
+---
+
+# Resource: aws_s3_bucket
+
+Provides a S3 bucket resource.
+
+## Argument Reference
+
+This resource supports the following arguments:
+
+* `bucket` - (Optional, Forces new resource) Name of the bucket. If omitted, the provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html). The name must not be in the format `[bucket_name]--[azid]--x-s3`. Use the `aws_s3_directory_bucket` resource to manage S3 Express buckets.
+
+The following arguments are deprecated, and will be removed in a future major version:
+
+* `acl` - (Optional, **Deprecated**) The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`. Terraform will only perform drift detection if a configuration value is provided. Use the resource `aws_s3_bucket_acl` instead.


### PR DESCRIPTION
We have logic in `fixupPropertyReference` to replace terraform resource references with pulumi references (i.e. `aws_s3_bucket` => `aws.s3.BucketV2`).

This logic is applied to the `Description` property, but it is not applied to the separate `DeprecationMessage` property. These two properties exist separately in the pulumi resource schema and are combined when creating the website docs and the SDK docs.

fixes #3028