### PR TITLE
Standardize a pf/tfbridge compatible provider on pf.ShimProvider

### DIFF
--- a/pf/internal/check/not_supported.go
+++ b/pf/internal/check/not_supported.go
@@ -21,8 +21,8 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 
+	"github.com/pulumi/pulumi-terraform-bridge/pf"
 	"github.com/pulumi/pulumi-terraform-bridge/pf/internal/muxer"
-	schemaShim "github.com/pulumi/pulumi-terraform-bridge/pf/internal/schemashim"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 )
 
@@ -40,7 +40,7 @@ func notSupported(sink diag.Sink, prov tfbridge.ProviderInfo, isPFResource, isPF
 	muxedProvider := false
 	if _, ok := prov.P.(*muxer.ProviderShim); ok {
 		muxedProvider = true
-	} else if _, ok := prov.P.(*schemaShim.SchemaOnlyProvider); !ok {
+	} else if _, ok := prov.P.(pf.ShimProvider); !ok {
 		warning := "Bridged Plugin Framework providers must have ProviderInfo.P be created from" +
 			" pf/tfbridge.ShimProvider or pf/tfbridge.ShimProviderWithContext.\nMuxed SDK and" +
 			" Plugin Framework based providers must have ProviderInfo.P be created from" +

--- a/pf/internal/muxer/muxer.go
+++ b/pf/internal/muxer/muxer.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/pulumi/pulumi-terraform-bridge/pf"
 	"github.com/pulumi/pulumi-terraform-bridge/pf/internal/schemashim"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
@@ -96,7 +97,7 @@ func (m *ProviderShim) ResourceIsPF(token string) bool {
 		if _, ok := p.ResourcesMap().GetOk(token); !ok {
 			continue
 		}
-		_, ok := p.(*schemashim.SchemaOnlyProvider)
+		_, ok := p.(pf.ShimProvider)
 		return ok
 
 	}
@@ -111,7 +112,7 @@ func (m *ProviderShim) DataSourceIsPF(token string) bool {
 		if _, ok := p.DataSourcesMap().GetOk(token); !ok {
 			continue
 		}
-		_, ok := p.(*schemashim.SchemaOnlyProvider)
+		_, ok := p.(pf.ShimProvider)
 		return ok
 
 	}

--- a/pf/provider.go
+++ b/pf/provider.go
@@ -1,0 +1,37 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pf
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/pulumi/pulumi-terraform-bridge/pf/internal/pfutils"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+)
+
+// ShimProvider is a shim.Provider that is capable of serving the
+// [github.com/pulumi/pulumi-terraform-bridge/pf] aspect of the bridge.
+//
+// The interface for ShimProvider is considered unstable, and may change at any time.
+type ShimProvider interface {
+	shim.Provider
+
+	Server(context.Context) (tfprotov6.ProviderServer, error)
+	Resources(context.Context) (pfutils.Resources, error)
+	DataSources(context.Context) (pfutils.DataSources, error)
+	Config(context.Context) (tftypes.Object, error)
+}

--- a/pf/tests/nested_attr_test.go
+++ b/pf/tests/nested_attr_test.go
@@ -22,15 +22,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/pulumi/pulumi-terraform-bridge/pf"
 	"github.com/pulumi/pulumi-terraform-bridge/pf/internal/pfutils"
-	"github.com/pulumi/pulumi-terraform-bridge/pf/internal/schemashim"
 	"github.com/pulumi/pulumi-terraform-bridge/pf/tests/internal/testprovider"
 )
 
 func TestNestedType(t *testing.T) {
 	ctx := context.TODO()
 	info := testprovider.SyntheticTestBridgeProvider()
-	res, err := pfutils.GatherResources(ctx, info.P.(*schemashim.SchemaOnlyProvider).PfProvider())
+	res, err := info.P.(pf.ShimProvider).Resources(ctx)
 	require.NoError(t, err)
 	testresTypeName := pfutils.TypeName("testbridge_testres")
 	testresType := res.Schema(testresTypeName).Type().TerraformType(ctx)

--- a/pf/tfbridge/main.go
+++ b/pf/tfbridge/main.go
@@ -27,8 +27,8 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 
+	"github.com/pulumi/pulumi-terraform-bridge/pf"
 	pfmuxer "github.com/pulumi/pulumi-terraform-bridge/pf/internal/muxer"
-	"github.com/pulumi/pulumi-terraform-bridge/pf/internal/schemashim"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/metadata"
 	"github.com/pulumi/pulumi-terraform-bridge/x/muxer"
@@ -167,8 +167,8 @@ func MakeMuxedServer(
 		for _, prov := range shim.MuxedProviders {
 			prov := prov // https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables
 
-			switch prov := prov.(type) {
-			case *schemashim.SchemaOnlyProvider:
+			switch prov.(type) {
+			case pf.ShimProvider:
 				m.Servers = append(m.Servers, muxer.Endpoint{
 					Server: func(host *rprovider.HostClient) (pulumirpc.ResourceProviderServer, error) {
 						infoCopy := info

--- a/pf/tfbridge/provider.go
+++ b/pf/tfbridge/provider.go
@@ -21,7 +21,6 @@ import (
 	"github.com/blang/semver"
 
 	pfprovider "github.com/hashicorp/terraform-plugin-framework/provider"
-	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
@@ -34,6 +33,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 
+	"github.com/pulumi/pulumi-terraform-bridge/pf"
 	"github.com/pulumi/pulumi-terraform-bridge/pf/internal/pfutils"
 	pl "github.com/pulumi/pulumi-terraform-bridge/pf/internal/plugin"
 	"github.com/pulumi/pulumi-terraform-bridge/pf/internal/schemashim"
@@ -48,7 +48,6 @@ import (
 //
 // https://www.terraform.io/plugin/framework
 type provider struct {
-	tfProvider    pfprovider.Provider
 	tfServer      tfprotov6.ProviderServer
 	info          tfbridge.ProviderInfo
 	resources     pfutils.Resources
@@ -95,44 +94,37 @@ func ShimProviderWithContext(ctx context.Context, p pfprovider.Provider) shim.Pr
 func newProviderWithContext(ctx context.Context, info tfbridge.ProviderInfo,
 	meta ProviderMetadata) (pl.ProviderWithContext, error) {
 	const infoPErrMSg string = "info.P must be constructed with ShimProvider or ShimProviderWithContext"
+
 	if info.P == nil {
 		return nil, fmt.Errorf("%s: cannot be nil", infoPErrMSg)
 	}
-	schemaOnlyProvider, ok := info.P.(*schemashim.SchemaOnlyProvider)
+
+	pfServer, ok := info.P.(pf.ShimProvider)
 	if !ok {
-		return nil, fmt.Errorf("%s: found non-conforming type %T", infoPErrMSg, info.P)
+		return nil, fmt.Errorf("Unknown inner type for info.P: %T, %s", info.P, infoPErrMSg)
 	}
-	p := schemaOnlyProvider.PfProvider()
-
-	server6, err := newProviderServer6(ctx, p)
+	server6, err := pfServer.Server(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("Fatal failure starting a provider server: %w", err)
+		return nil, err
 	}
-	resources, err := pfutils.GatherResources(ctx, p)
+	resources, err := pfServer.Resources(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("Fatal failure gathering resource metadata: %w", err)
+		return nil, err
 	}
-
-	datasources, err := pfutils.GatherDatasources(ctx, p)
+	datasources, err := pfServer.DataSources(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("Fatal failure gathering datasource metadata: %w", err)
+		return nil, err
 	}
 
 	if info.MetadataInfo == nil {
 		return nil, fmt.Errorf("[pf/tfbridge] ProviderInfo.BridgeMetadata is required but is nil")
 	}
 
-	enc := convert.NewEncoding(schemaOnlyProvider, &info)
-
-	schemaResponse := &pfprovider.SchemaResponse{}
-	p.Schema(ctx, pfprovider.SchemaRequest{}, schemaResponse)
-	schema, diags := schemaResponse.Schema, schemaResponse.Diagnostics
-	if diags.HasError() {
-		return nil, fmt.Errorf("Schema() returned diagnostics with HasError")
+	providerConfigType, err := pfServer.Config(ctx)
+	if err != nil {
+		return nil, err
 	}
-
-	providerConfigType := schema.Type().TerraformType(ctx).(tftypes.Object)
-
+	enc := convert.NewEncoding(info.P, &info)
 	configEncoder, err := enc.NewConfigEncoder(providerConfigType)
 	if err != nil {
 		return nil, fmt.Errorf("NewConfigEncoder failed: %w", err)
@@ -145,18 +137,16 @@ func newProviderWithContext(ctx context.Context, info tfbridge.ProviderInfo,
 	}
 
 	return &provider{
-		tfProvider:    p,
-		tfServer:      server6,
-		info:          info,
-		resources:     resources,
-		datasources:   datasources,
-		pulumiSchema:  meta.PackageSchema,
-		encoding:      enc,
-		configEncoder: configEncoder,
-		configType:    providerConfigType,
-		version:       semverVersion,
-
-		schemaOnlyProvider: schemaOnlyProvider,
+		tfServer:           server6,
+		info:               info,
+		resources:          resources,
+		datasources:        datasources,
+		pulumiSchema:       meta.PackageSchema,
+		encoding:           enc,
+		configEncoder:      configEncoder,
+		configType:         providerConfigType,
+		version:            semverVersion,
+		schemaOnlyProvider: info.P,
 	}, nil
 }
 
@@ -250,18 +240,4 @@ func (p *provider) ConstructWithContext(_ context.Context,
 	inputs resource.PropertyMap, options plugin.ConstructOptions) (plugin.ConstructResult, error) {
 	return plugin.ConstructResult{},
 		fmt.Errorf("Construct is not implemented for Terraform Plugin Framework bridged providers")
-}
-
-func newProviderServer6(ctx context.Context, p pfprovider.Provider) (tfprotov6.ProviderServer, error) {
-	newServer6 := providerserver.NewProtocol6(p)
-	server6 := newServer6()
-
-	// Somehow this GetProviderSchema call needs to happen at least once to avoid Resource Type Not Found in the
-	// tfServer, to init it properly to remember provider name and compute correct resource names like
-	// random_integer instead of _integer (unknown provider name).
-	if _, err := server6.GetProviderSchema(ctx, &tfprotov6.GetProviderSchemaRequest{}); err != nil {
-		return nil, err
-	}
-
-	return server6, nil
 }

--- a/pf/tfbridge/provider_get_mapping.go
+++ b/pf/tfbridge/provider_get_mapping.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/pulumi/pulumi-terraform-bridge/pf/internal/schemashim"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 )
 
@@ -54,7 +53,7 @@ func (p *provider) GetMappingWithContext(ctx context.Context, key, provider stri
 
 func (p *provider) marshalProviderInfo(ctx context.Context) *tfbridge.MarshallableProviderInfo {
 	var providerInfoCopy tfbridge.ProviderInfo = p.info
-	providerInfoCopy.P = schemashim.ShimSchemaOnlyProvider(ctx, p.tfProvider)
+	providerInfoCopy.P = p.info.P
 	return tfbridge.MarshalProviderInfo(&providerInfoCopy)
 }
 


### PR DESCRIPTION
This is a pure refactor and will not have any end user consequences.

This was broken off from https://github.com/pulumi/pulumi-terraform-bridge/pull/1973.