### PR TITLE
DO NOT MERGE: test PlanResourceChange handling of map creates

### DIFF
--- a/pkg/tfbridge/tests/provider_test.go
+++ b/pkg/tfbridge/tests/provider_test.go
@@ -39,9 +39,9 @@ func TestTagsMap(t *testing.T) {
 		{"setemp", false, true, map[string]string{}, map[string]any{"id": "*", "tags": map[string]any{}}},
 		{"setone", false, true, map[string]string{"a": "b"}, map[string]any{"id": "*", "tags": map[string]any{"a": "b"}}},
 
-		{"basic-prc", true, false, nil, map[string]any{"id": "*", "tags": nil}}, // suspect
-		{"setnil-prc", true, true, nil, map[string]any{"id": "*", "tags": map[string]any{}}},
-		{"setemp-prc", true, true, map[string]string{}, map[string]any{"id": "*", "tags": map[string]any{}}},
+		{"basic-prc", true, false, nil, map[string]any{"id": "*", "tags": nil}},                 // suspect
+		{"setnil-prc", true, true, nil, map[string]any{"id": "*", "tags": nil}},                 // suspect
+		{"setemp-prc", true, true, map[string]string{}, map[string]any{"id": "*", "tags": nil}}, // suspect
 		{"setone-prc", true, true, map[string]string{"a": "b"}, map[string]any{"id": "*", "tags": map[string]any{"a": "b"}}},
 	}
 
@@ -49,7 +49,6 @@ func TestTagsMap(t *testing.T) {
 		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
-
 			ctx := context.Background()
 			p := newTestProvider(ctx, tfbridge.ProviderInfo{
 				P: shimv2.NewProvider(&schema.Provider{
@@ -67,7 +66,6 @@ func TestTagsMap(t *testing.T) {
 								"tags": {
 									Type:     schema.TypeMap,
 									Optional: true,
-									Computed: true,
 									Elem:     &schema.Schema{Type: schema.TypeString},
 								},
 							},
@@ -75,7 +73,7 @@ func TestTagsMap(t *testing.T) {
 					},
 				}, shimv2.WithPlanResourceChange(func(tfResourceType string) bool {
 					return tc.planResourceChange
-				})),
+				}), shimv2.WithDiffStrategy(shimv2.PlanState)),
 				Name:           "testprov",
 				ResourcePrefix: "example",
 				Resources: map[string]*tfbridge.ResourceInfo{


### PR DESCRIPTION
Noticing that rolling out PlanResourceChange to AWS causes dirty refreshes of the form where "tags" are changing from "null" to "{}". 

It appears that what's changed is actually how Creates work, that is {} from Read is fine but null from Create is not. Before PRC we would have Create return `tags: {}`, but after PRC it returns `tags: null` instead on a program that does not set tags at all. 

Still investigating... it appears that AWS provider does set tags to the empty map but they proceed to disappear in normalizeNullValues:

```
normalizeNullValues
 dst: cty.MapValEmpty(cty.String)
 src: cty.NullVal(cty.Map(cty.String))
 apply: true
 finval: cty.NullVal(cty.Map(cty.String))
```

This behavior seems to match TF but in the case of TF this form of dirty refresh is invisible and subsequent terraform apply calls remove the problem.