### PR TITLE
Remove old examples caching

### DIFF
--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -16,7 +16,6 @@ package tfgen
 
 import (
 	"bytes"
-	"crypto/md5" //nolint:gosec
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1264,7 +1263,7 @@ func (p *tfMarkdownParser) reformatSubsection(lines []string) ([]string, bool, b
 
 // convertExamples converts any code snippets in a subsection to Pulumi-compatible code. This conversion is done on a
 // per-subsection basis; subsections with failing examples will be elided upon the caller's request.
-func (g *Generator) convertExamples(docs string, path examplePath) (result string) {
+func (g *Generator) convertExamples(docs string, path examplePath) string {
 	if docs == "" {
 		return ""
 	}
@@ -1282,39 +1281,6 @@ func (g *Generator) convertExamples(docs string, path examplePath) (result strin
 		// The provider author has explicitly written an entire markdown document including examples.
 		// We'll just return it as is.
 		return docs
-	}
-
-	// This function is very expensive for large providers. Permit experimental disk-based caching if the user
-	// specifies the PULUMI_CONVERT_EXAMPLES_CACHE_DIR environment variable, pointing to a folder for the cache.
-	if cache := g.getOrCreateExamplesCache(); cache.enabled {
-		path := path.String()
-		sep := string(rune(0))
-		var buf bytes.Buffer
-		fmt.Fprintf(&buf, "provider=%v%s", g.info.Name, sep)
-		fmt.Fprintf(&buf, "version=%v%s", g.info.Version, sep)
-		fmt.Fprintf(&buf, "path=%v%s", path, sep)
-		fmt.Fprintf(&buf, "docs=%v%s", docs, sep)
-
-		hash := fmt.Sprintf("%x", md5.Sum(buf.Bytes())) //nolint:gosec
-
-		filePath := filepath.Join(cache.dir, hash)
-
-		bytes, err := os.ReadFile(filePath)
-		if err == nil {
-			// cache hit
-			return string(bytes)
-		}
-		// ignore the error, assume cache miss or file not found
-		defer func() {
-			// only write the cache for sizable results, >0.5kb
-			if len(result) > 512 {
-				// try to write to the cache
-				err := os.WriteFile(filePath, []byte(result), 0600)
-				if err != nil {
-					panic(fmt.Errorf("failed to write examples-cache: %w", err))
-				}
-			}
-		}()
 	}
 
 	if strings.Contains(docs, "```typescript") || strings.Contains(docs, "```python") ||

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -1286,38 +1286,35 @@ func (g *Generator) convertExamples(docs string, path examplePath) (result strin
 
 	// This function is very expensive for large providers. Permit experimental disk-based caching if the user
 	// specifies the PULUMI_CONVERT_EXAMPLES_CACHE_DIR environment variable, pointing to a folder for the cache.
-	{
-		dir, enableCache := os.LookupEnv("PULUMI_CONVERT_EXAMPLES_CACHE_DIR")
-		if enableCache && dir != "" {
-			path := path.String()
-			sep := string(rune(0))
-			var buf bytes.Buffer
-			fmt.Fprintf(&buf, "provider=%v%s", g.info.Name, sep)
-			fmt.Fprintf(&buf, "version=%v%s", g.info.Version, sep)
-			fmt.Fprintf(&buf, "path=%v%s", path, sep)
-			fmt.Fprintf(&buf, "docs=%v%s", docs, sep)
+	if cache := g.getOrCreateExamplesCache(); cache.enabled {
+		path := path.String()
+		sep := string(rune(0))
+		var buf bytes.Buffer
+		fmt.Fprintf(&buf, "provider=%v%s", g.info.Name, sep)
+		fmt.Fprintf(&buf, "version=%v%s", g.info.Version, sep)
+		fmt.Fprintf(&buf, "path=%v%s", path, sep)
+		fmt.Fprintf(&buf, "docs=%v%s", docs, sep)
 
-			hash := fmt.Sprintf("%x", md5.Sum(buf.Bytes())) //nolint:gosec
+		hash := fmt.Sprintf("%x", md5.Sum(buf.Bytes())) //nolint:gosec
 
-			filePath := filepath.Join(dir, hash)
+		filePath := filepath.Join(cache.dir, hash)
 
-			bytes, err := os.ReadFile(filePath)
-			if err == nil {
-				// cache hit
-				return string(bytes)
-			}
-			// ignore the error, assume cache miss or file not found
-			defer func() {
-				// only write the cache for sizable results, >0.5kb
-				if len(result) > 512 {
-					// try to write to the cache
-					err := os.WriteFile(filePath, []byte(result), 0600)
-					if err != nil {
-						panic(fmt.Errorf("failed to write examples-cache: %w", err))
-					}
-				}
-			}()
+		bytes, err := os.ReadFile(filePath)
+		if err == nil {
+			// cache hit
+			return string(bytes)
 		}
+		// ignore the error, assume cache miss or file not found
+		defer func() {
+			// only write the cache for sizable results, >0.5kb
+			if len(result) > 512 {
+				// try to write to the cache
+				err := os.WriteFile(filePath, []byte(result), 0600)
+				if err != nil {
+					panic(fmt.Errorf("failed to write examples-cache: %w", err))
+				}
+			}
+		}()
 	}
 
 	if strings.Contains(docs, "```typescript") || strings.Contains(docs, "```python") ||

--- a/pkg/tfgen/examples_cache.go
+++ b/pkg/tfgen/examples_cache.go
@@ -69,6 +69,7 @@ func newExamplesCache(info *tfbridge.ProviderInfo, cacheDir string) *examplesCac
 	if !enabled {
 		return &examplesCache{}
 	}
+	contract.Assertf(dir != "", `Invalid %s=""`, pulumiConvertExamplesCacheDirEnvVar)
 	ec := &examplesCache{
 		enabled:      true,
 		dir:          dir,


### PR DESCRIPTION
This should fix failures like https://github.com/pulumi/pulumi-akamai/pull/476 and https://github.com/pulumi/pulumi-newrelic/pull/689. The full list of failures is https://github.com/search?q=org%3Apulumi+Update+GitHub+Actions+workflows.+is%3Aopen+AND+NOT+in%3Atitle+%22Bump+%22&type=pullrequests.

Originally removed in https://github.com/pulumi/pulumi-terraform-bridge/pull/1717.