### PR TITLE
feat: add resource urn to context in Check call

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -34,6 +34,26 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/logging"
 )
 
+type urnCtxKeyType string
+
+const urnCtxKey urnCtxKeyType = "urn"
+
+// WithUrn returns a copy of ctx with the resource URN value
+func WithUrn(ctx context.Context, urn resource.URN) context.Context {
+	return context.WithValue(ctx, urnCtxKey, urn)
+}
+
+// GetUrn gets a resource URN from context
+//
+//	urn, ok := GetUrn(ctx)
+//	if !ok {
+//	    // urn was not found
+//	}
+func GetUrn(ctx context.Context) (resource.URN, bool) {
+	urn, ok := ctx.Value(urnCtxKey).(resource.URN)
+	return urn, ok
+}
+
 const (
 	MPL20LicenseType      TFProviderLicense = "MPL 2.0"
 	MITLicenseType        TFProviderLicense = "MIT"

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -726,6 +726,7 @@ func (p *Provider) Configure(ctx context.Context,
 func (p *Provider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (*pulumirpc.CheckResponse, error) {
 	ctx = p.loggingContext(ctx, resource.URN(req.GetUrn()))
 	urn := resource.URN(req.GetUrn())
+	ctx = WithUrn(ctx, urn)
 	t := urn.Type()
 	res, has := p.resources[t]
 	if !has {

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -16,6 +16,7 @@ package tfbridge
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -770,6 +771,12 @@ func TestCheckCallback(t *testing.T) {
 	) (resource.PropertyMap, error) {
 		// We test that we have access to the logger in this callback.
 		GetLogger(ctx).Status().Info("Did not panic")
+
+		urn, ok := GetUrn(ctx)
+		if !ok {
+			return config, errors.New("Expected GetUrn to find urn")
+		}
+		assert.Equal(t, urn, resource.URN("urn:pulumi:st::pg::testprovider:index/res:Res::r"))
 
 		config["arrayPropertyValues"] = resource.NewArrayProperty(
 			[]resource.PropertyValue{meta["prop"]},


### PR DESCRIPTION
This PR adds the resource URN to the context in the `Check` method, along with methods to set and get the URN from context.

The motivation for this change was driven by trying to implement the suggested fix in [this
comment](https://github.com/pulumi/pulumi-aws/issues/3788#issuecomment-2051881787) in the aws provider. We want to be able to keep some global state of which resources have been seen by `Check`, but realized that we don't actually get any identifying information in the `PreCheckCallback` function.

An alternative approach would be to update the `PreCheckCallback` signature to also contain the URN, but that would be a breaking change.

re https://github.com/pulumi/pulumi-aws/issues/3788