### PR TITLE
Deduplicate set diffs

### DIFF
--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -1079,7 +1079,7 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 	// If there were changes in this diff, check to see if we have a replacement.
 	var replaces []string
 	var replaced map[string]bool
-	var properties []string
+	uniqueProps := map[string]struct{}{}
 
 	if changes == pulumirpc.DiffResponse_DIFF_SOME {
 		for k, d := range detailedDiff {
@@ -1087,7 +1087,7 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 			if firstSep := strings.IndexAny(k, ".["); firstSep != -1 {
 				k = k[:firstSep]
 			}
-			properties = append(properties, k)
+			uniqueProps[k] = struct{}{}
 
 			switch d.Kind {
 			case pulumirpc.PropertyDiff_ADD_REPLACE,
@@ -1137,6 +1137,11 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 		markWronglyTypedMaxItemsOneStateDiff(schema, fields, olds) {
 
 		changes = pulumirpc.DiffResponse_DIFF_SOME
+	}
+
+	properties := []string{}
+	for key := range uniqueProps {
+		properties = append(properties, key)
 	}
 
 	// Ensure that outputs are deterministic to enable gRPC testing.

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -5623,3 +5623,97 @@ func TestPlanResourceChangeUnknowns(t *testing.T) {
 	}`)
 	})
 }
+
+func TestSetDuplicatedDiffEntries(t *testing.T) {
+	p := &schemav2.Provider{
+		Schema: map[string]*schemav2.Schema{},
+		ResourcesMap: map[string]*schemav2.Resource{
+			"example_resource": {
+				Schema: map[string]*schemav2.Schema{
+					"privileges": &schema.Schema{
+						Type:     schema.TypeSet,
+						Optional: true,
+						Elem:     &schemav2.Schema{Type: schemav2.TypeString},
+					},
+				},
+			},
+		},
+	}
+	shimProv := shimv2.NewProvider(p)
+	provider := &Provider{
+		tf:     shimProv,
+		config: shimv2.NewSchemaMap(p.Schema),
+		info: ProviderInfo{
+			P:              shimProv,
+			ResourcePrefix: "example",
+			Resources: map[string]*ResourceInfo{
+				"example_resource": {Tok: "ExampleResource"},
+			},
+		},
+	}
+	provider.initResourceMaps()
+
+	testutils.Replay(t, provider, `
+{
+    "method": "/pulumirpc.ResourceProvider/Diff",
+    "request": {
+        "id": "id",
+		"urn": "urn:pulumi:dev::teststack::ExampleResource::exres",
+        "olds": {
+            "id": "id",
+            "privileges": [
+                "CREATE EXTERNAL TABLE",
+                "CREATE TABLE",
+                "CREATE VIEW",
+                "CREATE TEMPORARY TABLE",
+                "USAGE"
+            ]
+        },
+        "news": {
+            "__defaults": [],
+            "privileges": [
+                "USAGE"
+            ]
+        },
+        "oldInputs": {
+            "__defaults": [],
+            "privileges": [
+                "CREATE EXTERNAL TABLE",
+                "CREATE TABLE",
+                "CREATE VIEW",
+                "CREATE TEMPORARY TABLE",
+                "USAGE"
+            ]
+        }
+    },
+    "response": {
+        "changes": "DIFF_SOME",
+        "diffs": [
+            "privileges"
+        ],
+        "detailedDiff": {
+            "privileges": {
+                "kind": "UPDATE"
+            },
+            "privileges[0]": {
+                "kind": "DELETE"
+            },
+            "privileges[1]": {
+                "kind": "DELETE"
+            },
+            "privileges[2]": {
+                "kind": "DELETE"
+            },
+            "privileges[3]": {
+                "kind": "DELETE"
+            }
+        },
+        "hasDetailedDiff": true
+    },
+    "metadata": {
+        "kind": "resource",
+        "mode": "client",
+        "name": "snowflake"
+    }
+}`)
+}


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/2103

We were adding duplicates in the `diff` entry in `/Diff`, resulting in an incorrect detailed diff being displayed by the CLI in some cases.

This should make sure all the entries in `diff` are unique.