### PR TITLE
Correctly handle MaxItems: 1 for extractSchemaInputs

### DIFF
--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -1724,6 +1724,13 @@ func extractSchemaInputsObject(
 		_, etfs, eps := getInfoFromPulumiName(k, tfs, ps, false)
 		typeKnown := tfs != nil && etfs != nil
 
+		// We drop fields that are not present in the schema.
+		//
+		// We might want to reconsider, since any mismatch between what is
+		// returned and the schema indicates a bug somewhere.
+		//
+		// Since Pulumi is so schema based, it might be better to error on
+		// !typeKnown instead of dropping a field.
 		if !typeKnown || !(etfs.Optional() || etfs.Required()) {
 			glog.V(9).Infof("skipping '%v' (not an input)", k)
 			continue


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-cloudflare/issues/554

This corrects MaxItems: 1 handling for `extractSchemaInputs`. As part of that, I have separated the handling of `map<string,elem>` and `object` types to their own function. This vastly simplifies the code.

Tests are incoming shortly.