### PR TITLE
Rapid test ensure bitstream consumed

### DIFF
--- a/pkg/tests/cross-tests/rapid_tv_gen.go
+++ b/pkg/tests/cross-tests/rapid_tv_gen.go
@@ -209,6 +209,7 @@ func (tvg *tvGen) GenBlockWithDepth(depth int) *rapid.Generator[tb] {
 				return tftypes.NewValue(objType, fields)
 			})
 		} else {
+			_ = rapid.Bool().Draw(t, "consumeBitstream1")
 			objGen = rapid.Just(tftypes.NewValue(objType, map[string]tftypes.Value{}))
 		}
 		err := schema.InternalMap(fieldSchemas).InternalValidate(nil)
@@ -401,6 +402,7 @@ func (tvg *tvGen) WithNullAndUnknown(gen *rapid.Generator[tv]) *rapid.Generator[
 				nullGen := rapid.Just(tftypes.NewValue(tv0.typ, nil))
 				options = append(options, nullGen)
 			}
+			_ = rapid.Bool().Draw(t, "consumeBitstream2")
 			gen = rapid.OneOf(options...)
 		}
 		return tv{


### PR DESCRIPTION
```
[rapid] flaky test, can not reproduce a failure
        Traceback (group did not use any data from bitstream; this is likely a result of Custom generator not calling any of the built-in generators):
```

rapid wants us to always consume from the random bitstream but we don't do that when we generate empty collection values. This just adds some generators in those cases so that rapid doesn't panic.