### PR TITLE
Add InputTypes flag to Python codegen information

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -175,6 +175,15 @@ type OverlayInfo = info.Overlay
 // JavaScriptInfo contains optional overlay information for Python code-generation.
 type JavaScriptInfo = info.JavaScript
 
+const (
+	// Use the default type generation from pulumi/pulumi.
+	PythonInputTypeDefault = info.PythonInputTypeDefault
+	// Generate args classes only.
+	PythonInputTypeClasses = info.PythonInputTypeClasses
+	// Generate TypedDicts side-by-side with args classes.
+	PythonInputTypeClassesAndDicts = info.PythonInputTypeClassesAndDicts
+)
+
 // PythonInfo contains optional overlay information for Python code-generation.
 type PythonInfo = info.Python
 

--- a/pkg/tfbridge/info/info.go
+++ b/pkg/tfbridge/info/info.go
@@ -671,6 +671,12 @@ type Python struct {
 	PyProject struct {
 		Enabled bool
 	}
+
+	// Specifies what types are used for inputs.
+	// Allowed values are the following:
+	// - "classes" (default): Args classes only
+	// - "classes-and-dicts": TypedDicts side-by-side with Args classes.
+	InputTypes string
 }
 
 // Golang contains optional overlay information for Golang code-generation.

--- a/pkg/tfbridge/info/info.go
+++ b/pkg/tfbridge/info/info.go
@@ -645,6 +645,17 @@ type JavaScript struct {
 	UseTypeOnlyReferences bool
 }
 
+type PythonInputType string
+
+const (
+	// Use the default type generation from pulumi/pulumi.
+	PythonInputTypeDefault = ""
+	// Generate args classes only.
+	PythonInputTypeClasses = "classes"
+	// Generate TypedDicts side-by-side with args classes.
+	PythonInputTypeClassesAndDicts = "classes-and-dicts"
+)
+
 // Python contains optional overlay information for Python code-generation.
 type Python struct {
 	Requires      map[string]string // Pip install_requires information.
@@ -673,10 +684,7 @@ type Python struct {
 	}
 
 	// Specifies what types are used for inputs.
-	// Allowed values are the following:
-	// - "classes" (default): Args classes only
-	// - "classes-and-dicts": TypedDicts side-by-side with Args classes.
-	InputTypes string
+	InputTypes PythonInputType
 }
 
 // Golang contains optional overlay information for Golang code-generation.

--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -474,6 +474,7 @@ func pythonLanguageExtensions(providerInfo *tfbridge.ProviderInfo, readme string
 		ModuleNameOverrides:          p.ModuleNameOverrides,
 		LiftSingleValueMethodReturns: p.LiftSingleValueMethodReturns,
 		RespectSchemaVersion:         p.RespectSchemaVersion,
+		InputTypes:                   p.InputTypes,
 	}
 	info.PyProject.Enabled = p.PyProject.Enabled
 	return rawMessage(info)

--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -474,7 +474,7 @@ func pythonLanguageExtensions(providerInfo *tfbridge.ProviderInfo, readme string
 		ModuleNameOverrides:          p.ModuleNameOverrides,
 		LiftSingleValueMethodReturns: p.LiftSingleValueMethodReturns,
 		RespectSchemaVersion:         p.RespectSchemaVersion,
-		InputTypes:                   p.InputTypes,
+		InputTypes:                   string(p.InputTypes),
 	}
 	info.PyProject.Enabled = p.PyProject.Enabled
 	return rawMessage(info)


### PR DESCRIPTION
This flag was added to Pulumi Python codegen in
https://github.com/pulumi/pulumi/pull/15957 and enables the generation
of TypedDict based input types. This is currently opt in and defaults to
`classes`, leaving codegen unchanged. A future version of Python codegen
will flip this to `classes-and-dicts` to generate TypedDict types side
by side with Args classes.
