### PR TITLE
Remove the `shim.SchemaMap.{Delete,Set}` method

### DIFF
--- a/pf/internal/schemashim/object_pseudoresource.go
+++ b/pf/internal/schemashim/object_pseudoresource.go
@@ -160,14 +160,6 @@ func (r *objectPseudoResource) Range(each func(key string, value shim.Schema) bo
 	}
 }
 
-func (*objectPseudoResource) Set(key string, value shim.Schema) {
-	panic("Set not supported - is it possible to treat this as immutable?")
-}
-
-func (*objectPseudoResource) Delete(key string) {
-	panic("Delete not supported - is it possible to treat this as immutable?")
-}
-
 type tuplePseudoResource struct {
 	schemaOnly
 	attrs map[string]pfutils.Attr
@@ -238,14 +230,6 @@ func (r *tuplePseudoResource) Range(each func(key string, value shim.Schema) boo
 			break
 		}
 	}
-}
-
-func (*tuplePseudoResource) Set(key string, value shim.Schema) {
-	panic("Set not supported - is it possible to treat this as immutable?")
-}
-
-func (*tuplePseudoResource) Delete(key string) {
-	panic("Delete not supported - is it possible to treat this as immutable?")
 }
 
 type schemaOnly struct{ typ string }

--- a/pf/internal/schemashim/schema_map.go
+++ b/pf/internal/schemashim/schema_map.go
@@ -94,11 +94,3 @@ func (m *schemaMap) Range(each func(key string, value shim.Schema) bool) {
 		}
 	}
 }
-
-func (m *schemaMap) Set(key string, value shim.Schema) {
-	panic("Set not supported - is it possible to treat this as immutable?")
-}
-
-func (m *schemaMap) Delete(key string) {
-	panic("Delete not supported - is it possible to treat this as immutable?")
-}

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -1140,7 +1140,7 @@ func (g *Generator) gatherConfig() *module {
 	extraConfigMap := schema.SchemaMap{}
 	for key, val := range g.info.ExtraConfig {
 		extraConfigInfo[key] = val.Info
-		extraConfigMap.Set(key, val.Schema)
+		extraConfigMap[key] = val.Schema
 	}
 	for key := range g.info.ExtraConfig {
 		if prop := g.propertyVariable(cfgPath,

--- a/pkg/tfshim/schema/schema.go
+++ b/pkg/tfshim/schema/schema.go
@@ -154,11 +154,3 @@ func (m SchemaMap) Range(each func(key string, value shim.Schema) bool) {
 		}
 	}
 }
-
-func (m SchemaMap) Set(key string, value shim.Schema) {
-	m[key] = value
-}
-
-func (m SchemaMap) Delete(key string) {
-	delete(m, key)
-}

--- a/pkg/tfshim/sdk-v1/schema.go
+++ b/pkg/tfshim/sdk-v1/schema.go
@@ -177,11 +177,3 @@ func (m v1SchemaMap) Range(each func(key string, value shim.Schema) bool) {
 		}
 	}
 }
-
-func (m v1SchemaMap) Set(key string, value shim.Schema) {
-	m[key] = value.(v1Schema).tf
-}
-
-func (m v1SchemaMap) Delete(key string) {
-	delete(m, key)
-}

--- a/pkg/tfshim/sdk-v2/schema.go
+++ b/pkg/tfshim/sdk-v2/schema.go
@@ -177,11 +177,3 @@ func (m v2SchemaMap) Range(each func(key string, value shim.Schema) bool) {
 		}
 	}
 }
-
-func (m v2SchemaMap) Set(key string, value shim.Schema) {
-	m[key] = value.(v2Schema).tf
-}
-
-func (m v2SchemaMap) Delete(key string) {
-	delete(m, key)
-}

--- a/pkg/tfshim/shim.go
+++ b/pkg/tfshim/shim.go
@@ -145,8 +145,6 @@ type SchemaMap interface {
 	GetOk(key string) (Schema, bool)
 	Range(each func(key string, value Schema) bool)
 
-	Set(key string, value Schema)
-
 	Validate() error
 }
 

--- a/pkg/tfshim/shim.go
+++ b/pkg/tfshim/shim.go
@@ -146,7 +146,6 @@ type SchemaMap interface {
 	Range(each func(key string, value Schema) bool)
 
 	Set(key string, value Schema)
-	Delete(key string)
 
 	Validate() error
 }


### PR DESCRIPTION
It looks like we don't use this anywhere, and I don't expect that there are 3rd party dependencies on `shim.SchemaMap`.

Follow up on https://github.com/pulumi/pulumi-terraform-bridge/pull/1973#discussion_r1638456558.