### PR TITLE
Bump pf/go.mod's Bridge version to v3.83.0

### DIFF
--- a/pf/go.mod
+++ b/pf/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.33.0
 	github.com/pulumi/providertest v0.0.11
-	github.com/pulumi/pulumi-terraform-bridge/v3 v3.82.0
+	github.com/pulumi/pulumi-terraform-bridge/v3 v3.83.0
 	github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.8
 	github.com/stretchr/testify v1.9.0
 	google.golang.org/grpc v1.63.2

--- a/pf/tests/go.mod
+++ b/pf/tests/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hexops/autogold/v2 v2.2.1
 	github.com/pulumi/providertest v0.0.11
 	github.com/pulumi/pulumi-terraform-bridge/pf v0.0.0
-	github.com/pulumi/pulumi-terraform-bridge/v3 v3.82.0
+	github.com/pulumi/pulumi-terraform-bridge/v3 v3.83.0
 	github.com/stretchr/testify v1.9.0
 	github.com/terraform-providers/terraform-provider-random/randomshim v0.0.0
 )


### PR DESCRIPTION
Part of the v3.83.0 release.