### PR TITLE
Revert "Support overriding `int` with `string` (#1896)"

### DIFF
--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -1241,164 +1241,92 @@ func TestInvalidAsset(t *testing.T) {
 }
 
 func TestOverridingTFSchema(t *testing.T) {
-	t.Parallel()
+	ctx := context.Background()
 
-	const largeNumber int64 = 1<<62 + 1
+	tfInputs := map[string]interface{}{
+		"pulumi_override_tf_string_to_boolean":    MyString("true"),
+		"pulumi_override_tf_string_to_bool":       MyString("true"),
+		"pulumi_empty_tf_override":                MyString("true"),
+		"pulumi_override_tf_string_to_int":        MyString("1"),
+		"pulumi_override_tf_string_to_integer":    MyString("1"),
+		"tf_empty_string_to_pulumi_bool_override": MyString(""),
+	}
 
-	// We need to assert that when both the Pulumi type (String) and the Terraform
-	// type (Int) are large enough to hold a large number, we never round trip it
-	// through a smaller type like a float64.
-	//
-	// We assert this requirement by checking that the number we use *does not* round
-	// trip through float64.
-	t.Run("number_is_large", func(t *testing.T) {
-		t.Parallel()
-		assert.NotEqual(t, largeNumber, int64(float64(largeNumber)))
+	tfSchema := shimv1.NewSchemaMap(map[string]*schemav1.Schema{
+		"pulumi_override_tf_string_to_boolean":    {Type: schemav1.TypeString},
+		"pulumi_override_tf_string_to_bool":       {Type: schemav1.TypeString},
+		"pulumi_empty_tf_override":                {Type: schemav1.TypeString},
+		"pulumi_override_tf_string_to_int":        {Type: schemav1.TypeString},
+		"pulumi_override_tf_string_to_integer":    {Type: schemav1.TypeString},
+		"tf_empty_string_to_pulumi_bool_override": {Type: schemav1.TypeString},
 	})
 
-	tests := []struct {
-		name string
-
-		tfSchema *schemav1.Schema
-		info     *SchemaInfo
-
-		tfInput  any
-		tfOutput resource.PropertyValue
-	}{
-		{
-			name: "pulumi_override_tf_string_to_boolean",
-
-			tfSchema: &schemav1.Schema{Type: schemav1.TypeString},
-			info:     &SchemaInfo{Type: "boolean"},
-
-			tfInput:  MyString("true"),
-			tfOutput: resource.NewProperty(true),
+	typeOverrides := map[string]*SchemaInfo{
+		"pulumi_override_tf_string_to_boolean": {
+			Type: "boolean",
 		},
-		{
-			name: "pulumi_override_tf_string_to_bool",
-
-			tfSchema: &schemav1.Schema{Type: schemav1.TypeString},
-			info:     &SchemaInfo{Type: "bool"},
-
-			tfInput:  MyString("true"),
-			tfOutput: resource.NewProperty(true),
+		"pulumi_override_tf_string_to_bool": {
+			Type: "bool",
 		},
-		{
-			name: "pulumi_empty_tf_override",
-
-			tfSchema: &schemav1.Schema{Type: schemav1.TypeString},
-			info:     &SchemaInfo{Type: ""},
-
-			tfInput:  MyString("true"),
-			tfOutput: resource.NewProperty("true"),
+		"pulumi_empty_tf_override": {
+			Type: "",
 		},
-		{
-			name: "pulumi_override_tf_string_to_int",
-
-			tfSchema: &schemav1.Schema{Type: schemav1.TypeString},
-			info:     &SchemaInfo{Type: "int"},
-
-			tfInput:  MyString("1"),
-			tfOutput: resource.NewProperty(1.0),
+		"pulumi_override_tf_string_to_int": {
+			Type: "int",
 		},
-		{
-			name: "pulumi_override_tf_string_to_integer",
-
-			tfSchema: &schemav1.Schema{Type: schemav1.TypeString},
-			info:     &SchemaInfo{Type: "integer"},
-
-			tfInput:  MyString("1"),
-			tfOutput: resource.NewProperty(1.0),
+		"pulumi_override_tf_string_to_integer": {
+			Type: "integer",
 		},
-		{
-			name: "tf_empty_string_to_pulumi_bool_override",
-
-			tfSchema: &schemav1.Schema{Type: schemav1.TypeString},
-			info: &SchemaInfo{
-				Type:           "boolean",
-				MarkAsOptional: True(),
-			},
-
-			tfInput:  MyString(""),
-			tfOutput: resource.NewNullProperty(),
-		},
-		{
-			name: "tf_int_to_pulumi_string",
-
-			tfSchema: &schemav1.Schema{Type: schemav1.TypeInt},
-			info:     &SchemaInfo{Type: "string"},
-
-			tfInput:  largeNumber,
-			tfOutput: resource.NewProperty(strconv.FormatInt(largeNumber, 10)),
+		"tf_empty_string_to_pulumi_bool_override": {
+			Type:           "boolean",
+			MarkAsOptional: boolPointer(true),
 		},
 	}
 
-	const testProp = "prop"
+	tfOutputs := resource.NewPropertyMapFromMap(map[string]interface{}{
+		"pulumiOverrideTfStringToBoolean":   true,
+		"pulumiOverrideTfStringToBool":      true,
+		"pulumiEmptyTfOverride":             "true",
+		"pulumiOverrideTfStringToInt":       1,
+		"pulumiOverrideTfStringToInteger":   1,
+		"tfEmptyStringToPulumiBoolOverride": nil,
+	})
 
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			t.Run("MakeTerraformOutputs", func(t *testing.T) {
-				t.Parallel()
-
-				ctx := context.Background()
-				result := MakeTerraformOutputs(
-					ctx,
-					shimv1.NewProvider(testTFProvider),
-					map[string]any{
-						testProp: tt.tfInput,
-					},
-					shimv1.NewSchemaMap(map[string]*schemav1.Schema{
-						testProp: tt.tfSchema,
-					}),
-					map[string]*SchemaInfo{
-						testProp: tt.info,
-					},
-					nil, /* assets */
-					true,
-				)
-				assert.Equal(t, resource.PropertyMap{
-					testProp: tt.tfOutput,
-				}, result)
-			})
-			t.Run("MakeTerraformInputs", func(t *testing.T) {
-				t.Parallel()
-
-				result, _, err := makeTerraformInputsForConfig(
-					nil,
-					resource.PropertyMap{
-						testProp: tt.tfOutput,
-					},
-					shimv1.NewSchemaMap(map[string]*schemav1.Schema{
-						testProp: tt.tfSchema,
-					}),
-					map[string]*SchemaInfo{
-						testProp: tt.info,
-					},
-				)
-				require.NoError(t, err)
-				expected := map[string]any{
-					// SDKv2 Providers have __defaults included.
-					"__defaults": []any{},
-				}
-
-				switch tfInput := tt.tfInput.(type) {
-				// We don't transform nil values because terraform distinguished
-				// between nil and "" values.
-				case MyString:
-					if tfInput == "" {
-						expected[testProp] = nil
-					} else {
-						expected[testProp] = string(tfInput)
-					}
-				default:
-					expected[testProp] = tfInput
-				}
-				assert.Equal(t, expected, result)
-			})
-		})
-	}
+	t.Run("MakeTerraformOutputs", func(t *testing.T) {
+		result := MakeTerraformOutputs(
+			ctx,
+			shimv1.NewProvider(testTFProvider),
+			tfInputs,
+			tfSchema,
+			typeOverrides,
+			nil, /* assets */
+			true,
+		)
+		assert.Equal(t, tfOutputs, result)
+	})
+	t.Run("MakeTerraformInputs", func(t *testing.T) {
+		result, _, err := makeTerraformInputsForConfig(
+			nil,
+			tfOutputs,
+			tfSchema,
+			typeOverrides,
+		)
+		require.NoError(t, err)
+		expected := map[string]interface{}{
+			// SDKv2 Providers have __defaults included.
+			"__defaults": []interface{}{},
+		}
+		for k, v := range tfInputs {
+			// We don't transform nil values because terraform distinguished
+			// between nil and "" values.
+			if s := string(v.(MyString)); s == "" {
+				expected[k] = nil
+			} else {
+				expected[k] = s
+			}
+		}
+		assert.Equal(t, expected, result)
+	})
 }
 
 func TestArchiveAsAsset(t *testing.T) {


### PR DESCRIPTION
This reverts commit e71c1a6dafa243907e0b67fa12f13ec8fd8ca76c introduced in https://github.com/pulumi/pulumi-terraform-bridge/pull/1896.

For more context, see https://github.com/pulumi/pulumi/issues/16143.
