### PR TITLE
Add env vars to speed up bisecting tfgen

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,4 @@ tfgen, the command that generates Pulumi schema/code for a bridged provider supp
 * `PULUMI_SKIP_EXTRA_MAPPING_ERROR`: If truthy, tfgen will not fail if a mapped data source or resource does not exist in the TF provider. Instead, warning is printed. Default is `false`.
 * `PULUMI_MISSING_DOCS_ERROR`: If truthy, tfgen will fail if docs cannot be found for a data source or resource. Default is `false`.
 * `PULUMI_CONVERT`: If truthy, tfgen will shell out to `pulumi convert` for converting example code from TF HCL to Pulumi PCL
+* `PULUMI_CONVERT_ONLY`: If set to a resource or data source ID such as "aws_acm_certificate" will convert docs only for that single resource; useful to speed up debugging docs issues

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -285,6 +285,13 @@ func getDocsForResource(g *Generator, source DocsSource, kind DocKind,
 		panic("unknown docs kind")
 	}
 
+	// If requested, speed up debugging schema generation by targeting only one resource or datasource.
+	if t, ok := os.LookupEnv("PULUMI_CONVERT_ONLY"); ok {
+		if t != rawname {
+			docFile = nil
+		}
+	}
+
 	if err != nil {
 		return entityDocs{}, fmt.Errorf("get docs for token %s: %w", rawname, err)
 	}

--- a/pkg/tfgen/examples_cache.go
+++ b/pkg/tfgen/examples_cache.go
@@ -65,6 +65,13 @@ func newExamplesCache(info *tfbridge.ProviderInfo, cacheDir string) *examplesCac
 	enabled := true
 	if dir == "" {
 		dir, enabled = os.LookupEnv(pulumiConvertExamplesCacheDirEnvVar)
+		// If the provider author is debugging schema generation, example cache may get in the way of getting
+		// accurate results - there are some problems at the intersection of using Go workspaces and computing
+		// accurate keys. Disable it.
+		_, convertOnly := os.LookupEnv("PULUMI_CONVERT_ONLY")
+		if convertOnly {
+			enabled = false
+		}
 	}
 	if !enabled {
 		return &examplesCache{}


### PR DESCRIPTION
Schema generation takes a long time for large providers like pulumi-aws and adding these helper env vars to limit it to
one problematic resource or data source can be a helpful tool to speed up bisecting over bridge ranges.