### PR TITLE
Unify upgradeResourceState between `provider` and `provider2`

### DIFF
--- a/pkg/tfshim/sdk-v2/provider.go
+++ b/pkg/tfshim/sdk-v2/provider.go
@@ -124,7 +124,7 @@ func (p v2Provider) Apply(
 	if !ok {
 		return nil, fmt.Errorf("unknown resource %v", t)
 	}
-	state, err := upgradeResourceState(ctx, p.tf, r, stateFromShim(s))
+	state, err := upgradeResourceState(ctx, t, p.tf, r, stateFromShim(s))
 	if err != nil {
 		return nil, fmt.Errorf("failed to upgrade resource state: %w", err)
 	}
@@ -148,7 +148,7 @@ func (p v2Provider) Refresh(
 		return nil, fmt.Errorf("unknown resource %v", t)
 	}
 
-	state, err := upgradeResourceState(ctx, p.tf, r, stateFromShim(s))
+	state, err := upgradeResourceState(ctx, t, p.tf, r, stateFromShim(s))
 	if err != nil {
 		return nil, fmt.Errorf("failed to upgrade resource state: %w", err)
 	}

--- a/pkg/tfshim/sdk-v2/provider2_test.go
+++ b/pkg/tfshim/sdk-v2/provider2_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestUpgradeResourceState(t *testing.T) {
+func TestProvider2UpgradeResourceState(t *testing.T) {
 	const tfToken = "test_token"
 	for _, tc := range []struct {
 		name     string

--- a/pkg/tfshim/sdk-v2/provider_diff.go
+++ b/pkg/tfshim/sdk-v2/provider_diff.go
@@ -66,7 +66,7 @@ func (p v2Provider) Diff(
 		}
 	} else {
 		// Upgrades are needed only if we have non-empty prior state.
-		state, err = upgradeResourceState(ctx, p.tf, r, state)
+		state, err = upgradeResourceState(ctx, t, p.tf, r, state)
 		if err != nil {
 			return nil, fmt.Errorf("failed to upgrade resource state: %w", err)
 		}

--- a/pkg/tfshim/sdk-v2/provider_test.go
+++ b/pkg/tfshim/sdk-v2/provider_test.go
@@ -1,0 +1,106 @@
+package sdkv2
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProvider1UpgradeResourceState(t *testing.T) {
+	t.Parallel()
+
+	type tc struct {
+		name   string
+		schema *schema.Resource
+		input  func() *terraform.InstanceState
+		expect func(t *testing.T, actual *terraform.InstanceState, tc tc)
+	}
+
+	tests := []tc{
+		{
+			name: "roundtrip int64",
+			schema: &schema.Resource{
+				UseJSONNumber: true,
+				Schema: map[string]*schema.Schema{
+					"x": {Type: schema.TypeInt, Optional: true},
+				},
+			},
+			input: func() *terraform.InstanceState {
+				n, err := cty.ParseNumberVal("641577219598130723")
+				require.NoError(t, err)
+				v := cty.ObjectVal(map[string]cty.Value{"x": n})
+				s := terraform.NewInstanceStateShimmedFromValue(v, 0)
+				s.Meta["schema_version"] = "0"
+				s.ID = "id"
+				s.RawState = v
+				s.Attributes["id"] = s.ID
+				return s
+			},
+			expect: func(t *testing.T, actual *terraform.InstanceState, tc tc) {
+				assert.Equal(t, tc.input().Attributes, actual.Attributes)
+			},
+		},
+		{
+			name: "type change",
+			schema: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"x1": {Type: schema.TypeInt, Optional: true},
+				},
+				SchemaVersion: 1,
+				StateUpgraders: []schema.StateUpgrader{{
+					Version: 0,
+					Type: cty.Object(map[string]cty.Type{
+						"id": cty.String,
+						"x0": cty.String,
+					}),
+					Upgrade: func(_ context.Context, rawState map[string]any, _ interface{}) (map[string]any, error) {
+						return map[string]any{
+							"id": rawState["id"],
+							"x1": len(rawState["x0"].(string)),
+						}, nil
+					},
+				}},
+			},
+			input: func() *terraform.InstanceState {
+				s := terraform.NewInstanceStateShimmedFromValue(cty.ObjectVal(map[string]cty.Value{
+					"x0": cty.StringVal("123"),
+				}), 0)
+				s.Meta["schema_version"] = "0"
+				s.ID = "id"
+				return s
+			},
+			expect: func(t *testing.T, actual *terraform.InstanceState, tc tc) {
+				t.Logf("Actual = %#v", actual)
+				assert.Equal(t, map[string]string{
+					"id": "id",
+					"x1": "3",
+				}, actual.Attributes)
+			},
+		},
+	}
+
+	const tfToken = "test_token"
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			require.NoError(t, tt.schema.InternalValidate(tt.schema.Schema, true))
+
+			p := &schema.Provider{ResourcesMap: map[string]*schema.Resource{tfToken: tt.schema}}
+
+			actual, err := upgradeResourceState(ctx, tfToken, p, tt.schema, tt.input())
+			require.NoError(t, err)
+
+			tt.expect(t, actual, tt)
+		})
+	}
+}

--- a/pkg/tfshim/sdk-v2/upgrade_state.go
+++ b/pkg/tfshim/sdk-v2/upgrade_state.go
@@ -92,11 +92,6 @@ func upgradeResourceState(ctx context.Context, t string, p *schema.Provider, res
 		return nil, nil
 	}
 
-	version, hasVersion, err := extractSchemaVersion(instanceState.Meta)
-	if err != nil {
-		return nil, err
-	}
-
 	rawState := instanceState.RawState
 
 	// If RawState is not set but attributes is, we need to hydrate RawState
@@ -105,6 +100,12 @@ func upgradeResourceState(ctx context.Context, t string, p *schema.Provider, res
 		// We default to assuming that the old state has the same shape as the new
 		// resource.
 		typ := res.CoreConfigSchema().ImpliedType()
+
+		// Find the version, if present, to deserialize instanceState into.
+		version, hasVersion, err := extractSchemaVersion(instanceState.Meta)
+		if err != nil {
+			return nil, err
+		}
 
 		// If we have a version, we use the schema shape that matches the version
 		// specified.

--- a/pkg/tfshim/sdk-v2/upgrade_state.go
+++ b/pkg/tfshim/sdk-v2/upgrade_state.go
@@ -63,7 +63,9 @@ func upgradeResourceStateGRPC(
 	for k, v := range meta {
 		newMeta[k] = v
 	}
-	newMeta["schema_version"] = strconv.Itoa(res.SchemaVersion)
+	if res.SchemaVersion != 0 {
+		newMeta["schema_version"] = strconv.Itoa(res.SchemaVersion)
+	}
 
 	return newState, newMeta, nil
 }


### PR DESCRIPTION
This PR extracts the non provider2 specific part of `planResourceChangeImpl.upgradeState` into it's own function: `upgradeResourceStateGRPC`. This part is a pure refactor. 

The PR then re-implements `upgradeResourceState` in terms of `upgradeResourceStateGRPC`.

The driving motivation for this change is to reduce complexity and allow both upgraders to handle large JSON numbers.

Replaces https://github.com/pulumi/pulumi-terraform-bridge/pull/1735