### PR TITLE
Handle provider meta better in PlanResourceChange

### DIFF
--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -3932,13 +3932,13 @@ func TestProviderMetaPlanResourceChangeNoError(t *testing.T) {
 	type otherMetaType struct {
 		val string
 	}
-	
+
 	p := testprovider.ProviderV2()
 	er := p.ResourcesMap["example_resource"]
 	er.Schema = map[string]*schemav2.Schema{
 		"string_property_value": {Type: schema.TypeString, Optional: true},
 	}
-	er.Create = nil
+	er.Create = nil //nolint:all
 	er.CreateContext = func(ctx context.Context, rd *schema.ResourceData, i interface{}) diag.Diagnostics {
 		rd.SetId("r1")
 		return diag.Diagnostics{}

--- a/pkg/tfshim/sdk-v2/provider2.go
+++ b/pkg/tfshim/sdk-v2/provider2.go
@@ -278,12 +278,8 @@ func (p *planResourceChangeImpl) Importer(t string) shim.ImportFunc {
 }
 
 func (p *planResourceChangeImpl) providerMeta() (*cty.Value, error) {
-	if p.tf.ProviderMetaSchema == nil {
-		return nil, nil
-	}
-	metaSchema := schema.InternalMap(p.tf.ProviderMetaSchema).CoreConfigSchema()
-	v := cty.NullVal(metaSchema.ImpliedType())
-	return &v, nil
+	return nil, nil
+	// TODO: Implement this if needed. https://github.com/pulumi/pulumi-terraform-bridge/issues/1827
 }
 
 func (*planResourceChangeImpl) unpackDiff(ty cty.Type, d shim.InstanceDiff) *v2InstanceDiff2 {

--- a/pkg/tfshim/sdk-v2/provider2.go
+++ b/pkg/tfshim/sdk-v2/provider2.go
@@ -282,15 +282,7 @@ func (p *planResourceChangeImpl) providerMeta() (*cty.Value, error) {
 		return nil, nil
 	}
 	metaSchema := schema.InternalMap(p.tf.ProviderMetaSchema).CoreConfigSchema()
-	m := p.tf.Meta()
-	if m == nil {
-		v := cty.NullVal(metaSchema.ImpliedType())
-		return &v, nil
-	}
-	v, err := recoverAndCoerceCtyValueWithSchema(metaSchema, m)
-	if err != nil {
-		return nil, fmt.Errorf("ProviderMeta: %w", err)
-	}
+	v := cty.NullVal(metaSchema.ImpliedType())
 	return &v, nil
 }
 

--- a/pkg/tfshim/sdk-v2/provider2.go
+++ b/pkg/tfshim/sdk-v2/provider2.go
@@ -279,7 +279,7 @@ func (p *planResourceChangeImpl) Importer(t string) shim.ImportFunc {
 
 func (p *planResourceChangeImpl) providerMeta() (*cty.Value, error) {
 	return nil, nil
-	// TODO: Implement this if needed. https://github.com/pulumi/pulumi-terraform-bridge/issues/1827
+	// TODO[pulumi/pulumi-terraform-bridge#1827]: We do not believe that this is load bearing in any providers.
 }
 
 func (*planResourceChangeImpl) unpackDiff(ty cty.Type, d shim.InstanceDiff) *v2InstanceDiff2 {


### PR DESCRIPTION
fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/1822 and unlocks https://github.com/pulumi/pulumi-gcp/issues/1874

`ProviderMeta` seems to be an old experimental feature of TF which has not picked up.

AWS does not use it and GCP uses it only for one thing - setting UserAgent strings: https://github.com/modular-magician/terraform-provider-google-beta/commit/6cf6c51b6b3804d6ce050885c98ae030f378bd7e

The meta we receive does not match the schema provided and does not contain the module_name property. We should set it to null and potentially revisit if this causes issues. I've tested it for the GCP resource in https://github.com/pulumi/pulumi-terraform-bridge/pull/1825 and works fine.


I've opened https://github.com/pulumi/pulumi-terraform-bridge/issues/1827 as a follow-up to test with one of the resources which actually use the ProviderMeta.