### PR TITLE
Log redirector now respects TF_LOG

### DIFF
--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -282,15 +282,7 @@ func (p *Provider) loggingContext(ctx context.Context, urn resource.URN) context
 		return ctx
 	}
 
-	log.SetOutput(&LogRedirector{
-		writers: map[string]func(string) error{
-			tfTracePrefix: func(msg string) error { return p.host.Log(ctx, diag.Debug, "", msg) },
-			tfDebugPrefix: func(msg string) error { return p.host.Log(ctx, diag.Debug, "", msg) },
-			tfInfoPrefix:  func(msg string) error { return p.host.Log(ctx, diag.Info, "", msg) },
-			tfWarnPrefix:  func(msg string) error { return p.host.Log(ctx, diag.Warning, "", msg) },
-			tfErrorPrefix: func(msg string) error { return p.host.Log(ctx, diag.Error, "", msg) },
-		},
-	})
+	log.SetOutput(NewTerraformLogRedirector(ctx, p.host))
 
 	return logging.InitLogging(ctx, logging.LogOptions{
 		LogSink:         p.host,


### PR DESCRIPTION
Before this change all logs emitted with `log.Printf` were sent to Pulumi as DEBUG-level logs, making it difficult to detect errors and warnings emitted in this way, or to filter verbose logs to find errors or warnings.

Fixes #1632 

The are two changes:

- bridged providers will continue to send these logs as DEBUG-level logs by default but will now attach the original level label to the message, so that filtering verbose logs is easier

- if the user sets the TF_LOG environment variable to an appropriate value such as TF_LOG=WARN, these logs will be sent to Pulumi at their correct level and will be made visible by Pulumi CLI

The TF_LOG-gated behavior matches Terraform behavior where seeing logs in the CLI is opt-in and disabled by default.