### PR TITLE
Ensure validate called during tfgen

### DIFF
--- a/internal/testprovider_invalid_schema/.gitignore
+++ b/internal/testprovider_invalid_schema/.gitignore
@@ -1,0 +1,1 @@
+*/cmd/*/Pulumi.yaml

--- a/internal/testprovider_invalid_schema/README.md
+++ b/internal/testprovider_invalid_schema/README.md
@@ -1,0 +1,5 @@
+# testprovider_sdkv2
+
+Defines a provider using `github.com/hashicorp/terraform-plugin-sdk/v2` that is dedicated to testing the features of
+`pulumi-terraform-bridge`. Specifically the provider is crafted to support `ProgramTest` tests that exercise it together
+with the latest Pulumi CLI. These tests verify that the bridged providers integrate correctly with the engine.

--- a/internal/testprovider_invalid_schema/cmd/pulumi-resource-tpinvschema/main.go
+++ b/internal/testprovider_invalid_schema/cmd/pulumi-resource-tpinvschema/main.go
@@ -1,0 +1,29 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	_ "embed"
+
+	tpinvschema "github.com/pulumi/pulumi-terraform-bridge/v3/internal/testprovider_invalid_schema"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+)
+
+//go:embed schema.json
+var pulumiSchema []byte
+
+func main() {
+	tfbridge.Main("tpinvschema", "1.0.0", tpinvschema.ProviderInfo(), pulumiSchema)
+}

--- a/internal/testprovider_invalid_schema/cmd/pulumi-resource-tpinvschema/schema.json
+++ b/internal/testprovider_invalid_schema/cmd/pulumi-resource-tpinvschema/schema.json
@@ -1,0 +1,69 @@
+{
+    "name": "tpinvschema",
+    "attribution": "This Pulumi package is based on the [`tpinvschema` Terraform Provider](https://github.com/terraform-providers/terraform-provider-tpinvschema).",
+    "meta": {
+        "moduleFormat": "(.*)(?:/[^/]*)"
+    },
+    "language": {
+        "nodejs": {
+            "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-tpinvschema)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-tpinvschema` repo](/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-tpinvschema` repo](https://github.com/terraform-providers/terraform-provider-tpinvschema/issues).",
+            "compatibility": "tfbridge20",
+            "disableUnionOutputTypes": true
+        },
+        "python": {
+            "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-tpinvschema)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-tpinvschema` repo](/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-tpinvschema` repo](https://github.com/terraform-providers/terraform-provider-tpinvschema/issues).",
+            "compatibility": "tfbridge20",
+            "pyproject": {}
+        }
+    },
+    "config": {},
+    "provider": {
+        "description": "The provider type for the tpinvschema package. By default, resources use package-wide configuration\nsettings, however an explicit `Provider` instance may be created and passed during resource\nconstruction to achieve fine-grained programmatic control over provider settings. See the\n[documentation](https://www.pulumi.com/docs/reference/programming-model/#providers) for more information.\n"
+    },
+    "resources": {
+        "tpinvschema:index/invalid_res:invalid_res": {
+            "properties": {
+                "blockStringProp": {
+                    "type": "string"
+                },
+                "computedDefaultProp": {
+                    "type": "string"
+                },
+                "maxItemsStringProp": {
+                    "type": "string"
+                },
+                "optAndReqProp": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "blockStringProp",
+                "computedDefaultProp",
+                "maxItemsStringProp"
+            ],
+            "inputProperties": {
+                "optAndReqProp": {
+                    "type": "string"
+                }
+            },
+            "stateInputs": {
+                "description": "Input properties used for looking up and filtering invalid_res resources.\n",
+                "properties": {
+                    "blockStringProp": {
+                        "type": "string"
+                    },
+                    "computedDefaultProp": {
+                        "type": "string"
+                    },
+                    "maxItemsStringProp": {
+                        "type": "string"
+                    },
+                    "optAndReqProp": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            }
+        }
+    }
+}

--- a/internal/testprovider_invalid_schema/cmd/pulumi-tfgen-tpinvschema/main.go
+++ b/internal/testprovider_invalid_schema/cmd/pulumi-tfgen-tpinvschema/main.go
@@ -1,0 +1,24 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	tpinvschema "github.com/pulumi/pulumi-terraform-bridge/v3/internal/testprovider_invalid_schema"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen"
+)
+
+func main() {
+	tfgen.Main("tpinvschema", "1.0.0", tpinvschema.ProviderInfo())
+}

--- a/internal/testprovider_invalid_schema/provider.go
+++ b/internal/testprovider_invalid_schema/provider.go
@@ -1,0 +1,102 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tpinvschema
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// An assortment of invalid resources according to
+// https://github.com/pulumi/terraform-plugin-sdk/blob/b374785cb6462f8d89eb31d4874a9e3228d74633/helper/schema/resource.go#L1132
+//
+//nolint:lll
+func Provider() *schema.Provider {
+	return &schema.Provider{
+		Schema: map[string]*schema.Schema{},
+		ResourcesMap: map[string]*schema.Resource{
+			"invalid_res": {
+				Schema: map[string]*schema.Schema{
+					"opt_and_req_prop": {
+						Type:     schema.TypeString,
+						Optional: true,
+						Required: true,
+					},
+				},
+				Create: func(*schema.ResourceData, interface{}) error { return nil },
+				Update: func(*schema.ResourceData, interface{}) error { return nil },
+				Read:   func(*schema.ResourceData, interface{}) error { return nil },
+				Delete: func(*schema.ResourceData, interface{}) error { return nil },
+			},
+			"no_read_res": {
+				Schema: map[string]*schema.Schema{},
+				Create: func(*schema.ResourceData, interface{}) error { return nil },
+				Delete: func(*schema.ResourceData, interface{}) error { return nil },
+			},
+			"block_string_res": {
+				Schema: map[string]*schema.Schema{
+					"block_string_prop": {
+						Type:       schema.TypeString,
+						Required:   true,
+						ConfigMode: schema.SchemaConfigModeBlock,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+				},
+				Create: func(*schema.ResourceData, interface{}) error { return nil },
+				Update: func(*schema.ResourceData, interface{}) error { return nil },
+				Read:   func(*schema.ResourceData, interface{}) error { return nil },
+				Delete: func(*schema.ResourceData, interface{}) error { return nil },
+			},
+			"computed_default_res": {
+				Schema: map[string]*schema.Schema{
+					"computed_default_prop": {
+						Type:     schema.TypeString,
+						Computed: true,
+						Default:  "default",
+					},
+				},
+				Create: func(*schema.ResourceData, interface{}) error { return nil },
+				Read:   func(*schema.ResourceData, interface{}) error { return nil },
+				Delete: func(*schema.ResourceData, interface{}) error { return nil },
+			},
+			"max_string_res": {
+				Schema: map[string]*schema.Schema{
+					"max_string_prop": {
+						Type:     schema.TypeString,
+						MaxItems: 1,
+						Optional: true,
+					},
+				},
+				Create: func(*schema.ResourceData, interface{}) error { return nil },
+				Update: func(*schema.ResourceData, interface{}) error { return nil },
+				Read:   func(*schema.ResourceData, interface{}) error { return nil },
+				Delete: func(*schema.ResourceData, interface{}) error { return nil },
+			},
+			"create_and_create_context_res": {
+				Schema: map[string]*schema.Schema{},
+				Create: func(*schema.ResourceData, interface{}) error { return nil },
+				Read:   func(*schema.ResourceData, interface{}) error { return nil },
+				Delete: func(*schema.ResourceData, interface{}) error { return nil },
+				CreateContext: func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics {
+					return nil
+				},
+			},
+		},
+	}
+}

--- a/internal/testprovider_invalid_schema/resources.go
+++ b/internal/testprovider_invalid_schema/resources.go
@@ -1,0 +1,40 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tpinvschema
+
+import (
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	sdkv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
+func ProviderInfo() tfbridge.ProviderInfo {
+	prov := tfbridge.ProviderInfo{
+		P:    sdkv2.NewProvider(Provider()),
+		Name: "tpinvschema",
+
+		PreConfigureCallback: func(vars resource.PropertyMap, config shim.ResourceConfig) error {
+			return nil
+		},
+		Resources: map[string]*tfbridge.ResourceInfo{
+			"invalid_res": {
+				Tok: tfbridge.MakeResource("tpinvschema", "index", "invalid_res"),
+			},
+		},
+	}
+
+	return prov
+}

--- a/pf/internal/schemashim/provider.go
+++ b/pf/internal/schemashim/provider.go
@@ -61,7 +61,7 @@ func (p *SchemaOnlyProvider) DataSourcesMap() shim.ResourceMap {
 }
 
 func (p *SchemaOnlyProvider) Validate(context.Context, shim.ResourceConfig) ([]string, []error) {
-	panic("schemaOnlyProvider does not implement runtime operation Validate")
+	return nil, nil
 }
 
 func (p *SchemaOnlyProvider) ValidateResource(
@@ -126,7 +126,7 @@ func (p *SchemaOnlyProvider) NewDestroyDiff(context.Context, string, shim.Timeou
 }
 
 func (p *SchemaOnlyProvider) NewResourceConfig(context.Context, map[string]interface{}) shim.ResourceConfig {
-	panic("schemaOnlyProvider does not implement runtime operation ResourceConfig")
+	return nil
 }
 
 func (p *SchemaOnlyProvider) IsSet(context.Context, interface{}) ([]interface{}, bool) {

--- a/pf/internal/schemashim/provider.go
+++ b/pf/internal/schemashim/provider.go
@@ -16,6 +16,7 @@ package schemashim
 
 import (
 	"context"
+
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 
 	pfprovider "github.com/hashicorp/terraform-plugin-framework/provider"

--- a/pf/internal/schemashim/provider.go
+++ b/pf/internal/schemashim/provider.go
@@ -61,7 +61,7 @@ func (p *SchemaOnlyProvider) DataSourcesMap() shim.ResourceMap {
 }
 
 func (p *SchemaOnlyProvider) InternalValidate() error {
-    return nil
+	return nil
 }
 
 func (p *SchemaOnlyProvider) Validate(context.Context, shim.ResourceConfig) ([]string, []error) {

--- a/pf/internal/schemashim/provider.go
+++ b/pf/internal/schemashim/provider.go
@@ -16,6 +16,7 @@ package schemashim
 
 import (
 	"context"
+
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 
 	pfprovider "github.com/hashicorp/terraform-plugin-framework/provider"
@@ -59,8 +60,12 @@ func (p *SchemaOnlyProvider) DataSourcesMap() shim.ResourceMap {
 	return &schemaOnlyDataSourceMap{dataSources}
 }
 
+func (p *SchemaOnlyProvider) InternalValidate() error {
+    return nil
+}
+
 func (p *SchemaOnlyProvider) Validate(context.Context, shim.ResourceConfig) ([]string, []error) {
-	return nil, nil
+	panic("schemaOnlyProvider does not implement runtime operation Validate")
 }
 
 func (p *SchemaOnlyProvider) ValidateResource(
@@ -125,7 +130,7 @@ func (p *SchemaOnlyProvider) NewDestroyDiff(context.Context, string, shim.Timeou
 }
 
 func (p *SchemaOnlyProvider) NewResourceConfig(context.Context, map[string]interface{}) shim.ResourceConfig {
-	return nil
+	panic("schemaOnlyProvider does not implement runtime operation ResourceConfig")
 }
 
 func (p *SchemaOnlyProvider) IsSet(context.Context, interface{}) ([]interface{}, bool) {

--- a/pf/internal/schemashim/provider.go
+++ b/pf/internal/schemashim/provider.go
@@ -16,7 +16,6 @@ package schemashim
 
 import (
 	"context"
-
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 
 	pfprovider "github.com/hashicorp/terraform-plugin-framework/provider"

--- a/pf/tfgen/main.go
+++ b/pf/tfgen/main.go
@@ -86,11 +86,11 @@ func MainWithMuxer(provider string, info sdkBridge.ProviderInfo) {
 	// Validate any sdk providers that are being muxed in.
 	for _, prov := range shim.MuxedProviders {
 		err := prov.InternalValidate()
-		if err!= nil {
+		if err != nil {
 			_, fmterr := fmt.Fprintf(os.Stderr, "Internal validation of the provider failed: %v\n", err)
 			contract.IgnoreError(fmterr)
 			os.Exit(-1)
-        }
+		}
 	}
 
 	tfgen.MainWithCustomGenerate(provider, info.Version, info, func(opts tfgen.GeneratorOptions) error {

--- a/pf/tfgen/main.go
+++ b/pf/tfgen/main.go
@@ -87,7 +87,7 @@ func MainWithMuxer(provider string, info sdkBridge.ProviderInfo) {
 	for _, prov := range shim.MuxedProviders {
 		err := prov.InternalValidate()
 		if err!= nil {
-            _, fmterr := fmt.Fprintf(os.Stderr, "Internal validation of the provider failed: %v\n", err)
+			_, fmterr := fmt.Fprintf(os.Stderr, "Internal validation of the provider failed: %v\n", err)
 			contract.IgnoreError(fmterr)
 			os.Exit(-1)
         }

--- a/pf/tfgen/main.go
+++ b/pf/tfgen/main.go
@@ -87,7 +87,7 @@ func MainWithMuxer(provider string, info sdkBridge.ProviderInfo) {
 	for _, prov := range shim.MuxedProviders {
 		err := prov.InternalValidate()
 		if err!= nil {
-            _, fmterr := fmt.Fprintf(os.Stderr, "Errors occurred: %v\n", err)
+            _, fmterr := fmt.Fprintf(os.Stderr, "Internal validation of the provider failed: %v\n", err)
 			contract.IgnoreError(fmterr)
 			os.Exit(-1)
         }

--- a/pkg/tests/main_test.go
+++ b/pkg/tests/main_test.go
@@ -21,10 +21,10 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
-	"runtime"
 )
 
 func TestMain(m *testing.M) {
@@ -74,6 +74,9 @@ func ensureCompiledTestProviders(wd string) error {
 				"cmd", "pulumi-resource-tpsdkv2"),
 			filepath.Join(wd, "..", "..", "internal", "testprovider_sdkv2",
 				"cmd", "pulumi-tfgen-tpsdkv2"),
+		},
+		{
+			"testprovider_invschema", filepath.Join(wd, "..", "..", "internal", "testprovider_invalid_schema", "cmd", "pulumi-resource-tpinvschema"), filepath.Join(wd, "..", "..", "internal", "testprovider_invalid_schema", "cmd", "pulumi-tfgen-tpinvschema"),
 		},
 	}
 

--- a/pkg/tests/main_test.go
+++ b/pkg/tests/main_test.go
@@ -69,7 +69,7 @@ func ensureCompiledTestProviders(wd string) error {
 		expectTfgenError *string
 	}
 
-	const internalErrorMsg = "Internal validation of the provider failed!"
+	internalErrorMsg := "Internal validation of the provider failed!"
 
 	testProviders := []testProvider{
 		{

--- a/pkg/tests/main_test.go
+++ b/pkg/tests/main_test.go
@@ -28,13 +28,14 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 )
 
-func TestMains(t *testing.T) {
+func TestMain(m *testing.M) {
 	if err := setupIntegrationTests(); err != nil {
 		log.Fatal(err)
 	}
 
-	// exitCode := m.Run()
-	// os.Exit(exitCode)
+	exitCode := m.Run()
+	fmt.Fprintf(os.Stderr, "test main exited with code %d\n", exitCode)
+	os.Exit(exitCode)
 }
 
 func setupIntegrationTests() error {

--- a/pkg/tests/main_test.go
+++ b/pkg/tests/main_test.go
@@ -28,13 +28,13 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 )
 
-func TestMain(m *testing.M) {
+func TestMains(t *testing.T) {
 	if err := setupIntegrationTests(); err != nil {
 		log.Fatal(err)
 	}
 
-	exitCode := m.Run()
-	os.Exit(exitCode)
+	// exitCode := m.Run()
+	// os.Exit(exitCode)
 }
 
 func setupIntegrationTests() error {
@@ -69,7 +69,7 @@ func ensureCompiledTestProviders(wd string) error {
 		expectTfgenError *string
 	}
 
-	internalErrorMsg := "Internal validation of the provider failed!"
+	internalErrorMsg := "Internal validation of the provider failed"
 
 	testProviders := []testProvider{
 		{

--- a/pkg/tests/main_test.go
+++ b/pkg/tests/main_test.go
@@ -69,7 +69,7 @@ func ensureCompiledTestProviders(wd string) error {
 		expectTfgenError *string
 	}
 
-	internalErrorMsg := "Internal validation of the provider failed!"
+	const internalErrorMsg = "Internal validation of the provider failed!"
 
 	testProviders := []testProvider{
 		{

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -424,10 +424,9 @@ func (g *Generator) makePropertyType(typePath paths.TypePath,
 	case shim.TypeSet:
 		t.kind = kindSet
 	default:
-		errorStr := fmt.Sprintf(
+		contract.Failf(
 			"impossible: sch.Type() should be one of TypeMap, TypeList, TypeSet at this point path: %s, type: %s",
 			typePath.String(), sch.Type())
-		panic(errorStr)
 	}
 	t.element = element
 	return t

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -424,7 +424,10 @@ func (g *Generator) makePropertyType(typePath paths.TypePath,
 	case shim.TypeSet:
 		t.kind = kindSet
 	default:
-		panic("impossible: sch.Type() should be one of TypeMap, TypeList, TypeSet at this point")
+		errorStr := fmt.Sprintf(
+			"impossible: sch.Type() should be one of TypeMap, TypeList, TypeSet at this point path: %s, type: %s",
+			typePath.String(), sch.Type())
+		panic(errorStr)
 	}
 	t.element = element
 	return t

--- a/pkg/tfgen/main.go
+++ b/pkg/tfgen/main.go
@@ -15,6 +15,7 @@
 package tfgen
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -36,6 +37,7 @@ import (
 func Main(pkg string, version string, prov tfbridge.ProviderInfo) {
 	// Enable additional provider validation.
 	schema.RunProviderInternalValidation = true
+	prov.P.Validate(context.Background(), nil)
 
 	MainWithCustomGenerate(pkg, version, prov, func(opts GeneratorOptions) error {
 		// Create a generator with the specified settings.

--- a/pkg/tfgen/main.go
+++ b/pkg/tfgen/main.go
@@ -69,8 +69,8 @@ func Main(pkg string, version string, prov tfbridge.ProviderInfo) {
 
 // Like Main but allows to customize the generation logic past the parsing of cmd-line arguments.
 func MainWithCustomGenerate(pkg string, version string, prov tfbridge.ProviderInfo,
-	gen func(GeneratorOptions) error,
-) {
+	gen func(GeneratorOptions) error) {
+
 	if err := newTFGenCmd(pkg, version, prov, gen).Execute(); err != nil {
 		_, fmterr := fmt.Fprintf(os.Stderr, "An error occurred: %v\n", err)
 		contract.IgnoreError(fmterr)
@@ -79,8 +79,8 @@ func MainWithCustomGenerate(pkg string, version string, prov tfbridge.ProviderIn
 }
 
 func newTFGenCmd(pkg string, version string, prov tfbridge.ProviderInfo,
-	gen func(GeneratorOptions) error,
-) *cobra.Command {
+	gen func(GeneratorOptions) error) *cobra.Command {
+
 	var logToStderr bool
 	var outDir string
 	var overlaysDir string
@@ -150,7 +150,7 @@ func newTFGenCmd(pkg string, version string, prov tfbridge.ProviderInfo,
 				if err != nil {
 					return err
 				}
-				if err = os.MkdirAll(absOutDir, 0o700); err != nil {
+				if err = os.MkdirAll(absOutDir, 0700); err != nil {
 					return err
 				}
 				root = afero.NewBasePathFs(afero.NewOsFs(), absOutDir)

--- a/pkg/tfgen/main.go
+++ b/pkg/tfgen/main.go
@@ -15,7 +15,6 @@
 package tfgen
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"os"
@@ -25,7 +24,6 @@ import (
 	"runtime/trace"
 
 	"github.com/golang/glog"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -35,17 +33,9 @@ import (
 
 // Main executes the TFGen process for the given package pkg and provider prov.
 func Main(pkg string, version string, prov tfbridge.ProviderInfo) {
-	// Enable additional provider validation.
-	schema.RunProviderInternalValidation = true
-	warnings, errors := prov.P.Validate(context.Background(), prov.
-		P.NewResourceConfig(context.Background(), map[string]interface{}{}))
-	if len(warnings) > 0 {
-		for _, w := range warnings {
-			glog.Warning(w)
-		}
-	}
-	if len(errors) > 0 {
-		_, fmterr := fmt.Fprintf(os.Stderr, "Errors occurred: %v\n", errors)
+	err := prov.P.InternalValidate()
+	if err != nil {
+		_, fmterr := fmt.Fprintf(os.Stderr, "Errors occurred: %v\n", err)
 		contract.IgnoreError(fmterr)
 		os.Exit(-1)
 	}

--- a/pkg/tfgen/main.go
+++ b/pkg/tfgen/main.go
@@ -35,7 +35,7 @@ import (
 func Main(pkg string, version string, prov tfbridge.ProviderInfo) {
 	err := prov.P.InternalValidate()
 	if err != nil {
-		_, fmterr := fmt.Fprintf(os.Stderr, "Errors occurred: %v\n", err)
+		_, fmterr := fmt.Fprintf(os.Stderr, "Internal validation of the provider failed: %v\n", err)
 		contract.IgnoreError(fmterr)
 		os.Exit(-1)
 	}

--- a/pkg/tfshim/schema/provider.go
+++ b/pkg/tfshim/schema/provider.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"context"
+
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 

--- a/pkg/tfshim/schema/provider.go
+++ b/pkg/tfshim/schema/provider.go
@@ -2,7 +2,6 @@ package schema
 
 import (
 	"context"
-
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 

--- a/pkg/tfshim/schema/provider.go
+++ b/pkg/tfshim/schema/provider.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"context"
+
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
@@ -41,8 +42,12 @@ func (s ProviderShim) DataSourcesMap() shim.ResourceMap {
 	return s.V.DataSourcesMap
 }
 
+func (s ProviderShim) InternalValidate() error {
+	return nil
+}
+
 func (ProviderShim) Validate(ctx context.Context, c shim.ResourceConfig) ([]string, []error) {
-	return nil, nil
+	panic("this provider is schema-only and does not support runtime operations")
 }
 
 func (ProviderShim) ValidateResource(
@@ -112,7 +117,7 @@ func (ProviderShim) NewDestroyDiff(ctx context.Context, t string, _ shim.Timeout
 func (ProviderShim) NewResourceConfig(
 	ctx context.Context, object map[string]interface{},
 ) shim.ResourceConfig {
-	return nil
+	panic("this provider is schema-only and does not support runtime operations")
 }
 
 func (ProviderShim) IsSet(ctx context.Context, v interface{}) ([]interface{}, bool) {

--- a/pkg/tfshim/schema/provider.go
+++ b/pkg/tfshim/schema/provider.go
@@ -43,7 +43,7 @@ func (s ProviderShim) DataSourcesMap() shim.ResourceMap {
 }
 
 func (ProviderShim) Validate(ctx context.Context, c shim.ResourceConfig) ([]string, []error) {
-	panic("this provider is schema-only and does not support runtime operations")
+	return nil, nil
 }
 
 func (ProviderShim) ValidateResource(
@@ -113,7 +113,7 @@ func (ProviderShim) NewDestroyDiff(ctx context.Context, t string, _ shim.Timeout
 func (ProviderShim) NewResourceConfig(
 	ctx context.Context, object map[string]interface{},
 ) shim.ResourceConfig {
-	panic("this provider is schema-only and does not support runtime operations")
+	return nil
 }
 
 func (ProviderShim) IsSet(ctx context.Context, v interface{}) ([]interface{}, bool) {

--- a/pkg/tfshim/sdk-v1/provider.go
+++ b/pkg/tfshim/sdk-v1/provider.go
@@ -70,6 +70,10 @@ func (p v1Provider) DataSourcesMap() shim.ResourceMap {
 	return v1ResourceMap(p.tf.DataSourcesMap)
 }
 
+func (p v1Provider) InternalValidate() error {
+    return p.tf.InternalValidate()
+}
+
 func (p v1Provider) Validate(_ context.Context, c shim.ResourceConfig) ([]string, []error) {
 	return p.tf.Validate(configFromShim(c))
 }

--- a/pkg/tfshim/sdk-v1/provider.go
+++ b/pkg/tfshim/sdk-v1/provider.go
@@ -71,7 +71,7 @@ func (p v1Provider) DataSourcesMap() shim.ResourceMap {
 }
 
 func (p v1Provider) InternalValidate() error {
-    return p.tf.InternalValidate()
+	return p.tf.InternalValidate()
 }
 
 func (p v1Provider) Validate(_ context.Context, c shim.ResourceConfig) ([]string, []error) {

--- a/pkg/tfshim/sdk-v2/provider.go
+++ b/pkg/tfshim/sdk-v2/provider.go
@@ -78,6 +78,10 @@ func (p v2Provider) DataSourcesMap() shim.ResourceMap {
 	return v2ResourceMap(p.tf.DataSourcesMap)
 }
 
+func (p v2Provider) InternalValidate() error {
+    return p.tf.InternalValidate()
+}
+
 func (p v2Provider) Validate(_ context.Context, c shim.ResourceConfig) ([]string, []error) {
 	return warningsAndErrors(p.tf.Validate(configFromShim(c)))
 }

--- a/pkg/tfshim/sdk-v2/provider.go
+++ b/pkg/tfshim/sdk-v2/provider.go
@@ -79,7 +79,7 @@ func (p v2Provider) DataSourcesMap() shim.ResourceMap {
 }
 
 func (p v2Provider) InternalValidate() error {
-    return p.tf.InternalValidate()
+	return p.tf.InternalValidate()
 }
 
 func (p v2Provider) Validate(_ context.Context, c shim.ResourceConfig) ([]string, []error) {

--- a/pkg/tfshim/shim.go
+++ b/pkg/tfshim/shim.go
@@ -191,6 +191,7 @@ type Provider interface {
 	ResourcesMap() ResourceMap
 	DataSourcesMap() ResourceMap
 
+	InternalValidate() error
 	Validate(ctx context.Context, c ResourceConfig) ([]string, []error)
 	ValidateResource(ctx context.Context, t string, c ResourceConfig) ([]string, []error)
 	ValidateDataSource(ctx context.Context, t string, c ResourceConfig) ([]string, []error)

--- a/pkg/tfshim/tfplugin5/provider.go
+++ b/pkg/tfshim/tfplugin5/provider.go
@@ -179,6 +179,10 @@ func (p *provider) DataSourcesMap() shim.ResourceMap {
 	return p.dataSources
 }
 
+func (p *provider) InternalValidate() error {
+	return nil
+}
+
 func (p *provider) Validate(ctx context.Context, c shim.ResourceConfig) ([]string, []error) {
 	config, ok := c.(resourceConfig)
 	if !ok {

--- a/pkg/tfshim/util/filter.go
+++ b/pkg/tfshim/util/filter.go
@@ -16,6 +16,7 @@ package util
 
 import (
 	"context"
+
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
@@ -56,6 +57,10 @@ func (p *FilteringProvider) ResourcesMap() shim.ResourceMap {
 
 func (p *FilteringProvider) DataSourcesMap() shim.ResourceMap {
 	return &filteringMap{p.Provider.DataSourcesMap(), p.DataSourceFilter}
+}
+
+func (p *FilteringProvider) InternalValidate() error {
+    return p.Provider.InternalValidate()
 }
 
 func (p *FilteringProvider) Validate(ctx context.Context, c shim.ResourceConfig) ([]string, []error) {

--- a/pkg/tfshim/util/filter.go
+++ b/pkg/tfshim/util/filter.go
@@ -60,7 +60,7 @@ func (p *FilteringProvider) DataSourcesMap() shim.ResourceMap {
 }
 
 func (p *FilteringProvider) InternalValidate() error {
-    return p.Provider.InternalValidate()
+	return p.Provider.InternalValidate()
 }
 
 func (p *FilteringProvider) Validate(ctx context.Context, c shim.ResourceConfig) ([]string, []error) {

--- a/pkg/tfshim/util/util.go
+++ b/pkg/tfshim/util/util.go
@@ -29,7 +29,6 @@ func (UnimplementedProvider) Schema() shim.SchemaMap           { panic("unimplem
 func (UnimplementedProvider) ResourcesMap() shim.ResourceMap   { panic("unimplemented") }
 func (UnimplementedProvider) DataSourcesMap() shim.ResourceMap { panic("unimplemented") }
 
-
 func (UnimplementedProvider) InternalValidate() error { panic("unimplemented") }
 
 func (UnimplementedProvider) Validate(

--- a/pkg/tfshim/util/util.go
+++ b/pkg/tfshim/util/util.go
@@ -16,6 +16,7 @@ package util
 
 import (
 	"context"
+
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
@@ -27,6 +28,9 @@ type UnimplementedProvider struct{}
 func (UnimplementedProvider) Schema() shim.SchemaMap           { panic("unimplemented") }
 func (UnimplementedProvider) ResourcesMap() shim.ResourceMap   { panic("unimplemented") }
 func (UnimplementedProvider) DataSourcesMap() shim.ResourceMap { panic("unimplemented") }
+
+
+func (UnimplementedProvider) InternalValidate() error { panic("unimplemented") }
 
 func (UnimplementedProvider) Validate(
 	ctx context.Context, c shim.ResourceConfig,


### PR DESCRIPTION
fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/1852

https://github.com/pulumi/pulumi-terraform-bridge/pull/1669 removed the runtime calls to `InternalValidate` to speed up provider startup. This assumed it was called during tfgen but it turns out it was not.

This introduces an explicit call to `InternalValidate` during tfgen. Thanks to @t0yv0 for prompting the investigation and @iwahbe for helping with the muxer.

To facilitate that, I've added `InternalValidate` to the shim Provider interface. Technically breaking but seems unlikely to be depended on externally.

Calling `Validate` does not do the job as that requires passing in a valid config which is not available during tfgen.

I've added an e2e test for an sdk provider, need to add one for a pf provider.