### PR TITLE
Make the cache key more precise

### DIFF
--- a/pkg/tfgen/examples_cache.go
+++ b/pkg/tfgen/examples_cache.go
@@ -186,11 +186,17 @@ func (ec *examplesCache) inferSoftwareVersions() map[string]string {
 		}
 		type result struct {
 			Version string `json:"Version"`
+			Replace struct {
+				Version string `json:"Version"`
+			} `json:"Replace"`
 		}
 		var r result
 		err = json.Unmarshal(j, &r)
 		contract.AssertNoErrorf(err, "go list -json -m <pkg> result parsing failed")
 		p[u] = r.Version
+		if r.Replace.Version != "" {
+			p[u] = r.Replace.Version
+		}
 	}
 	return p
 }

--- a/pkg/tfgen/examples_cache_test.go
+++ b/pkg/tfgen/examples_cache_test.go
@@ -15,13 +15,21 @@
 package tfgen
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 )
 
 func TestExamplesCache(t *testing.T) {
 	t.Parallel()
+
+	exInfo := &tfbridge.ProviderInfo{
+		Name:    "ex",
+		Version: "0.0.1",
+	}
 
 	hcl := `
 		resource "random_password" "password" {
@@ -45,7 +53,7 @@ func TestExamplesCache(t *testing.T) {
 
 	t.Run("enabled", func(t *testing.T) {
 		dir := t.TempDir()
-		cache := newExamplesCache("ex", "0.0.1", dir)
+		cache := newExamplesCache(exInfo, dir)
 
 		_, ok := cache.Lookup(hcl, "typescript")
 		assert.False(t, ok)
@@ -58,7 +66,7 @@ func TestExamplesCache(t *testing.T) {
 	})
 
 	t.Run("disabled", func(t *testing.T) {
-		cache := newExamplesCache("ex", "0.0.1", "")
+		cache := newExamplesCache(exInfo, "")
 		assert.False(t, cache.enabled)
 
 		_, ok := cache.Lookup(hcl, "typescript")

--- a/pkg/tfgen/examples_cache_test.go
+++ b/pkg/tfgen/examples_cache_test.go
@@ -15,7 +15,6 @@
 package tfgen
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
Make the examples cache key more precise:

- do not look at provider version
- do not look at the entirety of go.mod, only check key package versions
- include MarshallableProviderInfo in the cache
- if go.work is used, still include that as before