### PR TITLE
feat: type check config values

### DIFF
--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -523,8 +523,8 @@ func (p *Provider) CheckConfig(ctx context.Context, req *pulumirpc.CheckRequest)
 		}
 	}
 
-	if err := p.typeCheckConfig(ctx, urn, news); err != nil {
-		return err, nil
+	if check := p.typeCheckConfig(ctx, urn, news); check != nil {
+		return check, nil
 	}
 
 	checkFailures := validateProviderConfig(ctx, urn, p, config)

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -529,38 +529,36 @@ func (p *Provider) CheckConfig(ctx context.Context, req *pulumirpc.CheckRequest)
 	validateShouldError := cmdutil.IsTruthy(os.Getenv("PULUMI_ERROR_CONFIG_TYPE_CHECKER"))
 	schemaMap := p.config
 	schemaInfos := p.info.GetConfig()
-	if p.pulumiSchema != nil {
-		if p.pulumiSchemaSpec != nil {
-			iv := NewInputValidator(urn, *p.pulumiSchemaSpec, true)
-			typeFailures := iv.ValidateConfig(news)
-			if len(typeFailures) > 0 {
-				logger.Warn("Type checking failed: ")
-				failures := []*pulumirpc.CheckFailure{}
-				for _, e := range typeFailures {
-					if validateShouldError {
-						pp := NewCheckFailurePath(schemaMap, schemaInfos, e.ResourcePath)
-						cf := NewCheckFailure(MiscFailure, e.Reason, &pp, urn, false, p.module, schemaMap, schemaInfos)
-						failures = append(failures, &pulumirpc.CheckFailure{
-							Property: string(cf.Property),
-							Reason:   cf.Reason,
-						})
-					} else {
-						logger.Warn(
-							fmt.Sprintf("Unexpected type at field %q: \n           %s", e.ResourcePath, e.Reason),
-						)
-					}
+	if p.pulumiSchemaSpec != nil {
+		iv := NewInputValidator(urn, *p.pulumiSchemaSpec, true)
+		typeFailures := iv.ValidateConfig(news)
+		if len(typeFailures) > 0 {
+			logger.Warn("Type checking failed: ")
+			failures := []*pulumirpc.CheckFailure{}
+			for _, e := range typeFailures {
+				if validateShouldError {
+					pp := NewCheckFailurePath(schemaMap, schemaInfos, e.ResourcePath)
+					cf := NewCheckFailure(MiscFailure, e.Reason, &pp, urn, false, p.module, schemaMap, schemaInfos)
+					failures = append(failures, &pulumirpc.CheckFailure{
+						Property: string(cf.Property),
+						Reason:   cf.Reason,
+					})
+				} else {
+					logger.Warn(
+						fmt.Sprintf("Unexpected type at field %q: \n           %s", e.ResourcePath, e.Reason),
+					)
 				}
-				if len(failures) > 0 {
-					return &pulumirpc.CheckResponse{
-						Failures: failures,
-					}, nil
-				}
-				logger.Warn("Type checking is still experimental. If you believe that a warning is incorrect,\n" +
-					"please let us know by creating an " +
-					"issue at https://github.com/pulumi/pulumi-terraform-bridge/issues.\n" +
-					"This will become a hard error in the future.",
-				)
 			}
+			if len(failures) > 0 {
+				return &pulumirpc.CheckResponse{
+					Failures: failures,
+				}, nil
+			}
+			logger.Warn("Type checking is still experimental. If you believe that a warning is incorrect,\n" +
+				"please let us know by creating an " +
+				"issue at https://github.com/pulumi/pulumi-terraform-bridge/issues.\n" +
+				"This will become a hard error in the future.",
+			)
 		}
 	}
 

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -523,6 +523,47 @@ func (p *Provider) CheckConfig(ctx context.Context, req *pulumirpc.CheckRequest)
 		}
 	}
 
+	logger := GetLogger(ctx)
+	// for now we are just going to log warnings if there are failures.
+	// over time we may want to turn these into actual errors
+	validateShouldError := cmdutil.IsTruthy(os.Getenv("PULUMI_ERROR_CONFIG_TYPE_CHECKER"))
+	schemaMap := p.config
+	schemaInfos := p.info.GetConfig()
+	if p.pulumiSchema != nil {
+		if p.pulumiSchemaSpec != nil {
+			iv := NewInputValidator(urn, *p.pulumiSchemaSpec, true)
+			typeFailures := iv.ValidateConfig(news)
+			if len(typeFailures) > 0 {
+				logger.Warn("Type checking failed: ")
+				failures := []*pulumirpc.CheckFailure{}
+				for _, e := range typeFailures {
+					if validateShouldError {
+						pp := NewCheckFailurePath(schemaMap, schemaInfos, e.ResourcePath)
+						cf := NewCheckFailure(MiscFailure, e.Reason, &pp, urn, false, p.module, schemaMap, schemaInfos)
+						failures = append(failures, &pulumirpc.CheckFailure{
+							Property: string(cf.Property),
+							Reason:   cf.Reason,
+						})
+					} else {
+						logger.Warn(
+							fmt.Sprintf("Unexpected type at field %q: \n           %s", e.ResourcePath, e.Reason),
+						)
+					}
+				}
+				if len(failures) > 0 {
+					return &pulumirpc.CheckResponse{
+						Failures: failures,
+					}, nil
+				}
+				logger.Warn("Type checking is still experimental. If you believe that a warning is incorrect,\n" +
+					"please let us know by creating an " +
+					"issue at https://github.com/pulumi/pulumi-terraform-bridge/issues.\n" +
+					"This will become a hard error in the future.",
+				)
+			}
+		}
+	}
+
 	checkFailures := validateProviderConfig(ctx, urn, p, config)
 	if len(checkFailures) > 0 {
 		return &pulumirpc.CheckResponse{
@@ -841,7 +882,7 @@ func (p *Provider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (*pul
 	if p.pulumiSchema != nil {
 		schema := p.pulumiSchemaSpec
 		if schema != nil {
-			iv := NewInputValidator(urn, *schema)
+			iv := NewInputValidator(urn, *schema, false)
 			typeFailures := iv.ValidateInputs(t, news)
 			if len(typeFailures) > 0 {
 				p.hasTypeErrors[urn] = struct{}{}

--- a/pkg/tfbridge/tests/provider_test.go
+++ b/pkg/tfbridge/tests/provider_test.go
@@ -685,7 +685,7 @@ func TestValidateConfig(t *testing.T) {
 		ResourcePrefix: "example",
 	}, newTestProviderOptions{})
 
-	t.Run("diff_panic", func(t *testing.T) {
+	t.Run("type_check_error", func(t *testing.T) {
 		t.Setenv("PULUMI_ERROR_CONFIG_TYPE_CHECKER", "true")
 		replay.ReplaySequence(t, p, `
 	[

--- a/pkg/tfbridge/validate_input_types.go
+++ b/pkg/tfbridge/validate_input_types.go
@@ -57,10 +57,10 @@ func (v *PulumiInputValidator) validatePropertyMap(
 		objType, knownType := propertyTypes[string(objectKey)]
 		if !knownType {
 			if v.validateUnknownTypes {
-				return []TypeFailure{{
+				failures = append(failures, TypeFailure{
 					Reason:       fmt.Sprintf("an unexpected argument %q was provided", string(objectKey)),
 					ResourcePath: propertyPath.String(),
-				}}
+				})
 			}
 			// permit extraneous properties to flow through
 			continue
@@ -274,16 +274,11 @@ func (v *PulumiInputValidator) ValidateInputs(resourceToken tokens.Type, inputs 
 	if !knownResourceSpec {
 		return nil
 	}
-	failures := v.validatePropertyMap(
+	return v.validatePropertyMap(
 		inputs,
 		resourceSpec.InputProperties,
 		resource.PropertyPath{},
 	)
-	if len(failures) > 0 {
-		return failures
-	}
-
-	return nil
 }
 
 // ValidateConfig will validate the provider config against the pulumi schema. It will
@@ -297,14 +292,9 @@ func (v *PulumiInputValidator) ValidateConfig(inputs resource.PropertyMap) []Typ
 			inputsToValidate[k] = inputs[k]
 		}
 	}
-	failures := v.validatePropertyMap(
+	return v.validatePropertyMap(
 		inputsToValidate,
 		v.schema.Config.Variables,
 		resource.PropertyPath{},
 	)
-	if len(failures) > 0 {
-		return failures
-	}
-
-	return nil
 }

--- a/pkg/tfbridge/validate_input_types.go
+++ b/pkg/tfbridge/validate_input_types.go
@@ -15,6 +15,10 @@ type PulumiInputValidator struct {
 
 	// The pulumi schema of the package
 	schema pschema.PackageSpec
+
+	// Whether or not to fail when properties are provided
+	// that do not exist in the spec. Defaults to false
+	validateUnknownTypes bool
 }
 
 type TypeFailure struct {
@@ -27,10 +31,11 @@ type TypeFailure struct {
 
 // NewInputValidator creates a new input validator for a given resource and
 // package schema
-func NewInputValidator(urn resource.URN, schema pschema.PackageSpec) *PulumiInputValidator {
+func NewInputValidator(urn resource.URN, schema pschema.PackageSpec, validateUnknownTypes bool) *PulumiInputValidator {
 	return &PulumiInputValidator{
-		urn:    urn,
-		schema: schema,
+		urn:                  urn,
+		schema:               schema,
+		validateUnknownTypes: validateUnknownTypes,
 	}
 }
 
@@ -51,6 +56,12 @@ func (v *PulumiInputValidator) validatePropertyMap(
 		objectValue := propertyMap[objectKey]
 		objType, knownType := propertyTypes[string(objectKey)]
 		if !knownType {
+			if v.validateUnknownTypes {
+				return []TypeFailure{{
+					Reason:       fmt.Sprintf("an unexpected argument %q was provided", string(objectKey)),
+					ResourcePath: propertyPath.String(),
+				}}
+			}
 			// permit extraneous properties to flow through
 			continue
 		}
@@ -266,6 +277,29 @@ func (v *PulumiInputValidator) ValidateInputs(resourceToken tokens.Type, inputs 
 	failures := v.validatePropertyMap(
 		inputs,
 		resourceSpec.InputProperties,
+		resource.PropertyPath{},
+	)
+	if len(failures) > 0 {
+		return failures
+	}
+
+	return nil
+}
+
+// ValidateConfig will validate the provider config against the pulumi schema. It will
+// return a list of type failures if any are found
+func (v *PulumiInputValidator) ValidateConfig(inputs resource.PropertyMap) []TypeFailure {
+	// The inputs that are provided to `CheckConfig` also include pulumi options
+	// so make sure we are only checking against properties in the config
+	inputsToValidate := resource.PropertyMap{}
+	for _, k := range inputs.StableKeys() {
+		if _, ok := v.schema.Config.Variables[string(k)]; ok {
+			inputsToValidate[k] = inputs[k]
+		}
+	}
+	failures := v.validatePropertyMap(
+		inputsToValidate,
+		v.schema.Config.Variables,
 		resource.PropertyPath{},
 	)
 	if len(failures) > 0 {

--- a/pkg/tfbridge/validate_input_types_test.go
+++ b/pkg/tfbridge/validate_input_types_test.go
@@ -1639,3 +1639,95 @@ func TestValidateInputType_toplevel(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateConfigType(t *testing.T) {
+	testCases := []struct {
+		name      string
+		inputName string
+		input     resource.PropertyValue
+		failures  []TypeFailure
+	}{
+		{
+			name:      "unexpected_argument",
+			inputName: "endpoints",
+			failures: []TypeFailure{{
+				Reason:       "an unexpected argument \"wxyz\" was provided",
+				ResourcePath: "endpoints[0]",
+			}},
+			input: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
+					"wxyz": "foo",
+				})),
+			}),
+		},
+		{
+			name:      "no_error_for_extra_inputs",
+			inputName: "doesnt_exist",
+			input: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
+					"wxyz": "foo",
+				})),
+			}),
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			pspec := pschema.PackageSpec{
+				Name: "test",
+				Types: map[string]pschema.ComplexTypeSpec{
+					"aws:config/endpoints:endpoints": {
+						ObjectTypeSpec: pschema.ObjectTypeSpec{
+							Type: "object",
+							Properties: map[string]pschema.PropertySpec{
+								"abcd": {
+									TypeSpec: pschema.TypeSpec{
+										Type: "string",
+									},
+								},
+							},
+						},
+					},
+				},
+				Config: pschema.ConfigSpec{
+					Variables: map[string]pschema.PropertySpec{
+						"endpoints": {
+							TypeSpec: pschema.TypeSpec{
+								Type: "array",
+								Items: &pschema.TypeSpec{
+									Ref: "#/types/aws:config/endpoints:endpoints",
+								},
+							},
+						},
+					},
+				},
+			}
+			urn := resource.CreateURN(
+				"testResource",
+				"pkg:mod:ResA",
+				"",
+				"stack",
+				"project",
+			)
+
+			v := &PulumiInputValidator{
+				urn:                  urn,
+				schema:               pspec,
+				validateUnknownTypes: true,
+			}
+			failures := v.ValidateConfig(resource.PropertyMap{
+				resource.PropertyKey(tc.inputName): tc.input,
+			})
+			if failures != nil && len(failures) != len(tc.failures) {
+				t.Fatalf("%d failures, got %d: %v", len(tc.failures), len(failures), failures)
+			}
+			if len(tc.failures) > 0 {
+				if failures == nil {
+					t.Fatalf("expected failures, got none")
+				} else {
+					assert.Equal(t, tc.failures, failures)
+				}
+			}
+		})
+	}
+}

--- a/pkg/tfbridge/validate_input_types_test.go
+++ b/pkg/tfbridge/validate_input_types_test.go
@@ -1663,6 +1663,7 @@ func TestValidateConfigType(t *testing.T) {
 		{
 			name:      "no_error_for_extra_inputs",
 			inputName: "doesnt_exist",
+			failures:  []TypeFailure{},
 			input: resource.NewArrayProperty([]resource.PropertyValue{
 				resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
 					"wxyz": "foo",
@@ -1718,16 +1719,7 @@ func TestValidateConfigType(t *testing.T) {
 			failures := v.ValidateConfig(resource.PropertyMap{
 				resource.PropertyKey(tc.inputName): tc.input,
 			})
-			if failures != nil && len(failures) != len(tc.failures) {
-				t.Fatalf("%d failures, got %d: %v", len(tc.failures), len(failures), failures)
-			}
-			if len(tc.failures) > 0 {
-				if failures == nil {
-					t.Fatalf("expected failures, got none")
-				} else {
-					assert.Equal(t, tc.failures, failures)
-				}
-			}
+			assert.Equal(t, tc.failures, failures)
 		})
 	}
 }


### PR DESCRIPTION
This PR extends the typechecker to also type check config values in `CheckConfig`. The motivation behind this is
https://github.com/pulumi/pulumi-aws/issues/4004. In that issue the user provides a key that is not in the allowed list and gets an opaque error message. In Terraform the user gets a more descriptive error message, so our behavior here is worse.

The big difference between the previous PR that is typechecking resource inputs is in that case we were preventing panics whereas in this case the primary motivation is to give _better_ error messages. I am still only writing a warning for now which gives a message to the user like this:

```console
  pulumi:providers:aws (provider):
    warning: Type checking failed:
    warning: Unexpected type at field "endpoints[0]":
               an unexpected argument "abcd" was provided
    warning: Type checking is still experimental. If you believe that a warning is incorrect,
    please let us know by creating an issue at https://github.com/pulumi/pulumi-terraform-bridge/issues.
    This will become a hard error in the future.
    error: pulumi:providers:aws resource 'chall-provider' has a problem: could not validate provider configuration: Invalid or unknown key. Examine values at 'chall-provider.endpoints'.
```

fixes https://github.com/pulumi/pulumi-aws/issues/4004