### PR TITLE
Fix panic in ReadDataDiff

### DIFF
--- a/pkg/tests/invoke_raw_config_test.go
+++ b/pkg/tests/invoke_raw_config_test.go
@@ -1,0 +1,98 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"context"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	testutils "github.com/pulumi/providertest/replay"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
+)
+
+func TestInvokeRawConfigDoesNotPanic(t *testing.T) {
+	ctx := context.Background()
+
+	resource := &schema.Resource{
+		ReadWithoutTimeout: func(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
+			rawConfigVal := data.GetRawConfig().GetAttr("engine")
+			err := data.Set("engine", rawConfigVal.AsString())
+			if err != nil {
+				panic(err)
+			}
+			data.SetId("123")
+			return diag.Diagnostics{}
+		},
+		Schema: map[string]*schema.Schema{
+			"engine": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+
+	tfProvider := &schema.Provider{
+		Schema: map[string]*schema.Schema{},
+		DataSourcesMap: map[string]*schema.Resource{
+			"aws_rds_engine_version": resource,
+		},
+	}
+
+	p := shimv2.NewProvider(tfProvider)
+
+	info := tfbridge.ProviderInfo{
+		P:    p,
+		Name: "aws",
+		DataSources: map[string]*tfbridge.DataSourceInfo{
+			"aws_rds_engine_version": {Tok: "aws:rds/getEngineVersion:getEngineVersion"},
+		},
+	}
+
+	server := tfbridge.NewProvider(ctx,
+		nil,      /* hostClient */
+		"aws",    /* module */
+		"",       /* version */
+		p,        /* tf */
+		info,     /* info */
+		[]byte{}, /* pulumiSchema */
+	)
+
+	testCase := `
+	{
+  "method": "/pulumirpc.ResourceProvider/Invoke",
+  "request": {
+    "tok": "aws:rds/getEngineVersion:getEngineVersion",
+    "args": {
+      "engine": "postgres"
+    }
+  },
+  "response": {
+    "return": {
+      "engine": "postgres",
+	  "id": "123"
+    }
+  },
+  "metadata": {
+    "kind": "resource",
+    "mode": "client",
+    "name": "aws"
+  }
+}`
+	testutils.Replay(t, server, testCase)
+}

--- a/pkg/tfshim/sdk-v2/provider.go
+++ b/pkg/tfshim/sdk-v2/provider.go
@@ -160,7 +160,7 @@ func (p v2Provider) ReadDataDiff(
 	t string,
 	c shim.ResourceConfig,
 ) (shim.InstanceDiff, error) {
-	r, ok := p.tf.DataSourcesMap[t]
+	resource, ok := p.tf.DataSourcesMap[t]
 	if !ok {
 		return nil, fmt.Errorf("unknown resource %v", t)
 	}
@@ -170,12 +170,12 @@ func (p v2Provider) ReadDataDiff(
 		return nil, err
 	}
 	config := configFromShim(c)
-	rawConfig := makeResourceRawConfig(providerOpts.diffStrategy, config, r)
+	rawConfig := makeResourceRawConfig(providerOpts.diffStrategy, config, resource)
 
-	instanceState := terraform.InstanceState{
-		RawConfig: rawConfig,
+	diff, err := resource.Diff(ctx, nil, config, p.tf.Meta())
+	if diff != nil {
+		diff.RawConfig = rawConfig
 	}
-	diff, err := r.Diff(ctx, &instanceState, configFromShim(c), p.tf.Meta())
 	return diffToShim(diff), err
 }
 


### PR DESCRIPTION
Previously, we passed a `nil` object as the terraform InstanceState.
Now, we pass a stuctured RawConfig object to avoid a panic when GetRawConfig is called in the ReadWithoutTimeout data source method.
Fixes #1809.
