### PR TITLE
Run lint in parallel

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,6 +6,10 @@ on:
     secrets:
       CODECOV_TOKEN:
         required: true
+      PULUMI_BOT_TOKEN:
+        required: true
+env:
+  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
 
 jobs:
   test:
@@ -36,6 +40,25 @@ jobs:
         run: make build
       - name: Build PF
         run: cd pf && make build
+      - name: Test
+        run: make test
+      - name: Test PF
+        run: cd pf && make test
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@master
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.22.x
+          cache-dependency-path: |
+            **/go.sum
       - name: Install golangci-lint
         uses: golangci/golangci-lint-action@v4
         with:
@@ -45,11 +68,3 @@ jobs:
             version: v1.57
       - name: Lint
         run: make lint
-      - name: Test
-        run: make test
-      - name: Test PF
-        run: cd pf && make test
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,55 @@
+name: Build and Test
+
+on:
+  workflow_call:
+    inputs: {}
+    secrets:
+      CODECOV_TOKEN:
+        required: true
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        # To avoid depending on features introduced in newer golang versions, we need to
+        # test our minimum supported golang versions.
+        #
+        # When we decide to bump our minimum go version, we need to remember to bump the
+        # go version in our go.mod files.
+        go-version: [1.21.x, 1.22.x]
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Install pulumi
+        uses: pulumi/actions@v5
+        with:
+          pulumi-version: ^3.0.0
+      - name: Check out source code
+        uses: actions/checkout@master
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache-dependency-path: |
+            **/go.sum
+      - name: Build
+        run: make build
+      - name: Build PF
+        run: cd pf && make build
+      - name: Install golangci-lint
+        uses: golangci/golangci-lint-action@v4
+        with:
+            skip-cache: true
+            skip-pkg-cache: true
+            skip-build-cache: true
+            version: v1.57
+      - name: Lint
+        run: make lint
+      - name: Test
+        run: make test
+      - name: Test PF
+        run: cd pf && make test
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,52 +7,9 @@ on: [pull_request]
 
 jobs:
   build:
-    name: Build and Test Bridge
-    strategy:
-      matrix:
-        # To avoid depending on features introduced in newer golang versions, we need to
-        # test our minimum supported golang versions.
-        #
-        # When we decide to bump our minimum go version, we need to remember to bump the
-        # go version in our go.mod files.
-        go-version: [1.21.x, 1.22.x]
-        platform: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.platform }}
-    steps:
-      - name: Install pulumi
-        uses: pulumi/actions@v5
-        with:
-          pulumi-version: ^3.0.0
-      - name: Check out source code
-        uses: actions/checkout@master
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ matrix.go-version }}
-          cache-dependency-path: |
-            **/go.sum
-      - name: Build
-        run: make build
-      - name: Build PF
-        run: cd pf && make build
-      - name: Install golangci-lint
-        uses: golangci/golangci-lint-action@v4
-        with:
-            skip-cache: true
-            skip-pkg-cache: true
-            skip-build-cache: true
-            version: v1.57
-      - name: Lint
-        run: make lint
-      - name: Test
-        run: make test
-      - name: Test PF
-        run: cd pf && make test
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
+    name: Test and Lint
+    uses: ./.github/workflows/build-and-test.yml
+    secrets: inherit
   clean-files:
     name: Ensure test assets build cleanly
     runs-on: ubuntu-latest

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -15,43 +15,5 @@ env:
 
 jobs:
   build:
-    name: Build and Test Bridge
-    strategy:
-      matrix:
-        go-version: [1.21.x]
-        platform: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.platform }}
-    steps:
-      - name: Check out source code
-        uses: actions/checkout@master
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ matrix.go-version }}
-          cache-dependency-path: |
-            **/go.sum
-      - name: Install pulumi
-        uses: pulumi/actions@v5
-        with:
-          pulumi-version: ^3.0.0
-      - name: Build
-        run: make build
-      - name: Build PF
-        run: cd pf && make build
-      - name: Install golangci-lint
-        uses: golangci/golangci-lint-action@v4
-        with:
-            skip-cache: true
-            skip-pkg-cache: true
-            skip-build-cache: true
-            version: v1.57
-      - name: Lint
-        run: make lint
-      - name: Test
-        run: make test
-      - name: Test PF
-        run: cd pf && make test
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    uses: ./.github/workflows/build-and-test.yml
+    secrets: inherit


### PR DESCRIPTION
About a third of CI time in this repo is spent running lints. The lints are extremely valuable, but don't need to be run synchronously with tests. Further, we don't need to run lints for the full matrix of test target.


A [representative CI](https://github.com/pulumi/pulumi-terraform-bridge/actions/runs/8648192062/job/23711430770?pr=1854) run breaks down as:

- [Ensure test assets build cleanly](https://github.com/pulumi/pulumi-terraform-bridge/runs/23711430418?check_suite_focus=true): No lint step
- [Build and Test Bridge (1.21.x, ubuntu-latest)](https://github.com/pulumi/pulumi-terraform-bridge/runs/23711430770?check_suite_focus=true): lint takes 63s/212s = 30%
- [Build and Test Bridge (1.21.x, macos-latest)](https://github.com/pulumi/pulumi-terraform-bridge/runs/23711431263?check_suite_focus=true): lint takes 197s/561s = 35%
- [Build and Test Bridge (1.21.x, windows-latest)](https://github.com/pulumi/pulumi-terraform-bridge/runs/23711431692?check_suite_focus=true): lint takes 184s/622s = 30%
- [Build and Test Bridge (1.22.x, ubuntu-latest)](https://github.com/pulumi/pulumi-terraform-bridge/runs/23711431966?check_suite_focus=true): lint takes 92s/210s = 44%
- [Build and Test Bridge (1.22.x, macos-latest)](https://github.com/pulumi/pulumi-terraform-bridge/runs/23711432264?check_suite_focus=true): lint takes 209s/541s = 39%
- [Build and Test Bridge (1.22.x, windows-latest)](https://github.com/pulumi/pulumi-terraform-bridge/runs/23711432585?check_suite_focus=true): lint takes 183s/823s = %22

At the cost of spinning up an additional ubuntu-latest runner, we should be able to decrease end-to-end CI times by more then 20% without a loss in fidelity.