### PR TITLE
Rapid test: correctly produce null for optional values

### DIFF
--- a/pkg/tests/cross-tests/rapid_tv_gen.go
+++ b/pkg/tests/cross-tests/rapid_tv_gen.go
@@ -391,18 +391,16 @@ func (tvg *tvGen) WithNullAndUnknown(gen *rapid.Generator[tv]) *rapid.Generator[
 	return rapid.Custom[tv](func(t *rapid.T) tv {
 		tv0 := gen.Draw(t, "tv")
 		gen := tv0.valueGen
-		if tvg.generateUnknowns || tv0.schema.Required {
-			options := []*rapid.Generator[tftypes.Value]{gen}
-			if tvg.generateUnknowns {
-				unkGen := rapid.Just(tftypes.NewValue(tv0.typ, tftypes.UnknownValue))
-				options = append(options, unkGen)
-			}
-			if !tv0.schema.Required {
-				nullGen := rapid.Just(tftypes.NewValue(tv0.typ, nil))
-				options = append(options, nullGen)
-			}
-			gen = rapid.OneOf(options...)
+		options := []*rapid.Generator[tftypes.Value]{gen}
+		if tvg.generateUnknowns {
+			unkGen := rapid.Just(tftypes.NewValue(tv0.typ, tftypes.UnknownValue))
+			options = append(options, unkGen)
 		}
+		if !tv0.schema.Required {
+			nullGen := rapid.Just(tftypes.NewValue(tv0.typ, nil))
+			options = append(options, nullGen)
+		}
+		gen = rapid.OneOf(options...)
 		return tv{
 			schema:   tv0.schema,
 			typ:      tv0.typ,


### PR DESCRIPTION
The encompassing if check was flipped and this didn't work correctly.
https://github.com/pulumi/pulumi-terraform-bridge/pull/2013 should take care of the rapid panics for unconsumed bitrstreams, so the encompassing if check should not be needed any more.