### PR TITLE
Testing bridge upgrades should not open P1s

### DIFF
--- a/.github/workflows/update-providers-test.yml
+++ b/.github/workflows/update-providers-test.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           token: ${{ secrets.PULUMI_BOT_TOKEN }}
           repository: pulumi/pulumi-${{ matrix.provider }}
-          event-type: upgrade-bridge
+          event-type: upgrade-bridge-test
           client-payload: |-
             {
                "target-pulumi-version": ${{ toJSON(github.event.inputs.pulumiVersion) }},


### PR DESCRIPTION
See https://github.com/pulumi/ci-mgmt/issues/815