### PR TITLE
Remove tfgen warning on unexpected snippets

### DIFF
--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -749,7 +749,7 @@ func (p *tfMarkdownParser) parseSection(h2Section []string) error {
 		}
 
 		// Remove the "Open in Cloud Shell" button if any and check for the presence of code snippets.
-		reformattedH3Section, hasExamples, isEmpty := p.reformatSubsection(h3Section)
+		reformattedH3Section, _, isEmpty := p.reformatSubsection(h3Section)
 		if isEmpty {
 			// Skip empty subsections (they just add unnecessary padding and headers).
 			continue

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -749,7 +749,7 @@ func (p *tfMarkdownParser) parseSection(h2Section []string) error {
 		}
 
 		// Remove the "Open in Cloud Shell" button if any and check for the presence of code snippets.
-		reformattedH3Section, _, isEmpty := p.reformatSubsection(h3Section)
+		reformattedH3Section, isEmpty := p.reformatSubsection(h3Section)
 		if isEmpty {
 			// Skip empty subsections (they just add unnecessary padding and headers).
 			continue
@@ -1229,9 +1229,9 @@ func isBlank(line string) bool {
 
 // reformatSubsection strips any "Open in Cloud Shell" buttons from the subsection and detects the presence of example
 // code snippets.
-func (p *tfMarkdownParser) reformatSubsection(lines []string) ([]string, bool, bool) {
+func (p *tfMarkdownParser) reformatSubsection(lines []string) ([]string, bool) {
 	var result []string
-	hasExamples, isEmpty := false, true
+	isEmpty := true
 
 	var inOICSButton bool // True if we are removing an "Open in Cloud Shell" button.
 	for i, line := range lines {
@@ -1243,18 +1243,15 @@ func (p *tfMarkdownParser) reformatSubsection(lines []string) ([]string, bool, b
 			if strings.Index(line, "<div") == 0 && strings.Contains(line, "oics-button") {
 				inOICSButton = true
 			} else {
-				if strings.Index(line, "```") == 0 {
-					hasExamples = true
-				} else if !isBlank(line) {
+				if !(strings.Index(line, "```") == 0) && !isBlank(line) {
 					isEmpty = false
 				}
-
 				result = append(result, line)
 			}
 		}
 	}
 
-	return result, hasExamples, isEmpty
+	return result, isEmpty
 }
 
 // convertExamples converts any code snippets in a subsection to Pulumi-compatible code. This conversion is done on a

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -754,11 +754,6 @@ func (p *tfMarkdownParser) parseSection(h2Section []string) error {
 			// Skip empty subsections (they just add unnecessary padding and headers).
 			continue
 		}
-		if hasExamples && sectionKind != sectionExampleUsage && sectionKind != sectionImports &&
-			!p.info.ReplaceExamplesSection() {
-			p.sink.warn("Unexpected code snippets in section '%v' for %v '%v'. The HCL code will be converted if possible, "+
-				"but may not display correctly in the generated docs.", header, p.kind, p.rawname)
-		}
 
 		// Now process the content based on the H2 topic. These are mostly standard across TF's docs.
 		switch sectionKind {


### PR DESCRIPTION
Analyzing 64 instances of this warning in pulumi-aws finding that these actually render appropriate in the Registry and
no action needs to be taken.

One example where we might need to take action is making the language chooser work, such as for the EMR Cluster resource.
https://github.com/pulumi/pulumi-hugo/issues/4133

Spot-checking the other resources, they seem to render fine. The sections are not always called Examples, but sometimes
are called Usage etc.

```


   1 warning: Unexpected code snippets in section 'Argument Reference' for data source 'aws_dx_router_configuration'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Argument Reference' for data source 'aws_ebs_volumes'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Argument Reference' for data source 'aws_licensemanager_grants'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Argument Reference' for data source 'aws_licensemanager_received_licenses'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Argument Reference' for data source 'aws_subnets'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   2 warning: Unexpected code snippets in section 'Argument Reference' for resource 'aws_appautoscaling_policy'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Argument Reference' for resource 'aws_appflow_flow'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Argument Reference' for resource 'aws_autoscaling_policy'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Argument Reference' for resource 'aws_cloudfront_distribution'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Argument Reference' for resource 'aws_cognito_user_pool'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Argument Reference' for resource 'aws_db_instance'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Argument Reference' for resource 'aws_ec2_fleet'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Argument Reference' for resource 'aws_emr_cluster'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Argument Reference' for resource 'aws_emr_instance_group'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Argument Reference' for resource 'aws_internet_gateway'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Argument Reference' for resource 'aws_kinesis_firehose_delivery_stream'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Argument Reference' for resource 'aws_neptune_cluster'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Argument Reference' for resource 'aws_networkmanager_core_network'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   4 warning: Unexpected code snippets in section 'Argument Reference' for resource 'aws_rds_cluster'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Argument Reference' for resource 'aws_s3_bucket_legacy'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   7 warning: Unexpected code snippets in section 'Argument Reference' for resource 'aws_s3_bucket_replication_configuration'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Argument Reference' for resource 'aws_servicecatalog_constraint'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Argument Reference' for resource 'aws_transfer_user'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Basic Usage with an AWS Customer Managed Key' for resource 'aws_ssmincidents_replication_set'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'CloudWatch Logging and Permissions' for resource 'aws_lambda_function'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Dead-letter queue' for resource 'aws_sqs_queue'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   2 warning: Unexpected code snippets in section 'Default Behavior and `IAMAllowedPrincipals`' for resource 'aws_lakeformation_permissions'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Encrypting the automated backup with KMS' for resource 'aws_db_instance_automated_backups_replication'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Example IPv6 Usage' for resource 'aws_route'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Example Update add-on usage with resolve_conflicts_on_update and PRESERVE' for resource 'aws_eks_addon'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   2 warning: Unexpected code snippets in section 'Example add-on usage with custom configuration_values' for resource 'aws_eks_addon'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Example all optional arguments' for resource 'aws_cloudwatch_event_archive'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Example in Conjunction with Scaling Policies' for resource 'aws_cloudwatch_metric_alarm'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Example including a RDS DB instance' for resource 'aws_db_instance_automated_backups_replication'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Example of monitoring Healthy Hosts on NLB using Target Group and NLB' for resource 'aws_cloudwatch_metric_alarm'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Example with Delivery Policy' for resource 'aws_sns_topic'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Example with First-In-First-Out (FIFO)' for resource 'aws_sns_topic'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Example with Server-side encryption (SSE)' for resource 'aws_sns_topic'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Example with an Expression' for resource 'aws_cloudwatch_metric_alarm'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'FIFO queue' for resource 'aws_sqs_queue'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'High-throughput FIFO queue' for resource 'aws_sqs_queue'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Lambda integration' for resource 'aws_api_gateway_integration'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Lustre Example' for resource 'aws_fsx_backup'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Multiple Region Usage' for resource 'aws_ecr_replication_configuration'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'ONTAP Example' for resource 'aws_fsx_backup'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'OpenZFS Example' for resource 'aws_fsx_backup'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Option Settings' for resource 'aws_elastic_beanstalk_environment'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Policy with a Custom Action for Stateless Inspection' for resource 'aws_networkfirewall_firewall_policy'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Policy with a HOME_NET Override' for resource 'aws_networkfirewall_firewall_policy'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Repository Filter Usage' for resource 'aws_ecr_replication_configuration'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Required Services Example' for resource 'aws_storagegateway_file_system_association'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Search by filters' for data source 'aws_ram_resource_share'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Server-side encryption (SSE)' for resource 'aws_sqs_queue'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Usage with Cognito User Pool Authorizer' for resource 'aws_api_gateway_method'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Usage with Logging Configuration to S3 Bucket' for resource 'aws_ivschat_room'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   2 warning: Unexpected code snippets in section 'Using With CloudFront' for resource 'aws_cloudfront_origin_access_identity'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Using with AutoScaling Groups' for resource 'aws_launch_configuration'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Using with Spot Instances' for resource 'aws_launch_configuration'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'VPC Link' for resource 'aws_api_gateway_integration'. The HCL code will be converted if possible, but may not display correctly in the generated docs.
   1 warning: Unexpected code snippets in section 'Windows Example' for resource 'aws_fsx_backup'. The HCL code will be converted if possible, but may not display correctly in the generated docs.

```