### PR TITLE
Add an example schema-aware test

### DIFF
--- a/pkg/tfbridge/tests/provider_test.go
+++ b/pkg/tfbridge/tests/provider_test.go
@@ -1,0 +1,108 @@
+package tfbridgetests
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+
+	"github.com/pulumi/providertest/replay"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen"
+	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+)
+
+// Demonstrating the use of the newTestProvider helper.
+func TestWithNewTestProvider(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider(ctx, tfbridge.ProviderInfo{
+		P: shimv2.NewProvider(&schema.Provider{
+			Schema: map[string]*schema.Schema{},
+			ResourcesMap: map[string]*schema.Resource{
+				"example_resource": {
+					Schema: map[string]*schema.Schema{
+						"array_property_values": {
+							Type: schema.TypeList,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+							Optional: true,
+						},
+					},
+				},
+			},
+		}),
+		Name:           "testprov",
+		ResourcePrefix: "example",
+		Resources: map[string]*tfbridge.ResourceInfo{
+			"example_resource": {Tok: "testprov:index:ExampleResource"},
+		},
+	}, newTestProviderOptions{})
+
+	replay.Replay(t, p, `
+	{
+	  "method": "/pulumirpc.ResourceProvider/Check",
+	  "request": {
+	    "urn": "urn:pulumi:dev::teststack::testprov:index:ExampleResource::exres",
+	    "randomSeed": "ZCiVOcvG/CT5jx4XriguWgj2iMpQEb8P3ZLqU/AS2yg=",
+	    "olds": {
+	      "__defaults": []
+	    },
+	    "news": {
+	      "arrayPropertyValues": []
+	    }
+	  },
+	  "response": {
+	    "inputs": {
+	      "__defaults": [],
+	      "arrayPropertyValues": []
+	    }
+	  }
+	}
+	`)
+}
+
+func nilSink() diag.Sink {
+	nilSink := diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{
+		Color: colors.Never,
+	})
+	return nilSink
+}
+
+// Variation of NewProvider to facilitate white-box testing.
+func newTestProvider(
+	ctx context.Context,
+	info tfbridge.ProviderInfo,
+	opts newTestProviderOptions,
+) pulumirpc.ResourceProviderServer {
+	if opts.version == "" {
+		opts.version = "0.0.1"
+	}
+	if opts.module == "" {
+		opts.module = "testprovier"
+	}
+
+	var schemaBytes []byte
+
+	if !opts.noSchema {
+		packageSpec, err := tfgen.GenerateSchema(info, nilSink())
+		contract.AssertNoErrorf(err, "Failed to generate a schema for the test provider")
+		bytes, err := json.Marshal(packageSpec)
+		contract.AssertNoErrorf(err, "Failed to marshal a schema for the test provider")
+		schemaBytes = bytes
+	}
+
+	return tfbridge.NewProvider(ctx, nil, opts.module, opts.version, info.P, info, schemaBytes)
+}
+
+type newTestProviderOptions struct {
+	module   string
+	version  string
+	noSchema bool
+}


### PR DESCRIPTION
Currently it is difficult to add quick unit tests that have an accurate Pulumi Package Schema available in the provider. Adding them in the tfbridge package runs into the limitation that these tests cannot reference tfgen due to circular references. This change adds a new package that works around the limitations. Unfortunately it can only test the exported API and not the internals, but that may be sufficient for some applications.