### PR TITLE
Handle diags from gRPC state upgrader

### DIFF
--- a/pkg/tfshim/sdk-v2/provider2.go
+++ b/pkg/tfshim/sdk-v2/provider2.go
@@ -353,7 +353,7 @@ type grpcServer struct {
 // This will return an error if any of the diagnostics are error-level, or a given err is non-nil.
 // It will also logs the diagnostics into TF loggers, so they appear when debugging with the bridged
 // provider with TF_LOG=TRACE or similar.
-func (s *grpcServer) handle(ctx context.Context, diags []*tfprotov5.Diagnostic, err error) error {
+func handleDiagnostics(ctx context.Context, diags []*tfprotov5.Diagnostic, err error) error {
 	var dd diag.Diagnostics
 	for _, d := range diags {
 		if d == nil {
@@ -430,7 +430,7 @@ func (s *grpcServer) PlanResourceChange(
 		req.ProviderMeta = &tfprotov5.DynamicValue{MsgPack: providerMetaVal}
 	}
 	resp, err := s.gserver.PlanResourceChangeExtra(ctx, req)
-	if err := s.handle(ctx, resp.Diagnostics, err); err != nil {
+	if err := handleDiagnostics(ctx, resp.Diagnostics, err); err != nil {
 		return nil, err
 	}
 	// Ignore resp.UnsafeToUseLegacyTypeSystem - does not matter for Pulumi bridged providers.
@@ -508,7 +508,7 @@ func (s *grpcServer) ApplyResourceChange(
 		req.ProviderMeta = &tfprotov5.DynamicValue{MsgPack: providerMetaVal}
 	}
 	resp, err := s.gserver.ApplyResourceChange(ctx, req)
-	if err := s.handle(ctx, resp.Diagnostics, err); err != nil {
+	if err := handleDiagnostics(ctx, resp.Diagnostics, err); err != nil {
 		return nil, err
 	}
 	newState, err := msgpack.Unmarshal(resp.NewState.MsgPack, ty)
@@ -559,7 +559,7 @@ func (s *grpcServer) ReadResource(
 		req.ProviderMeta = &tfprotov5.DynamicValue{MsgPack: providerMetaVal}
 	}
 	resp, err := s.gserver.ReadResource(ctx, req)
-	if err := s.handle(ctx, resp.Diagnostics, err); err != nil {
+	if err := handleDiagnostics(ctx, resp.Diagnostics, err); err != nil {
 		return nil, err
 	}
 	newState, err := msgpack.Unmarshal(resp.NewState.MsgPack, ty)
@@ -590,7 +590,7 @@ func (s *grpcServer) ImportResourceState(
 		ID:       id,
 	}
 	resp, err := s.gserver.ImportResourceState(ctx, req)
-	if err := s.handle(ctx, resp.Diagnostics, err); err != nil {
+	if err := handleDiagnostics(ctx, resp.Diagnostics, err); err != nil {
 		return nil, err
 	}
 	out := []v2InstanceState2{}

--- a/pkg/tfshim/sdk-v2/provider2_test.go
+++ b/pkg/tfshim/sdk-v2/provider2_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hexops/autogold/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -229,10 +228,7 @@ func TestProvider2UpgradeResourceState(t *testing.T) {
 			}(),
 			expectErr: func(t *testing.T, err error) {
 				require.Error(t, err)
-				autogold.Expect(`1 error occurred:
-* missing expected [
-
-`).Equal(t, err.Error())
+				require.ErrorContains(t, err, "missing expected [")
 			},
 			rSchema: &schema.Resource{
 				Schema: map[string]*schema.Schema{

--- a/pkg/tfshim/sdk-v2/upgrade_state.go
+++ b/pkg/tfshim/sdk-v2/upgrade_state.go
@@ -49,8 +49,8 @@ func upgradeResourceStateGRPC(
 		RawState: &tfprotov5.RawState{JSON: jsonBytes},
 		Version:  version,
 	})
-	if err != nil {
-		return cty.Value{}, nil, err
+	if uerr := handleDiagnostics(ctx, resp.Diagnostics, err); uerr != nil {
+		return cty.Value{}, nil, uerr
 	}
 
 	newState, err := msgpack.Unmarshal(resp.UpgradedState.MsgPack, res.CoreConfigSchema().ImpliedType())


### PR DESCRIPTION
Isolating this from an AWS test failure; handling diags turns a panic into a regular error. Looks like the error message is still unfortunate. The test is isolated from https://github.com/pulumi/pulumi-aws/issues/4015