### PR TITLE
iwahbe/test large int as string roundtrip

### DIFF
--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -393,23 +393,33 @@ func (ctx *conversionContext) makeTerraformInput(
 		v = nv
 	}
 
+	if tfs == nil {
+		tfs = (&schema.Schema{}).Shim()
+	}
+
+	pathErr := func(v any, err error) (any, error) {
+		if err == nil {
+			return v, nil
+		}
+
+		return v, fmt.Errorf("%s: %w", name, err)
+	}
+
 	switch {
 	case v.IsNull():
 		return nil, nil
 	case v.IsBool():
-		if tfs != nil && tfs.Type() == shim.TypeString {
+		switch tfs.Type() {
+		case shim.TypeString:
 			if v.BoolValue() {
 				return "true", nil
 			}
 			return "false", nil
+		default:
+			return v.BoolValue(), nil
 		}
-		return v.BoolValue(), nil
 	case v.IsNumber():
-		var typ shim.ValueType
-		if tfs != nil {
-			typ = tfs.Type()
-		}
-		switch typ {
+		switch tfs.Type() {
 		case shim.TypeFloat:
 			return v.NumberValue(), nil
 		case shim.TypeString:
@@ -418,7 +428,12 @@ func (ctx *conversionContext) makeTerraformInput(
 			return int(v.NumberValue()), nil
 		}
 	case v.IsString():
-		return v.StringValue(), nil
+		switch tfs.Type() {
+		case shim.TypeInt:
+			return pathErr(strconv.ParseInt(v.StringValue(), 10, 64))
+		default:
+			return v.StringValue(), nil
+		}
 	case v.IsArray():
 		var oldArr []resource.PropertyValue
 		if old.IsArray() {
@@ -1100,6 +1115,10 @@ func MakeTerraformOutput(
 			v = list
 		}
 
+		if ps == nil {
+			ps = &SchemaInfo{}
+		}
+
 		// We use reflection instead of a type switch so that we can support mapping values whose underlying type is
 		// supported into a Pulumi value, even if they stored as a wrapper type (such as a strongly-typed enum).
 		//
@@ -1111,7 +1130,12 @@ func MakeTerraformOutput(
 		case reflect.Bool:
 			return resource.NewBoolProperty(val.Bool())
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-			return resource.NewNumberProperty(float64(val.Int()))
+			switch ps.Type {
+			case "string":
+				return resource.NewProperty(strconv.FormatInt(val.Int(), 10))
+			default:
+				return resource.NewNumberProperty(float64(val.Int()))
+			}
 		case reflect.Float32, reflect.Float64:
 			return resource.NewNumberProperty(val.Float())
 		case reflect.String:


### PR DESCRIPTION
- **Refactor TestOverridingTFSchema for clarity.**
  This commit is a pure refactor of the tests, and does not add or remove any tests.
  

- **Support override int with string**
  This conversion was previously handled by by terraform as a best-effort approach. We
  should handle it in-house for 2 reasons:
  1. To provider errors at the pulumi level.
  2. To ensure that providers receive the same inputs as from TF, instead of relying on TF
  to convert on the wrong type.
  