### PR TITLE
Apply `reformatText` to the backup .Description text

### DIFF
--- a/pf/tests/internal/testprovider/cmd/pulumi-resource-muxedrandom/schema.json
+++ b/pf/tests/internal/testprovider/cmd/pulumi-resource-muxedrandom/schema.json
@@ -101,7 +101,7 @@
                     "additionalProperties": {
                         "type": "string"
                     },
-                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                 },
                 "length": {
                     "type": "integer",
@@ -119,7 +119,7 @@
                     "additionalProperties": {
                         "type": "string"
                     },
-                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                 },
                 "length": {
                     "type": "integer",
@@ -147,7 +147,7 @@
                         "additionalProperties": {
                             "type": "string"
                         },
-                        "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                        "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                     },
                     "length": {
                         "type": "integer",
@@ -242,7 +242,7 @@
                     "additionalProperties": {
                         "type": "string"
                     },
-                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                 },
                 "prefix": {
                     "type": "string",
@@ -266,7 +266,7 @@
                     "additionalProperties": {
                         "type": "string"
                     },
-                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                 },
                 "prefix": {
                     "type": "string",
@@ -304,7 +304,7 @@
                         "additionalProperties": {
                             "type": "string"
                         },
-                        "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                        "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                     },
                     "prefix": {
                         "type": "string",
@@ -321,7 +321,7 @@
                     "additionalProperties": {
                         "type": "string"
                     },
-                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                 },
                 "max": {
                     "type": "integer",
@@ -351,7 +351,7 @@
                     "additionalProperties": {
                         "type": "string"
                     },
-                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                 },
                 "max": {
                     "type": "integer",
@@ -378,7 +378,7 @@
                         "additionalProperties": {
                             "type": "string"
                         },
-                        "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                        "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                     },
                     "max": {
                         "type": "integer",
@@ -412,7 +412,7 @@
                     "additionalProperties": {
                         "type": "string"
                     },
-                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                 },
                 "length": {
                     "type": "integer",
@@ -485,7 +485,7 @@
                     "additionalProperties": {
                         "type": "string"
                     },
-                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                 },
                 "length": {
                     "type": "integer",
@@ -549,7 +549,7 @@
                         "additionalProperties": {
                             "type": "string"
                         },
-                        "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                        "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                     },
                     "length": {
                         "type": "integer",
@@ -612,7 +612,7 @@
                     "additionalProperties": {
                         "type": "string"
                     },
-                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                 },
                 "length": {
                     "type": "integer",
@@ -637,7 +637,7 @@
                     "additionalProperties": {
                         "type": "string"
                     },
-                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                 },
                 "length": {
                     "type": "integer",
@@ -660,7 +660,7 @@
                         "additionalProperties": {
                             "type": "string"
                         },
-                        "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                        "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                     },
                     "length": {
                         "type": "integer",
@@ -692,7 +692,7 @@
                     "additionalProperties": {
                         "type": "string"
                     },
-                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                 },
                 "resultCount": {
                     "type": "integer",
@@ -706,8 +706,7 @@
                     "description": "Random permutation of the list of strings given in `input`.\n"
                 },
                 "seed": {
-                    "type": "string",
-                    "description": "Arbitrary string with which to seed the random number generator, in order to produce less-volatile permutations of the\nlist. **Important:** Even with an identical seed, it is not guaranteed that the same permutation will be produced across\ndifferent versions of Terraform. This argument causes the result to be *less volatile*, but not fixed for all time.\n"
+                    "type": "string"
                 }
             },
             "required": [
@@ -727,15 +726,14 @@
                     "additionalProperties": {
                         "type": "string"
                     },
-                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                 },
                 "resultCount": {
                     "type": "integer",
                     "description": "The number of results to return. Defaults to the number of items in the `input` list. If fewer items are requested, some\nelements will be excluded from the result. If more items are requested, items will be repeated in the result but not\nmore frequently than the number of items in the input list.\n"
                 },
                 "seed": {
-                    "type": "string",
-                    "description": "Arbitrary string with which to seed the random number generator, in order to produce less-volatile permutations of the\nlist. **Important:** Even with an identical seed, it is not guaranteed that the same permutation will be produced across\ndifferent versions of Terraform. This argument causes the result to be *less volatile*, but not fixed for all time.\n"
+                    "type": "string"
                 }
             },
             "requiredInputs": [
@@ -756,7 +754,7 @@
                         "additionalProperties": {
                             "type": "string"
                         },
-                        "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                        "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                     },
                     "resultCount": {
                         "type": "integer",
@@ -770,8 +768,7 @@
                         "description": "Random permutation of the list of strings given in `input`.\n"
                     },
                     "seed": {
-                        "type": "string",
-                        "description": "Arbitrary string with which to seed the random number generator, in order to produce less-volatile permutations of the\nlist. **Important:** Even with an identical seed, it is not guaranteed that the same permutation will be produced across\ndifferent versions of Terraform. This argument causes the result to be *less volatile*, but not fixed for all time.\n"
+                        "type": "string"
                     }
                 },
                 "type": "object"
@@ -784,7 +781,7 @@
                     "additionalProperties": {
                         "type": "string"
                     },
-                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                 },
                 "length": {
                     "type": "integer",
@@ -855,7 +852,7 @@
                     "additionalProperties": {
                         "type": "string"
                     },
-                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                 },
                 "length": {
                     "type": "integer",
@@ -914,7 +911,7 @@
                         "additionalProperties": {
                             "type": "string"
                         },
-                        "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                        "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                     },
                     "length": {
                         "type": "integer",
@@ -976,7 +973,7 @@
                     "additionalProperties": {
                         "type": "string"
                     },
-                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                 },
                 "result": {
                     "type": "string",
@@ -992,7 +989,7 @@
                     "additionalProperties": {
                         "type": "string"
                     },
-                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                 }
             },
             "stateInputs": {
@@ -1003,7 +1000,7 @@
                         "additionalProperties": {
                             "type": "string"
                         },
-                        "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                        "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                     },
                     "result": {
                         "type": "string",

--- a/pf/tests/internal/testprovider/cmd/pulumi-resource-random/schema.json
+++ b/pf/tests/internal/testprovider/cmd/pulumi-resource-random/schema.json
@@ -70,7 +70,7 @@
                     "additionalProperties": {
                         "type": "string"
                     },
-                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                 },
                 "length": {
                     "type": "integer",
@@ -88,7 +88,7 @@
                     "additionalProperties": {
                         "type": "string"
                     },
-                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                 },
                 "length": {
                     "type": "integer",
@@ -116,7 +116,7 @@
                         "additionalProperties": {
                             "type": "string"
                         },
-                        "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                        "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                     },
                     "length": {
                         "type": "integer",
@@ -153,7 +153,7 @@
                     "additionalProperties": {
                         "type": "string"
                     },
-                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                 },
                 "prefix": {
                     "type": "string",
@@ -177,7 +177,7 @@
                     "additionalProperties": {
                         "type": "string"
                     },
-                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                 },
                 "prefix": {
                     "type": "string",
@@ -215,7 +215,7 @@
                         "additionalProperties": {
                             "type": "string"
                         },
-                        "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                        "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                     },
                     "prefix": {
                         "type": "string",
@@ -232,7 +232,7 @@
                     "additionalProperties": {
                         "type": "string"
                     },
-                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                 },
                 "max": {
                     "type": "integer",
@@ -262,7 +262,7 @@
                     "additionalProperties": {
                         "type": "string"
                     },
-                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                 },
                 "max": {
                     "type": "integer",
@@ -289,7 +289,7 @@
                         "additionalProperties": {
                             "type": "string"
                         },
-                        "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                        "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                     },
                     "max": {
                         "type": "integer",
@@ -323,7 +323,7 @@
                     "additionalProperties": {
                         "type": "string"
                     },
-                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                 },
                 "length": {
                     "type": "integer",
@@ -396,7 +396,7 @@
                     "additionalProperties": {
                         "type": "string"
                     },
-                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                 },
                 "length": {
                     "type": "integer",
@@ -460,7 +460,7 @@
                         "additionalProperties": {
                             "type": "string"
                         },
-                        "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                        "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                     },
                     "length": {
                         "type": "integer",
@@ -523,7 +523,7 @@
                     "additionalProperties": {
                         "type": "string"
                     },
-                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                 },
                 "length": {
                     "type": "integer",
@@ -548,7 +548,7 @@
                     "additionalProperties": {
                         "type": "string"
                     },
-                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                 },
                 "length": {
                     "type": "integer",
@@ -571,7 +571,7 @@
                         "additionalProperties": {
                             "type": "string"
                         },
-                        "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                        "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                     },
                     "length": {
                         "type": "integer",
@@ -603,7 +603,7 @@
                     "additionalProperties": {
                         "type": "string"
                     },
-                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                 },
                 "resultCount": {
                     "type": "integer",
@@ -617,8 +617,7 @@
                     "description": "Random permutation of the list of strings given in `input`.\n"
                 },
                 "seed": {
-                    "type": "string",
-                    "description": "Arbitrary string with which to seed the random number generator, in order to produce less-volatile permutations of the\nlist. **Important:** Even with an identical seed, it is not guaranteed that the same permutation will be produced across\ndifferent versions of Terraform. This argument causes the result to be *less volatile*, but not fixed for all time.\n"
+                    "type": "string"
                 }
             },
             "required": [
@@ -638,15 +637,14 @@
                     "additionalProperties": {
                         "type": "string"
                     },
-                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                 },
                 "resultCount": {
                     "type": "integer",
                     "description": "The number of results to return. Defaults to the number of items in the `input` list. If fewer items are requested, some\nelements will be excluded from the result. If more items are requested, items will be repeated in the result but not\nmore frequently than the number of items in the input list.\n"
                 },
                 "seed": {
-                    "type": "string",
-                    "description": "Arbitrary string with which to seed the random number generator, in order to produce less-volatile permutations of the\nlist. **Important:** Even with an identical seed, it is not guaranteed that the same permutation will be produced across\ndifferent versions of Terraform. This argument causes the result to be *less volatile*, but not fixed for all time.\n"
+                    "type": "string"
                 }
             },
             "requiredInputs": [
@@ -667,7 +665,7 @@
                         "additionalProperties": {
                             "type": "string"
                         },
-                        "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                        "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                     },
                     "resultCount": {
                         "type": "integer",
@@ -681,8 +679,7 @@
                         "description": "Random permutation of the list of strings given in `input`.\n"
                     },
                     "seed": {
-                        "type": "string",
-                        "description": "Arbitrary string with which to seed the random number generator, in order to produce less-volatile permutations of the\nlist. **Important:** Even with an identical seed, it is not guaranteed that the same permutation will be produced across\ndifferent versions of Terraform. This argument causes the result to be *less volatile*, but not fixed for all time.\n"
+                        "type": "string"
                     }
                 },
                 "type": "object"
@@ -695,7 +692,7 @@
                     "additionalProperties": {
                         "type": "string"
                     },
-                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                 },
                 "length": {
                     "type": "integer",
@@ -766,7 +763,7 @@
                     "additionalProperties": {
                         "type": "string"
                     },
-                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                 },
                 "length": {
                     "type": "integer",
@@ -825,7 +822,7 @@
                         "additionalProperties": {
                             "type": "string"
                         },
-                        "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                        "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                     },
                     "length": {
                         "type": "integer",
@@ -887,7 +884,7 @@
                     "additionalProperties": {
                         "type": "string"
                     },
-                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                 },
                 "result": {
                     "type": "string",
@@ -903,7 +900,7 @@
                     "additionalProperties": {
                         "type": "string"
                     },
-                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                    "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                 }
             },
             "stateInputs": {
@@ -914,7 +911,7 @@
                         "additionalProperties": {
                             "type": "string"
                         },
-                        "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+                        "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
                     },
                     "result": {
                         "type": "string",

--- a/pf/tests/internal/testprovider/cmd/pulumi-resource-tls/schema.json
+++ b/pf/tests/internal/testprovider/cmd/pulumi-resource-tls/schema.json
@@ -265,8 +265,7 @@
         "tls:index/certRequest:CertRequest": {
             "properties": {
                 "certRequestPem": {
-                    "type": "string",
-                    "description": "The certificate request data in [PEM (RFC 1421)](https://datatracker.ietf.org/doc/html/rfc1421) format. **NOTE**: the\n[underlying](https://pkg.go.dev/encoding/pem#Encode)\n[libraries](https://pkg.go.dev/golang.org/x/crypto/ssh#MarshalAuthorizedKey) that generate this value append a `\\n` at\nthe end of the PEM. In case this disrupts your use case, we recommend using\n[`trimspace()`](https://www.terraform.io/language/functions/trimspace).\n"
+                    "type": "string"
                 },
                 "dnsNames": {
                     "type": "array",
@@ -288,7 +287,6 @@
                 },
                 "privateKeyPem": {
                     "type": "string",
-                    "description": "Private key in [PEM (RFC 1421)](https://datatracker.ietf.org/doc/html/rfc1421) format, that the certificate will belong\nto. This can be read from a separate file using the [`file`](https://www.terraform.io/language/functions/file)\ninterpolation function. Only an irreversible secure hash of the private key will be stored in the Terraform state.\n",
                     "secret": true
                 },
                 "subject": {
@@ -325,7 +323,6 @@
                 },
                 "privateKeyPem": {
                     "type": "string",
-                    "description": "Private key in [PEM (RFC 1421)](https://datatracker.ietf.org/doc/html/rfc1421) format, that the certificate will belong\nto. This can be read from a separate file using the [`file`](https://www.terraform.io/language/functions/file)\ninterpolation function. Only an irreversible secure hash of the private key will be stored in the Terraform state.\n",
                     "secret": true
                 },
                 "subject": {
@@ -347,8 +344,7 @@
                 "description": "Input properties used for looking up and filtering CertRequest resources.\n",
                 "properties": {
                     "certRequestPem": {
-                        "type": "string",
-                        "description": "The certificate request data in [PEM (RFC 1421)](https://datatracker.ietf.org/doc/html/rfc1421) format. **NOTE**: the\n[underlying](https://pkg.go.dev/encoding/pem#Encode)\n[libraries](https://pkg.go.dev/golang.org/x/crypto/ssh#MarshalAuthorizedKey) that generate this value append a `\\n` at\nthe end of the PEM. In case this disrupts your use case, we recommend using\n[`trimspace()`](https://www.terraform.io/language/functions/trimspace).\n"
+                        "type": "string"
                     },
                     "dnsNames": {
                         "type": "array",
@@ -370,7 +366,6 @@
                     },
                     "privateKeyPem": {
                         "type": "string",
-                        "description": "Private key in [PEM (RFC 1421)](https://datatracker.ietf.org/doc/html/rfc1421) format, that the certificate will belong\nto. This can be read from a separate file using the [`file`](https://www.terraform.io/language/functions/file)\ninterpolation function. Only an irreversible secure hash of the private key will be stored in the Terraform state.\n",
                         "secret": true
                     },
                     "subject": {
@@ -411,16 +406,14 @@
                     "secret": true
                 },
                 "certPem": {
-                    "type": "string",
-                    "description": "Certificate data in [PEM (RFC 1421)](https://datatracker.ietf.org/doc/html/rfc1421) format. **NOTE**: the\n[underlying](https://pkg.go.dev/encoding/pem#Encode)\n[libraries](https://pkg.go.dev/golang.org/x/crypto/ssh#MarshalAuthorizedKey) that generate this value append a `\\n` at\nthe end of the PEM. In case this disrupts your use case, we recommend using\n[`trimspace()`](https://www.terraform.io/language/functions/trimspace).\n"
+                    "type": "string"
                 },
                 "certRequestPem": {
                     "type": "string",
                     "description": "Certificate request data in [PEM (RFC 1421)](https://datatracker.ietf.org/doc/html/rfc1421) format.\n"
                 },
                 "earlyRenewalHours": {
-                    "type": "integer",
-                    "description": "The resource will consider the certificate to have expired the given number of hours before its actual expiry time. This\ncan be useful to deploy an updated certificate in advance of the expiration of the current certificate. However, the old\ncertificate remains valid until its true expiration time, since this resource does not (and cannot) support certificate\nrevocation. Also, this advance update can only be performed should the Terraform configuration be applied during the\nearly renewal period. (default: `0`)\n"
+                    "type": "integer"
                 },
                 "isCaCertificate": {
                     "type": "boolean",
@@ -484,8 +477,7 @@
                     "description": "Certificate request data in [PEM (RFC 1421)](https://datatracker.ietf.org/doc/html/rfc1421) format.\n"
                 },
                 "earlyRenewalHours": {
-                    "type": "integer",
-                    "description": "The resource will consider the certificate to have expired the given number of hours before its actual expiry time. This\ncan be useful to deploy an updated certificate in advance of the expiration of the current certificate. However, the old\ncertificate remains valid until its true expiration time, since this resource does not (and cannot) support certificate\nrevocation. Also, this advance update can only be performed should the Terraform configuration be applied during the\nearly renewal period. (default: `0`)\n"
+                    "type": "integer"
                 },
                 "isCaCertificate": {
                     "type": "boolean",
@@ -531,16 +523,14 @@
                         "secret": true
                     },
                     "certPem": {
-                        "type": "string",
-                        "description": "Certificate data in [PEM (RFC 1421)](https://datatracker.ietf.org/doc/html/rfc1421) format. **NOTE**: the\n[underlying](https://pkg.go.dev/encoding/pem#Encode)\n[libraries](https://pkg.go.dev/golang.org/x/crypto/ssh#MarshalAuthorizedKey) that generate this value append a `\\n` at\nthe end of the PEM. In case this disrupts your use case, we recommend using\n[`trimspace()`](https://www.terraform.io/language/functions/trimspace).\n"
+                        "type": "string"
                     },
                     "certRequestPem": {
                         "type": "string",
                         "description": "Certificate request data in [PEM (RFC 1421)](https://datatracker.ietf.org/doc/html/rfc1421) format.\n"
                     },
                     "earlyRenewalHours": {
-                        "type": "integer",
-                        "description": "The resource will consider the certificate to have expired the given number of hours before its actual expiry time. This\ncan be useful to deploy an updated certificate in advance of the expiration of the current certificate. However, the old\ncertificate remains valid until its true expiration time, since this resource does not (and cannot) support certificate\nrevocation. Also, this advance update can only be performed should the Terraform configuration be applied during the\nearly renewal period. (default: `0`)\n"
+                        "type": "integer"
                     },
                     "isCaCertificate": {
                         "type": "boolean",
@@ -597,19 +587,17 @@
                 },
                 "publicKeyFingerprintMd5": {
                     "type": "string",
-                    "description": "The fingerprint of the public key data in OpenSSH MD5 hash format, e.g. `aa:bb:cc:...`. Only available if the selected\nprivate key format is compatible, similarly to `public_key_openssh` and the [ECDSA P224\nlimitations](../../docs#limitations).\n"
+                    "description": "The fingerprint of the public key data in OpenSSH MD5 hash format, e.g. `aa:bb:cc:...`. Only available if the selected\nprivate key format is compatible, similarly to `public_key_openssh` and the ECDSA P224 limitations.\n"
                 },
                 "publicKeyFingerprintSha256": {
                     "type": "string",
-                    "description": "The fingerprint of the public key data in OpenSSH SHA256 hash format, e.g. `SHA256:...`. Only available if the selected\nprivate key format is compatible, similarly to `public_key_openssh` and the [ECDSA P224\nlimitations](../../docs#limitations).\n"
+                    "description": "The fingerprint of the public key data in OpenSSH SHA256 hash format, e.g. `SHA256:...`. Only available if the selected\nprivate key format is compatible, similarly to `public_key_openssh` and the ECDSA P224 limitations.\n"
                 },
                 "publicKeyOpenssh": {
-                    "type": "string",
-                    "description": "The public key data in [\"Authorized\nKeys\"](https://www.ssh.com/academy/ssh/authorized_keys/openssh#format-of-the-authorized-keys-file) format. This is not\npopulated for `ECDSA` with curve `P224`, as it is [not supported](../../docs#limitations). **NOTE**: the\n[underlying](https://pkg.go.dev/encoding/pem#Encode)\n[libraries](https://pkg.go.dev/golang.org/x/crypto/ssh#MarshalAuthorizedKey) that generate this value append a `\\n` at\nthe end of the PEM. In case this disrupts your use case, we recommend using\n[`trimspace()`](https://www.terraform.io/language/functions/trimspace).\n"
+                    "type": "string"
                 },
                 "publicKeyPem": {
-                    "type": "string",
-                    "description": "Public key data in [PEM (RFC 1421)](https://datatracker.ietf.org/doc/html/rfc1421) format. **NOTE**: the\n[underlying](https://pkg.go.dev/encoding/pem#Encode)\n[libraries](https://pkg.go.dev/golang.org/x/crypto/ssh#MarshalAuthorizedKey) that generate this value append a `\\n` at\nthe end of the PEM. In case this disrupts your use case, we recommend using\n[`trimspace()`](https://www.terraform.io/language/functions/trimspace).\n"
+                    "type": "string"
                 },
                 "rsaBits": {
                     "type": "integer",
@@ -673,19 +661,17 @@
                     },
                     "publicKeyFingerprintMd5": {
                         "type": "string",
-                        "description": "The fingerprint of the public key data in OpenSSH MD5 hash format, e.g. `aa:bb:cc:...`. Only available if the selected\nprivate key format is compatible, similarly to `public_key_openssh` and the [ECDSA P224\nlimitations](../../docs#limitations).\n"
+                        "description": "The fingerprint of the public key data in OpenSSH MD5 hash format, e.g. `aa:bb:cc:...`. Only available if the selected\nprivate key format is compatible, similarly to `public_key_openssh` and the ECDSA P224 limitations.\n"
                     },
                     "publicKeyFingerprintSha256": {
                         "type": "string",
-                        "description": "The fingerprint of the public key data in OpenSSH SHA256 hash format, e.g. `SHA256:...`. Only available if the selected\nprivate key format is compatible, similarly to `public_key_openssh` and the [ECDSA P224\nlimitations](../../docs#limitations).\n"
+                        "description": "The fingerprint of the public key data in OpenSSH SHA256 hash format, e.g. `SHA256:...`. Only available if the selected\nprivate key format is compatible, similarly to `public_key_openssh` and the ECDSA P224 limitations.\n"
                     },
                     "publicKeyOpenssh": {
-                        "type": "string",
-                        "description": "The public key data in [\"Authorized\nKeys\"](https://www.ssh.com/academy/ssh/authorized_keys/openssh#format-of-the-authorized-keys-file) format. This is not\npopulated for `ECDSA` with curve `P224`, as it is [not supported](../../docs#limitations). **NOTE**: the\n[underlying](https://pkg.go.dev/encoding/pem#Encode)\n[libraries](https://pkg.go.dev/golang.org/x/crypto/ssh#MarshalAuthorizedKey) that generate this value append a `\\n` at\nthe end of the PEM. In case this disrupts your use case, we recommend using\n[`trimspace()`](https://www.terraform.io/language/functions/trimspace).\n"
+                        "type": "string"
                     },
                     "publicKeyPem": {
-                        "type": "string",
-                        "description": "Public key data in [PEM (RFC 1421)](https://datatracker.ietf.org/doc/html/rfc1421) format. **NOTE**: the\n[underlying](https://pkg.go.dev/encoding/pem#Encode)\n[libraries](https://pkg.go.dev/golang.org/x/crypto/ssh#MarshalAuthorizedKey) that generate this value append a `\\n` at\nthe end of the PEM. In case this disrupts your use case, we recommend using\n[`trimspace()`](https://www.terraform.io/language/functions/trimspace).\n"
+                        "type": "string"
                     },
                     "rsaBits": {
                         "type": "integer",
@@ -705,8 +691,7 @@
                     "description": "List of key usages allowed for the issued certificate. Values are defined in [RFC\n5280](https://datatracker.ietf.org/doc/html/rfc5280) and combine flags defined by both [Key\nUsages](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.3) and [Extended Key\nUsages](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.12). Accepted values: `any_extended`,\n`cert_signing`, `client_auth`, `code_signing`, `content_commitment`, `crl_signing`, `data_encipherment`,\n`decipher_only`, `digital_signature`, `email_protection`, `encipher_only`, `ipsec_end_system`, `ipsec_tunnel`,\n`ipsec_user`, `key_agreement`, `key_encipherment`, `microsoft_commercial_code_signing`, `microsoft_kernel_code_signing`,\n`microsoft_server_gated_crypto`, `netscape_server_gated_crypto`, `ocsp_signing`, `server_auth`, `timestamping`.\n"
                 },
                 "certPem": {
-                    "type": "string",
-                    "description": "Certificate data in [PEM (RFC 1421)](https://datatracker.ietf.org/doc/html/rfc1421) format. **NOTE**: the\n[underlying](https://pkg.go.dev/encoding/pem#Encode)\n[libraries](https://pkg.go.dev/golang.org/x/crypto/ssh#MarshalAuthorizedKey) that generate this value append a `\\n` at\nthe end of the PEM. In case this disrupts your use case, we recommend using\n[`trimspace()`](https://www.terraform.io/language/functions/trimspace).\n"
+                    "type": "string"
                 },
                 "dnsNames": {
                     "type": "array",
@@ -716,8 +701,7 @@
                     "description": "List of DNS names for which a certificate is being requested (i.e. certificate subjects).\n"
                 },
                 "earlyRenewalHours": {
-                    "type": "integer",
-                    "description": "The resource will consider the certificate to have expired the given number of hours before its actual expiry time. This\ncan be useful to deploy an updated certificate in advance of the expiration of the current certificate. However, the old\ncertificate remains valid until its true expiration time, since this resource does not (and cannot) support certificate\nrevocation. Also, this advance update can only be performed should the Terraform configuration be applied during the\nearly renewal period. (default: `0`)\n"
+                    "type": "integer"
                 },
                 "ipAddresses": {
                     "type": "array",
@@ -736,7 +720,6 @@
                 },
                 "privateKeyPem": {
                     "type": "string",
-                    "description": "Private key in [PEM (RFC 1421)](https://datatracker.ietf.org/doc/html/rfc1421) format, that the certificate will belong\nto. This can be read from a separate file using the [`file`](https://www.terraform.io/language/functions/file)\ninterpolation function. Only an irreversible secure hash of the private key will be stored in the Terraform state.\n",
                     "secret": true
                 },
                 "readyForRenewal": {
@@ -805,8 +788,7 @@
                     "description": "List of DNS names for which a certificate is being requested (i.e. certificate subjects).\n"
                 },
                 "earlyRenewalHours": {
-                    "type": "integer",
-                    "description": "The resource will consider the certificate to have expired the given number of hours before its actual expiry time. This\ncan be useful to deploy an updated certificate in advance of the expiration of the current certificate. However, the old\ncertificate remains valid until its true expiration time, since this resource does not (and cannot) support certificate\nrevocation. Also, this advance update can only be performed should the Terraform configuration be applied during the\nearly renewal period. (default: `0`)\n"
+                    "type": "integer"
                 },
                 "ipAddresses": {
                     "type": "array",
@@ -821,7 +803,6 @@
                 },
                 "privateKeyPem": {
                     "type": "string",
-                    "description": "Private key in [PEM (RFC 1421)](https://datatracker.ietf.org/doc/html/rfc1421) format, that the certificate will belong\nto. This can be read from a separate file using the [`file`](https://www.terraform.io/language/functions/file)\ninterpolation function. Only an irreversible secure hash of the private key will be stored in the Terraform state.\n",
                     "secret": true
                 },
                 "setAuthorityKeyId": {
@@ -864,8 +845,7 @@
                         "description": "List of key usages allowed for the issued certificate. Values are defined in [RFC\n5280](https://datatracker.ietf.org/doc/html/rfc5280) and combine flags defined by both [Key\nUsages](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.3) and [Extended Key\nUsages](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.12). Accepted values: `any_extended`,\n`cert_signing`, `client_auth`, `code_signing`, `content_commitment`, `crl_signing`, `data_encipherment`,\n`decipher_only`, `digital_signature`, `email_protection`, `encipher_only`, `ipsec_end_system`, `ipsec_tunnel`,\n`ipsec_user`, `key_agreement`, `key_encipherment`, `microsoft_commercial_code_signing`, `microsoft_kernel_code_signing`,\n`microsoft_server_gated_crypto`, `netscape_server_gated_crypto`, `ocsp_signing`, `server_auth`, `timestamping`.\n"
                     },
                     "certPem": {
-                        "type": "string",
-                        "description": "Certificate data in [PEM (RFC 1421)](https://datatracker.ietf.org/doc/html/rfc1421) format. **NOTE**: the\n[underlying](https://pkg.go.dev/encoding/pem#Encode)\n[libraries](https://pkg.go.dev/golang.org/x/crypto/ssh#MarshalAuthorizedKey) that generate this value append a `\\n` at\nthe end of the PEM. In case this disrupts your use case, we recommend using\n[`trimspace()`](https://www.terraform.io/language/functions/trimspace).\n"
+                        "type": "string"
                     },
                     "dnsNames": {
                         "type": "array",
@@ -875,8 +855,7 @@
                         "description": "List of DNS names for which a certificate is being requested (i.e. certificate subjects).\n"
                     },
                     "earlyRenewalHours": {
-                        "type": "integer",
-                        "description": "The resource will consider the certificate to have expired the given number of hours before its actual expiry time. This\ncan be useful to deploy an updated certificate in advance of the expiration of the current certificate. However, the old\ncertificate remains valid until its true expiration time, since this resource does not (and cannot) support certificate\nrevocation. Also, this advance update can only be performed should the Terraform configuration be applied during the\nearly renewal period. (default: `0`)\n"
+                        "type": "integer"
                     },
                     "ipAddresses": {
                         "type": "array",
@@ -895,7 +874,6 @@
                     },
                     "privateKeyPem": {
                         "type": "string",
-                        "description": "Private key in [PEM (RFC 1421)](https://datatracker.ietf.org/doc/html/rfc1421) format, that the certificate will belong\nto. This can be read from a separate file using the [`file`](https://www.terraform.io/language/functions/file)\ninterpolation function. Only an irreversible secure hash of the private key will be stored in the Terraform state.\n",
                         "secret": true
                     },
                     "readyForRenewal": {

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -2183,8 +2183,9 @@ func extractExamples(description string) string {
 }
 
 var (
-	reTerraform = regexp.MustCompile("[Tt]erraform")
-	reHashicorp = regexp.MustCompile("[Hh]ashicorp")
+	reTerraform        = regexp.MustCompile("[Tt]erraform")
+	reHashicorp        = regexp.MustCompile("[Hh]ashicorp")
+	illegalJavaPattern = regexp.MustCompile("(?m)^@pattern.*")
 )
 
 func elide(text string) bool {
@@ -2194,6 +2195,9 @@ func elide(text string) bool {
 
 // reformatText processes markdown strings from TF docs and cleans them for inclusion in Pulumi docs
 func reformatText(g infoContext, text string, footerLinks map[string]string) (string, bool) {
+	// TODO[pulumi/pulumi-java#1271]: This should be fixed in pulumi/pulumi-java
+	text = illegalJavaPattern.ReplaceAllString(text, "")
+
 	cleanupText := func(text string) (string, bool) {
 		// Remove incorrect documentation.
 		if elide(text) {

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -1254,7 +1254,14 @@ func (g *Generator) gatherResource(rawname string,
 
 		// TODO[pulumi/pulumi#397]: represent sensitive types using a Secret<T> type.
 		doc, foundInAttributes := getDescriptionFromParsedDocs(entityDocs, key)
-		rawdoc := propschema.Description()
+		rawdoc, elided := reformatText(infoContext{
+			language: g.language,
+			pkg:      g.pkg,
+			info:     g.info,
+		}, propschema.Description(), nil)
+		if elided {
+			rawdoc = ""
+		}
 
 		propinfo := info.Fields[key]
 		// If we are generating a provider, we do not emit output property definitions as provider outputs are not

--- a/pkg/tfgen/test_data/minimuxed-schema.json
+++ b/pkg/tfgen/test_data/minimuxed-schema.json
@@ -51,7 +51,7 @@
           "additionalProperties": {
             "$ref": "pulumi.json#/Any"
           },
-          "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+          "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
         },
         "max": {
           "type": "integer",
@@ -81,7 +81,7 @@
           "additionalProperties": {
             "$ref": "pulumi.json#/Any"
           },
-          "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n",
+          "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n",
           "willReplaceOnChanges": true
         },
         "max": {
@@ -112,7 +112,7 @@
             "additionalProperties": {
               "$ref": "pulumi.json#/Any"
             },
-            "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n",
+            "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n",
             "willReplaceOnChanges": true
           },
           "max": {

--- a/pkg/tfgen/test_data/minirandom-schema-csharp.json
+++ b/pkg/tfgen/test_data/minirandom-schema-csharp.json
@@ -37,7 +37,7 @@
           "additionalProperties": {
             "$ref": "pulumi.json#/Any"
           },
-          "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+          "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
         },
         "max": {
           "type": "integer",
@@ -77,7 +77,7 @@
           "additionalProperties": {
             "$ref": "pulumi.json#/Any"
           },
-          "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n",
+          "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n",
           "willReplaceOnChanges": true
         },
         "max": {
@@ -113,7 +113,7 @@
             "additionalProperties": {
               "$ref": "pulumi.json#/Any"
             },
-            "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n",
+            "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n",
             "willReplaceOnChanges": true
           },
           "max": {

--- a/pkg/tfgen/test_data/regress-611-schema.json
+++ b/pkg/tfgen/test_data/regress-611-schema.json
@@ -2291,8 +2291,7 @@
           "type": "string"
         },
         "forceDestroy": {
-          "type": "boolean",
-          "description": "Delete user even if it has non-Terraform-managed IAM access keys, login profile or MFA devices\n"
+          "type": "boolean"
         },
         "name": {
           "type": "string"
@@ -2327,8 +2326,7 @@
       ],
       "inputProperties": {
         "forceDestroy": {
-          "type": "boolean",
-          "description": "Delete user even if it has non-Terraform-managed IAM access keys, login profile or MFA devices\n"
+          "type": "boolean"
         },
         "name": {
           "type": "string"
@@ -2353,8 +2351,7 @@
             "type": "string"
           },
           "forceDestroy": {
-            "type": "boolean",
-            "description": "Delete user even if it has non-Terraform-managed IAM access keys, login profile or MFA devices\n"
+            "type": "boolean"
           },
           "name": {
             "type": "string"

--- a/pkg/tfgen/test_data/regress-minirandom-schema.json
+++ b/pkg/tfgen/test_data/regress-minirandom-schema.json
@@ -37,7 +37,7 @@
           "additionalProperties": {
             "$ref": "pulumi.json#/Any"
           },
-          "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+          "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
         },
         "max": {
           "type": "integer",
@@ -67,7 +67,7 @@
           "additionalProperties": {
             "$ref": "pulumi.json#/Any"
           },
-          "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n",
+          "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n",
           "willReplaceOnChanges": true
         },
         "max": {
@@ -98,7 +98,7 @@
             "additionalProperties": {
               "$ref": "pulumi.json#/Any"
             },
-            "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n",
+            "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n",
             "willReplaceOnChanges": true
           },
           "max": {

--- a/pkg/tfgen/test_data/test-propagate-language-options.json
+++ b/pkg/tfgen/test_data/test-propagate-language-options.json
@@ -54,7 +54,7 @@
           "additionalProperties": {
             "$ref": "pulumi.json#/Any"
           },
-          "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n"
+          "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n"
         },
         "max": {
           "type": "integer",
@@ -84,7 +84,7 @@
           "additionalProperties": {
             "$ref": "pulumi.json#/Any"
           },
-          "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n",
+          "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n",
           "willReplaceOnChanges": true
         },
         "max": {
@@ -115,7 +115,7 @@
             "additionalProperties": {
               "$ref": "pulumi.json#/Any"
             },
-            "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See [the main provider\ndocumentation](../index.html) for more information.\n",
+            "description": "Arbitrary map of values that, when changed, will trigger recreation of resource. See the main provider documentation for\nmore information.\n",
             "willReplaceOnChanges": true
           },
           "max": {


### PR DESCRIPTION
This fixes the root cause for https://github.com/pulumi/pulumi-gcp/issues/1950.