### PR TITLE
Fix spurious ForcesProviderReplace activation

### DIFF
--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -675,6 +675,12 @@ func (p *configDiffer) DiffConfig(
 		keyPath, err := resource.ParsePropertyPath(key)
 		contract.AssertNoErrorf(err, "Unexpected failed parse of PropertyPath %q", key)
 		if p.forcesProviderReplace(keyPath) {
+			// NOTE: for states provisioned on the older versions of Pulumi CLI oldInputs will have no entry
+			// for the changing property. Causing cascading replacements in this case is undesirable, since
+			// it is not a real change. Err on the side of not replacing (pulumi/pulumi-aws#3826).
+			if _, ok := keyPath.Get(resource.NewObjectProperty(oldInputs)); !ok {
+				continue
+			}
 			detailedDiff[key] = change.ToReplace()
 		}
 	}

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -307,6 +307,33 @@ func TestDiffConfig(t *testing.T) {
 		}`)
 	})
 
+	t.Run("changing region from empty does not result in a cascading replace", func(t *testing.T) {
+		testutils.Replay(t, provider, `
+		{
+		  "method": "/pulumirpc.ResourceProvider/DiffConfig",
+		  "request": {
+		    "urn": "urn:pulumi:dev2::bridge-244::pulumi:providers:aws::name1",
+		    "olds": {
+		      "version": "6.22.0"
+		    },
+		    "news": {
+		      "region": "us-west-1",
+		      "version": "6.22.0"
+		    },
+		    "oldInputs": {
+		      "version": "6.22.0"
+		    }
+		  },
+		  "response": {
+                    "diffs": ["region"],
+		    "changes": "DIFF_SOME",
+                    "detailedDiff": {
+                      "region": {"inputDiff": true}
+                    }
+		  }
+		}`)
+	})
+
 	t.Run("changing region can be ignored", func(t *testing.T) {
 		testutils.Replay(t, provider, `
 		{


### PR DESCRIPTION
The ForceProviderReplace setting introduces cascading replaces when a certain Provider-level configuration setting changes. For example, changing the region in the AWS Provider is able to recreate all the affected resources in the new desired region with this setting. There was however a practical problem fixed with this PR that caused accidental re-creation of resources in the same region.

Specifically, some of the resources states provisioned by older versions of Pulumi CLI may not have oldInputs sufficiently populated in the call to DetailedDiff. This caused ForceProviderReplace logic to assume that the region is changing from "" to "us-east-1" where it did not, in fact, change. To compensate for this, the logic no longer initiates cascading replace when the oldInputs map does not contain the value.

See also:

- pulumi/pulumi-aws#3826
- pulumi/pulumi-aws#3674