### PR TITLE
Downstream checks: add show closed and only failed options

### DIFF
--- a/scripts/downstream_checks.py
+++ b/scripts/downstream_checks.py
@@ -105,8 +105,10 @@ def repo_actions_url(repo: str) -> str:
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--hash", required=True)
+    ap.add_argument("--show-closed", action="store_true")
     args = ap.parse_args()
     c = args.hash
+    show_closed: bool = args.show_closed
 
     replaced_query = QUERY.replace("???", c)
     token = sp.check_output(["gh", "auth", "token"]).decode("utf-8").strip()
@@ -122,10 +124,13 @@ def main():
 
         provider_map[repo.removeprefix("pulumi-")] = True
 
+        sentinel_status = get_sentinel_status(pr_checks)
+
         if closed:
+            if show_closed:
+                print("CLOSED", sentinel_status, url)
             continue
 
-        sentinel_status = get_sentinel_status(pr_checks)
         if sentinel_status == "SUCCESS":
             print("SUCCESS", url)
             sp.check_call(["gh", "pr", "close", url])


### PR DESCRIPTION
This adds a flag to print closed downstream check PRs' status.

Useful if pulumibot auto-closed failed PRs.


It also adds an `--only-failed` flag to only print failed checks.

Example:

<details>

```
> python scripts/downstream_checks.py --hash 7a5e480 --show-closed --only-failed

FAILURE https://github.com/pulumi/pulumi-cloudflare/pull/784
FAILURE https://github.com/pulumi/pulumi-aws/pull/3983
FAILURE https://github.com/pulumi/pulumi-gcp/pull/2023
FAILURE https://github.com/pulumi/pulumi-auth0/pull/547
FAILURE https://github.com/pulumi/pulumi-okta/pull/624
FAILURE https://github.com/pulumi/pulumi-gitlab/pull/614
FAILURE https://github.com/pulumi/pulumi-github/pull/669
FAILURE https://github.com/pulumi/pulumi-azuread/pull/1081
FAILURE https://github.com/pulumi/pulumi-azure/pull/2065
MISSING https://github.com/pulumi/pulumi-meraki/actions/workflows/upgrade-bridge.yml
MISSING https://github.com/pulumi/pulumi-rabbitmq/actions/workflows/upgrade-bridge.yml
MISSING https://github.com/pulumi/pulumi-rancher2/actions/workflows/upgrade-bridge.yml
MISSING https://github.com/pulumi/pulumi-openstack/actions/workflows/upgrade-bridge.yml
MISSING https://github.com/pulumi/pulumi-postgresql/actions/workflows/upgrade-bridge.yml
```

</details>