### PR TITLE
Add additional checks on input cross tests for ResourceData.Get values

### DIFF
--- a/pkg/tests/cross-tests/input_check.go
+++ b/pkg/tests/cross-tests/input_check.go
@@ -14,6 +14,7 @@ package crosstests
 
 import (
 	"context"
+	"q"
 
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
@@ -33,14 +34,20 @@ type inputTestCase struct {
 
 	Config     any
 	ObjectType *tftypes.Object
+
+	SkipCompareRaw bool
+}
+
+func FailNotEqual(t T, name string, tfVal, pulVal any) {
+	t.Logf(name + " not equal!")
+	t.Logf("TF value %s", tfVal)
+	t.Logf("PU value %s", pulVal)
+	t.Fail()
 }
 
 func assertCtyValEqual(t T, name string, tfVal, pulVal cty.Value) {
 	if !tfVal.RawEquals(pulVal) {
-		t.Logf(name + " not equal!")
-		t.Logf("TF value " + tfVal.GoString())
-		t.Logf("PU value " + pulVal.GoString())
-		t.Fail()
+		FailNotEqual(t, name, tfVal, pulVal)
 	}
 }
 
@@ -113,11 +120,29 @@ func runCreateInputCheck(t T, tc inputTestCase) {
 
 	pt.Up()
 
-	// TODO: verify that these comparisons ensure full equality.
-	// compare the two inputs
-	assertCtyValEqual(t, "RawConfig", tfResData.GetRawConfig(), pulResData.GetRawConfig())
-	assertCtyValEqual(t, "RawPlan", tfResData.GetRawPlan(), pulResData.GetRawPlan())
+	for k := range tc.Resource.Schema {
+		// TODO: make this recursive
+		tfVal := tfResData.Get(k)
+		pulVal := pulResData.Get(k)
+		q.Q(tfVal, pulVal)
+		if tfVal == nil && pulVal == nil {
+			continue
+		}
+		t.Logf("%T\n", tfVal)
+		// usually plugin-sdk schema types
+		if hasEqualTfVal, ok := tfVal.(interface{ Equal(interface{}) bool }); ok {
+			if !hasEqualTfVal.Equal(pulVal) {
+				FailNotEqual(t, k, tfVal, pulVal)
+			}
+		} else {
+			require.Equal(t, tfVal, pulVal, "Values for key %s do not match", k)
+		}
+	}
 
-	// TODO: we currently represent null state values wrong. We should fix it.
-	// assertCtyValEqual(t, "RawState", tfResData.GetRawState(), pulResData.GetRawState())
+	if !tc.SkipCompareRaw {
+		assertCtyValEqual(t, "RawConfig", tfResData.GetRawConfig(), pulResData.GetRawConfig())
+		assertCtyValEqual(t, "RawPlan", tfResData.GetRawPlan(), pulResData.GetRawPlan())
+		// TODO: we currently represent null state values wrong. We should fix it.
+		// assertCtyValEqual(t, "RawState", tfResData.GetRawState(), pulResData.GetRawState())
+	}
 }

--- a/pkg/tests/cross-tests/input_check.go
+++ b/pkg/tests/cross-tests/input_check.go
@@ -14,7 +14,6 @@ package crosstests
 
 import (
 	"context"
-	"q"
 
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
@@ -124,11 +123,6 @@ func runCreateInputCheck(t T, tc inputTestCase) {
 		// TODO: make this recursive
 		tfVal := tfResData.Get(k)
 		pulVal := pulResData.Get(k)
-		q.Q(tfVal, pulVal)
-		if tfVal == nil && pulVal == nil {
-			continue
-		}
-		t.Logf("%T\n", tfVal)
 		// usually plugin-sdk schema types
 		if hasEqualTfVal, ok := tfVal.(interface{ Equal(interface{}) bool }); ok {
 			if !hasEqualTfVal.Equal(pulVal) {

--- a/pkg/tests/cross-tests/input_cross_test.go
+++ b/pkg/tests/cross-tests/input_cross_test.go
@@ -104,22 +104,20 @@ func TestInputsEqualObjectBasic(t *testing.T) {
 // Isolated from rapid-generated tests
 func TestInputsEmptySchema(t *testing.T) {
 	skipUnlessLinux(t)
-	t.Skip("We represent resources with empty schemas wrong.")
-	// TODO[pulumi/pulumi-terraform-bridge#1914]
 	runCreateInputCheck(
 		t, inputTestCase{
 			Resource: &schema.Resource{
 				Schema: map[string]*schema.Schema{},
 			},
 			Config: tftypes.NewValue(tftypes.Object{}, map[string]tftypes.Value{}),
+			// TODO[pulumi/pulumi-terraform-bridge#1914]
+			SkipCompareRaw: true,
 		},
 	)
 }
 
 func TestInputsEqualEmptyList(t *testing.T) {
 	skipUnlessLinux(t)
-	t.Skip("We misrepresent empty lists")
-	// TODO[pulumi/pulumi-terraform-bridge#1915]
 	for _, maxItems := range []int{0, 1} {
 		for _, configMode := range []schema.SchemaConfigMode{schema.SchemaConfigModeAuto, schema.SchemaConfigModeBlock, schema.SchemaConfigModeAttr} {
 			name := fmt.Sprintf("MaxItems: %v, ConfigMode: %v", maxItems, configMode)
@@ -152,6 +150,8 @@ func TestInputsEqualEmptyList(t *testing.T) {
 							"f0": tftypes.NewValue(t1, []tftypes.Value{}),
 						},
 					),
+					// TODO[pulumi/pulumi-terraform-bridge#1915]
+					SkipCompareRaw: true,
 				})
 			})
 		}
@@ -161,8 +161,6 @@ func TestInputsEqualEmptyList(t *testing.T) {
 // Isolated from rapid-generated tests
 func TestInputsEmptyString(t *testing.T) {
 	skipUnlessLinux(t)
-	t.Skip("Empty strings are misrepresented")
-	// TODO[pulumi/pulumi-terraform-bridge#1916]
 	runCreateInputCheck(t, inputTestCase{
 		Resource: &schema.Resource{
 			Schema: map[string]*schema.Schema{
@@ -180,15 +178,16 @@ func TestInputsEmptyString(t *testing.T) {
 			},
 			map[string]tftypes.Value{
 				"f0": tftypes.NewValue(tftypes.String, ""),
-			}),
+			},
+		),
+		// TODO[pulumi/pulumi-terraform-bridge#1916]
+		SkipCompareRaw: true,
 	})
 }
 
 // Isolated from rapid-generated tests
 func TestInputsEmptyConfigModeAttrSet(t *testing.T) {
 	skipUnlessLinux(t)
-	t.Skip("Our handling of ConfigModeAttr is wrong.")
-	// TODO[pulumi/pulumi-terraform-bridge#1762]
 	t2 := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
 		"f0": tftypes.String,
 	}}
@@ -217,5 +216,7 @@ func TestInputsEmptyConfigModeAttrSet(t *testing.T) {
 		Config: tftypes.NewValue(t0, map[string]tftypes.Value{
 			"f1": tftypes.NewValue(tftypes.Set{ElementType: t2}, []tftypes.Value{}),
 		}),
+		// TODO[pulumi/pulumi-terraform-bridge#1762]
+		SkipCompareRaw: true,
 	})
 }


### PR DESCRIPTION
This is the interface terraform providers use and is what we really should be testing as suggested by @t0yv0.

Not clear if RawConfig, RawPlane, RawState equivalence => .Get equivalence