### PR TITLE
New refresh example

### DIFF
--- a/pkg/tests/schema_pulumi_test.go
+++ b/pkg/tests/schema_pulumi_test.go
@@ -980,6 +980,7 @@ resources:
 		res, err := pt.CurrentStack().Refresh(pt.Context(), optrefresh.ExpectNoChanges())
 		require.NoError(t, err)
 		t.Logf(res.StdOut)
+		pt.Preview(optpreview.ExpectNoChanges(), optpreview.Diff())
 	})
 
 	t.Run("two res", func(t *testing.T) {
@@ -988,5 +989,6 @@ resources:
 		res, err := pt.CurrentStack().Refresh(pt.Context(), optrefresh.ExpectNoChanges())
 		require.NoError(t, err)
 		t.Logf(res.StdOut)
+		pt.Preview(optpreview.ExpectNoChanges(), optpreview.Diff())
 	})
 }


### PR DESCRIPTION
Short example of difference in behaviour with new pulumi CLI.

Two resource:
`prov_test` - this one has a fully computed property - `out_val`
`prov_aux` - this one will use the computed property as an input.

Note the read behaviour on `prov_test` - it produces a different value for `out_val` than Create.

### Test one:
This just uses prov_test - `out_val` is only an output in this program. This is meant to represent how most of our provider tests look like.

### Test two:
this uses `out_val` as an input to the second resource. This might be a user program.


Under old refresh both tests failed at the refresh step - the `outVal` output is changed.
Under new refresh only test 2 fails an it only fails at preview, refresh --expect-no-changes is fine.

Most of our tests in providers don't exercise properties as an input to another resource, so we might miss regressions in any refresh behaviour.