### PR TITLE
Instrument DecodePropertyMap failures to assist root-causing refresh issues in Plugin Framework

### DIFF
--- a/pf/tests/internal/providerbuilder/build_resource.go
+++ b/pf/tests/internal/providerbuilder/build_resource.go
@@ -24,6 +24,11 @@ import (
 type Resource struct {
 	Name           string
 	ResourceSchema schema.Schema
+
+	CreateFunc func(context.Context, resource.CreateRequest, *resource.CreateResponse)
+	ReadFunc   func(context.Context, resource.ReadRequest, *resource.ReadResponse)
+	UpdateFunc func(context.Context, resource.UpdateRequest, *resource.UpdateResponse)
+	DeleteFunc func(context.Context, resource.DeleteRequest, *resource.DeleteResponse)
 }
 
 func (r *Resource) Metadata(ctx context.Context, req resource.MetadataRequest, re *resource.MetadataResponse) {
@@ -34,9 +39,32 @@ func (r *Resource) Schema(ctx context.Context, _ resource.SchemaRequest, re *res
 	re.Schema = r.ResourceSchema
 }
 
-func (*Resource) Create(context.Context, resource.CreateRequest, *resource.CreateResponse) {}
-func (*Resource) Read(context.Context, resource.ReadRequest, *resource.ReadResponse)       {}
-func (*Resource) Update(context.Context, resource.UpdateRequest, *resource.UpdateResponse) {}
-func (*Resource) Delete(context.Context, resource.DeleteRequest, *resource.DeleteResponse) {}
+func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	if r.CreateFunc == nil {
+		return
+	}
+	r.CreateFunc(ctx, req, resp)
+}
+
+func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	if r.ReadFunc == nil {
+		return
+	}
+	r.ReadFunc(ctx, req, resp)
+}
+
+func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	if r.UpdateFunc == nil {
+		return
+	}
+	r.UpdateFunc(ctx, req, resp)
+}
+
+func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	if r.DeleteFunc == nil {
+		return
+	}
+	r.DeleteFunc(ctx, req, resp)
+}
 
 var _ resource.Resource = &Resource{}

--- a/pf/tests/internal/providerbuilder/build_resource.go
+++ b/pf/tests/internal/providerbuilder/build_resource.go
@@ -25,10 +25,10 @@ type Resource struct {
 	Name           string
 	ResourceSchema schema.Schema
 
-	CreateFunc func(context.Context, resource.CreateRequest, *resource.CreateResponse)
-	ReadFunc   func(context.Context, resource.ReadRequest, *resource.ReadResponse)
-	UpdateFunc func(context.Context, resource.UpdateRequest, *resource.UpdateResponse)
-	DeleteFunc func(context.Context, resource.DeleteRequest, *resource.DeleteResponse)
+	CreateFunc func(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse)
+	ReadFunc   func(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse)
+	UpdateFunc func(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse)
+	DeleteFunc func(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse)
 }
 
 func (r *Resource) Metadata(ctx context.Context, req resource.MetadataRequest, re *resource.MetadataResponse) {

--- a/pf/tfbridge/provider_create.go
+++ b/pf/tfbridge/provider_create.go
@@ -61,7 +61,7 @@ func (p *provider) CreateWithContext(
 	// NOTE: it seems that planResp.RequiresReplace can be ignored in Create and must be false.
 
 	if preview {
-		plannedStatePropertyMap, err := convert.DecodePropertyMapFromDynamic(
+		plannedStatePropertyMap, err := convert.DecodePropertyMapFromDynamic(ctx,
 			rh.decoder, tfType, planResp.PlannedState)
 		if err != nil {
 			return "", nil, 0, err
@@ -109,7 +109,7 @@ func (p *provider) CreateWithContext(
 		return "", nil, 0, err
 	}
 
-	createdStateMap, err := createdState.ToPropertyMap(&rh)
+	createdStateMap, err := createdState.ToPropertyMap(ctx, &rh)
 	if err != nil {
 		return "", nil, 0, err
 	}

--- a/pf/tfbridge/provider_invoke.go
+++ b/pf/tfbridge/provider_invoke.go
@@ -101,7 +101,7 @@ func (p *provider) readDataSource(ctx context.Context, handle datasourceHandle,
 		return nil, failures, err
 	}
 
-	propertyMap, err := convert.DecodePropertyMapFromDynamic(handle.decoder, typ, resp.State)
+	propertyMap, err := convert.DecodePropertyMapFromDynamic(ctx, handle.decoder, typ, resp.State)
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot decode state from a call to ReadDataSource for %q: %w",
 			handle.terraformDataSourceName, err)

--- a/pf/tfbridge/provider_read.go
+++ b/pf/tfbridge/provider_read.go
@@ -151,7 +151,7 @@ func (p *provider) readResource(
 		return plugin.ReadResult{}, nil
 	}
 
-	readStateMap, err := readState.ToPropertyMap(rh)
+	readStateMap, err := readState.ToPropertyMap(ctx, rh)
 	if err != nil {
 		return plugin.ReadResult{}, fmt.Errorf("converting to property map: %w", err)
 	}
@@ -225,7 +225,7 @@ func (p *provider) importResource(
 		return plugin.ReadResult{}, err
 	}
 
-	readStateMap, err := readState.ToPropertyMap(rh)
+	readStateMap, err := readState.ToPropertyMap(ctx, rh)
 	if err != nil {
 		return plugin.ReadResult{}, err
 	}

--- a/pf/tfbridge/provider_read.go
+++ b/pf/tfbridge/provider_read.go
@@ -141,19 +141,14 @@ func (p *provider) readResource(
 		return plugin.ReadResult{}, nil
 	}
 
-	// TF interpretes a null new state as an indication that the resource does not
-	// exist in the cloud provider.
-	newStateNull, err := resp.NewState.IsNull()
-	if err != nil {
-		return plugin.ReadResult{}, fmt.Errorf("checking null state: %w", err)
-	}
-	if newStateNull {
-		return plugin.ReadResult{}, nil
-	}
-
 	readState, err := parseResourceStateFromTF(ctx, rh, resp.NewState, resp.Private)
 	if err != nil {
 		return plugin.ReadResult{}, fmt.Errorf("parsing resource state: %w", err)
+	}
+
+	// TF interprets a null new state as an indication that the resource does not exist in the cloud provider.
+	if readState.state.Value.IsNull() {
+		return plugin.ReadResult{}, nil
 	}
 
 	readStateMap, err := readState.ToPropertyMap(rh)

--- a/pf/tfbridge/provider_update.go
+++ b/pf/tfbridge/provider_update.go
@@ -78,7 +78,7 @@ func (p *provider) UpdateWithContext(
 	}
 
 	if preview {
-		plannedStatePropertyMap, err := convert.DecodePropertyMapFromDynamic(
+		plannedStatePropertyMap, err := convert.DecodePropertyMapFromDynamic(ctx,
 			rh.decoder, tfType, planResp.PlannedState)
 		if err != nil {
 			return nil, 0, err
@@ -123,7 +123,7 @@ func (p *provider) UpdateWithContext(
 		return nil, 0, err
 	}
 
-	updatedStateMap, err := updatedState.ToPropertyMap(&rh)
+	updatedStateMap, err := updatedState.ToPropertyMap(ctx, &rh)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/pf/tfbridge/resource_state.go
+++ b/pf/tfbridge/resource_state.go
@@ -47,8 +47,8 @@ func (u *upgradedResourceState) PrivateState() []byte {
 	return u.state.Private
 }
 
-func (u *upgradedResourceState) ToPropertyMap(rh *resourceHandle) (resource.PropertyMap, error) {
-	propMap, err := convert.DecodePropertyMap(rh.decoder, u.state.Value)
+func (u *upgradedResourceState) ToPropertyMap(ctx context.Context, rh *resourceHandle) (resource.PropertyMap, error) {
+	propMap, err := convert.DecodePropertyMap(ctx, rh.decoder, u.state.Value)
 	if err != nil {
 		return nil, err
 	}

--- a/pf/tfbridge/resource_state.go
+++ b/pf/tfbridge/resource_state.go
@@ -115,15 +115,30 @@ func parseResourceStateFromTF(
 	private []byte,
 ) (*upgradedResourceState, error) {
 	tfType := rh.schema.Type().TerraformType(ctx)
-	v, err := state.Unmarshal(tfType)
-	if err != nil {
-		return nil, err
-	}
-	return &upgradedResourceState{state: &resourceState{
-		TFSchemaVersion: rh.schema.ResourceSchemaVersion(),
-		Value:           v,
+	return parseResourceStateFromTFInner(ctx, tfType, rh.schema.ResourceSchemaVersion(), state, private)
+}
+
+func parseResourceStateFromTFInner(
+	ctx context.Context,
+	resourceTerraformType tftypes.Type,
+	resourceSchemaVersion int64,
+	state *tfprotov6.DynamicValue,
+	private []byte,
+) (*upgradedResourceState, error) {
+	rs := &resourceState{
+		TFSchemaVersion: resourceSchemaVersion,
 		Private:         private,
-	}}, nil
+	}
+	if state == nil {
+		rs.Value = tftypes.NewValue(resourceTerraformType, nil)
+	} else {
+		v, err := state.Unmarshal(resourceTerraformType)
+		if err != nil {
+			return nil, err
+		}
+		rs.Value = v
+	}
+	return &upgradedResourceState{state: rs}, nil
 }
 
 type metaState struct {

--- a/pf/tfbridge/resource_state_test.go
+++ b/pf/tfbridge/resource_state_test.go
@@ -1,0 +1,76 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfbridge
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hexops/autogold/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseResourceStateFromTFInner(t *testing.T) {
+	ctx := context.Background()
+
+	ty := tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{
+			"id": tftypes.String,
+			"x":  tftypes.String,
+		},
+	}
+
+	t.Run("parses physical nil", func(t *testing.T) {
+		up, err := parseResourceStateFromTFInner(ctx, ty, 0, nil, nil)
+		require.NoError(t, err)
+		autogold.Expect(`tftypes.Object["id":tftypes.String, "x":tftypes.String]<null>`).Equal(t, up.state.Value.String())
+	})
+
+	t.Run("parses logical nil", func(t *testing.T) {
+		dv, err := makeDynamicValue(tftypes.NewValue(ty, nil))
+		require.NoError(t, err)
+		up, err := parseResourceStateFromTFInner(ctx, ty, 0, &dv, nil)
+		require.NoError(t, err)
+		autogold.Expect(`tftypes.Object["id":tftypes.String, "x":tftypes.String]<null>`).Equal(t, up.state.Value.String())
+	})
+
+	t.Run("parses a valid object", func(t *testing.T) {
+		dv, err := makeDynamicValue(tftypes.NewValue(ty, map[string]tftypes.Value{
+			"id": tftypes.NewValue(tftypes.String, "id1"),
+			"x":  tftypes.NewValue(tftypes.String, nil),
+		}))
+		require.NoError(t, err)
+		up, err := parseResourceStateFromTFInner(ctx, ty, 0, &dv, nil)
+		require.NoError(t, err)
+		autogold.Expect(`tftypes.Object["id":tftypes.String, "x":tftypes.String]<"id":tftypes.String<"id1">, "x":tftypes.String<null>>`).Equal(t, up.state.Value.String())
+	})
+
+	t.Run("fails to parse a malformed object", func(t *testing.T) {
+		dv, err := makeDynamicValue(tftypes.NewValue(tftypes.Object{
+			AttributeTypes: map[string]tftypes.Type{
+				"id": tftypes.String,
+			},
+		}, map[string]tftypes.Value{
+			"id": tftypes.NewValue(tftypes.String, "id1"),
+		}))
+		require.NoError(t, err)
+		up, err := parseResourceStateFromTFInner(ctx, ty, 0, &dv, nil)
+		require.Nil(t, up)
+		autogold.Expect("error decoding object; expected 2 attributes, got 1").Equal(t, err.Error())
+		t.Log(err)
+		require.Error(t, err)
+	})
+}

--- a/pf/tfbridge/resource_state_test.go
+++ b/pf/tfbridge/resource_state_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
-	"github.com/hexops/autogold/v2"
 	"github.com/stretchr/testify/require"
 )
 
@@ -36,7 +35,7 @@ func TestParseResourceStateFromTFInner(t *testing.T) {
 	t.Run("parses physical nil", func(t *testing.T) {
 		up, err := parseResourceStateFromTFInner(ctx, ty, 0, nil, nil)
 		require.NoError(t, err)
-		autogold.Expect(`tftypes.Object["id":tftypes.String, "x":tftypes.String]<null>`).Equal(t, up.state.Value.String())
+		require.Equal(t, `tftypes.Object["id":tftypes.String, "x":tftypes.String]<null>`, up.state.Value.String())
 	})
 
 	t.Run("parses logical nil", func(t *testing.T) {
@@ -44,7 +43,7 @@ func TestParseResourceStateFromTFInner(t *testing.T) {
 		require.NoError(t, err)
 		up, err := parseResourceStateFromTFInner(ctx, ty, 0, &dv, nil)
 		require.NoError(t, err)
-		autogold.Expect(`tftypes.Object["id":tftypes.String, "x":tftypes.String]<null>`).Equal(t, up.state.Value.String())
+		require.Equal(t, `tftypes.Object["id":tftypes.String, "x":tftypes.String]<null>`, up.state.Value.String())
 	})
 
 	t.Run("parses a valid object", func(t *testing.T) {
@@ -55,7 +54,8 @@ func TestParseResourceStateFromTFInner(t *testing.T) {
 		require.NoError(t, err)
 		up, err := parseResourceStateFromTFInner(ctx, ty, 0, &dv, nil)
 		require.NoError(t, err)
-		autogold.Expect(`tftypes.Object["id":tftypes.String, "x":tftypes.String]<"id":tftypes.String<"id1">, "x":tftypes.String<null>>`).Equal(t, up.state.Value.String())
+		//nolint:lll
+		require.Equal(t, `tftypes.Object["id":tftypes.String, "x":tftypes.String]<"id":tftypes.String<"id1">, "x":tftypes.String<null>>`, up.state.Value.String())
 	})
 
 	t.Run("fails to parse a malformed object", func(t *testing.T) {
@@ -69,7 +69,7 @@ func TestParseResourceStateFromTFInner(t *testing.T) {
 		require.NoError(t, err)
 		up, err := parseResourceStateFromTFInner(ctx, ty, 0, &dv, nil)
 		require.Nil(t, up)
-		autogold.Expect("error decoding object; expected 2 attributes, got 1").Equal(t, err.Error())
+		require.Equal(t, "error decoding object; expected 2 attributes, got 1", err.Error())
 		t.Log(err)
 		require.Error(t, err)
 	})

--- a/pkg/convert/encoding_test.go
+++ b/pkg/convert/encoding_test.go
@@ -15,6 +15,7 @@
 package convert
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -169,7 +170,7 @@ func TestResourceDecoder(t *testing.T) {
 			enc := NewEncoding(makeProvider(tc.schema).Shim(), tc.info)
 			decoder, err := enc.NewResourceDecoder(myResource, tc.typ)
 			require.NoError(t, err)
-			got, err := DecodePropertyMap(decoder, tc.val)
+			got, err := DecodePropertyMap(context.Background(), decoder, tc.val)
 			require.NoError(t, err)
 			if tc.expectMap != nil {
 				require.Equal(t, tc.expectMap, got)
@@ -340,7 +341,7 @@ func TestDataSourceDecoder(t *testing.T) {
 			enc := NewEncoding(makeProvider(tc.schema).Shim(), tc.info)
 			decoder, err := enc.NewDataSourceDecoder(myDataSource, tc.typ)
 			require.NoError(t, err)
-			got, err := DecodePropertyMap(decoder, tc.val)
+			got, err := DecodePropertyMap(context.Background(), decoder, tc.val)
 			require.NoError(t, err)
 			tc.expect.Equal(t, got)
 		})
@@ -549,7 +550,7 @@ func TestTypeDerivations(t *testing.T) {
 
 			tc.expected.Equal(t, tfv.String())
 
-			back, err := DecodePropertyMap(dec, tfv)
+			back, err := DecodePropertyMap(context.Background(), dec, tfv)
 			require.NoError(t, err)
 			require.Equal(t, tc.sample, back)
 		})
@@ -626,7 +627,7 @@ func TestTupleDerivations(t *testing.T) {
 
 			tc.expected.Equal(t, tfv.String())
 
-			back, err := DecodePropertyMap(dec, tfv)
+			back, err := DecodePropertyMap(context.Background(), dec, tfv)
 			require.NoError(t, err)
 			require.Equal(t, tc.sample, back)
 		})

--- a/pkg/convert/secret_test.go
+++ b/pkg/convert/secret_test.go
@@ -15,6 +15,7 @@
 package convert
 
 import (
+	"context"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
@@ -137,7 +138,7 @@ func TestSecretDecoderInjectsSchemaSecrets(t *testing.T) {
 				SchemaInfos: tc.schemaInfos,
 			})
 			require.NoError(t, err)
-			pm, err := DecodePropertyMap(d, tc.val)
+			pm, err := DecodePropertyMap(context.Background(), d, tc.val)
 			require.NoError(t, err)
 			tc.expect.Equal(t, pm)
 		})

--- a/pkg/tests/cross-tests/pu_driver.go
+++ b/pkg/tests/cross-tests/pu_driver.go
@@ -178,7 +178,7 @@ func (pd *pulumiDriver) convertConfigToPulumi(
 	}
 
 	// There is not yet a way to opt out of marking schema secrets, so the resulting map might have secrets marked.
-	pm, err := convert.DecodePropertyMap(decoder, *v)
+	pm, err := convert.DecodePropertyMap(context.Background(), decoder, *v)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Investigating https://github.com/pulumi/pulumi-terraform-bridge/issues/1919

DecodePropertyMap called from Read fails because it decoded something to a null but a PropertyMap is expected. It appears it should never happen because Read will not call DecodePropertyMap with a tftypes.Value=nil but instead short-circuit the "resource not found path".

`resp.State.RemoveResource(ctx)` likewise seems to work correctly.

Testing this further, still unable to reproduce the scenario in test. Instead, opting for adding some more debugging instrumentation around the line that emits the error, and doing some conservative code tightening around this code path. 

