### PR TITLE
Fix automatic aliasing of muxed providers

### DIFF
--- a/pf/internal/muxer/muxer.go
+++ b/pf/internal/muxer/muxer.go
@@ -122,9 +122,9 @@ func (m *ProviderShim) DataSourceIsPF(token string) bool {
 //
 // `provider` will be the `len(m.MuxedProviders)` when mappings are computed.
 func (m *ProviderShim) extend(provider shim.Provider) ([]string, []string) {
-	res := newUnionResourceMap(m.resources, provider.ResourcesMap())
+	res := newUnionMap(m.resources, provider.ResourcesMap())
 	conflictingResources := res.ConflictingKeys()
-	data := newUnionResourceMap(m.dataSources, provider.DataSourcesMap())
+	data := newUnionMap(m.dataSources, provider.DataSourcesMap())
 	conflictingDataSources := data.ConflictingKeys()
 	m.resources = res
 	m.dataSources = data

--- a/pf/internal/muxer/muxer.go
+++ b/pf/internal/muxer/muxer.go
@@ -16,7 +16,6 @@ package muxer
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 
 	"context"
@@ -26,7 +25,6 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/pf/internal/schemashim"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
-	shimSchema "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
 	"github.com/pulumi/pulumi-terraform-bridge/x/muxer"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -124,10 +122,10 @@ func (m *ProviderShim) DataSourceIsPF(token string) bool {
 //
 // `provider` will be the `len(m.MuxedProviders)` when mappings are computed.
 func (m *ProviderShim) extend(provider shim.Provider) ([]string, []string) {
-	res, conflictingResources := union(m.resources, provider.ResourcesMap())
-
-	data, conflictingDataSources := union(m.dataSources, provider.DataSourcesMap())
-
+	res := newUnionResourceMap(m.resources, provider.ResourcesMap())
+	conflictingResources := res.ConflictingKeys()
+	data := newUnionResourceMap(m.dataSources, provider.DataSourcesMap())
+	conflictingDataSources := data.ConflictingKeys()
 	m.resources = res
 	m.dataSources = data
 	m.MuxedProviders = append(m.MuxedProviders, provider)
@@ -255,46 +253,3 @@ func (p *simpleSchemaProvider) DataSourcesMap() shim.ResourceMap {
 }
 
 var _ shim.Provider = (*simpleSchemaProvider)(nil)
-
-func union(baseline, extension shim.ResourceMap) (shim.ResourceMap, []string) {
-	union, conflictingKeys := mapUnion(toResourceMap(baseline), toResourceMap(extension))
-	return shimSchema.ResourceMap(union), conflictingKeys
-}
-
-func toResourceMap(rmap shim.ResourceMap) shimSchema.ResourceMap {
-	m := map[string]shim.Resource{}
-	rmap.Range(func(key string, value shim.Resource) bool {
-		m[key] = value
-		return true
-	})
-	return m
-}
-
-func mapUnion[T any](baseline, extension map[string]T) (map[string]T, []string) {
-	u := copyMap(baseline)
-
-	var conflictingKeys []string
-
-	for k, v := range extension {
-		if _, conflict := baseline[k]; conflict {
-			conflictingKeys = append(conflictingKeys, k)
-			continue
-		}
-		u[k] = v
-	}
-
-	sort.Strings(conflictingKeys)
-
-	return u, conflictingKeys
-}
-
-func copyMap[K comparable, V any](m map[K]V) map[K]V {
-	if m == nil {
-		return nil
-	}
-	out := make(map[K]V, len(m))
-	for k, v := range m {
-		out[k] = v
-	}
-	return out
-}

--- a/pf/internal/muxer/union.go
+++ b/pf/internal/muxer/union.go
@@ -1,0 +1,149 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package muxer
+
+import (
+	"fmt"
+	"sort"
+
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+type unionResourceMap struct {
+	baseline  shim.ResourceMap
+	extension shim.ResourceMap
+}
+
+var _ shim.ResourceMapWithClone = (*unionResourceMap)(nil)
+
+func newUnionResourceMap(baseline, extension shim.ResourceMap) *unionResourceMap {
+	return &unionResourceMap{
+		baseline:  baseline,
+		extension: extension,
+	}
+}
+
+func (m *unionResourceMap) Len() int {
+	n := 0
+	m.baseline.Range(func(key string, value shim.Resource) bool {
+		n++
+		return true
+	})
+	m.extension.Range(func(key string, value shim.Resource) bool {
+		if _, conflict := m.baseline.GetOk(key); !conflict {
+			n++
+		}
+		return true
+	})
+	return n
+}
+
+func (m *unionResourceMap) Get(key string) shim.Resource {
+	if v, ok := m.GetOk(key); ok {
+		return v
+	}
+	contract.Failf("key not found: %v", key)
+	return nil
+}
+
+func (m *unionResourceMap) GetOk(key string) (shim.Resource, bool) {
+	if v, ok := m.baseline.GetOk(key); ok {
+		return v, true
+	}
+	if v, ok := m.extension.GetOk(key); ok {
+		return v, true
+	}
+	return nil, false
+}
+
+func (m *unionResourceMap) Range(each func(key string, value shim.Resource) bool) {
+	iterating := true
+	m.baseline.Range(func(key string, value shim.Resource) bool {
+		if value == nil {
+			panic("GAH1! nil resource in baseline")
+		}
+		iterating = iterating && each(key, value)
+		return iterating
+	})
+	if !iterating {
+		return
+	}
+	m.extension.Range(func(key string, value shim.Resource) bool {
+		if _, conflict := m.baseline.GetOk(key); conflict {
+			return true
+		}
+		if value == nil {
+			panic("GAH2! nil resource in extension")
+		}
+		return each(key, value)
+	})
+}
+
+func (m *unionResourceMap) Set(key string, value shim.Resource) {
+	if value == nil {
+		panic("GAH! nil in Set")
+	}
+	// Sending edits to the owner map.
+	_, b := m.baseline.GetOk(key)
+	_, e := m.extension.GetOk(key)
+	switch {
+	case b && e:
+		// In the case of conflict, send the edit to both.
+		m.baseline.Set(key, value)
+		m.extension.Set(key, value)
+	case b:
+		m.baseline.Set(key, value)
+	case e:
+		m.extension.Set(key, value)
+	default:
+		// Net-new keys accumulate in baseline, this is arbitrary:
+		m.baseline.Set(key, value)
+	}
+}
+
+func (m *unionResourceMap) Clone(oldKey, newKey string) error {
+	// Sending the clone operation to the owner map.
+	_, b := m.baseline.GetOk(oldKey)
+	_, e := m.extension.GetOk(oldKey)
+
+	switch {
+	case b && e:
+		// In the case of conflict, send the clone operation to both.
+		m.baseline.Set(newKey, m.baseline.Get(oldKey))
+		m.extension.Set(newKey, m.extension.Get(oldKey))
+		return nil
+	case b:
+		m.baseline.Set(newKey, m.baseline.Get(oldKey))
+		return nil
+	case e:
+		m.extension.Set(newKey, m.extension.Get(oldKey))
+		return nil
+	default:
+		return fmt.Errorf("Cannot clone non-existing key %q to %q", oldKey, newKey)
+	}
+}
+
+func (m *unionResourceMap) ConflictingKeys() []string {
+	conflicts := []string{}
+	m.baseline.Range(func(key string, value shim.Resource) bool {
+		if _, ok := m.extension.GetOk(key); ok {
+			conflicts = append(conflicts, key)
+		}
+		return true
+	})
+	sort.Strings(conflicts)
+	return nil
+}

--- a/pf/internal/muxer/union.go
+++ b/pf/internal/muxer/union.go
@@ -108,6 +108,9 @@ func (m *unionMap[T]) Set(key string, value T) {
 	}
 }
 
+// Clone will delegate the operation to the sub-map owning oldKey, or fail if the owner is ambiguous. In the sub-map the
+// value associated with oldKey will now be also associated with newKey. In Pulumi this is relied on to track ownership
+// of aliased resources in muxed providers as RenameResourceWithAlias uses Clone.
 func (m *unionMap[T]) Clone(oldKey, newKey string) error {
 	// Sending the clone operation to the owner map.
 	bv, b := m.baseline.GetOk(oldKey)

--- a/pf/internal/muxer/union.go
+++ b/pf/internal/muxer/union.go
@@ -28,6 +28,7 @@ type unionMap[T any] struct {
 }
 
 type mapLike[T any] interface {
+	Len() int
 	Range(func(key string, value T) bool)
 	GetOk(key string) (T, bool)
 	Set(key string, value T)
@@ -43,11 +44,7 @@ func newUnionMap[T any](baseline, extension mapLike[T]) *unionMap[T] {
 }
 
 func (m *unionMap[T]) Len() int {
-	n := 0
-	m.baseline.Range(func(key string, value T) bool {
-		n++
-		return true
-	})
+	n := m.baseline.Len()
 	m.extension.Range(func(key string, value T) bool {
 		if _, conflict := m.baseline.GetOk(key); !conflict {
 			n++

--- a/pf/internal/muxer/union_test.go
+++ b/pf/internal/muxer/union_test.go
@@ -1,0 +1,137 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package muxer
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnionMap(t *testing.T) {
+	m1 := testMap{
+		"one": "n1",
+		"two": "n2",
+	}
+	m2 := testMap{
+		"two":   "x2",
+		"three": "x3",
+	}
+	m := newUnionMap(m1, m2)
+
+	t.Run("Len", func(t *testing.T) {
+		assert.Equal(t, 3, m.Len())
+	})
+	t.Run("GetOk", func(t *testing.T) {
+		_, ok := m.GetOk("zero")
+		assert.False(t, ok)
+		n1, ok := m.GetOk("one")
+		assert.Equal(t, "n1", n1)
+		assert.True(t, ok)
+		// Conflicting keys served from the left (baseline) map.
+		n2, ok := m.GetOk("two")
+		assert.Equal(t, "n2", n2)
+		assert.True(t, ok)
+		n3, ok := m.GetOk("three")
+		assert.Equal(t, "x3", n3)
+		assert.True(t, ok)
+	})
+	t.Run("Get", func(t *testing.T) {
+		n1 := m.Get("one")
+		assert.Equal(t, "n1", n1)
+	})
+	t.Run("ConflictingKeys", func(t *testing.T) {
+		assert.Equal(t, []string{"two"}, m.ConflictingKeys())
+	})
+	t.Run("Range", func(t *testing.T) {
+		keys := []string{}
+		values := []string{}
+		m.Range(func(key, value string) bool {
+			keys = append(keys, key)
+			values = append(values, value)
+			return true
+		})
+		sort.Strings(keys)
+		sort.Strings(values)
+		assert.Equal(t, []string{"one", "three", "two"}, keys)
+		assert.Equal(t, []string{"n1", "n2", "x3"}, values)
+	})
+	t.Run("Set", func(t *testing.T) {
+		m1 := testMap{
+			"one": "n1",
+			"two": "n2",
+		}
+		m2 := testMap{
+			"two":   "x2",
+			"three": "x3",
+		}
+		m := newUnionMap(m1, m2)
+		m.Set("one", "n1!")
+		assert.Equal(t, "n1!", m1["one"])
+		m.Set("three", "x3!")
+		assert.Equal(t, "x3!", m2["three"])
+		m.Set("zero", "n0!")
+		assert.Equal(t, "n0!", m1["zero"])
+		t.Run("conflict", func(t *testing.T) {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Errorf("The code did not panic")
+				}
+			}()
+			m.Set("two", "n2!")
+		})
+	})
+	t.Run("Clone", func(t *testing.T) {
+		m1 := testMap{
+			"one": "n1",
+			"two": "n2",
+		}
+		m2 := testMap{
+			"two":   "x2",
+			"three": "x3",
+		}
+		m := newUnionMap(m1, m2)
+		err := m.Clone("one", "one_legacy")
+		assert.NoError(t, err)
+		assert.Equal(t, "n1", m1["one_legacy"])
+		err = m.Clone("three", "three_legacy")
+		assert.NoError(t, err)
+		assert.Equal(t, "x3", m2["three_legacy"])
+		assert.Error(t, m.Clone("two", "two_legacy"))
+		assert.Error(t, m.Clone("zero", "zero_legacy"))
+	})
+}
+
+type testMap map[string]string
+
+var _ mapLike[string] = make(testMap)
+
+func (x testMap) GetOk(key string) (string, bool) {
+	v, ok := x[key]
+	return v, ok
+}
+
+func (x testMap) Set(key string, value string) {
+	x[key] = value
+}
+
+func (x testMap) Range(each func(key string, value string) bool) {
+	for k, v := range x {
+		if !each(k, v) {
+			return
+		}
+	}
+}

--- a/pf/internal/muxer/union_test.go
+++ b/pf/internal/muxer/union_test.go
@@ -119,6 +119,10 @@ type testMap map[string]string
 
 var _ mapLike[string] = make(testMap)
 
+func (x testMap) Len() int {
+	return len(x)
+}
+
 func (x testMap) GetOk(key string) (string, bool) {
 	v, ok := x[key]
 	return v, ok

--- a/pf/internal/schemashim/provider.go
+++ b/pf/internal/schemashim/provider.go
@@ -24,8 +24,9 @@ import (
 )
 
 type SchemaOnlyProvider struct {
-	ctx context.Context
-	tf  pfprovider.Provider
+	ctx         context.Context
+	tf          pfprovider.Provider
+	resourceMap shim.ResourceMap
 }
 
 func (p *SchemaOnlyProvider) PfProvider() pfprovider.Provider {
@@ -45,11 +46,7 @@ func (p *SchemaOnlyProvider) Schema() shim.SchemaMap {
 }
 
 func (p *SchemaOnlyProvider) ResourcesMap() shim.ResourceMap {
-	resources, err := pfutils.GatherResources(context.TODO(), p.tf)
-	if err != nil {
-		panic(err)
-	}
-	return &schemaOnlyResourceMap{resources}
+	return p.resourceMap
 }
 
 func (p *SchemaOnlyProvider) DataSourcesMap() shim.ResourceMap {

--- a/pf/internal/schemashim/schemashim.go
+++ b/pf/internal/schemashim/schemashim.go
@@ -18,12 +18,19 @@ import (
 	"context"
 
 	pfprovider "github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/pulumi/pulumi-terraform-bridge/pf/internal/pfutils"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
 func ShimSchemaOnlyProvider(ctx context.Context, provider pfprovider.Provider) shim.Provider {
+	resources, err := pfutils.GatherResources(ctx, provider)
+	if err != nil {
+		panic(err)
+	}
+	resourceMap := newSchemaOnlyResourceMap(resources)
 	return &SchemaOnlyProvider{
-		ctx: ctx,
-		tf:  provider,
+		ctx:         ctx,
+		tf:          provider,
+		resourceMap: resourceMap,
 	}
 }

--- a/pf/tests/tfgen_test.go
+++ b/pf/tests/tfgen_test.go
@@ -1,0 +1,63 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfbridgetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/pulumi/pulumi-terraform-bridge/pf/internal/muxer"
+	"github.com/pulumi/pulumi-terraform-bridge/pf/tests/internal/providerbuilder"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen"
+	helper "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenameResourceWithAliasInAugmentedProvider(t *testing.T) {
+	ctx := context.Background()
+	discardSink := diag.DefaultSink(os.Stdout, os.Stdout, diag.FormatOptions{Color: colors.Never})
+	providerID := "my"
+	resourceID := "res"
+	fullResourceID := fmt.Sprintf("%s_%s", providerID, resourceID)
+	resModule := "mod"
+	baselineProvider := (&helper.Provider{}).Shim()
+	pfProvider := &providerbuilder.Provider{
+		TypeName: providerID,
+		AllResources: []providerbuilder.Resource{
+			{Name: resourceID},
+		},
+	}
+	legacyToken := tokens.Type(fmt.Sprintf("my:%s:Resource", resModule))
+	aliasToken := tokens.Type(fmt.Sprintf("my:%s:LegacyResource", resModule))
+	ri := &info.Resource{Tok: legacyToken}
+	i := info.Provider{
+		Name: providerID,
+		P:    muxer.AugmentShimWithPF(ctx, baselineProvider, pfProvider),
+		Resources: map[string]*info.Resource{
+			fullResourceID: ri,
+		},
+	}
+	i.RenameResourceWithAlias(fullResourceID, legacyToken, aliasToken, resModule, resModule, nil)
+	_, err := tfgen.GenerateSchema(i, discardSink)
+	require.NoError(t, err)
+	_, err = i.P.(*muxer.ProviderShim).ResolveDispatch(&i)
+	require.NoError(t, err)
+}

--- a/pkg/tfbridge/info/rename.go
+++ b/pkg/tfbridge/info/rename.go
@@ -20,6 +20,7 @@ import (
 
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 const RenamedEntitySuffix string = "_legacy"
@@ -60,7 +61,8 @@ func (p *Provider) RenameResourceWithAlias(resourceName string, legacyTok tokens
 			currentInfo.Tok.Name().String()))
 	p.Resources[resourceName] = &currentInfo
 	p.Resources[legacyResourceName] = &legacyInfo
-	shim.CloneResource(p.P.ResourcesMap(), resourceName, legacyResourceName)
+	err := shim.CloneResource(p.P.ResourcesMap(), resourceName, legacyResourceName)
+	contract.AssertNoErrorf(err, "Failed to rename the resource")
 }
 
 func (p *Provider) RenameDataSource(resourceName string, legacyTok tokens.ModuleMember, newTok tokens.ModuleMember,

--- a/pkg/tfbridge/info/rename.go
+++ b/pkg/tfbridge/info/rename.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"strings"
 
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 )
 
@@ -59,7 +60,7 @@ func (p *Provider) RenameResourceWithAlias(resourceName string, legacyTok tokens
 			currentInfo.Tok.Name().String()))
 	p.Resources[resourceName] = &currentInfo
 	p.Resources[legacyResourceName] = &legacyInfo
-	p.P.ResourcesMap().Set(legacyResourceName, p.P.ResourcesMap().Get(resourceName))
+	shim.CloneResource(p.P.ResourcesMap(), resourceName, legacyResourceName)
 }
 
 func (p *Provider) RenameDataSource(resourceName string, legacyTok tokens.ModuleMember, newTok tokens.ModuleMember,

--- a/pkg/tfshim/shim.go
+++ b/pkg/tfshim/shim.go
@@ -2,6 +2,7 @@ package shim
 
 import (
 	"context"
+	"fmt"
 	"time"
 )
 
@@ -193,12 +194,17 @@ type ResourceMapWithClone interface {
 	Clone(oldKey, newKey string) error
 }
 
-func CloneResource(rm ResourceMap, oldKey string, newKey string) {
+func CloneResource(rm ResourceMap, oldKey string, newKey string) error {
 	switch rm := rm.(type) {
 	case ResourceMapWithClone:
-		rm.Clone(oldKey, newKey)
+		return rm.Clone(oldKey, newKey)
 	default:
-		rm.Set(newKey, rm.Get(oldKey))
+		v, ok := rm.GetOk(oldKey)
+		if !ok {
+			return fmt.Errorf("key not found: %q", oldKey)
+		}
+		rm.Set(newKey, v)
+		return nil
 	}
 }
 

--- a/pkg/tfshim/shim.go
+++ b/pkg/tfshim/shim.go
@@ -188,6 +188,20 @@ type ResourceMap interface {
 	Set(key string, value Resource)
 }
 
+type ResourceMapWithClone interface {
+	ResourceMap
+	Clone(oldKey, newKey string) error
+}
+
+func CloneResource(rm ResourceMap, oldKey string, newKey string) {
+	switch rm := rm.(type) {
+	case ResourceMapWithClone:
+		rm.Clone(oldKey, newKey)
+	default:
+		rm.Set(newKey, rm.Get(oldKey))
+	}
+}
+
 type Provider interface {
 	Schema() SchemaMap
 	ResourcesMap() ResourceMap


### PR DESCRIPTION
Fixes #1937

This PR fixes the automatic aliasing of muxed providers by dispatching a ResourceMap Clone operation to the sub-map that owns the key being cloned and making PF resource maps mutable.