### PR TITLE
pf resources show diff for empty map

### DIFF
--- a/pf/tests/provider_diff_test.go
+++ b/pf/tests/provider_diff_test.go
@@ -195,3 +195,39 @@ func TestDiffVersionUpgrade(t *testing.T) {
         }`
 	testutils.Replay(t, server, testCase)
 }
+
+// Test shows that an empty object shows a diff if it is not provided
+func TestEmptyObjectDiff(t *testing.T) {
+	server := newProviderServer(t, testprovider.SyntheticTestBridgeProvider())
+	testCase := `
+        {
+          "method": "/pulumirpc.ResourceProvider/Diff",
+          "request": {
+            "id": "0",
+            "urn": "urn:pulumi:test-stack::basicprogram::testbridge:index/testres:Testres::testres1",
+						"olds": {
+							"id": "none",
+							"statedir": "res-461023c",
+							"requiredInputString": "abc",
+							"requiredInputStringCopy": "abc",
+							"optionalInputStringMap": {}
+						},
+						"news": {
+							"statedir": "res-461023c",
+							"requiredInputString": "abc"
+						},
+						"oldInputs": {
+							"statedir": "res-461023c",
+							"requiredInputString": "abc"
+						}
+          },
+					"response": {
+						"changes": "DIFF_SOME",
+						"diffs": [
+						"optionalInputStringMap"
+						]
+					}
+        }
+        `
+	testutils.Replay(t, server, testCase)
+}


### PR DESCRIPTION
re https://github.com/pulumi/pulumi-aws/issues/4080

I've noticed different behavior between sdkv2 and pf resources.
Sometimes if you do not provide a value for a map property it will write
an empty value to the outputs (i.e. `{ \"tagsAll\": {} }`).

When diff is called, the `olds` show the empty object value and the news
show no entry at all. sdkv2 resources handle this and do not display any
diff whereas pf resources show a diff.