### PR TITLE
Remove spurious ConflictsWith warnings on import

### DIFF
--- a/pkg/tfbridge/deconflict.go
+++ b/pkg/tfbridge/deconflict.go
@@ -34,6 +34,12 @@ import (
 //
 // Why is this necessary: Read in Pulumi is expected to produce an input bag that is going to subsequently pass Check,
 // but TF providers are not always well-behaved in this regard.
+//
+// TODO[pulumi/pulumi-terraform-bridge#1949] handle too-many ExactlyOneOf values specified violations similarly.
+//
+// There may be cases where the dropout strategy is going to generate new issues with ExactlyOneOf or RequiredWith
+// constraints. Before a SAT solver is brought to bear at this problem to solve it in full generality, it is good to
+// collect some evidence it happens in practice.
 func deconflict(
 	ctx context.Context,
 	schemaMap shim.SchemaMap,

--- a/pkg/tfbridge/deconflict.go
+++ b/pkg/tfbridge/deconflict.go
@@ -1,0 +1,112 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfbridge
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/walk"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/propertyvalue"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+// Transforms inputs to enforce input bag conformance with ConflictsWith constraints.
+//
+// This arbitrarily drops properties until none are left in conflict.
+//
+// Why is this necessary: Read in Pulumi is expected to produce an input bag that is going to subsequently pass Check,
+// but TF providers are not always well-behaved in this regard.
+func deconflict(
+	ctx context.Context,
+	schemaMap shim.SchemaMap,
+	schemaInfos map[string]*info.Schema,
+	inputs resource.PropertyMap,
+) resource.PropertyMap {
+	cm := newConflictsMap(schemaMap)
+	visitedPaths := map[string]struct{}{}
+	visit := func(pp resource.PropertyPath, pv resource.PropertyValue) (resource.PropertyValue, error) {
+		sp := PropertyPathToSchemaPath(pp, schemaMap, schemaInfos)
+		conflict := false
+		var conflictAt walk.SchemaPath
+		for _, cp := range cm.ConflictingPaths(sp) {
+			if _, ok := visitedPaths[cp.MustEncodeSchemaPath()]; ok {
+				conflict = true
+				conflictAt = cp
+				break
+			}
+		}
+		if conflict {
+			msg := fmt.Sprintf("Dropping property at %q to respect ConflictsWith constraint from %q",
+				pp.String(), conflictAt.MustEncodeSchemaPath())
+			GetLogger(ctx).Debug(msg)
+			return resource.NewNullProperty(), nil
+		}
+		visitedPaths[sp.MustEncodeSchemaPath()] = struct{}{}
+		return pv, nil
+	}
+
+	obj := resource.NewObjectProperty(inputs)
+	pv, err := propertyvalue.TransformPropertyValue(resource.PropertyPath{}, visit, obj)
+	contract.AssertNoErrorf(err, "deconflict transformation is never expected to fail")
+	contract.Assertf(pv.IsObject(), "deconflict transformation is not expected to change objects to something else")
+	return pv.ObjectValue()
+}
+
+type conflictsMap struct {
+	conflicts map[string][]walk.SchemaPath
+}
+
+func (cm *conflictsMap) ConflictingPaths(atPath walk.SchemaPath) []walk.SchemaPath {
+	return cm.conflicts[atPath.MustEncodeSchemaPath()]
+}
+
+func (cm *conflictsMap) AddConflict(atPath walk.SchemaPath, conflictingPaths []walk.SchemaPath) {
+	cm.conflicts[atPath.MustEncodeSchemaPath()] = conflictingPaths
+}
+
+func newConflictsMap(schemaMap shim.SchemaMap) *conflictsMap {
+	cm := &conflictsMap{conflicts: map[string][]walk.SchemaPath{}}
+	walk.VisitSchemaMap(schemaMap, func(sp walk.SchemaPath, s shim.Schema) {
+		if len(s.ConflictsWith()) > 0 {
+			conflictingPaths := []walk.SchemaPath{}
+			for _, p := range s.ConflictsWith() {
+				conflictingPaths = append(conflictingPaths, parseConflictsWith(p))
+			}
+			cm.AddConflict(sp, conflictingPaths)
+		}
+	})
+	return cm
+}
+
+func parseConflictsWith(s string) walk.SchemaPath {
+	parts := strings.Split(s, ".")
+	result := walk.NewSchemaPath()
+	for _, p := range parts {
+		_, strconvErr := strconv.Atoi(p)
+		isNum := strconvErr == nil
+		if isNum {
+			result = result.Element()
+		} else {
+			result = result.GetAttr(p)
+		}
+	}
+	return result
+}

--- a/pkg/tfbridge/deconflict_test.go
+++ b/pkg/tfbridge/deconflict_test.go
@@ -1,0 +1,28 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfbridge
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseConflictsWith(t *testing.T) {
+	cw := "capacity_reservation_specification.0.capacity_reservation_target.0.capacity_reservation_id"
+	actual := parseConflictsWith(cw)
+	expect := "capacity_reservation_specification.$.capacity_reservation_target.$.capacity_reservation_id"
+	require.Equal(t, expect, actual.MustEncodeSchemaPath())
+}

--- a/pkg/tfbridge/deconflict_test.go
+++ b/pkg/tfbridge/deconflict_test.go
@@ -88,8 +88,7 @@ func TestDeconflict(t *testing.T) {
 				"availabilityZoneId": resource.NewStringProperty("use1-az1"),
 			},
 			expected: resource.PropertyMap{
-				"availabilityZone":   resource.NewStringProperty("us-east-1c"),
-				"availabilityZoneId": resource.NewNullProperty(),
+				"availabilityZone": resource.NewStringProperty("us-east-1c"),
 			},
 		},
 		{
@@ -114,8 +113,7 @@ func TestDeconflict(t *testing.T) {
 				"netmaskLength": resource.NewNumberProperty(24),
 			},
 			expected: resource.PropertyMap{
-				"cidr":          resource.NewStringProperty("192.0.2.0/24"),
-				"netmaskLength": resource.NewNullProperty(),
+				"cidr": resource.NewStringProperty("192.0.2.0/24"),
 			},
 		},
 	}
@@ -204,7 +202,6 @@ func TestDeconflict(t *testing.T) {
 					resource.NewStringProperty("arn1"),
 					resource.NewStringProperty("arn2"),
 				}),
-				"trafficSources": resource.NewNullProperty(),
 			},
 		},
 	}...)

--- a/pkg/tfbridge/deconflict_test.go
+++ b/pkg/tfbridge/deconflict_test.go
@@ -15,10 +15,64 @@
 package tfbridge
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/logging"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/require"
 )
+
+func TestDeconflict(t *testing.T) {
+	ctx := context.Background()
+
+	ctx = logging.InitLogging(ctx, logging.LogOptions{})
+	schema := &schema.SchemaMap{
+		"availability_zone": (&schema.Schema{
+			Type:          shim.TypeString,
+			Optional:      true,
+			Computed:      true,
+			ForceNew:      true,
+			ConflictsWith: []string{"availability_zone_id"},
+		}).Shim(),
+		"availability_zone_id": (&schema.Schema{
+			Type:          shim.TypeString,
+			Optional:      true,
+			Computed:      true,
+			ForceNew:      true,
+			ConflictsWith: []string{"availability_zone"},
+		}).Shim(),
+	}
+
+	type testCase struct {
+		inputs   resource.PropertyMap
+		expected resource.PropertyMap
+	}
+
+	testCases := []testCase{
+		{
+			inputs: resource.PropertyMap{
+				"availabilityZone":   resource.NewStringProperty("us-east-1c"),
+				"availabilityZoneId": resource.NewStringProperty("use1-az1"),
+			},
+			expected: resource.PropertyMap{
+				"availabilityZone":   resource.NewStringProperty("us-east-1c"),
+				"availabilityZoneId": resource.NewNullProperty(),
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		tc := tc
+		t.Run(fmt.Sprintf("case-%d", i), func(t *testing.T) {
+			actual := deconflict(ctx, schema, nil, tc.inputs)
+			require.Equal(t, tc.expected, actual)
+		})
+	}
+}
 
 func TestParseConflictsWith(t *testing.T) {
 	cw := "capacity_reservation_specification.0.capacity_reservation_target.0.capacity_reservation_id"

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -1239,7 +1239,10 @@ func (p *Provider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*pulum
 		if err != nil {
 			return nil, err
 		}
-		minputs, err := plugin.MarshalProperties(inputs, plugin.MarshalOptions{
+
+		cleanInputs := deconflict(ctx, res.TF.Schema(), res.Schema.Fields, inputs)
+
+		minputs, err := plugin.MarshalProperties(cleanInputs, plugin.MarshalOptions{
 			Label:       label + ".inputs",
 			KeepSecrets: p.supportsSecrets,
 		})


### PR DESCRIPTION
Toward https://github.com/pulumi/pulumi-terraform-bridge/issues/1225 - this fixes the special case of ConflictsWith warnings. This fixes spurious warnings on `pulumi import`, popular bugs such as:

- https://github.com/pulumi/pulumi-aws/issues/2318 
- https://github.com/pulumi/pulumi-aws/issues/3670
- https://github.com/pulumi/pulumi-gitlab/issues/293
- https://github.com/pulumi/pulumi-gcp/issues/844
- https://github.com/pulumi/pulumi-linode/issues/373

TF does not guarantee Read results to be compatible with calling Check on, in particular Read can return results that run afoul of ConflictsWith constraint. This change compensates by arbitrarily dropping data from the Read result until it passes ConflictsWith checks.

This affects `pulumi refresh` as well as I think it should although I have not seen "in the wild" cases where refresh is affected, since it typically will not copy these properties to the input bag unless they're present in old inputs, which are usually correct wrt to ConflictsWith. 