### PR TITLE
Bump default Go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi-terraform-bridge/v3
 
-go 1.21
+go 1.21.12
 
 replace github.com/pulumi/pulumi-terraform-bridge/x/muxer => ./x/muxer
 

--- a/pf/go.mod
+++ b/pf/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi-terraform-bridge/pf
 
-go 1.21
+go 1.21.12
 
 replace (
 	github.com/pulumi/pulumi-terraform-bridge/v3 => ./..

--- a/pf/tests/go.mod
+++ b/pf/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi-terraform-bridge/pf/tests
 
-go 1.21
+go 1.21.12
 
 require (
 	github.com/hashicorp/terraform-plugin-framework v1.6.0

--- a/pkg/tests/go.mod
+++ b/pkg/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests
 
-go 1.21
+go 1.21.12
 
 replace (
 	github.com/pulumi/pulumi-terraform-bridge/v3 => ../..


### PR DESCRIPTION
Should address the go security warnings in all providers once picked up.

Example https://github.com/pulumi/pulumi-random/pull/1034