### PR TITLE
Provider2 upgrade state rewrite

### DIFF
--- a/pkg/tests/cross-tests/input_check.go
+++ b/pkg/tests/cross-tests/input_check.go
@@ -34,7 +34,9 @@ type inputTestCase struct {
 	Config     any
 	ObjectType *tftypes.Object
 
-	SkipCompareRaw bool
+	SkipCompareRawPlan   bool
+	SkipCompareRawConfig bool
+	SkipCompareRawState  bool
 }
 
 func FailNotEqual(t T, name string, tfVal, pulVal any) {
@@ -143,10 +145,15 @@ func runCreateInputCheck(t T, tc inputTestCase) {
 		assertValEqual(t, k+" Change New", tfChangeValNew, pulChangeValNew)
 	}
 
-	if !tc.SkipCompareRaw {
+	if !tc.SkipCompareRawConfig {
 		assertCtyValEqual(t, "RawConfig", tfResData.GetRawConfig(), pulResData.GetRawConfig())
+	}
+
+	if !tc.SkipCompareRawPlan {
 		assertCtyValEqual(t, "RawPlan", tfResData.GetRawPlan(), pulResData.GetRawPlan())
-		// TODO: we currently represent null state values wrong. We should fix it.
-		// assertCtyValEqual(t, "RawState", tfResData.GetRawState(), pulResData.GetRawState())
+	}
+
+	if !tc.SkipCompareRawState {
+		assertCtyValEqual(t, "RawState", tfResData.GetRawState(), pulResData.GetRawState())
 	}
 }

--- a/pkg/tests/cross-tests/input_cross_test.go
+++ b/pkg/tests/cross-tests/input_cross_test.go
@@ -110,8 +110,6 @@ func TestInputsEmptySchema(t *testing.T) {
 				Schema: map[string]*schema.Schema{},
 			},
 			Config: tftypes.NewValue(tftypes.Object{}, map[string]tftypes.Value{}),
-			// TODO[pulumi/pulumi-terraform-bridge#1914]
-			SkipCompareRaw: true,
 		},
 	)
 }
@@ -151,7 +149,8 @@ func TestInputsEqualEmptyList(t *testing.T) {
 						},
 					),
 					// TODO[pulumi/pulumi-terraform-bridge#1915]
-					SkipCompareRaw: true,
+					SkipCompareRawPlan:   true,
+					SkipCompareRawConfig: true,
 				})
 			})
 		}
@@ -180,8 +179,6 @@ func TestInputsEmptyString(t *testing.T) {
 				"f0": tftypes.NewValue(tftypes.String, ""),
 			},
 		),
-		// TODO[pulumi/pulumi-terraform-bridge#1916]
-		SkipCompareRaw: true,
 	})
 }
 
@@ -217,6 +214,6 @@ func TestInputsEmptyConfigModeAttrSet(t *testing.T) {
 			"f1": tftypes.NewValue(tftypes.Set{ElementType: t2}, []tftypes.Value{}),
 		}),
 		// TODO[pulumi/pulumi-terraform-bridge#1762]
-		SkipCompareRaw: true,
+		SkipCompareRawConfig: true,
 	})
 }

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -4310,6 +4310,8 @@ func TestStringValForOtherProperty(t *testing.T) {
 }
 
 func TestPlanResourceChangeStateUpgrade(t *testing.T) {
+	// TODO[pulumi/pulumi-terraform-bridge#1667]
+	t.Skipf("Skip since we try to use the current schema for the state.")
 	p := &schemav2.Provider{
 		Schema: map[string]*schemav2.Schema{},
 		ResourcesMap: map[string]*schemav2.Resource{

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -4318,7 +4318,6 @@ func TestPlanResourceChangeStateUpgrade(t *testing.T) {
 					"prop": &schema.Schema{
 						Type:     schema.TypeSet,
 						Optional: true,
-						MaxItems: 1,
 						Elem:     &schemav2.Schema{Type: schemav2.TypeString},
 					},
 				},
@@ -4358,6 +4357,9 @@ func TestPlanResourceChangeStateUpgrade(t *testing.T) {
 			"urn": "urn:pulumi:dev::teststack::ExampleResource::exres",
 			"id": "0",
 			"olds": {
+				"__meta": {
+					"version": 0
+				},
 				"prop": "val"
 			},
 			"news": {

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hexops/autogold/v2"
@@ -4306,4 +4307,66 @@ func TestStringValForOtherProperty(t *testing.T) {
 			}
 		}`)
 	})
+}
+
+func TestPlanResourceChangeStateUpgrade(t *testing.T) {
+	p := &schemav2.Provider{
+		Schema: map[string]*schemav2.Schema{},
+		ResourcesMap: map[string]*schemav2.Resource{
+			"example_resource": {
+				Schema: map[string]*schemav2.Schema{
+					"prop": &schema.Schema{
+						Type:     schema.TypeSet,
+						Optional: true,
+						MaxItems: 1,
+						Elem:     &schemav2.Schema{Type: schemav2.TypeString},
+					},
+				},
+				StateUpgraders: []schema.StateUpgrader{
+					{
+						Version: 0,
+						Type:    cty.Object(map[string]cty.Type{"prop": cty.String}),
+						Upgrade: func(
+							ctx context.Context, rawState map[string]interface{}, meta interface{},
+						) (map[string]interface{}, error) {
+							rawState["prop"] = []interface{}{rawState["prop"]}
+							return rawState, nil
+						},
+					},
+				},
+			},
+		},
+	}
+	shimProv := shimv2.NewProvider(p, shimv2.WithPlanResourceChange(func(tfResourceType string) bool { return true }))
+	provider := &Provider{
+		tf:     shimProv,
+		config: shimv2.NewSchemaMap(p.Schema),
+		info: ProviderInfo{
+			P:              shimProv,
+			ResourcePrefix: "example",
+			Resources: map[string]*ResourceInfo{
+				"example_resource": {Tok: "ExampleResource"},
+			},
+		},
+	}
+	provider.initResourceMaps()
+
+	testutils.Replay(t, provider, `
+	{
+		"method": "/pulumirpc.ResourceProvider/Diff",
+		"request": {
+			"urn": "urn:pulumi:dev::teststack::ExampleResource::exres",
+			"id": "0",
+			"olds": {
+				"prop": "val"
+			},
+			"news": {
+				"prop": ["val"]
+			}
+		},
+		"response": {
+			"changes": "DIFF_NONE",
+			"hasDetailedDiff": true
+		}
+	}`)
 }

--- a/pkg/tfshim/sdk-v2/provider2.go
+++ b/pkg/tfshim/sdk-v2/provider2.go
@@ -46,6 +46,8 @@ func (r *v2Resource2) InstanceState(
 		copy["id"] = id
 		object = copy
 	}
+	// TODO[pulumi/pulumi-terraform-bridge#1667]: This is not right since it uses the
+	// current schema. 1667 should make this redundant
 	s, err := recoverAndCoerceCtyValueWithSchema(r.v2Resource.tf.CoreConfigSchema(), object)
 	if err != nil {
 		return nil, fmt.Errorf("InstanceState: %v", err)

--- a/pkg/tfshim/sdk-v2/provider2_test.go
+++ b/pkg/tfshim/sdk-v2/provider2_test.go
@@ -1,0 +1,205 @@
+package sdkv2
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpgradeResourceState(t *testing.T) {
+	const tfToken = "test_token"
+	for _, tc := range []struct {
+		name     string
+		state    cty.Value
+		rSchema  *schema.Resource
+		expected cty.Value
+	}{
+		{
+			name: "no upgrade",
+			state: cty.ObjectVal(map[string]cty.Value{
+				"id": cty.StringVal("1"),
+				"x":  cty.NumberIntVal(1),
+			}),
+			rSchema: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"x": {Type: schema.TypeInt, Optional: true},
+				},
+			},
+			expected: cty.ObjectVal(map[string]cty.Value{
+				"id": cty.StringVal("1"),
+				"x":  cty.NumberIntVal(1),
+			}),
+		},
+		{
+			name: "basic upgrade type",
+			state: cty.ObjectVal(map[string]cty.Value{
+				"id": cty.StringVal("1"),
+				"x":  cty.StringVal("1"),
+			}),
+			rSchema: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"x": {Type: schema.TypeInt, Optional: true},
+				},
+				StateUpgraders: []schema.StateUpgrader{
+					{
+						Version: 0,
+						Type:    cty.Object(map[string]cty.Type{"x": cty.String}),
+						Upgrade: func(
+							ctx context.Context, rawState map[string]interface{}, meta interface{},
+						) (map[string]interface{}, error) {
+							newVal, err := strconv.ParseInt(rawState["x"].(string), 10, 64)
+							if err != nil {
+								return nil, err
+							}
+							rawState["x"] = int(newVal)
+							return rawState, nil
+						},
+					},
+				},
+			},
+			expected: cty.ObjectVal(map[string]cty.Value{
+				"id": cty.StringVal("1"),
+				"x":  cty.NumberIntVal(1),
+			}),
+		},
+		{
+			name: "rename property",
+			state: cty.ObjectVal(map[string]cty.Value{
+				"id": cty.StringVal("1"),
+				"x":  cty.StringVal("1"),
+			}),
+			rSchema: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"y": {Type: schema.TypeString, Optional: true},
+				},
+				StateUpgraders: []schema.StateUpgrader{
+					{
+						Version: 0,
+						Type:    cty.Object(map[string]cty.Type{"x": cty.String}),
+						Upgrade: func(
+							ctx context.Context, rawState map[string]interface{}, meta interface{},
+						) (map[string]interface{}, error) {
+							rawState["y"] = rawState["x"]
+							delete(rawState, "x")
+							return rawState, nil
+						},
+					},
+				},
+			},
+			expected: cty.ObjectVal(map[string]cty.Value{
+				"id": cty.StringVal("1"),
+				"y":  cty.StringVal("1"),
+			}),
+		},
+		{
+			name: "flat prop to collection",
+			state: cty.ObjectVal(map[string]cty.Value{
+				"id": cty.StringVal("1"),
+				"x":  cty.StringVal("1"),
+			}),
+			rSchema: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"x": {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+				},
+				StateUpgraders: []schema.StateUpgrader{
+					{
+						Version: 0,
+						Type:    cty.Object(map[string]cty.Type{"x": cty.String}),
+						Upgrade: func(
+							ctx context.Context, rawState map[string]interface{}, meta interface{},
+						) (map[string]interface{}, error) {
+							rawState["x"] = []interface{}{rawState["x"]}
+							return rawState, nil
+						},
+					},
+				},
+			},
+			expected: cty.ObjectVal(map[string]cty.Value{
+				"id": cty.StringVal("1"),
+				"x":  cty.ListVal([]cty.Value{cty.StringVal("1")}),
+			}),
+		},
+		{
+			name: "collection to flat prop",
+			state: cty.ObjectVal(map[string]cty.Value{
+				"id": cty.StringVal("1"),
+				"x":  cty.ListVal([]cty.Value{cty.StringVal("1")}),
+			}),
+			rSchema: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"x": {Type: schema.TypeString, Optional: true},
+				},
+				StateUpgraders: []schema.StateUpgrader{
+					{
+						Version: 0,
+						Type:    cty.Object(map[string]cty.Type{"x": cty.List(cty.String)}),
+						Upgrade: func(
+							ctx context.Context, rawState map[string]interface{}, meta interface{},
+						) (map[string]interface{}, error) {
+							rawState["x"] = rawState["x"].([]interface{})[0]
+							return rawState, nil
+						},
+					},
+				},
+			},
+			expected: cty.ObjectVal(map[string]cty.Value{
+				"id": cty.StringVal("1"),
+				"x":  cty.StringVal("1"),
+			}),
+		},
+		{
+			name: "change list to set",
+			state: cty.ObjectVal(map[string]cty.Value{
+				"id": cty.StringVal("1"),
+				"x":  cty.ListVal([]cty.Value{cty.StringVal("1"), cty.StringVal("2")}),
+			}),
+			rSchema: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"x": {
+						Type:     schema.TypeSet,
+						Optional: true,
+						Elem:     &schema.Schema{Type: schema.TypeString},
+					},
+				},
+				StateUpgraders: []schema.StateUpgrader{
+					{
+						Version: 0,
+						Type:    cty.Object(map[string]cty.Type{"x": cty.List(cty.String)}),
+						Upgrade: func(
+							ctx context.Context, rawState map[string]interface{}, meta interface{},
+						) (map[string]interface{}, error) {
+							return rawState, nil
+						},
+					},
+				},
+			},
+			expected: cty.ObjectVal(map[string]cty.Value{
+				"id": cty.StringVal("1"),
+				"x":  cty.SetVal([]cty.Value{cty.StringVal("1"), cty.StringVal("2")}),
+			}),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tf := &schema.Provider{
+				ResourcesMap: map[string]*schema.Resource{
+					tfToken: tc.rSchema,
+				},
+			}
+			actual, err := (&planResourceChangeImpl{
+				tf:     tf,
+				server: &grpcServer{schema.NewGRPCProviderServer(tf)},
+			}).upgradeState(context.Background(), tfToken, &v2InstanceState2{
+				resourceType: tfToken,
+				stateValue:   tc.state,
+			})
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expected, actual.(*v2InstanceState2).stateValue)
+		})
+	}
+}


### PR DESCRIPTION
fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/1916
fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/1914

This rewrites the provider2 upgrade state implementation to use the upstream GRPC method instead of the bridge implementation. This should cut out a bunch of unnecessary code and some type conversions of the data.

Originally done as part of https://github.com/pulumi/pulumi-terraform-bridge/pull/1971 but I'm pulling this out to merge separately.

@t0yv0 did a lot of the heavy lifting here.