### PR TITLE
Change the name of the output binary from bridge to provider

### DIFF
--- a/dynamic/Makefile
+++ b/dynamic/Makefile
@@ -2,7 +2,7 @@ LDFLAGS := -ldflags "-X google.golang.org/protobuf/reflect/protoregistry.conflic
 
 build: bin
 	go build \
-		-o bin/pulumi-resource-terraform-bridge \
+		-o bin/pulumi-resource-terraform-provider \
 		${LDFLAGS} \
 		github.com/pulumi/pulumi-terraform-bridge/dynamic
 


### PR DESCRIPTION
Part of changing the name of the final provider from `pulumi-terraform-bridge` to `pulumi-terraform-provider`.