### PR TITLE
Cross test fix required empty blocks

### DIFF
--- a/pkg/convert/encoding.go
+++ b/pkg/convert/encoding.go
@@ -232,6 +232,7 @@ func deriveDecoder(pctx *schemaPropContext, t tftypes.Type) (Decoder, error) {
 		}
 		return &flattenedDecoder{
 			elementDecoder: decoder,
+			elementType:    elementType,
 		}, nil
 	}
 

--- a/pkg/convert/flattened.go
+++ b/pkg/convert/flattened.go
@@ -63,8 +63,6 @@ func (dec *flattenedDecoder) toPropertyValue(v tftypes.Value) (resource.Property
 			tfVal := tftypes.NewValue(dec.elementType, []tftypes.Value{})
 			return dec.elementDecoder.toPropertyValue(tfVal)
 		}
-		// TODO: handle nested flattened decoders.
-		// TestNonEmptyNestedMaxItemsOnes
 		return resource.NewNullProperty(), nil
 	case 1:
 		return dec.elementDecoder.toPropertyValue(list[0])

--- a/pkg/tests/cross-tests/input_cross_test.go
+++ b/pkg/tests/cross-tests/input_cross_test.go
@@ -365,12 +365,12 @@ func TestNonEmptyNestedMaxItemsOnes(t *testing.T) {
 	config2 := tftypes.NewValue(t0, map[string]tftypes.Value{
 		"d3f0": tftypes.NewValue(tftypes.List{ElementType: t1}, []tftypes.Value{}),
 	})
-	// second level empty
-	// config3 := tftypes.NewValue(t0, map[string]tftypes.Value{
-	// 	"d3f0": tftypes.NewValue(tftypes.List{ElementType: t1}, []tftypes.Value{
-	// 		tftypes.NewValue(t1, []tftypes.Value{}),
-	// 	}),
-	// })
+	// second level empty - this is impossible to handle because of flattening
+	_ = tftypes.NewValue(t0, map[string]tftypes.Value{
+		"d3f0": tftypes.NewValue(tftypes.List{ElementType: t1}, []tftypes.Value{
+			tftypes.NewValue(t1, []tftypes.Value{}),
+		}),
+	})
 
 	for _, tc := range []struct {
 		name   string
@@ -378,7 +378,6 @@ func TestNonEmptyNestedMaxItemsOnes(t *testing.T) {
 	}{
 		{"non-empty", config1},
 		{"first-level-empty", config2},
-		// TODO: fix.
 		// {"second-level-empty", config3},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/tests/cross-tests/input_cross_test.go
+++ b/pkg/tests/cross-tests/input_cross_test.go
@@ -257,6 +257,148 @@ func TestExplicitNilList(t *testing.T) {
 			},
 		},
 		// TODO: How does one express this with tftypes?
+		// tftypes.NewValue(tftypes.DynamicPseudoType, nil)?
 		Config: map[string]interface{}{"f0": nil},
 	})
+}
+
+func TestRequiredEmptyListOfObjects(t *testing.T) {
+	skipUnlessLinux(t)
+
+	t1 := tftypes.Object{}
+	t0 := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"d3f0": tftypes.List{ElementType: t1},
+	}}
+	config := tftypes.NewValue(t0, map[string]tftypes.Value{
+		"d3f0": tftypes.NewValue(tftypes.List{ElementType: t1}, []tftypes.Value{}),
+	})
+
+	runCreateInputCheck(t, inputTestCase{
+		Resource: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"d3f0": {
+					Type:     schema.TypeList,
+					Required: true,
+					Elem:     &schema.Resource{Schema: map[string]*schema.Schema{}},
+					MaxItems: 1,
+				},
+			},
+		},
+		Config: config,
+	})
+}
+
+func TestRequiredEmptyListOfLists(t *testing.T) {
+	skipUnlessLinux(t)
+	t.Skipf("Fix - returns []interface {}{interface {}(nil)} instead of []interface {}{}")
+
+	t1 := tftypes.List{ElementType: tftypes.String}
+	t0 := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"d3f0": tftypes.List{ElementType: t1},
+	}}
+	config := tftypes.NewValue(t0, map[string]tftypes.Value{
+		"d3f0": tftypes.NewValue(tftypes.List{ElementType: t1}, []tftypes.Value{}),
+	})
+
+	runCreateInputCheck(t, inputTestCase{
+		Resource: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"d3f0": {
+					Type:     schema.TypeList,
+					Required: true,
+					Elem: &schema.Schema{
+						Type: schema.TypeList, Elem: &schema.Schema{Type: schema.TypeString},
+					},
+					MaxItems: 1,
+				},
+			},
+		},
+		Config: config,
+	})
+}
+
+func TestRequiredEmptyListOfSets(t *testing.T) {
+	skipUnlessLinux(t)
+	t.Skipf("Fix - returns []interface {}{interface {}(nil)} instead of []interface {}{}")
+
+	t1 := tftypes.Set{ElementType: tftypes.String}
+	t0 := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"d3f0": tftypes.List{ElementType: t1},
+	}}
+	config := tftypes.NewValue(t0, map[string]tftypes.Value{
+		"d3f0": tftypes.NewValue(tftypes.List{ElementType: t1}, []tftypes.Value{}),
+	})
+
+	runCreateInputCheck(t, inputTestCase{
+		Resource: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"d3f0": {
+					Type:     schema.TypeList,
+					Required: true,
+					Elem: &schema.Schema{
+						Type: schema.TypeSet, Elem: &schema.Schema{Type: schema.TypeString},
+					},
+					MaxItems: 1,
+				},
+			},
+		},
+		Config: config,
+	})
+}
+
+func TestNonEmptyNestedMaxItemsOnes(t *testing.T) {
+	skipUnlessLinux(t)
+
+	t1 := tftypes.List{ElementType: tftypes.String}
+	t0 := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"d3f0": tftypes.List{ElementType: t1},
+	}}
+	// Non-empty
+	config1 := tftypes.NewValue(t0, map[string]tftypes.Value{
+		"d3f0": tftypes.NewValue(tftypes.List{ElementType: t1}, []tftypes.Value{
+			tftypes.NewValue(t1, []tftypes.Value{
+				tftypes.NewValue(tftypes.String, "foo"),
+			}),
+		}),
+	})
+	// first level empty
+	config2 := tftypes.NewValue(t0, map[string]tftypes.Value{
+		"d3f0": tftypes.NewValue(tftypes.List{ElementType: t1}, []tftypes.Value{}),
+	})
+	// second level empty
+	// config3 := tftypes.NewValue(t0, map[string]tftypes.Value{
+	// 	"d3f0": tftypes.NewValue(tftypes.List{ElementType: t1}, []tftypes.Value{
+	// 		tftypes.NewValue(t1, []tftypes.Value{}),
+	// 	}),
+	// })
+
+	for _, tc := range []struct {
+		name   string
+		config tftypes.Value
+	}{
+		{"non-empty", config1},
+		{"first-level-empty", config2},
+		// TODO: fix.
+		// {"second-level-empty", config3},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runCreateInputCheck(t, inputTestCase{
+				Resource: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"d3f0": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem: &schema.Schema{
+								Type:     schema.TypeList,
+								MaxItems: 1,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							MaxItems: 1,
+						},
+					},
+				},
+				Config: tc.config,
+			})
+		})
+	}
 }

--- a/pkg/tests/cross-tests/tfwrite.go
+++ b/pkg/tests/cross-tests/tfwrite.go
@@ -60,8 +60,12 @@ func writeBlock(body *hclwrite.Body, schemas map[string]*schema.Schema, values m
 					continue
 				}
 
-				newBlock := body.AppendNewBlock(key, nil)
+				if value.LengthInt() == 0 {
+					body.AppendNewBlock(key, nil)
+				}
+
 				for _, v := range value.AsValueSet().Values() {
+					newBlock := body.AppendNewBlock(key, nil)
 					writeBlock(newBlock.Body(), elem.Schema, v.AsValueMap())
 				}
 			} else if sch.Type == schema.TypeList {
@@ -69,8 +73,12 @@ func writeBlock(body *hclwrite.Body, schemas map[string]*schema.Schema, values m
 					continue
 				}
 
-				newBlock := body.AppendNewBlock(key, nil)
+				if value.LengthInt() == 0 {
+					body.AppendNewBlock(key, nil)
+				}
+
 				for _, v := range value.AsValueSlice() {
+					newBlock := body.AppendNewBlock(key, nil)
 					writeBlock(newBlock.Body(), elem.Schema, v.AsValueMap())
 				}
 			} else {

--- a/pkg/tests/cross-tests/tfwrite.go
+++ b/pkg/tests/cross-tests/tfwrite.go
@@ -60,8 +60,8 @@ func writeBlock(body *hclwrite.Body, schemas map[string]*schema.Schema, values m
 					continue
 				}
 
+				newBlock := body.AppendNewBlock(key, nil)
 				for _, v := range value.AsValueSet().Values() {
-					newBlock := body.AppendNewBlock(key, nil)
 					writeBlock(newBlock.Body(), elem.Schema, v.AsValueMap())
 				}
 			} else if sch.Type == schema.TypeList {
@@ -69,8 +69,8 @@ func writeBlock(body *hclwrite.Body, schemas map[string]*schema.Schema, values m
 					continue
 				}
 
+				newBlock := body.AppendNewBlock(key, nil)
 				for _, v := range value.AsValueSlice() {
-					newBlock := body.AppendNewBlock(key, nil)
 					writeBlock(newBlock.Body(), elem.Schema, v.AsValueMap())
 				}
 			} else {

--- a/pkg/tests/cross-tests/tfwrite_test.go
+++ b/pkg/tests/cross-tests/tfwrite_test.go
@@ -168,6 +168,7 @@ resource "res" "ex" {
 }
 `),
 		},
+		// TODO: empty list/set test case
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
We were generating wrong HCL and Pulumi code in the cross test framework for empty required lists of other collections. This should fix both.

TF errors:

```
│ Error: Insufficient d2f0 blocks
│
│   on test.tf line 1, in resource "crossprovider_testres" "example":
│    1: resource "crossprovider_testres" "example" {
│
│ At least 1 "d2f0" blocks are required.
```

Pulumi errors:
```
Error: crossprovider:index:TestRes is not assignable from {}
  Cannot assign '{}' to 'crossprovider:index:TestRes':
    d3f0: Missing required property 'd3f0'
```

Also adds a test case for nested maxItemsOne properties - the `second level empty` test case is impossible to match because of the reduced information in the pulumi representation, right?