### PR TITLE
Emit upstream Installation instructions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -208,7 +208,7 @@ require (
 	github.com/pulumi/pulumi/pkg/v3 v3.118.0
 	github.com/pulumi/pulumi/sdk/v3 v3.118.0
 	github.com/rivo/uniseg v0.4.4 // indirect
-	github.com/rogpeppe/go-internal v1.11.0 // indirect
+	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1931,8 +1931,9 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
-github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
+github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
+github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=

--- a/pf/go.mod
+++ b/pf/go.mod
@@ -198,7 +198,7 @@ require (
 	github.com/pulumi/pulumi/sdk/v3 v3.118.0
 	github.com/pulumi/schema-tools v0.1.2 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
-	github.com/rogpeppe/go-internal v1.11.0 // indirect
+	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect

--- a/pf/go.sum
+++ b/pf/go.sum
@@ -1929,8 +1929,9 @@ github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYe
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
-github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
+github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
+github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=

--- a/pf/tests/go.mod
+++ b/pf/tests/go.mod
@@ -213,7 +213,7 @@ require (
 	github.com/pulumi/pulumi/sdk/v3 v3.118.0
 	github.com/pulumi/schema-tools v0.1.2 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
-	github.com/rogpeppe/go-internal v1.11.0 // indirect
+	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect

--- a/pf/tests/go.sum
+++ b/pf/tests/go.sum
@@ -1957,8 +1957,9 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
-github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
+github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
+github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=

--- a/pkg/tests/go.mod
+++ b/pkg/tests/go.mod
@@ -206,7 +206,7 @@ require (
 	github.com/pulumi/pulumi/sdk/v3 v3.118.0
 	github.com/pulumi/terraform-diff-reader v0.0.2 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
-	github.com/rogpeppe/go-internal v1.11.0 // indirect
+	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0 // indirect

--- a/pkg/tests/go.sum
+++ b/pkg/tests/go.sum
@@ -1941,8 +1941,9 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
-github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
+github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
+github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -2368,15 +2368,12 @@ func plainDocsParser(docFile *DocFile, pkgName string, g *Generator) ([]byte, er
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO: translate code blocks
-
-	//TODO: apply default edit rules
-
-	//TODO: reformat text
-
-	//TODO: Light translation / possible eliding for certain headers such as "Arguments Reference"
-	// or "Configuration block"
+	//TODO: See https://github.com/pulumi/pulumi-terraform-bridge/issues/2078
+	// - translate code blocks with code choosers
+	// - apply default edit rules
+	// - reformat TF names
+	// - Translation for certain headers such as "Arguments Reference" or "Configuration block"
+	// - Ability to omit irrelevant sections
 	return []byte(contentStr), nil
 }
 

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -2363,8 +2363,9 @@ func guessIsHCL(code string) bool {
 }
 
 func plainDocsParser(docFile *DocFile, g *Generator) ([]byte, error) {
-	// Replace upstream front matter with Pulumi registry's
+	// Get file content without front matter, and split title
 	contentStr, title := getBodyAndTitle(string(docFile.Content))
+	// Add pulumi-specific front matter
 	contentStr = writeFrontMatter(title) + contentStr
 
 	//TODO: See https://github.com/pulumi/pulumi-terraform-bridge/issues/2078
@@ -2377,13 +2378,12 @@ func plainDocsParser(docFile *DocFile, g *Generator) ([]byte, error) {
 }
 
 func writeFrontMatter(title string) string {
-	newFrontMatter := fmt.Sprintf(delimiter+
+	return fmt.Sprintf(delimiter+
 		"title: %s Installation & Configuration\n"+
 		"meta_desc: Provides an overview on how to configure the Pulumi %s.\n"+
 		"layout: package\n"+
 		delimiter,
 		title, title)
-	return newFrontMatter
 }
 
 func writeIndexFrontMatter(displayName string) string {

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -47,6 +47,9 @@ import (
 const (
 	startPulumiCodeChooser = "<!--Start PulumiCodeChooser -->"
 	endPulumiCodeChooser   = "<!--End PulumiCodeChooser -->"
+
+	// The Hugo front matter delimiter
+	delimiter = "---\n"
 )
 
 // argumentDocs contains the documentation metadata for an argument of the resource.
@@ -2366,7 +2369,7 @@ func plainDocsParser(docFile *DocFile, pkgName string, g *Generator) ([]byte, er
 		return nil, err
 	}
 
-	contentStr, err = translateCodeBlocks(contentStr, g)
+	// TODO: translate code blocks
 
 	//TODO: apply default edit rules
 
@@ -2382,87 +2385,29 @@ func replaceUpstreamFrontMatter(content, pkgName string) (string, error) {
 	capitalize := cases.Title(language.English)
 	pkgName = capitalize.String(pkgName)
 
-	start := strings.Index(content, "---\n")
+	start := strings.Index(content, delimiter)
 	if start == -1 {
 		return "", errors.New("finding front matter")
 	}
-	end := start + len("---\n") + strings.Index(content[start+len("---\n"):], "---\n") + len("---\n")
-
-	newFrontMatter := fmt.Sprintf("---\n"+
+	end := start + len(delimiter) + strings.Index(content[start+len(delimiter):], delimiter) + len(delimiter)
+	newFrontMatter := fmt.Sprintf(delimiter+
 		"title: %s Installation & Configuration\n"+
 		"meta_desc: Provides an overview on how to configure the Pulumi %s Provider.\n"+
 		"layout: package\n"+
-		"---\n",
+		delimiter,
 		pkgName, pkgName)
-	content = newFrontMatter + content[end:]
-	return content, nil
+
+	return newFrontMatter + content[end:], nil
 }
 
-func translateCodeBlocks(contentStr string, g *Generator) (string, error) {
-
-	var returnContent string
-
-	examples := map[string]string{}
-	// Extract code blocks
-	codeFence := "```"
-	var codeBlocks []codeBlock
-	for i := 0; i < (len(contentStr) - len(codeFence)); i++ {
-		block, found := findCodeBlock(contentStr, i)
-		if found {
-			codeBlocks = append(codeBlocks, block)
-			i = block.end + 1
-		}
-	}
-	if len(codeBlocks) == 0 {
-		return contentStr, nil
-	}
-	startIndex := 0
-	for i, block := range codeBlocks {
-		// Write the content up to the start of the code block
-		returnContent = returnContent + contentStr[startIndex:block.start]
-		nextNewLine := strings.Index(contentStr[block.start:block.end], "\n")
-		if nextNewLine == -1 {
-			//Write the inline block
-			returnContent = returnContent + contentStr[block.start:block.end] + codeFence + "\n"
-			continue
-		}
-		fenceLanguage := contentStr[block.start : block.start+nextNewLine+1]
-		code := contentStr[block.start+nextNewLine+1 : block.end]
-		// Only convert code blocks that we have reasonable suspicion of actually being Terraform.
-		if fenceLanguage == "```terraform\n" || fenceLanguage == "```hcl\n" ||
-			(fenceLanguage == "```\n" && guessIsHCL(code)) {
-
-			//  Make an example to record in the cliConverter.
-			fileName := fmt.Sprintf("configuration-installation-%d", i)
-			examples[fileName] = code
-
-			// Convert to PCL, which is what ConvertViaPulumiCLI does.
-			// This gives us a map of translatedExamples.
-			result, err := g.cliConverter().convertViaPulumiCLI(examples, []tfbridge.ProviderInfo{
-				g.cliConverter().info,
-			})
-			if err != nil {
-				return "", err
-			}
-
-			// Write the result to the pcls map of our cli converter.
-			g.cliConverter().pcls[code] = translatedExample{
-				PCL: result[fileName].PCL, // TODO: hook up to diagnostics if necessary
-			}
-
-			//  Now we can call ConvertHCL
-			exPath := examplePath{fullPath: fileName}
-			var conversionResult *Example
-			conversionResult = g.coverageTracker.getOrCreateExample(
-				exPath.String(), code)
-
-			langs := genLanguageToSlice(g.language)
-			convertedBlock, err := g.convertHCL(conversionResult, code, exPath.String(), langs)
-			returnContent = returnContent + convertedBlock
-			startIndex = block.end + len(codeFence)
-		}
-	}
-	// Write any remainder.
-	returnContent = returnContent + contentStr[codeBlocks[len(codeBlocks)-1].end+len(codeFence):]
-	return returnContent, nil
+func writeIndexFrontMatter(pkgName string) string {
+	// Capitalize the package name
+	capitalize := cases.Title(language.English)
+	pkgName = capitalize.String(pkgName)
+	return fmt.Sprintf(delimiter+
+		"title: %s\n"+
+		"meta_desc: The %s provider for Pulumi can be used to provision any of the cloud resources available in %s.\n"+
+		"layout: package\n"+
+		delimiter,
+		pkgName, pkgName, pkgName)
 }

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -2009,3 +2009,43 @@ resource "aws_ami" "example" {
 		})
 	}
 }
+
+func TestPlainDocsParser(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		// The name of the test case.
+		name     string
+		docFile  DocFile
+		expected []byte
+	}
+
+	tests := []testCase{
+		{
+			name: "Replaces Upstream Front Matter With Pulumi Front Matter",
+			docFile: DocFile{
+				Content: []byte("---\nlayout: \"openstack\"\npage_title: \"Provider: OpenStack\"\nsidebar_current: \"docs-openstack-index\"\ndescription: |-\n  The OpenStack provider is used to interact with the many resources supported by OpenStack. The provider needs to be configured with the proper credentials before it can be used.\n---\n\n# OpenStack Provider\n\nThe OpenStack provider is used to interact with the\nmany resources supported by OpenStack. The provider needs to be configured\nwith the proper credentials before it can be used.\n\nUse the navigation to the left to read about the available resources."),
+			},
+			expected: []byte("---\ntitle: OpenStack Provider Installation & Configuration\nmeta_desc: Provides an overview on how to configure the Pulumi OpenStack Provider.\nlayout: package\n---\n\nThe OpenStack provider is used to interact with the\nmany resources supported by OpenStack. The provider needs to be configured\nwith the proper credentials before it can be used.\n\nUse the navigation to the left to read about the available resources."),
+		},
+		{
+			name: "Writes Pulumi Style Front Matter If Not Present",
+			docFile: DocFile{
+				Content: []byte("# Artifactory Provider\n\nThe [Artifactory](https://jfrog.com/artifactory/) provider is used to interact with the resources supported by Artifactory. The provider needs to be configured with the proper credentials before it can be used.\n\nLinks to documentation for specific resources can be found in the table of contents to the left.\n\nThis provider requires access to Artifactory APIs, which are only available in the _licensed_ pro and enterprise editions. You can determine which license you have by accessing the following the URL `${host}/artifactory/api/system/licenses/`.\n\nYou can either access it via API, or web browser - it require admin level credentials."),
+			},
+			expected: []byte("---\ntitle: Artifactory Provider Installation & Configuration\nmeta_desc: Provides an overview on how to configure the Pulumi Artifactory Provider.\nlayout: package\n---\n\nThe [Artifactory](https://jfrog.com/artifactory/) provider is used to interact with the resources supported by Artifactory. The provider needs to be configured with the proper credentials before it can be used.\n\nLinks to documentation for specific resources can be found in the table of contents to the left.\n\nThis provider requires access to Artifactory APIs, which are only available in the _licensed_ pro and enterprise editions. You can determine which license you have by accessing the following the URL `${host}/artifactory/api/system/licenses/`.\n\nYou can either access it via API, or web browser - it require admin level credentials."),
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := &Generator{
+				sink: mockSink{t},
+			}
+			actual, err := plainDocsParser(&tt.docFile, g)
+			require.NoError(t, err)
+			require.Equal(t, string(tt.expected), string(actual))
+		})
+	}
+}

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -1798,6 +1798,17 @@ func (m mockSource) getDatasource(rawname string, info *tfbridge.DocInfo) (*DocF
 	return nil, nil
 }
 
+func (m mockSource) getInstallation(info *tfbridge.DocInfo) (*DocFile, error) {
+	f, ok := m["index.md"]
+	if !ok {
+		return nil, nil
+	}
+	return &DocFile{
+		Content:  []byte(f),
+		FileName: "index.md",
+	}, nil
+}
+
 type mockSink struct{ t *testing.T }
 
 func (mockSink) warn(string, ...interface{})                                  {}

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -962,6 +962,9 @@ func (g *Generator) UnstableGenerateFromSchema(genSchemaResult *GenerateSchemaRe
 	case RegistryDocs:
 		source := NewGitRepoDocsSource(g)
 		installationFile, err := source.getInstallation(nil)
+		if err != nil {
+			return errors.Wrapf(err, "failed to obtain an index.md file for this provider")
+		}
 		content, err := plainDocsParser(installationFile, g)
 		if err != nil {
 			return errors.Wrapf(err, "failed to parse installation docs")

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -90,12 +90,19 @@ type Generator struct {
 type Language string
 
 const (
-	Golang       Language = "go"
-	NodeJS       Language = "nodejs"
-	Python       Language = "python"
-	CSharp       Language = "dotnet"
-	Schema       Language = "schema"
-	PCL          Language = "pulumi"
+	Golang Language = "go"
+	NodeJS Language = "nodejs"
+	Python Language = "python"
+	CSharp Language = "dotnet"
+	Schema Language = "schema"
+	PCL    Language = "pulumi"
+	// RegistryDocs
+	// Setting RegistryDocs as a separate bridge "language" in the bridge allows us to create custom logic specific to
+	// transforming and emitting upstream installation docs.
+	// When we generate registry docs, we want to:
+	//- be able to generate them via a separate command so we can enable it on a per-provider basis
+	//- be able to pass a separate output location from the schema location (in this case, `docs/`)
+	//- convert examples into all Pulumi-supported languages
 	RegistryDocs Language = "registry-docs"
 )
 

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	"os"
 	"path"
 	"path/filepath"
@@ -952,15 +954,20 @@ func (g *Generator) UnstableGenerateFromSchema(genSchemaResult *GenerateSchemaRe
 	switch g.language {
 	case RegistryDocs:
 		source := NewGitRepoDocsSource(g)
-		pkgName := g.info.Name
 		installationFile, err := source.getInstallation(nil)
-		content, err := plainDocsParser(installationFile, pkgName, g)
+		content, err := plainDocsParser(installationFile, g)
 		if err != nil {
 			return errors.Wrapf(err, "failed to parse installation docs")
 		}
 		files["installation-configuration.md"] = content
 		// Populate minimal _index.md file
-		indexContent := writeIndexFrontMatter(pkgName)
+		displayName := g.info.DisplayName
+		if displayName == "" {
+			// Capitalize the package name
+			capitalize := cases.Title(language.English)
+			displayName = capitalize.String(g.info.Name)
+		}
+		indexContent := writeIndexFrontMatter(displayName)
 		files["_index.md"] = []byte(indexContent)
 	case Schema:
 		// Omit the version so that the spec is stable if the version is e.g. derived from the current Git commit hash.

--- a/pkg/tfgen/main.go
+++ b/pkg/tfgen/main.go
@@ -163,6 +163,7 @@ func newTFGenCmd(pkg string, version string, prov tfbridge.ProviderInfo,
 				SkipExamples:    skipExamples,
 				CoverageTracker: coverageTracker,
 			}
+
 			err := gen(opts)
 
 			// Exporting collected coverage data to the directory specified by COVERAGE_OUTPUT_DIR

--- a/pkg/tfgen/main.go
+++ b/pkg/tfgen/main.go
@@ -163,7 +163,6 @@ func newTFGenCmd(pkg string, version string, prov tfbridge.ProviderInfo,
 				SkipExamples:    skipExamples,
 				CoverageTracker: coverageTracker,
 			}
-
 			err := gen(opts)
 
 			// Exporting collected coverage data to the directory specified by COVERAGE_OUTPUT_DIR

--- a/pkg/tfgen/source.go
+++ b/pkg/tfgen/source.go
@@ -106,6 +106,7 @@ func (gh *gitRepoSource) getFile(
 	default:
 		return nil, fmt.Errorf("unknown docs kind: %s", kind)
 	}
+
 	return readMarkdown(repoPath, kind, possibleMarkdownNames)
 }
 

--- a/pkg/tfgen/source.go
+++ b/pkg/tfgen/source.go
@@ -254,6 +254,12 @@ func getDocsPath(repo string, kind DocKind) ([]string, error) {
 		if p := filepath.Join(repo, "docs"); exists(p) {
 			paths = append(paths, p)
 		}
+		// ${repo}/website/docs
+		//
+		// This is the legacy way to describe docs.
+		if p := filepath.Join(repo, "website", "docs"); exists(p) {
+			paths = append(paths, p)
+		}
 		return paths, err
 	}
 	// ${repo}/website/docs/r


### PR DESCRIPTION
This pull request is the scaffold implementation of generating installation docs for bridged providers from upstream source.

In this change, a new "language" called `registry-docs` is added to the bridge. (Note that "language" in this case is a bit of a misnomer - it is the `tfgen` CLI's input for determining which generating tactic to use - this is why `schema` is a language as well).

This change reads the upstream `index.md` file and emits it as a Pulumi [package installation instruction file](https://www.pulumi.com/docs/using-pulumi/pulumi-packages/how-to-author/#overview-installation--configuration) to a top-level folder called `docs/` (the current registry standard). We also emit a minimal `_index.md` file. When these files exist in a provider, the registry will use those instead of the hard coded files existing in the registry currently.

This pull request includes a fair bit of TODOs in the docs parser - currently only the Hugo front matter is implemented, to show the scaffold. Transformations for this document to be Pulumi-friendly will follow in a separate PR.

This change does not affect any current use of the bridge - to flip it on, we'd add another Make target to a provider's Makefile, e.g. `./bin/pulumi-tfgen-openstack registry-docs --out docs/`. I'd like us to consider adding this change despite the TODOs, so we can keep the changes somewhat atomic and reduce merge conflicts.

Closes https://github.com/pulumi/pulumi-terraform-bridge/issues/2082.