### PR TITLE
Remove unused method: runtypes.{Resources,DataSources}.Diagnostic

### DIFF
--- a/pf/internal/pfutils/common.go
+++ b/pf/internal/pfutils/common.go
@@ -44,9 +44,8 @@ func checkDiagsForErrors(diag diag.Diagnostics) error {
 }
 
 type entry[T any] struct {
-	schema      Schema
-	t           T
-	diagnostics diag.Diagnostics
+	schema Schema
+	t      T
 }
 
 type collection[T any] map[runtypes.TypeName]entry[T]
@@ -72,8 +71,4 @@ func (c collection[T]) Has(name runtypes.TypeName) bool {
 
 func (c collection[T]) Schema(name runtypes.TypeName) Schema {
 	return c[name].schema
-}
-
-func (c collection[T]) Diagnostics(name runtypes.TypeName) diag.Diagnostics {
-	return c[name].diagnostics
 }

--- a/pf/internal/pfutils/datasources.go
+++ b/pf/internal/pfutils/datasources.go
@@ -48,9 +48,8 @@ func GatherDatasources[F func(Schema) shim.SchemaMap](
 		}
 
 		ds[runtypes.TypeName(meta.TypeName)] = entry[func() datasource.DataSource]{
-			t:           makeDataSource,
-			schema:      FromDataSourceSchema(dataSourceSchema),
-			diagnostics: diag,
+			t:      makeDataSource,
+			schema: FromDataSourceSchema(dataSourceSchema),
 		}
 	}
 

--- a/pf/internal/pfutils/resources.go
+++ b/pf/internal/pfutils/resources.go
@@ -48,9 +48,8 @@ func GatherResources[F func(Schema) shim.SchemaMap](
 		}
 
 		rs[runtypes.TypeName(meta.TypeName)] = entry[func() resource.Resource]{
-			t:           makeResource,
-			schema:      FromResourceSchema(resSchema),
-			diagnostics: diag,
+			t:      makeResource,
+			schema: FromResourceSchema(resSchema),
 		}
 	}
 

--- a/pf/internal/runtypes/types.go
+++ b/pf/internal/runtypes/types.go
@@ -17,7 +17,6 @@ package runtypes
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
@@ -45,7 +44,6 @@ type collection interface {
 	All() []TypeName
 	Has(TypeName) bool
 	Schema(TypeName) Schema
-	Diagnostics(TypeName) diag.Diagnostics
 }
 
 // Represents all provider's resources pre-indexed by TypeName.

--- a/pf/proto/runtypes.go
+++ b/pf/proto/runtypes.go
@@ -17,7 +17,6 @@ package proto
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
@@ -91,9 +90,4 @@ func (c collection) Schema(key runtypes.TypeName) runtypes.Schema {
 	contract.Assertf(ok, "called Schema on a resource that does not exist")
 
 	return schema{s}
-}
-
-func (c collection) Diagnostics(runtypes.TypeName) diag.Diagnostics {
-	// It's not clear how to split diagnostics by resource
-	return nil
 }


### PR DESCRIPTION
This method is never called in our code.