### PR TITLE
Fix implicit conversion error

### DIFF
--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -4013,3 +4013,53 @@ func TestProviderMetaPlanResourceChangeNoError(t *testing.T) {
 		  }`)
 	})
 }
+
+func TestStringValForIntProperty(t *testing.T) {
+	p := &schemav2.Provider{
+		Schema: map[string]*schemav2.Schema{},
+		ResourcesMap: map[string]*schemav2.Resource{
+			"res": {
+				Schema: map[string]*schemav2.Schema{
+					"IntProp": {
+						Optional: true,
+						Type:     schema.TypeInt,
+					},
+				},
+			},
+		},
+	}
+	shimProv := shimv2.NewProvider(p)
+	provider := &Provider{
+		tf:     shimProv,
+		config: shimv2.NewSchemaMap(p.Schema),
+		info:   ProviderInfo{P: shimProv},
+		resources: map[tokens.Type]Resource{
+			"Res": {
+				TF:     shimv2.NewResource(p.ResourcesMap["res"]),
+				TFName: "res",
+				Schema: &ResourceInfo{},
+			},
+		},
+	}
+
+	testutils.Replay(t, provider, `
+	{
+		"method": "/pulumirpc.ResourceProvider/Check",
+		"request": {
+			"urn": "urn:pulumi:dev::teststack::Res::exres",
+			"olds": {
+				"__defaults": []
+			},
+			"news": {
+				"__defaults": [],
+				"IntProp": "80"
+			},
+			"randomSeed": "zjSL8IMF68r5aLLepOpsIT53uBTbkDryYFDnHQHkjko="
+		},
+		"response": {
+			"inputs": {
+				"__defaults": []
+			}
+		}
+	}`)
+}

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -4058,7 +4058,8 @@ func TestStringValForIntProperty(t *testing.T) {
 		},
 		"response": {
 			"inputs": {
-				"__defaults": []
+				"__defaults": [],
+				"IntProp": 80
 			}
 		}
 	}`)

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -4015,6 +4015,8 @@ func TestProviderMetaPlanResourceChangeNoError(t *testing.T) {
 }
 
 func TestStringValForOtherProperty(t *testing.T) {
+	const largeNumber int64 = 1<<62 + 1
+
 	p := &schemav2.Provider{
 		Schema: map[string]*schemav2.Schema{},
 		ResourcesMap: map[string]*schemav2.Resource{
@@ -4092,6 +4094,29 @@ func TestStringValForOtherProperty(t *testing.T) {
 				}
 			}
 		}`)
+	})
+
+	t.Run("String value for large int property", func(t *testing.T) {
+		testutils.Replay(t, provider, fmt.Sprintf(`
+		{
+			"method": "/pulumirpc.ResourceProvider/Check",
+			"request": {
+				"urn": "urn:pulumi:dev::teststack::Res::exres",
+				"olds": {
+				},
+				"news": {
+					"__defaults": [],
+					"intProp": "%d"
+				},
+				"randomSeed": "zjSL8IMF68r5aLLepOpsIT53uBTbkDryYFDnHQHkjko="
+			},
+			"response": {
+				"inputs": {
+					"__defaults": [],
+					"intProp": %d
+				}
+			}
+		}`, largeNumber, largeNumber))
 	})
 
 	t.Run("String value for bool property", func(t *testing.T) {

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -4014,15 +4014,44 @@ func TestProviderMetaPlanResourceChangeNoError(t *testing.T) {
 	})
 }
 
-func TestStringValForIntProperty(t *testing.T) {
+func TestStringValForOtherProperty(t *testing.T) {
 	p := &schemav2.Provider{
 		Schema: map[string]*schemav2.Schema{},
 		ResourcesMap: map[string]*schemav2.Resource{
 			"res": {
 				Schema: map[string]*schemav2.Schema{
-					"IntProp": {
+					"int_prop": {
 						Optional: true,
 						Type:     schema.TypeInt,
+					},
+					"float_prop": {
+						Optional: true,
+						Type:     schema.TypeFloat,
+					},
+					"bool_prop": {
+						Optional: true,
+						Type:     schema.TypeBool,
+					},
+					"nested_int": {
+						Optional: true,
+						Type:     schema.TypeList,
+						Elem: &schemav2.Schema{
+							Type: schema.TypeInt,
+						},
+					},
+					"nested_float": {
+						Optional: true,
+						Type:     schema.TypeList,
+						Elem: &schemav2.Schema{
+							Type: schema.TypeFloat,
+						},
+					},
+					"nested_bool": {
+						Optional: true,
+						Type:     schema.TypeList,
+						Elem: &schemav2.Schema{
+							Type: schema.TypeBool,
+						},
 					},
 				},
 			},
@@ -4042,25 +4071,187 @@ func TestStringValForIntProperty(t *testing.T) {
 		},
 	}
 
-	testutils.Replay(t, provider, `
-	{
-		"method": "/pulumirpc.ResourceProvider/Check",
-		"request": {
-			"urn": "urn:pulumi:dev::teststack::Res::exres",
-			"olds": {
-				"__defaults": []
+	t.Run("String value for int property", func(t *testing.T) {
+		testutils.Replay(t, provider, `
+		{
+			"method": "/pulumirpc.ResourceProvider/Check",
+			"request": {
+				"urn": "urn:pulumi:dev::teststack::Res::exres",
+				"olds": {
+				},
+				"news": {
+					"__defaults": [],
+					"intProp": "80"
+				},
+				"randomSeed": "zjSL8IMF68r5aLLepOpsIT53uBTbkDryYFDnHQHkjko="
 			},
-			"news": {
-				"__defaults": [],
-				"IntProp": "80"
-			},
-			"randomSeed": "zjSL8IMF68r5aLLepOpsIT53uBTbkDryYFDnHQHkjko="
-		},
-		"response": {
-			"inputs": {
-				"__defaults": [],
-				"IntProp": 80
+			"response": {
+				"inputs": {
+					"__defaults": [],
+					"intProp": 80
+				}
 			}
-		}
-	}`)
+		}`)
+	})
+
+	t.Run("String value for bool property", func(t *testing.T) {
+		testutils.Replay(t, provider, `
+		{
+			"method": "/pulumirpc.ResourceProvider/Check",
+			"request": {
+				"urn": "urn:pulumi:dev::teststack::Res::exres",
+				"olds": {
+				},
+				"news": {
+					"__defaults": [],
+					"boolProp": "true"
+				},
+				"randomSeed": "zjSL8IMF68r5aLLepOpsIT53uBTbkDryYFDnHQHkjko="
+			},
+			"response": {
+				"inputs": {
+					"__defaults": [],
+					"boolProp": true
+				}
+			}
+		}`)
+	})
+
+	t.Run("String num value for bool property", func(t *testing.T) {
+		testutils.Replay(t, provider, `
+		{
+			"method": "/pulumirpc.ResourceProvider/Check",
+			"request": {
+				"urn": "urn:pulumi:dev::teststack::Res::exres",
+				"olds": {
+				},
+				"news": {
+					"__defaults": [],
+					"boolProp": "1"
+				},
+				"randomSeed": "zjSL8IMF68r5aLLepOpsIT53uBTbkDryYFDnHQHkjko="
+			},
+			"response": {
+				"inputs": {
+					"__defaults": [],
+					"boolProp": true
+				}
+			}
+		}`)
+	})
+
+	t.Run("String value for float property", func(t *testing.T) {
+		testutils.Replay(t, provider, `
+		{
+			"method": "/pulumirpc.ResourceProvider/Check",
+			"request": {
+				"urn": "urn:pulumi:dev::teststack::Res::exres",
+				"olds": {
+				},
+				"news": {
+					"__defaults": [],
+					"floatProp": "8.2"
+				},
+				"randomSeed": "zjSL8IMF68r5aLLepOpsIT53uBTbkDryYFDnHQHkjko="
+			},
+			"response": {
+				"inputs": {
+					"__defaults": [],
+					"floatProp": 8.2
+				}
+			}
+		}`)
+	})
+
+	t.Run("String value for nested int property", func(t *testing.T) {
+		testutils.Replay(t, provider, `
+		{
+			"method": "/pulumirpc.ResourceProvider/Check",
+			"request": {
+				"urn": "urn:pulumi:dev::teststack::Res::exres",
+				"olds": {
+				},
+				"news": {
+					"__defaults": [],
+					"nestedInts": ["80"]
+				},
+				"randomSeed": "zjSL8IMF68r5aLLepOpsIT53uBTbkDryYFDnHQHkjko="
+			},
+			"response": {
+				"inputs": {
+					"__defaults": [],
+					"nestedInts": [80]
+				}
+			}
+		}`)
+	})
+
+	t.Run("String value for nested float property", func(t *testing.T) {
+		testutils.Replay(t, provider, `
+		{
+			"method": "/pulumirpc.ResourceProvider/Check",
+			"request": {
+				"urn": "urn:pulumi:dev::teststack::Res::exres",
+				"olds": {
+				},
+				"news": {
+					"__defaults": [],
+					"nestedFloats": ["8.2"]
+				},
+				"randomSeed": "zjSL8IMF68r5aLLepOpsIT53uBTbkDryYFDnHQHkjko="
+			},
+			"response": {
+				"inputs": {
+					"__defaults": [],
+					"nestedFloats": [8.2]
+				}
+			}
+		}`)
+	})
+
+	t.Run("String value for nested bool property", func(t *testing.T) {
+		testutils.Replay(t, provider, `
+		{
+			"method": "/pulumirpc.ResourceProvider/Check",
+			"request": {
+				"urn": "urn:pulumi:dev::teststack::Res::exres",
+				"olds": {
+				},
+				"news": {
+					"__defaults": [],
+					"nestedBools": ["true"]
+				},
+				"randomSeed": "zjSL8IMF68r5aLLepOpsIT53uBTbkDryYFDnHQHkjko="
+			},
+			"response": {
+				"inputs": {
+					"__defaults": [],
+					"nestedBools": [true]
+				}
+			}
+		}`)
+	})
+
+	t.Run("String num value for nested bool property", func(t *testing.T) {
+		testutils.Replay(t, provider, `
+		{
+			"method": "/pulumirpc.ResourceProvider/Check",
+			"request": {
+				"urn": "urn:pulumi:dev::teststack::Res::exres",
+				"olds": {
+				},
+				"news": {
+					"__defaults": [],
+					"nestedBools": ["1"]
+				},
+				"randomSeed": "zjSL8IMF68r5aLLepOpsIT53uBTbkDryYFDnHQHkjko="
+			},
+			"response": {
+				"inputs": {
+					"__defaults": [],
+					"nestedBools": [true]
+				}
+			}
+		}`)
+	})
 }

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -431,6 +431,7 @@ func (ctx *conversionContext) makeTerraformInput(
 		switch tfs.Type() {
 		case shim.TypeInt:
 			v, err := wrapError(strconv.ParseInt(v.StringValue(), 10, 64))
+			// The plugin sdk asserts against the type - need this to be an int.
 			return int(v.(int64)), err
 		default:
 			return v.StringValue(), nil

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -430,8 +430,7 @@ func (ctx *conversionContext) makeTerraformInput(
 	case v.IsString():
 		switch tfs.Type() {
 		case shim.TypeInt:
-			v, err := wrapError(strconv.ParseInt(v.StringValue(), 10, 0))
-			// We can't pass int64 to the Terraform plugin-sdk, so we convert to int.
+			v, err := wrapError(strconv.ParseInt(v.StringValue(), 10, 64))
 			return int(v.(int64)), err
 		default:
 			return v.StringValue(), nil

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -430,7 +430,8 @@ func (ctx *conversionContext) makeTerraformInput(
 	case v.IsString():
 		switch tfs.Type() {
 		case shim.TypeInt:
-			return wrapError(strconv.ParseInt(v.StringValue(), 10, 64))
+			v, err := wrapError(strconv.ParseInt(v.StringValue(), 10, 0))
+			return int(v.(int64)), err
 		default:
 			return v.StringValue(), nil
 		}

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -431,6 +431,7 @@ func (ctx *conversionContext) makeTerraformInput(
 		switch tfs.Type() {
 		case shim.TypeInt:
 			v, err := wrapError(strconv.ParseInt(v.StringValue(), 10, 0))
+			// We can't pass int64 to the Terraform plugin-sdk, so we convert to int.
 			return int(v.(int64)), err
 		default:
 			return v.StringValue(), nil

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -1322,15 +1322,6 @@ func TestOverridingTFSchema(t *testing.T) {
 			tfInput:  MyString(""),
 			tfOutput: resource.NewNullProperty(),
 		},
-		{
-			name: "tf_int_to_pulumi_string",
-
-			tfSchema: &schemav1.Schema{Type: schemav1.TypeInt},
-			info:     &SchemaInfo{Type: "string"},
-
-			tfInput:  largeNumber,
-			tfOutput: resource.NewProperty(strconv.FormatInt(largeNumber, 10)),
-		},
 	}
 
 	const testProp = "prop"

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -1245,6 +1245,8 @@ func TestOverridingTFSchema(t *testing.T) {
 
 	const largeNumber int64 = 1<<62 + 1
 
+	const notSoLargeNumber int64 = 1<<50 + 1
+
 	// We need to assert that when both the Pulumi type (String) and the Terraform
 	// type (Int) are large enough to hold a large number, we never round trip it
 	// through a smaller type like a float64.
@@ -1254,6 +1256,11 @@ func TestOverridingTFSchema(t *testing.T) {
 	t.Run("number_is_large", func(t *testing.T) {
 		t.Parallel()
 		assert.NotEqual(t, largeNumber, int64(float64(largeNumber)))
+	})
+
+	t.Run("number_is_not_so_large", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, notSoLargeNumber, int64(float64(notSoLargeNumber)))
 	})
 
 	tests := []struct {
@@ -1321,6 +1328,22 @@ func TestOverridingTFSchema(t *testing.T) {
 
 			tfInput:  MyString(""),
 			tfOutput: resource.NewNullProperty(),
+		},
+		{
+			name:     "tf_mid_int_to_pulumi_string",
+			tfSchema: &schemav1.Schema{Type: schemav1.TypeInt},
+			info:     &SchemaInfo{Type: "string"},
+			tfInput:  int(notSoLargeNumber),
+			tfOutput: resource.NewProperty(strconv.FormatInt(notSoLargeNumber, 10)),
+		},
+		{
+			name: "tf_int_to_pulumi_string",
+
+			tfSchema: &schemav1.Schema{Type: schemav1.TypeInt},
+			info:     &SchemaInfo{Type: "string"},
+
+			tfInput:  int(largeNumber),
+			tfOutput: resource.NewProperty(strconv.FormatInt(largeNumber, 10)),
 		},
 	}
 
@@ -2615,7 +2638,6 @@ func TestExtractDefaultIntegerInputs(t *testing.T) {
 }
 
 func TestExtractSchemaInputsNestedMaxItemsOne(t *testing.T) {
-
 	provider := func(info *ResourceInfo) *Provider {
 		if info == nil {
 			info = &ResourceInfo{}
@@ -2673,12 +2695,14 @@ func TestExtractSchemaInputsNestedMaxItemsOne(t *testing.T) {
 			set(d, "list_object", []any{
 				map[string]any{
 					"field1":      false,
-					"list_scalar": []any{1}},
+					"list_scalar": []any{1},
+				},
 			})
 			set(d, "list_object_maxitems", []any{
 				map[string]any{
 					"field1":      true,
-					"list_scalar": []any{2}},
+					"list_scalar": []any{2},
+				},
 			})
 			return nil
 		}


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/1940

The tf-plugin-sdk type checks input to int fields and only allows explicit ints and strings, not int64 and similar:

https://github.com/hashicorp/terraform-plugin-sdk/blob/1f499688ebd9420768f501d4ed622a51b2135ced/helper/schema/schema.go#L2269

This corrects the type there and adds tests for implicitly converting all primitive types.