### PR TITLE
[Breaking] Remove UnknownValue from shim.Schema

### DIFF
--- a/pf/internal/schemashim/attr_schema.go
+++ b/pf/internal/schemashim/attr_schema.go
@@ -138,10 +138,6 @@ func (s *attrSchema) Sensitive() bool {
 	return s.attr.IsSensitive()
 }
 
-func (*attrSchema) UnknownValue() interface{} {
-	panic("UnknownValue() should not be called during schema generation")
-}
-
 func (*attrSchema) SetElement(config interface{}) (interface{}, error) {
 	panic("SetElement() should not be called during schema generation")
 }

--- a/pf/internal/schemashim/block_schema.go
+++ b/pf/internal/schemashim/block_schema.go
@@ -151,7 +151,3 @@ func (*blockSchema) SetHash(v interface{}) int {
 func (*blockSchema) StateFunc() shim.SchemaStateFunc {
 	panic("StateFunc() should not be called during schema generation")
 }
-
-func (*blockSchema) UnknownValue() interface{} {
-	panic("UnknownValue() should not be called during schema generation")
-}

--- a/pf/internal/schemashim/type_schema.go
+++ b/pf/internal/schemashim/type_schema.go
@@ -118,10 +118,6 @@ func (*typeSchema) ExactlyOneOf() []string {
 
 func (*typeSchema) Removed() string { panic("Removed() should not be called during schema generation") }
 
-func (*typeSchema) UnknownValue() interface{} {
-	panic("UnknownValue() should not be called during schema generation")
-}
-
 func (*typeSchema) SetElement(config interface{}) (interface{}, error) {
 	panic("SetElement() should not be called during schema generation")
 }

--- a/pkg/tfshim/schema/schema.go
+++ b/pkg/tfshim/schema/schema.go
@@ -4,12 +4,6 @@ import (
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
-// UnknownVariableValue is the sentinal defined in github.com/hashicorp/terraform/configs/hcl2shim,
-// representing a variable whose value is not known at some particular time. The value is duplicated here in
-// order to prevent an additional dependency - it is unlikely to ever change upstream since that would break
-// rather a lot of things.
-const UnknownVariableValue = "74D93920-ED26-11E3-AC10-0800200C9A66"
-
 var _ = shim.SchemaMap(SchemaMap{})
 
 type Schema struct {
@@ -123,10 +117,6 @@ func (s SchemaShim) Deprecated() string {
 
 func (s SchemaShim) Sensitive() bool {
 	return s.V.Sensitive
-}
-
-func (s SchemaShim) UnknownValue() interface{} {
-	return UnknownVariableValue
 }
 
 func (s SchemaShim) SetElement(v interface{}) (interface{}, error) {

--- a/pkg/tfshim/sdk-v1/schema.go
+++ b/pkg/tfshim/sdk-v1/schema.go
@@ -119,50 +119,6 @@ func (s v1Schema) Sensitive() bool {
 	return s.tf.Sensitive
 }
 
-// makeUnknownElement creates an unknown value to be used as an element of a list or set using the given
-// element schema to guide the shape of the value.
-func makeUnknownElement(elem interface{}) interface{} {
-	// If we have no element schema, just return a simple unknown.
-	if elem == nil {
-		return UnknownVariableValue
-	}
-
-	switch e := elem.(type) {
-	case *schema.Schema:
-		// If the element uses a normal schema, defer to UnknownValue.
-		return v1Schema{e}.UnknownValue()
-	case *schema.Resource:
-		// If the element uses a resource schema, fill in unknown values for any required properties.
-		res := make(map[string]interface{})
-		for k, v := range e.Schema {
-			if v.Required {
-				res[k] = v1Schema{v}.UnknownValue()
-			}
-		}
-		return res
-	default:
-		return UnknownVariableValue
-	}
-}
-
-func (s v1Schema) UnknownValue() interface{} {
-	switch s.tf.Type {
-	case schema.TypeList, schema.TypeSet:
-		// TF does not accept unknown lists or sets. Instead, it accepts lists or sets of unknowns.
-		count := 1
-		if s.tf.MinItems > 0 {
-			count = s.tf.MinItems
-		}
-		arr := make([]interface{}, count)
-		for i := range arr {
-			arr[i] = makeUnknownElement(s.tf.Elem)
-		}
-		return arr
-	default:
-		return UnknownVariableValue
-	}
-}
-
 func (s v1Schema) SetElement(v interface{}) (interface{}, error) {
 	raw := map[string]interface{}{"e": []interface{}{v}}
 	reader := &schema.ConfigFieldReader{

--- a/pkg/tfshim/shim.go
+++ b/pkg/tfshim/shim.go
@@ -134,8 +134,6 @@ type Schema interface {
 	Removed() string
 	Sensitive() bool
 
-	UnknownValue() interface{}
-
 	SetElement(config interface{}) (interface{}, error)
 	SetHash(v interface{}) int
 }

--- a/pkg/tfshim/tfplugin5/schema.go
+++ b/pkg/tfshim/tfplugin5/schema.go
@@ -104,10 +104,6 @@ func (s *attributeSchema) Sensitive() bool {
 	return s.sensitive
 }
 
-func (s *attributeSchema) UnknownValue() interface{} {
-	return UnknownVariableValue
-}
-
 func (s *attributeSchema) SetElement(v interface{}) (interface{}, error) {
 	val, err := goToCty(v, s.ctyType)
 	if err != nil {


### PR DESCRIPTION
It looks like nothing uses this code, so we don't need to keep it around. While this is technically a breaking change, I don't expect that anyone would use this method.