### PR TITLE
Remove `rawNames` from `makeObjectTerraformInputs`

### DIFF
--- a/pkg/tfbridge/diff.go
+++ b/pkg/tfbridge/diff.go
@@ -103,7 +103,7 @@ func visitPropertyValue(
 				// fill in default values for empty fields (note that this is a property of the field reader, not of
 				// the schema) as it does when computing the hash code for a set element.
 				ctx := &conversionContext{Ctx: ctx}
-				ev, err := ctx.makeTerraformInput(ep, resource.PropertyValue{}, e, etfs, eps, rawNames)
+				ev, err := ctx.makeTerraformInput(ep, resource.PropertyValue{}, e, etfs, eps)
 				if err != nil {
 					return
 				}

--- a/pkg/tfbridge/diff.go
+++ b/pkg/tfbridge/diff.go
@@ -145,7 +145,7 @@ func visitPropertyValue(
 						elementPath = fmt.Sprintf("%s.%s", path, k)
 					}
 
-					en, etf, eps := getInfoFromPulumiName(k, tfflds, psflds, false)
+					en, etf, eps := getInfoFromPulumiName(k, tfflds, psflds)
 					visitPropertyValue(ctx, name+"."+en, elementPath, e, etf, eps, visitor)
 				}
 				return
@@ -305,11 +305,11 @@ func computeIgnoreChanges(
 		return true
 	}
 	for k, v := range olds {
-		en, etf, eps := getInfoFromPulumiName(k, tfs, ps, false)
+		en, etf, eps := getInfoFromPulumiName(k, tfs, ps)
 		visitPropertyValue(ctx, en, string(k), v, etf, eps, visitor)
 	}
 	for k, v := range news {
-		en, etf, eps := getInfoFromPulumiName(k, tfs, ps, false)
+		en, etf, eps := getInfoFromPulumiName(k, tfs, ps)
 		visitPropertyValue(ctx, en, string(k), v, etf, eps, visitor)
 	}
 	return ignoredKeySet
@@ -361,17 +361,17 @@ func makeDetailedDiffExtra(
 	diff := map[string]*pulumirpc.PropertyDiff{}
 	collectionDiffs := map[string]*pulumirpc.PropertyDiff{}
 	for k, v := range olds {
-		en, etf, eps := getInfoFromPulumiName(k, tfs, ps, false)
+		en, etf, eps := getInfoFromPulumiName(k, tfs, ps)
 		makePropertyDiff(ctx, en, string(k), v, tfDiff, diff, collectionDiffs, forceDiff,
 			etf, eps, false)
 	}
 	for k, v := range news {
-		en, etf, eps := getInfoFromPulumiName(k, tfs, ps, false)
+		en, etf, eps := getInfoFromPulumiName(k, tfs, ps)
 		makePropertyDiff(ctx, en, string(k), v, tfDiff, diff, collectionDiffs, forceDiff,
 			etf, eps, false)
 	}
 	for k, v := range olds {
-		en, etf, eps := getInfoFromPulumiName(k, tfs, ps, false)
+		en, etf, eps := getInfoFromPulumiName(k, tfs, ps)
 		makePropertyDiff(ctx, en, string(k), v, tfDiff, diff, collectionDiffs, forceDiff,
 			etf, eps, true)
 	}

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -810,7 +810,7 @@ func (p *Provider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (*pul
 
 	// After all is said and done, we need to go back and return only what got populated as a diff from the origin.
 	pinputs := MakeTerraformOutputs(
-		ctx, p.tf, inputs, res.TF.Schema(), res.Schema.Fields, assets, false, p.supportsSecrets,
+		ctx, p.tf, inputs, res.TF.Schema(), res.Schema.Fields, assets, p.supportsSecrets,
 	)
 
 	pinputsWithSecrets := MarkSchemaSecrets(ctx, res.TF.Schema(), res.Schema.Fields,

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -626,7 +626,7 @@ func (ctx *conversionContext) makeObjectTerraformInputs(
 	}
 
 	// Now enumerate and propagate defaults if the corresponding values are still missing.
-	if err := ctx.applyDefaults(result, olds, news, tfs, ps, false); err != nil {
+	if err := ctx.applyDefaults(result, olds, news, tfs, ps); err != nil {
 		return nil, err
 	}
 
@@ -710,7 +710,6 @@ func (ctx *conversionContext) applyDefaults(
 	olds, news resource.PropertyMap,
 	tfs shim.SchemaMap,
 	ps map[string]*SchemaInfo,
-	rawNames bool,
 ) error {
 
 	if !ctx.ApplyDefaults {
@@ -756,7 +755,7 @@ func (ctx *conversionContext) applyDefaults(
 			var source string
 
 			// If we already have a default value from a previous version of this resource, use that instead.
-			key, tfi, psi := getInfoFromTerraformName(name, tfs, ps, rawNames)
+			key, tfi, psi := getInfoFromTerraformName(name, tfs, ps, false)
 
 			if old, hasold := olds[key]; hasold && useOldDefault(key) {
 				v, err := ctx.makeTerraformInput(name, resource.PropertyValue{},
@@ -908,8 +907,9 @@ func (ctx *conversionContext) applyDefaults(
 					return true
 				}
 
-				// Next, if we already have a default value from a previous version of this resource, use that instead.
-				key, tfi, psi := getInfoFromTerraformName(name, tfs, ps, rawNames)
+				// Next, if we already have a default value from a previous version of this
+				// resource, use that instead.
+				key, tfi, psi := getInfoFromTerraformName(name, tfs, ps, false)
 
 				if old, hasold := olds[key]; hasold && useOldDefault(key) {
 					v, err := ctx.makeTerraformInput(name, resource.PropertyValue{}, old, tfi, psi)

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -68,7 +68,7 @@ func makeTerraformInputsForCreate(olds, news resource.PropertyMap,
 
 func makeTerraformInput(v resource.PropertyValue, tfs shim.Schema, ps *SchemaInfo) (interface{}, error) {
 	ctx := &conversionContext{}
-	return ctx.makeTerraformInput("v", resource.PropertyValue{}, v, tfs, ps, false)
+	return ctx.makeTerraformInput("v", resource.PropertyValue{}, v, tfs, ps)
 }
 
 func TestMakeTerraformInputMixedMaxItemsOne(t *testing.T) {

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -3130,6 +3130,32 @@ func Test_makeTerraformInputsNoDefaults(t *testing.T) {
 			expect: autogold.Expect(map[string]interface{}{"nested_resource": []interface{}{map[string]interface{}{"configuration": map[string]interface{}{"configurationValue": true}}}}),
 		},
 		{
+			testCaseName: "set_nested_block",
+			schemaMap: map[string]*schema.Schema{
+				"nested_resource": {
+					Optional: true,
+					Type:     shim.TypeSet,
+					Elem: (&schema.Resource{
+						Schema: schemaMap(map[string]*schema.Schema{
+							"configuration": {
+								Type:     shim.TypeMap,
+								Optional: true,
+							},
+						}),
+					}).Shim(),
+				},
+			},
+			propMap: resource.NewPropertyMapFromMap(map[string]interface{}{
+				"nestedResources": []map[string]interface{}{{
+					"configuration": map[string]interface{}{
+						"configurationValue": true,
+					},
+				}},
+			}),
+			//nolint:lll
+			expect: autogold.Expect(map[string]interface{}{"nested_resource": []interface{}{map[string]interface{}{"configuration": map[string]interface{}{"configurationValue": true}}}}),
+		},
+		{
 			testCaseName: "optional_config",
 			schemaMap: map[string]*schema.Schema{
 				"optional_config": {
@@ -3262,6 +3288,40 @@ func Test_makeTerraformInputsNoDefaults(t *testing.T) {
 				"nilPropertyValue": nil,
 			}),
 			expect: autogold.Expect(map[string]interface{}{"nil_property_value": nil}),
+		},
+		{
+			testCaseName: "set_attribute",
+			schemaMap: map[string]*schema.Schema{
+				"set_attribute": {
+					Type:     shim.TypeSet,
+					Optional: true,
+					Elem:     (&schema.Schema{Type: shim.TypeInt}).Shim(),
+				},
+			},
+			propMap: resource.PropertyMap{
+				"set_attribute": resource.NewProperty([]resource.PropertyValue{
+					resource.NewProperty(1.0),
+					resource.NewProperty(2.0),
+				}),
+			},
+			expect: autogold.Expect(map[string]interface{}{"set_attribute": []interface{}{1, 2}}),
+		},
+		{
+			testCaseName: "list_attribute",
+			schemaMap: map[string]*schema.Schema{
+				"set_attribute": {
+					Type:     shim.TypeList,
+					Optional: true,
+					Elem:     (&schema.Schema{Type: shim.TypeInt}).Shim(),
+				},
+			},
+			propMap: resource.PropertyMap{
+				"set_attribute": resource.NewProperty([]resource.PropertyValue{
+					resource.NewProperty(1.0),
+					resource.NewProperty(2.0),
+				}),
+			},
+			expect: autogold.Expect(map[string]interface{}{"set_attribute": []interface{}{1, 2}}),
 		},
 		// {
 		// 	testCaseName: "???",

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -3082,7 +3082,7 @@ func Test_makeTerraformInputsNoDefaults(t *testing.T) {
 				},
 			}),
 			//nolint:lll
-			expect: autogold.Expect(map[string]interface{}{"property_a": "a", "property_b": true, "property_c": map[string]interface{}{"nested_property_a": true}}),
+			expect: autogold.Expect(map[string]interface{}{"property_a": "a", "property_b": true, "property_c": map[string]interface{}{"nestedPropertyA": true}}),
 		},
 		{
 			testCaseName: "list_nested_block",


### PR DESCRIPTION
It never makes sense to pass `rawNames=true` to `makeObjectTerraformInputs` since that implies we have an object type with properties, but that we should not do property name translations. This is never the case.

This PR introduces a subtle change in behavior when walking values of unknown type:

Before this PR, we assumed that an untyped `resource.PropertyMap` was an object (name translation is performed) but all nested `resource.PropertyMap` values were then assumed to be a map (name translation is not performed).

After this PR, we treat all untyped `resource.PropertyMap` values as maps. IMO this makes more sense: the rule is we don't apply name translation unless we know a value is an object (and can thus generate naming tables for it).

I don't expect that this change will break users since user's should never hit untyped values. If they do, neither before or after will work consistently.

Addressing the test change:

"object_property_value" was used to test object names but never given a type. In light of the above change, we needed to make it typed to get the expected name translation.

---

Fixes #1830 

This PR is best reviewed on a commit by commit basis. Each commit passes tests and includes a description of what it does (if anything). The commits build, with each commit able to remove `rawNames` from one additional place.