### PR TITLE
Reduce tfgen failing example warning verbosity

### DIFF
--- a/pkg/tfgen/convert_cli_test.go
+++ b/pkg/tfgen/convert_cli_test.go
@@ -341,6 +341,7 @@ This is some intentionally broken HCL that should not convert.
 		require.NoError(t, err)
 
 		autogold.Expect("").Equal(t, stdout.String())
+		//nolint:lll
 		autogold.Expect(`warning: unable to convert HCL example for Pulumi entity '#/resources/azure:webpubsub/customCertificate:CustomCertificate': 1 error occurred:
 * [csharp, go, java, python, typescript, yaml] <nil>: unexpected HCL snippet in Convert "\nThis is some intentionally broken HCL that should not convert.\n{}";
 

--- a/pkg/tfgen/convert_cli_test.go
+++ b/pkg/tfgen/convert_cli_test.go
@@ -341,19 +341,8 @@ This is some intentionally broken HCL that should not convert.
 		require.NoError(t, err)
 
 		autogold.Expect("").Equal(t, stdout.String())
-		autogold.Expect(`warning: failed to convert HCL for #/resources/azure:webpubsub/customCertificate:CustomCertificate to typescript: <nil>: unexpected HCL snippet in Convert "\nThis is some intentionally broken HCL that should not convert.\n{}";
-warning: failed to convert HCL for #/resources/azure:webpubsub/customCertificate:CustomCertificate to python: <nil>: unexpected HCL snippet in Convert "\nThis is some intentionally broken HCL that should not convert.\n{}";
-warning: failed to convert HCL for #/resources/azure:webpubsub/customCertificate:CustomCertificate to csharp: <nil>: unexpected HCL snippet in Convert "\nThis is some intentionally broken HCL that should not convert.\n{}";
-warning: failed to convert HCL for #/resources/azure:webpubsub/customCertificate:CustomCertificate to go: <nil>: unexpected HCL snippet in Convert "\nThis is some intentionally broken HCL that should not convert.\n{}";
-warning: failed to convert HCL for #/resources/azure:webpubsub/customCertificate:CustomCertificate to yaml: <nil>: unexpected HCL snippet in Convert "\nThis is some intentionally broken HCL that should not convert.\n{}";
-warning: failed to convert HCL for #/resources/azure:webpubsub/customCertificate:CustomCertificate to java: <nil>: unexpected HCL snippet in Convert "\nThis is some intentionally broken HCL that should not convert.\n{}";
-warning: unable to convert HCL example for Pulumi entity '#/resources/azure:webpubsub/customCertificate:CustomCertificate': 6 errors occurred:
-* <nil>: unexpected HCL snippet in Convert "\nThis is some intentionally broken HCL that should not convert.\n{}";
-* <nil>: unexpected HCL snippet in Convert "\nThis is some intentionally broken HCL that should not convert.\n{}";
-* <nil>: unexpected HCL snippet in Convert "\nThis is some intentionally broken HCL that should not convert.\n{}";
-* <nil>: unexpected HCL snippet in Convert "\nThis is some intentionally broken HCL that should not convert.\n{}";
-* <nil>: unexpected HCL snippet in Convert "\nThis is some intentionally broken HCL that should not convert.\n{}";
-* <nil>: unexpected HCL snippet in Convert "\nThis is some intentionally broken HCL that should not convert.\n{}";
+		autogold.Expect(`warning: unable to convert HCL example for Pulumi entity '#/resources/azure:webpubsub/customCertificate:CustomCertificate': 1 error occurred:
+* [csharp, go, java, python, typescript, yaml] <nil>: unexpected HCL snippet in Convert "\nThis is some intentionally broken HCL that should not convert.\n{}";
 
 . The example will be dropped from any generated docs or SDKs.
 `).Equal(t, stderr.String())

--- a/pkg/tfgen/convert_cli_test.go
+++ b/pkg/tfgen/convert_cli_test.go
@@ -342,10 +342,10 @@ This is some intentionally broken HCL that should not convert.
 
 		autogold.Expect("").Equal(t, stdout.String())
 		//nolint:lll
-		autogold.Expect(`warning: unable to convert HCL example for Pulumi entity '#/resources/azure:webpubsub/customCertificate:CustomCertificate': 1 error occurred:
+		autogold.Expect(`warning: unable to convert HCL example for Pulumi entity '#/resources/azure:webpubsub/customCertificate:CustomCertificate'. The example will be dropped from any generated docs or SDKs: 1 error occurred:
 * [csharp, go, java, python, typescript, yaml] <nil>: unexpected HCL snippet in Convert "\nThis is some intentionally broken HCL that should not convert.\n{}";
 
-. The example will be dropped from any generated docs or SDKs.
+
 `).Equal(t, stderr.String())
 	})
 

--- a/pkg/tfgen/convert_cli_test.go
+++ b/pkg/tfgen/convert_cli_test.go
@@ -287,6 +287,78 @@ resource "azurerm_web_pubsub_custom_certificate" "test" {
 		require.NoError(t, err)
 	})
 
+	t.Run("broken-hcl-warnings", func(t *testing.T) {
+		md := []byte(strings.ReplaceAll(`
+# azurerm_web_pubsub_custom_certificate
+
+Manages an Azure Web PubSub Custom Certificate.
+
+## Example Usage
+
+%%%hcl
+
+This is some intentionally broken HCL that should not convert.
+%%%`, "%%%", "```"))
+		p := &schema.Provider{
+			ResourcesMap: map[string]*schema.Resource{
+				"azurerm_web_pubsub_custom_certificate": {
+					Schema: map[string]*schema.Schema{"name": {
+						Type:     schema.TypeString,
+						Optional: true,
+					}},
+				},
+			},
+		}
+		pi := tfbridge.ProviderInfo{
+			P:       shimv2.NewProvider(p),
+			Name:    "azurerm",
+			Version: "0.0.1",
+			Resources: map[string]*tfbridge.ResourceInfo{
+				"azurerm_web_pubsub_custom_certificate": {
+					Tok:  "azure:webpubsub/customCertificate:CustomCertificate",
+					Docs: &tfbridge.DocInfo{Markdown: md},
+				},
+			},
+		}
+
+		var stdout bytes.Buffer
+		var stderr bytes.Buffer
+
+		g, err := NewGenerator(GeneratorOptions{
+			Package:      "azure",
+			Version:      "0.0.1",
+			PluginHost:   &testPluginHost{},
+			Language:     Schema,
+			ProviderInfo: pi,
+			Root:         afero.NewBasePathFs(afero.NewOsFs(), t.TempDir()),
+			Sink: diag.DefaultSink(&stdout, &stderr, diag.FormatOptions{
+				Color: colors.Never,
+			}),
+		})
+		require.NoError(t, err)
+
+		err = g.Generate()
+		require.NoError(t, err)
+
+		autogold.Expect("").Equal(t, stdout.String())
+		autogold.Expect(`warning: failed to convert HCL for #/resources/azure:webpubsub/customCertificate:CustomCertificate to typescript: <nil>: unexpected HCL snippet in Convert "\nThis is some intentionally broken HCL that should not convert.\n{}";
+warning: failed to convert HCL for #/resources/azure:webpubsub/customCertificate:CustomCertificate to python: <nil>: unexpected HCL snippet in Convert "\nThis is some intentionally broken HCL that should not convert.\n{}";
+warning: failed to convert HCL for #/resources/azure:webpubsub/customCertificate:CustomCertificate to csharp: <nil>: unexpected HCL snippet in Convert "\nThis is some intentionally broken HCL that should not convert.\n{}";
+warning: failed to convert HCL for #/resources/azure:webpubsub/customCertificate:CustomCertificate to go: <nil>: unexpected HCL snippet in Convert "\nThis is some intentionally broken HCL that should not convert.\n{}";
+warning: failed to convert HCL for #/resources/azure:webpubsub/customCertificate:CustomCertificate to yaml: <nil>: unexpected HCL snippet in Convert "\nThis is some intentionally broken HCL that should not convert.\n{}";
+warning: failed to convert HCL for #/resources/azure:webpubsub/customCertificate:CustomCertificate to java: <nil>: unexpected HCL snippet in Convert "\nThis is some intentionally broken HCL that should not convert.\n{}";
+warning: unable to convert HCL example for Pulumi entity '#/resources/azure:webpubsub/customCertificate:CustomCertificate': 6 errors occurred:
+* <nil>: unexpected HCL snippet in Convert "\nThis is some intentionally broken HCL that should not convert.\n{}";
+* <nil>: unexpected HCL snippet in Convert "\nThis is some intentionally broken HCL that should not convert.\n{}";
+* <nil>: unexpected HCL snippet in Convert "\nThis is some intentionally broken HCL that should not convert.\n{}";
+* <nil>: unexpected HCL snippet in Convert "\nThis is some intentionally broken HCL that should not convert.\n{}";
+* <nil>: unexpected HCL snippet in Convert "\nThis is some intentionally broken HCL that should not convert.\n{}";
+* <nil>: unexpected HCL snippet in Convert "\nThis is some intentionally broken HCL that should not convert.\n{}";
+
+. The example will be dropped from any generated docs or SDKs.
+`).Equal(t, stderr.String())
+	})
+
 	t.Run("regress-1839", func(t *testing.T) {
 		mdPath := filepath.Join(
 			"test_data",

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -1793,8 +1793,8 @@ func (g *Generator) convertHCL(e *Example, hcl, path string, languages []string)
 			err = multierror.Append(err, fmt.Errorf("[%s] %w", ls, convertErr))
 		}
 
-		g.warn(fmt.Sprintf("unable to convert HCL example for Pulumi entity '%s': %v. The example will be dropped "+
-			"from any generated docs or SDKs.", path, err))
+		g.warn("unable to convert HCL example for Pulumi entity '%s'. The example will be dropped "+
+			"from any generated docs or SDKs: %v", path, err)
 
 		return "", err
 	}

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -1764,13 +1764,14 @@ func (g *Generator) convertHCL(e *Example, hcl, path string, languages []string)
 	isCompleteFailure := len(failedLangs) == len(languages)
 
 	if isCompleteFailure {
+		// Index sets of languages by error message to avoid emitting similar errors for each language.
 		languagesByErrMsg := map[string]map[string]struct{}{}
 		for lang, convertErr := range failedLangs {
-			m := convertErr.Error()
-			if _, ok := languagesByErrMsg[m]; !ok {
-				languagesByErrMsg[m] = map[string]struct{}{}
+			errMsg := convertErr.Error()
+			if _, ok := languagesByErrMsg[errMsg]; !ok {
+				languagesByErrMsg[errMsg] = map[string]struct{}{}
 			}
-			languagesByErrMsg[m][lang] = struct{}{}
+			languagesByErrMsg[errMsg][lang] = struct{}{}
 		}
 
 		var err error
@@ -1780,15 +1781,15 @@ func (g *Generator) convertHCL(e *Example, hcl, path string, languages []string)
 			if _, dup := seen[convertErr.Error()]; dup {
 				continue
 			}
-			m := convertErr.Error()
-			seen[m] = struct{}{}
+			errMsg := convertErr.Error()
+			seen[errMsg] = struct{}{}
 
 			langs := []string{}
-			for l := range languagesByErrMsg[m] {
+			for l := range languagesByErrMsg[errMsg] {
 				langs = append(langs, l)
 			}
 			sort.Strings(langs)
-			ls := strings.Join(langs, ", ")
+			ls := strings.Join(langs, ", ") // all languages that have this error
 			err = multierror.Append(err, fmt.Errorf("[%s] %w", ls, convertErr))
 		}
 

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -1753,7 +1753,6 @@ func (g *Generator) convertHCL(e *Example, hcl, path string, languages []string)
 		hclConversions[lang], convertErr = g.convertHCLToString(e, hcl, path, lang)
 		if convertErr != nil {
 			failedLangs[lang] = convertErr
-			//err = multierror.Append(err, convertErr)
 		}
 	}
 


### PR DESCRIPTION
Before this change we emitted a lot of duplicated warnings for examples that failed to convert. This change removes the
duplication and aggregates similar errors so that when every language conversion fails with the same error, which is
common when the failure pertains to the HCL->PCL pass of the conversion, we get one warning only not many.