### PR TITLE
Support signalfx style documentation headers

### DIFF
--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -725,11 +725,11 @@ func (p *tfMarkdownParser) parseSection(h2Section []string) error {
 		p.sink.debug("Ignoring doc section [%v] for [%v]", header, p.rawname)
 		ignoredDocHeaders[header]++
 		return nil
-	case "Example Usage":
+	case "Example Usage", "Example":
 		sectionKind = sectionExampleUsage
-	case "Arguments Reference", "Argument Reference", "Argument reference", "Nested Blocks", "Nested blocks":
+	case "Arguments Reference", "Argument Reference", "Argument reference", "Nested Blocks", "Nested blocks", "Arguments":
 		sectionKind = sectionArgsReference
-	case "Attributes Reference", "Attribute Reference", "Attribute reference":
+	case "Attributes Reference", "Attribute Reference", "Attribute reference", "Attributes":
 		sectionKind = sectionAttributesReference
 	case "Import", "Imports":
 		sectionKind = sectionImports

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -1500,6 +1500,7 @@ func TestParseTFMarkdown(t *testing.T) {
 		test("link"),
 		test("azurerm-sql-firewall-rule"),
 		test("address_map"),
+		test("signalfx-log-timeline"),
 
 		test("custom-replaces", func(tc *testCase) {
 			rule := tfbridge.DocsEdit{

--- a/pkg/tfgen/test_data/signalfx-log-timeline/expected.json
+++ b/pkg/tfgen/test_data/signalfx-log-timeline/expected.json
@@ -1,0 +1,31 @@
+{
+  "Description": "You can add logs data to your Observability Cloud dashboards without turning your logs into metrics first.\n\nA log timeline chart displays timeline visualization in a dashboard and shows you in detail what is happening and why.\n\n## Example\n\n```tf\nresource \"signalfx_log_timeline\" \"my_log_timeline\" {\n  name        = \"Sample Log Timeline\"\n  description = \"Lorem ipsum dolor sit amet, laudem tibique iracundia at mea. Nam posse dolores ex, nec cu adhuc putent honestatis\"\n\n  program_text = <<-EOF\n  logs(filter=field('message') == 'Transaction processed' and field('service.name') == 'paymentservice').publish()\n  EOF\n\n  time_range = 900\n\n}\n```",
+  "Arguments": {
+    "default_connection": {
+      "description": "The connection that the log timeline uses to fetch data. This could be Splunk Enterprise, Splunk Enterprise Cloud or Observability Cloud."
+    },
+    "description": {
+      "description": "Description of the log timeline."
+    },
+    "end_time": {
+      "description": "Seconds since epoch. Used for visualization. Conflicts with `time_range`."
+    },
+    "name": {
+      "description": "Name of the log timeline."
+    },
+    "program_text": {
+      "description": "Signalflow program text for the log timeline. More info at https://dev.splunk.com/observability/docs/."
+    },
+    "start_time": {
+      "description": "Seconds since epoch. Used for visualization. Conflicts with `time_range`."
+    },
+    "time_range": {
+      "description": "From when to display data. Splunk Observability Cloud time syntax (e.g. `\"-5m\"`, `\"-1h\"`). Conflicts with `start_time` and `end_time`."
+    }
+  },
+  "Attributes": {
+    "url": "The URL of the log timeline.",
+    "id": "The ID of the log timeline."
+  },
+  "Import": ""
+}

--- a/pkg/tfgen/test_data/signalfx-log-timeline/input.md
+++ b/pkg/tfgen/test_data/signalfx-log-timeline/input.md
@@ -1,0 +1,48 @@
+---
+layout: "signalfx"
+page_title: "Splunk Observability Cloud: signalfx_log_timeline"
+sidebar_current: "docs-signalfx-resource-log-timeline"
+description: |-
+  Allows Terraform to create and manage log timelines in Splunk Observability Cloud
+---
+
+# signalfx_log_timeline
+
+You can add logs data to your Observability Cloud dashboards without turning your logs into metrics first.
+
+A log timeline chart displays timeline visualization in a dashboard and shows you in detail what is happening and why.
+
+## Example
+
+```tf
+resource "signalfx_log_timeline" "my_log_timeline" {
+  name        = "Sample Log Timeline"
+  description = "Lorem ipsum dolor sit amet, laudem tibique iracundia at mea. Nam posse dolores ex, nec cu adhuc putent honestatis"
+
+  program_text = <<-EOF
+  logs(filter=field('message') == 'Transaction processed' and field('service.name') == 'paymentservice').publish()
+  EOF
+
+  time_range = 900
+
+}
+```
+
+## Arguments
+
+The following arguments are supported in the resource block:
+
+* `name` - (Required) Name of the log timeline.
+* `program_text` - (Required) Signalflow program text for the log timeline. More info at https://dev.splunk.com/observability/docs/.
+* `description` - (Optional) Description of the log timeline.
+* `time_range` - (Optional) From when to display data. Splunk Observability Cloud time syntax (e.g. `"-5m"`, `"-1h"`). Conflicts with `start_time` and `end_time`.
+* `start_time` - (Optional) Seconds since epoch. Used for visualization. Conflicts with `time_range`.
+* `end_time` - (Optional) Seconds since epoch. Used for visualization. Conflicts with `time_range`.
+* `default_connection` - (Optional) The connection that the log timeline uses to fetch data. This could be Splunk Enterprise, Splunk Enterprise Cloud or Observability Cloud.
+
+## Attributes
+
+In a addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the log timeline.
+* `url` - The URL of the log timeline.


### PR DESCRIPTION
This pull request adds support for docs parsing when upstream sections are named,

"Example" (in addition to "Example Usage")
"Arguments" (in addition "Argument Reference" et al)
"Attributes (in addition to "Attribute Reference et al)

Fix for https://github.com/pulumi/pulumi-signalfx/issues/377.

Please see the [diff in Signalfx that is generated against these changes](https://github.com/pulumi/pulumi-signalfx/compare/guin/fix-docs?expand=1#diff-db769bdd3d42df05dc11c4ff4fe7ca9b7e27416864f483ddbf355b0542afd0f5)

Screenshot of local docs build for `signalfx.log.Timeline`:
<img width="1187" alt="Screenshot 2024-05-10 at 2 12 37 PM" src="https://github.com/pulumi/pulumi-terraform-bridge/assets/13116240/b8c45216-123c-4f99-91eb-27ba3056c289">


- Support section headers used by Signalfx
- Add test that uses signalfx style headings to parse sections
