### PR TITLE
Add GoString to v2InstanceDiff2

### DIFF
--- a/pkg/tfshim/sdk-v2/provider2.go
+++ b/pkg/tfshim/sdk-v2/provider2.go
@@ -109,6 +109,23 @@ type v2InstanceDiff2 struct {
 	plannedState cty.Value
 }
 
+func (d *v2InstanceDiff2) String() string {
+	return d.GoString()
+}
+
+func (d *v2InstanceDiff2) GoString() string {
+	if d == nil {
+		return "nil"
+	}
+	return fmt.Sprintf(`&v2InstanceDiff2{
+    v2InstanceDiff: v2InstanceDiff{
+        tf: %#v,
+    },
+    config:         %#v,
+    plannedState:   %#v,
+}`, d.v2InstanceDiff.tf, d.config, d.plannedState)
+}
+
 var _ shim.InstanceDiff = (*v2InstanceDiff2)(nil)
 
 func (d *v2InstanceDiff2) ProposedState(


### PR DESCRIPTION
Implement String() and GoString() on v2InstanceDiff2. This should not be user-visible but helps working with and debugging tests in the codebase.