### PR TITLE
Revert "[convert] Ensure not supported lifecycle hook warning before …

### DIFF
--- a/pkg/tfgen/convert_cli.go
+++ b/pkg/tfgen/convert_cli.go
@@ -485,7 +485,6 @@ func (cc *cliConverter) postProcessDiagnostics(diag hcl.Diagnostics) hcl.Diagnos
 		copy := *d
 		cc.removeFileName(&copy)
 		cc.ensureNotYetImplementedIsAnError(&copy)
-		cc.ensureNotSupportedLifecycleHooksIsError(&copy)
 		out = append(out, &copy)
 	}
 	return out
@@ -504,18 +503,11 @@ func (*cliConverter) removeFileName(d *hcl.Diagnostic) {
 }
 
 var (
-	notYetImplementedPattern         = regexp.MustCompile("(?i)not yet implemented")
-	notSupportedLifecycleHookPattern = regexp.MustCompile("(?i)lifecycle hook is not supported")
+	notYetImplementedPattern = regexp.MustCompile("(?i)not yet implemented")
 )
 
 func (*cliConverter) ensureNotYetImplementedIsAnError(d *hcl.Diagnostic) {
 	if notYetImplementedPattern.MatchString(d.Error()) {
-		d.Severity = hcl.DiagError
-	}
-}
-
-func (*cliConverter) ensureNotSupportedLifecycleHooksIsError(d *hcl.Diagnostic) {
-	if notSupportedLifecycleHookPattern.MatchString(d.Error()) {
 		d.Severity = hcl.DiagError
 	}
 }

--- a/pkg/tfgen/convert_cli_test.go
+++ b/pkg/tfgen/convert_cli_test.go
@@ -315,30 +315,6 @@ func TestNotYetImplementedErrorHandling(t *testing.T) {
 	require.Equal(t, hcl.DiagError, result[0].Severity)
 }
 
-func TestNotSupportedLifecyleHookErrorHandling(t *testing.T) {
-	warningReplaceTriggeredBy := &hcl.Diagnostic{
-		Severity: hcl.DiagWarning,
-		Summary:  "converting replace_triggered_by lifecycle hook is not supported",
-		Subject:  &hcl.Range{},
-	}
-
-	warningCreateBeforeDelete := &hcl.Diagnostic{
-		Severity: hcl.DiagWarning,
-		Summary:  "converting create_before_destroy lifecycle hook is not supported",
-		Subject:  &hcl.Range{},
-	}
-
-	cc := &cliConverter{}
-	result := cc.postProcessDiagnostics(hcl.Diagnostics{
-		warningReplaceTriggeredBy,
-		warningCreateBeforeDelete,
-	})
-
-	require.Equal(t, 2, len(result))
-	require.Equal(t, hcl.DiagError, result[0].Severity)
-	require.Equal(t, hcl.DiagError, result[1].Severity)
-}
-
 type testPluginHost struct{}
 
 func (*testPluginHost) ServerAddr() string { panic("Unexpected call") }


### PR DESCRIPTION
…an error"

This reverts commit 1c48a5189015c954ce8b6ff9ebdb909b12b53bb0.

Will get it in after releasing the bridge since downstream tests were run without this commit.