### PR TITLE
Handle errors during ReadDataApply

### DIFF
--- a/pkg/tfshim/tfplugin5/provider.go
+++ b/pkg/tfshim/tfplugin5/provider.go
@@ -534,6 +534,10 @@ func (p *provider) ReadDataApply(ctx context.Context, t string, d shim.InstanceD
 		return nil, err
 	}
 
+	if err := unmarshalErrors(resp.Diagnostics); err != nil {
+		return nil, err
+	}
+
 	stateVal, err := msgpack.Unmarshal(resp.State.Msgpack, dataSource.ctyType)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
As seen in the Protobuf, ReadDataSource_Response can contain diagnostics errors.