### PR TITLE
Only parse all-lowercase patterns as potential TF properties

### DIFF
--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -441,11 +441,11 @@ var (
 	linkFooterRegexp = regexp.MustCompile(`(?m)^(\[\d+\]):\s(.*)`)
 
 	argumentBulletRegexp = regexp.MustCompile(
-		"^\\s*[*+-]\\s*`([a-zA-z0-9_]*)`\\s*(\\([a-zA-Z]*\\)\\s*)?\\s*[:–-]?\\s*(\\([^\\)]*\\)[-\\s]*)?(.*)",
+		"^\\s*[*+-]\\s*`([a-z0-9_]*)`\\s*(\\([a-zA-Z]*\\)\\s*)?\\s*[:–-]?\\s*(\\([^\\)]*\\)[-\\s]*)?(.*)",
 	)
 
-	bulletPointRegexStr       = "^\\s*[*+-]"             // matches any bullet point-like character
-	attributePathNameRegexStr = "\\s*`([a-zA-z0-9._]*)`" // matches any TF attribute path name
+	bulletPointRegexStr       = "^\\s*[*+-]"          // matches any bullet point-like character
+	attributePathNameRegexStr = "\\s*`([a-z0-9._]*)`" // matches any TF attribute path name
 
 	// matches any line starting with a bullet point followed by a TF path or resource name)
 	attributeBulletRegexp = regexp.MustCompile(


### PR DESCRIPTION
This pull request asserts that [according to Terraform best practices](https://www.terraform-best-practices.com/naming) we should not parse backticked values containing uppercase letters as potential schema properties.

While it is a convention to use `snake_case` for TF properties, it is a strong one. The AWS provider [requires it](https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/naming.md), and other providers follow this convention strictly as well.

The reason I would like to bring this change is because it allows us to detect documentation sections that are not actually nested property types, but rather lists of possible values, as described in #1507 in pulumi-mongodbatlas. Rather than add an ever-elusive regex for "Possible values include" et al, we can rely with reasonable confidence on the fact that TF properties are in general lowercase. See sample comparison diffs below.

A [comparison diff for mongodbatlas](https://github.com/pulumi/pulumi-mongodbatlas/compare/missing-settings?expand=1) shows multiple improvements. There are a few regressions but the main one is for [a resource](https://www.pulumi.com/registry/packages/mongodbatlas/api-docs/getthirdpartyintegrations/) whose upstream doc is so unconventional that our representation of it is already flawed. Overall, we gain a lot more information than we're losing - the cost is that in a couple of places we get a nonsensical appendage of a real TF description. This should be fixed with docs overrides or by opening an upstream PR.
A [comparison diff for AWS](https://github.com/pulumi/pulumi-aws/compare/missing-settings?expand=1) shows even more improvements, with only `V2modelsBotVersionLocaleSpecification` having a single regression, because the upstream docs are erroneously using camelCase.
A [comparison diff for GCP](https://github.com/pulumi/pulumi-gcp/compare/missing-settings?expand=1) shows only improvements.
A [comparison diff for Azure](https://github.com/pulumi/pulumi-azure/compare/missing-descriptions?expand=1) shows only improvements.

**Note** I refactored the tests slightly because I wanted to be able to run individual tests and leave hints as to what they were testing.

Fixes #1507.
