### PR TITLE
Fixes issues with name overrides in Plugin Framework invokes

### DIFF
--- a/pf/internal/convert/encoding_test.go
+++ b/pf/internal/convert/encoding_test.go
@@ -295,6 +295,43 @@ func TestDataSourceDecoder(t *testing.T) {
 				},
 			}),
 		},
+		{
+			testName: "respect name overrides",
+			schema: &schema.SchemaMap{
+				"foo": (&schema.Schema{
+					Type:     shim.TypeString,
+					Optional: true,
+				}).Shim(),
+			},
+			info: &tfbridge.ProviderInfo{
+				DataSources: map[string]*tfbridge.DataSourceInfo{
+					myDataSource: {
+						Fields: map[string]*tfbridge.SchemaInfo{
+							"foo": {
+								Name: "renamedFoo",
+							},
+						},
+					},
+				},
+			},
+			typ: tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"foo": tftypes.String,
+				},
+			},
+			val: tftypes.NewValue(tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"foo": tftypes.String,
+				},
+			}, map[string]tftypes.Value{
+				"foo": tftypes.NewValue(tftypes.String, "bar"),
+			}),
+			expect: autogold.Expect(resource.PropertyMap{
+				resource.PropertyKey("renamedFoo"): resource.PropertyValue{
+					V: "bar",
+				},
+			}),
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pf/internal/convert/schema_context.go
+++ b/pf/internal/convert/schema_context.go
@@ -66,7 +66,7 @@ func newDataSourceSchemaMapContext(
 	sm := r.Schema()
 	var fields map[string]*tfbridge.SchemaInfo
 	if providerInfo != nil {
-		fields = providerInfo.Resources[dataSource].GetFields()
+		fields = providerInfo.DataSources[dataSource].GetFields()
 	}
 	return newSchemaMapContext(sm, fields)
 }


### PR DESCRIPTION
This change fixes an issue where Plugin Framework invokes did not respect SchemaInfo overrides, in particular there could be issues with incorrect translation of incoming PropertyMap data when SchemaInfo specified a different name for a data source property.

On top of [t0yv0/improve-convert-module](https://github.com/pulumi/pulumi-terraform-bridge/pull/1779).