### PR TITLE
Rapid test set single nested blocks

### DIFF
--- a/pkg/tests/cross-tests/rapid_test.go
+++ b/pkg/tests/cross-tests/rapid_test.go
@@ -70,7 +70,9 @@ func TestCreateInputsConvergence(outerT *testing.T) {
 	outerT.Parallel()
 
 	log.SetOutput(io.Discard)
-	typedValGenerator := &tvGen{}
+	typedValGenerator := &tvGen{
+		skipNullCollections: true,
+	}
 
 	rapid.Check(outerT, func(t *rapid.T) {
 		outerT.Logf("Iterating..")


### PR DESCRIPTION
- Single nested blocks should be sets, not lists as that's how TF represents objects
- Flag for skipping null collections as these currently don't match the TF representation with explicit nulls