### PR TITLE
PlanResourceChange: do not call state upgraders during Create

### DIFF
--- a/pf/internal/check/checks.go
+++ b/pf/internal/check/checks.go
@@ -64,8 +64,9 @@ func checkIDProperties(sink diag.Sink, info tfbridge.ProviderInfo, isPFResource 
 		m := fmt.Sprintf("Resource %s has a problem: %s. "+
 			"To map this resource consider specifying ResourceInfo.ComputeID",
 			rname, reason)
-		errors++
-		sink.Errorf(&diag.Diag{Message: m})
+		// errors++
+		fmt.Println(m)
+		//sink.Errorf(&diag.Diag{Message: m})
 
 		return true
 	})

--- a/pf/internal/check/checks.go
+++ b/pf/internal/check/checks.go
@@ -64,9 +64,8 @@ func checkIDProperties(sink diag.Sink, info tfbridge.ProviderInfo, isPFResource 
 		m := fmt.Sprintf("Resource %s has a problem: %s. "+
 			"To map this resource consider specifying ResourceInfo.ComputeID",
 			rname, reason)
-		// errors++
-		fmt.Println(m)
-		//sink.Errorf(&diag.Diag{Message: m})
+		errors++
+		sink.Errorf(&diag.Diag{Message: m})
 
 		return true
 	})

--- a/pkg/tests/cross-tests/adapt.go
+++ b/pkg/tests/cross-tests/adapt.go
@@ -103,6 +103,8 @@ func (ta *typeAdapter) NewValue(value any) tftypes.Value {
 		case map[string]any:
 			values := map[string]tftypes.Value{}
 			for k, el := range v {
+				_, ok := aT[k]
+				contract.Assertf(ok, "no type for attribute %q", k)
 				values[k] = fromType(aT[k]).NewValue(el)
 			}
 			return tftypes.NewValue(t, values)
@@ -112,6 +114,7 @@ func (ta *typeAdapter) NewValue(value any) tftypes.Value {
 }
 
 func fromType(t tftypes.Type) *typeAdapter {
+	contract.Assertf(t != nil, "type cannot be nil")
 	return &typeAdapter{t}
 }
 

--- a/pkg/tests/cross-tests/input_cross_test.go
+++ b/pkg/tests/cross-tests/input_cross_test.go
@@ -505,6 +505,8 @@ func TestTimeouts(t *testing.T) {
 // TestAccCloudWatch failed with PlanResourceChange to do a simple Create preview because the state upgrade was
 // unexpectedly called with nil state. Emulate this here to test it does not fail.
 func TestCreateDoesNotPanicWithStateUpgraders(t *testing.T) {
+	skipUnlessLinux(t)
+
 	resourceRuleV0 := func() *schema.Resource {
 		return &schema.Resource{
 			Schema: map[string]*schema.Schema{

--- a/pkg/tests/cross-tests/input_cross_test.go
+++ b/pkg/tests/cross-tests/input_cross_test.go
@@ -1,10 +1,12 @@
 package crosstests
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	//"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -498,5 +500,56 @@ func TestTimeouts(t *testing.T) {
 			},
 		},
 		Config: emptyConfig,
+	})
+}
+
+// TestAccCloudWatch failed with PlanResourceChange to do a simple Create preview because the state upgrade was
+// unexpectedly called with nil state. Emulate this here to test it does not fail.
+func TestCreateDoesNotPanicWithStateUpgraders(t *testing.T) {
+	resourceRuleV0 := func() *schema.Resource {
+		return &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"event_bus_name": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"is_enabled": {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
+			},
+		}
+	}
+
+	resourceRuleUpgradeV0 := func(ctx context.Context, rawState map[string]any, meta any) (map[string]any, error) {
+		if rawState == nil {
+			rawState = map[string]any{}
+		}
+
+		if rawState["is_enabled"].(bool) { // used to panic here
+			t.Logf("enabled")
+		} else {
+			t.Logf("disabled")
+		}
+
+		return rawState, nil
+	}
+
+	runCreateInputCheck(t, inputTestCase{
+		Resource: &schema.Resource{
+			//CreateWithoutTimeout: resourceRuleCreate,
+			SchemaVersion: 1,
+			StateUpgraders: []schema.StateUpgrader{
+				{
+					Type:    resourceRuleV0().CoreConfigSchema().ImpliedType(),
+					Upgrade: resourceRuleUpgradeV0,
+					Version: 0,
+				},
+			},
+			Schema: resourceRuleV0().Schema,
+		},
+		Config: map[string]any{
+			"event_bus_name": "default",
+		},
 	})
 }

--- a/pkg/tests/cross-tests/input_cross_test.go
+++ b/pkg/tests/cross-tests/input_cross_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
-	//"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -537,7 +536,6 @@ func TestCreateDoesNotPanicWithStateUpgraders(t *testing.T) {
 
 	runCreateInputCheck(t, inputTestCase{
 		Resource: &schema.Resource{
-			//CreateWithoutTimeout: resourceRuleCreate,
 			SchemaVersion: 1,
 			StateUpgraders: []schema.StateUpgrader{
 				{

--- a/pkg/tests/cross-tests/tf_driver.go
+++ b/pkg/tests/cross-tests/tf_driver.go
@@ -120,6 +120,9 @@ func (d *tfDriver) coalesce(t T, x any) *tftypes.Value {
 		return nil
 	}
 	objectType := convert.InferObjectType(sdkv2.NewSchemaMap(d.res.Schema), nil)
+	for k := range objectType.AttributeTypes {
+		objectType.OptionalAttributes[k] = struct{}{}
+	}
 	t.Logf("infer object type: %v", objectType)
 	v := fromType(objectType).NewValue(x)
 	return &v

--- a/pkg/tfshim/sdk-v2/provider2.go
+++ b/pkg/tfshim/sdk-v2/provider2.go
@@ -328,6 +328,11 @@ func (p *planResourceChangeImpl) upgradeState(
 	res := p.tf.ResourcesMap[t]
 	state := p.unpackInstanceState(t, s)
 
+	// In the case of Create, prior state is encoded as Null and should not be subject to upgrades.
+	if state.stateValue.IsNull() {
+		return s, nil
+	}
+
 	newState, newMeta, err := upgradeResourceStateGRPC(ctx, t, res, state.stateValue, state.meta, p.server.gserver)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When testing rolling out PlanResourceChange to the entirety of AWS, basic tests such as TestAccCloudWatch  started failing with a panic from the provider upgrade machinery.  The issue is that provider upgrades should not be called on Create. This is now fixed.