### PR TITLE
Cross test ensure bitstream consumed

### DIFF
--- a/pkg/tests/cross-tests/input_cross_test.go
+++ b/pkg/tests/cross-tests/input_cross_test.go
@@ -401,3 +401,32 @@ func TestNonEmptyNestedMaxItemsOnes(t *testing.T) {
 		})
 	}
 }
+
+func TestEmptySetOfEmptyObjects(t *testing.T) {
+	skipUnlessLinux(t)
+	t.Skipf("Fix")
+	// TODO
+	// RawPlan not equal!
+    // TF value cty.ObjectVal(map[string]cty.Value{"d2f0":cty.SetVal([]cty.Value{cty.EmptyObjectVal}), "d2f1":cty.SetVal([]cty.Value{cty.EmptyObjectVal}), "id":cty.UnknownVal(cty.String)})
+    // PU value cty.ObjectVal(map[string]cty.Value{"d2f0":cty.SetValEmpty(cty.EmptyObject), "d2f1":cty.SetVal([]cty.Value{cty.EmptyObjectVal}), "id":cty.UnknownVal(cty.String)})
+	t1 := tftypes.Object{}
+	t0 := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"d3f0": tftypes.Set{ElementType: t1},
+	}}
+	config := tftypes.NewValue(t0, map[string]tftypes.Value{
+		"d3f0": tftypes.NewValue(tftypes.Set{ElementType: t1}, []tftypes.Value{}),
+	})
+
+	runCreateInputCheck(t, inputTestCase{
+		Resource: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"d3f0": {
+        			Type:     schema.TypeSet,
+        			Optional: true,
+        			Elem:     &schema.Resource{Schema: map[string]*schema.Schema{}},
+        		},
+			},
+		},
+		Config: config,
+	})
+}

--- a/pkg/tests/cross-tests/rapid_tv_gen.go
+++ b/pkg/tests/cross-tests/rapid_tv_gen.go
@@ -204,6 +204,7 @@ func (tvg *tvGen) GenBlockWithDepth(depth int, parentName string) *rapid.Generat
 				return tftypes.NewValue(objType, fields)
 			})
 		} else {
+			_ = rapid.Bool().Draw(t, "consumeBitstream3")
 			objGen = rapid.Just(tftypes.NewValue(objType, map[string]tftypes.Value{}))
 		}
 		err := schema.InternalMap(fieldSchemas).InternalValidate(nil)
@@ -221,7 +222,7 @@ func (tvg *tvGen) GenBlockWithDepth(depth int, parentName string) *rapid.Generat
 // See https://developer.hashicorp.com/terraform/plugin/framework/handling-data/blocks/single-nested
 func (tvg *tvGen) GenSingleNestedBlock(depth int, parentName string) *rapid.Generator[tv] {
 	ge := rapid.Custom[tv](func(t *rapid.T) tv {
-		bl := tvg.GenBlockWithDepth(depth, parentName).Draw(t, "block")
+		bl := tvg.GenBlockWithDepth(depth-1, parentName).Draw(t, "block")
 		setWrapType := tftypes.Set{ElementType: bl.typ}
 		setWrap := func(v tftypes.Value) tftypes.Value {
 			return tftypes.NewValue(setWrapType, []tftypes.Value{v})
@@ -385,6 +386,7 @@ func (tvg *tvGen) WithNullAndUnknown(gen *rapid.Generator[tv]) *rapid.Generator[
 		gen := tv0.valueGen
 		options := []*rapid.Generator[tftypes.Value]{gen}
 		if tvg.generateUnknowns {
+			_ = rapid.Bool().Draw(t, "consumeBitstream1")
 			unkGen := rapid.Just(tftypes.NewValue(tv0.typ, tftypes.UnknownValue))
 			options = append(options, unkGen)
 		}
@@ -392,6 +394,7 @@ func (tvg *tvGen) WithNullAndUnknown(gen *rapid.Generator[tv]) *rapid.Generator[
 			(tv0.schema.Type == schema.TypeList ||
 				tv0.schema.Type == schema.TypeSet)) &&
 			!tv0.schema.Required {
+			_ = rapid.Bool().Draw(t, "consumeBitstream2")
 			nullGen := rapid.Just(tftypes.NewValue(tv0.typ, nil))
 			options = append(options, nullGen)
 		}


### PR DESCRIPTION
```
[rapid] flaky test, can not reproduce a failure
        Traceback (group did not use any data from bitstream; this is likely a result of Custom generator not calling any of the built-in generators):
```

rapid wants us to always consume from the random bitstream but we don't do that when we generate empty collection values. This just adds some generators in those cases so that rapid doesn't panic.

Also revert the depth off by one error - that was intentional since SingleNestedBlocks give one additional level of nesting.