### PR TITLE
Fix empty pre-header docs panic

### DIFF
--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -535,6 +535,10 @@ func reformatExamples(sections [][]string) [][]string {
 	var exampleUsageSection []string
 	var exampleSectionIndices []int
 	for i, s := range sections {
+		if len(s) == 0 {
+			// Skip empty sections.
+			continue
+		}
 		matches := exampleHeaderRegexp.FindStringSubmatch(s[0])
 		if len(matches) == 0 {
 			continue

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -844,6 +844,23 @@ content 2`
 	}
 
 	runTest(gcpDoc2, gcpDoc2Expected)
+
+	misformattedDocNoPanic := `## jetstream_kv_entry Resource
+content
+### Example
+content`
+
+	misformattedDocsExpected := [][]string{
+		nil,
+		{
+			"## jetstream_kv_entry Resource",
+			"content",
+			"### Example",
+			"content",
+		},
+	}
+
+	runTest(misformattedDocNoPanic, misformattedDocsExpected)
 }
 
 func TestFormatEntityName(t *testing.T) {


### PR DESCRIPTION
fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/2176

For docs which don't match the TF docs format we probably won't do a good job of converting them but we should at least not panic.

This fixes a reported panic with non-standard docs formats.

The panic was reported by an external user trying to bridge https://github.com/nats-io/terraform-provider-jetstream