### PR TITLE
Error for dynamic types in makePropertyType

### DIFF
--- a/pf/internal/schemashim/convert_type.go
+++ b/pf/internal/schemashim/convert_type.go
@@ -42,8 +42,7 @@ func convertType(typ pfattr.Type) (shim.ValueType, error) {
 	case is(tftypes.String):
 		return shim.TypeString, nil
 	case is(tftypes.DynamicPseudoType):
-		// This means that any type can be used,
-		return shim.TypeInvalid, nil
+		return shim.TypeDynamic, nil
 	default:
 		switch tftype.(type) {
 		case tftypes.List:

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -445,7 +445,8 @@ func (g *Generator) makePropertyType(typePath paths.TypePath,
 		return nil, errors.New("Error in schema generation: Dynamic types are not implemented")
 	default:
 		contract.Failf(
-			"impossible: sch.Type() should be one of TypeMap, TypeList, TypeSet at this point path: %s, type: %s",
+			"impossible: sch.Type() should be one of TypeMap, TypeList, TypeSet, TypeDynamic at this point path: "+
+				"%s, type: %s",
 			typePath.String(), sch.Type())
 	}
 	t.element = element

--- a/pkg/tfgen/generate_test.go
+++ b/pkg/tfgen/generate_test.go
@@ -155,6 +155,7 @@ func Test_makePropertyType(t *testing.T) {
 
 	strType := (&shimschema.Schema{Type: shim.TypeString}).Shim()
 	intType := (&shimschema.Schema{Type: shim.TypeInt}).Shim()
+	dynamicType := (&shimschema.Schema{Type: shim.TypeDynamic}).Shim()
 
 	xySchema := (&shimschema.Resource{
 		Schema: shimschema.SchemaMap{
@@ -165,8 +166,15 @@ func Test_makePropertyType(t *testing.T) {
 
 	t.Run("String", func(t *testing.T) {
 		p, err := g.makePropertyType(path, "obj", strType, nil, false, entityDocs{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, typeKind(kindString), p.kind)
+	})
+
+	//TODO: change this test to assert typeKind when implementing
+	// https://github.com/pulumi/pulumi-terraform-bridge/issues/2127
+	t.Run("Dynamic Unimplemented", func(t *testing.T) {
+		_, err := g.makePropertyType(path, "obj", dynamicType, nil, false, entityDocs{})
+		assert.Error(t, err, "Error in schema generation: Dynamic types are not implemented")
 	})
 
 	t.Run("ListString", func(t *testing.T) {
@@ -175,7 +183,7 @@ func Test_makePropertyType(t *testing.T) {
 			Elem: strType,
 		}).Shim()
 		p, err := g.makePropertyType(path, "obj", strListType, nil, false, entityDocs{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, typeKind(kindList), p.kind)
 		assert.Equal(t, typeKind(kindString), p.element.kind)
 	})
@@ -186,7 +194,7 @@ func Test_makePropertyType(t *testing.T) {
 			Elem: strType,
 		}).Shim()
 		p, err := g.makePropertyType(path, "obj", strMapType, nil, false, entityDocs{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, typeKind(kindMap), p.kind)
 		assert.Equal(t, typeKind(kindString), p.element.kind)
 	})
@@ -196,7 +204,7 @@ func Test_makePropertyType(t *testing.T) {
 			Type: shim.TypeMap,
 		}).Shim()
 		p, err := g.makePropertyType(path, "obj", unkMapType, nil, false, entityDocs{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, typeKind(kindMap), p.kind)
 		assert.Nil(t, p.element)
 	})
@@ -207,7 +215,7 @@ func Test_makePropertyType(t *testing.T) {
 			Elem: xySchema,
 		}).Shim()
 		p, err := g.makePropertyType(path, "obj", objType, nil, false, entityDocs{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, typeKind(kindObject), p.kind)
 		assert.Equal(t, "config.prop", p.properties[0].parentPath.String())
 	})
@@ -218,7 +226,7 @@ func Test_makePropertyType(t *testing.T) {
 			Elem: xySchema,
 		}).Shim()
 		p, err := g.makePropertyType(path, "obj", objType, nil, false, entityDocs{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, typeKind(kindList), p.kind)
 		assert.Equal(t, typeKind(kindObject), p.element.kind)
 		assert.Equal(t, "config.prop.$", p.element.properties[0].parentPath.String())
@@ -231,7 +239,7 @@ func Test_makePropertyType(t *testing.T) {
 			MaxItems: 1,
 		}).Shim()
 		p, err := g.makePropertyType(path, "obj", objType, nil, false, entityDocs{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, typeKind(kindObject), p.kind)
 		assert.Equal(t, "config.prop", p.properties[0].parentPath.String())
 	})
@@ -242,7 +250,7 @@ func Test_makePropertyType(t *testing.T) {
 			Elem: xySchema,
 		}).Shim()
 		p, err := g.makePropertyType(path, "obj", objType, nil, false, entityDocs{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, typeKind(kindSet), p.kind)
 		assert.Equal(t, typeKind(kindObject), p.element.kind)
 		assert.Equal(t, "config.prop.$", p.element.properties[0].parentPath.String())
@@ -255,7 +263,7 @@ func Test_makePropertyType(t *testing.T) {
 			MaxItems: 1,
 		}).Shim()
 		p, err := g.makePropertyType(path, "obj", objType, nil, false, entityDocs{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, typeKind(kindObject), p.kind)
 		assert.Equal(t, "config.prop", p.properties[0].parentPath.String())
 	})

--- a/pkg/tfgen/generate_test.go
+++ b/pkg/tfgen/generate_test.go
@@ -164,7 +164,8 @@ func Test_makePropertyType(t *testing.T) {
 	}).Shim()
 
 	t.Run("String", func(t *testing.T) {
-		p := g.makePropertyType(path, "obj", strType, nil, false, entityDocs{})
+		p, err := g.makePropertyType(path, "obj", strType, nil, false, entityDocs{})
+		assert.NoError(t, err)
 		assert.Equal(t, typeKind(kindString), p.kind)
 	})
 
@@ -173,7 +174,8 @@ func Test_makePropertyType(t *testing.T) {
 			Type: shim.TypeList,
 			Elem: strType,
 		}).Shim()
-		p := g.makePropertyType(path, "obj", strListType, nil, false, entityDocs{})
+		p, err := g.makePropertyType(path, "obj", strListType, nil, false, entityDocs{})
+		assert.NoError(t, err)
 		assert.Equal(t, typeKind(kindList), p.kind)
 		assert.Equal(t, typeKind(kindString), p.element.kind)
 	})
@@ -183,7 +185,8 @@ func Test_makePropertyType(t *testing.T) {
 			Type: shim.TypeMap,
 			Elem: strType,
 		}).Shim()
-		p := g.makePropertyType(path, "obj", strMapType, nil, false, entityDocs{})
+		p, err := g.makePropertyType(path, "obj", strMapType, nil, false, entityDocs{})
+		assert.NoError(t, err)
 		assert.Equal(t, typeKind(kindMap), p.kind)
 		assert.Equal(t, typeKind(kindString), p.element.kind)
 	})
@@ -192,7 +195,8 @@ func Test_makePropertyType(t *testing.T) {
 		unkMapType := (&shimschema.Schema{
 			Type: shim.TypeMap,
 		}).Shim()
-		p := g.makePropertyType(path, "obj", unkMapType, nil, false, entityDocs{})
+		p, err := g.makePropertyType(path, "obj", unkMapType, nil, false, entityDocs{})
+		assert.NoError(t, err)
 		assert.Equal(t, typeKind(kindMap), p.kind)
 		assert.Nil(t, p.element)
 	})
@@ -202,7 +206,8 @@ func Test_makePropertyType(t *testing.T) {
 			Type: shim.TypeMap,
 			Elem: xySchema,
 		}).Shim()
-		p := g.makePropertyType(path, "obj", objType, nil, false, entityDocs{})
+		p, err := g.makePropertyType(path, "obj", objType, nil, false, entityDocs{})
+		assert.NoError(t, err)
 		assert.Equal(t, typeKind(kindObject), p.kind)
 		assert.Equal(t, "config.prop", p.properties[0].parentPath.String())
 	})
@@ -212,7 +217,8 @@ func Test_makePropertyType(t *testing.T) {
 			Type: shim.TypeList,
 			Elem: xySchema,
 		}).Shim()
-		p := g.makePropertyType(path, "obj", objType, nil, false, entityDocs{})
+		p, err := g.makePropertyType(path, "obj", objType, nil, false, entityDocs{})
+		assert.NoError(t, err)
 		assert.Equal(t, typeKind(kindList), p.kind)
 		assert.Equal(t, typeKind(kindObject), p.element.kind)
 		assert.Equal(t, "config.prop.$", p.element.properties[0].parentPath.String())
@@ -224,7 +230,8 @@ func Test_makePropertyType(t *testing.T) {
 			Elem:     xySchema,
 			MaxItems: 1,
 		}).Shim()
-		p := g.makePropertyType(path, "obj", objType, nil, false, entityDocs{})
+		p, err := g.makePropertyType(path, "obj", objType, nil, false, entityDocs{})
+		assert.NoError(t, err)
 		assert.Equal(t, typeKind(kindObject), p.kind)
 		assert.Equal(t, "config.prop", p.properties[0].parentPath.String())
 	})
@@ -234,7 +241,8 @@ func Test_makePropertyType(t *testing.T) {
 			Type: shim.TypeSet,
 			Elem: xySchema,
 		}).Shim()
-		p := g.makePropertyType(path, "obj", objType, nil, false, entityDocs{})
+		p, err := g.makePropertyType(path, "obj", objType, nil, false, entityDocs{})
+		assert.NoError(t, err)
 		assert.Equal(t, typeKind(kindSet), p.kind)
 		assert.Equal(t, typeKind(kindObject), p.element.kind)
 		assert.Equal(t, "config.prop.$", p.element.properties[0].parentPath.String())
@@ -246,7 +254,8 @@ func Test_makePropertyType(t *testing.T) {
 			Elem:     xySchema,
 			MaxItems: 1,
 		}).Shim()
-		p := g.makePropertyType(path, "obj", objType, nil, false, entityDocs{})
+		p, err := g.makePropertyType(path, "obj", objType, nil, false, entityDocs{})
+		assert.NoError(t, err)
 		assert.Equal(t, typeKind(kindObject), p.kind)
 		assert.Equal(t, "config.prop", p.properties[0].parentPath.String())
 	})

--- a/pkg/tfshim/shim.go
+++ b/pkg/tfshim/shim.go
@@ -61,6 +61,7 @@ const (
 	TypeList
 	TypeMap
 	TypeSet
+	TypeDynamic
 )
 
 func (i ValueType) String() string {
@@ -79,6 +80,8 @@ func (i ValueType) String() string {
 		return "Map"
 	case TypeSet:
 		return "Set"
+	case TypeDynamic:
+		return "Dynamic"
 	default:
 		return ""
 	}


### PR DESCRIPTION
Rather than panic, bubble up an error from makePropertyType when user attempts to make a dynamic property type.

Handles panic reported in #1988. Note that it does not implement the missing logic.
