### PR TITLE
Remove usage of plugin framework types in favor of interface types

### DIFF
--- a/pf/internal/schemashim/convert_type.go
+++ b/pf/internal/schemashim/convert_type.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 
 	pfattr "github.com/hashicorp/terraform-plugin-framework/attr"
-	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
@@ -34,7 +34,7 @@ func convertType(typ pfattr.Type) (shim.ValueType, error) {
 	switch {
 	case is(tftypes.Bool):
 		return shim.TypeBool, nil
-	case typ.Equal(types.Int64Type):
+	case typ.Equal(basetypes.Int64Type{}):
 		// We special case int, since it is a stable type but not present on the wire.
 		return shim.TypeInt, nil
 	case is(tftypes.Number):

--- a/pf/internal/schemashim/custom_object_type_test.go
+++ b/pf/internal/schemashim/custom_object_type_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/stretchr/testify/assert"
@@ -35,12 +34,12 @@ func TestCustomObject(t *testing.T) {
 
 	obj := newObjectPseudoResource(NewObjectTypeOf[SomeType](ctx), nil, nil)
 
-	s := obj.Schema().Get("s")
+	s := obj.Schema().Get("sample_string")
 	assert.Equal(t, shim.TypeString, s.Type())
 }
 
 type SomeType struct {
-	S types.String `tfsdk:"s"`
+	SampleString basetypes.StringValue `tfsdk:"sample_string"`
 }
 
 // --- custom object machinery ---

--- a/pf/internal/schemashim/custom_type_test.go
+++ b/pf/internal/schemashim/custom_type_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/stretchr/testify/assert"
 
@@ -31,7 +30,7 @@ import (
 // This example is taken from aws:resourceexplorer/index:Index "timeouts" property.
 func TestCustomTypeEmbeddingObjectType(t *testing.T) {
 	type timeoutsType struct {
-		types.ObjectType
+		basetypes.ObjectType
 	}
 
 	raw := schema.SingleNestedBlock{
@@ -41,11 +40,11 @@ func TestCustomTypeEmbeddingObjectType(t *testing.T) {
 			"update": schema.StringAttribute{},
 		},
 		CustomType: timeoutsType{
-			ObjectType: types.ObjectType{
+			ObjectType: basetypes.ObjectType{
 				AttrTypes: map[string]attr.Type{
-					"create": types.StringType,
-					"read":   types.StringType,
-					"update": types.StringType,
+					"create": basetypes.StringType{},
+					"read":   basetypes.StringType{},
+					"update": basetypes.StringType{},
 				},
 			},
 		},
@@ -65,7 +64,7 @@ func TestCustomListType(t *testing.T) {
 	ctx := context.Background()
 
 	raw := schema.ListNestedBlock{
-		CustomType: newListNestedObjectTypeOf[searchFilterModel](ctx, types.ObjectType{
+		CustomType: newListNestedObjectTypeOf[searchFilterModel](ctx, basetypes.ObjectType{
 			AttrTypes: map[string]attr.Type{
 				"filter_string": basetypes.StringType{},
 			},
@@ -93,7 +92,7 @@ func TestCustomListAttribute(t *testing.T) {
 	ctx := context.Background()
 
 	raw := schema.ListNestedAttribute{
-		CustomType: newListNestedObjectTypeOf[searchFilterModel](ctx, types.ObjectType{
+		CustomType: newListNestedObjectTypeOf[searchFilterModel](ctx, basetypes.ObjectType{
 			AttrTypes: map[string]attr.Type{
 				"filter_string": basetypes.StringType{},
 			},
@@ -121,7 +120,7 @@ func TestCustomSetType(t *testing.T) {
 	ctx := context.Background()
 
 	raw := schema.SetNestedBlock{
-		CustomType: newSetNestedObjectTypeOf[searchFilterModel](ctx, types.ObjectType{
+		CustomType: newSetNestedObjectTypeOf[searchFilterModel](ctx, basetypes.ObjectType{
 			AttrTypes: map[string]attr.Type{
 				"filter_string": basetypes.StringType{},
 			},
@@ -146,7 +145,7 @@ func TestCustomSetType(t *testing.T) {
 }
 
 type searchFilterModel struct {
-	FilterString types.String `tfsdk:"filter_string"`
+	FilterString basetypes.StringType `tfsdk:"filter_string"`
 }
 
 type listNestedObjectTypeOf[T any] struct {

--- a/pf/internal/schemashim/object_type_test.go
+++ b/pf/internal/schemashim/object_type_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -33,7 +33,7 @@ import (
 func TestObjectAttribute(t *testing.T) {
 	objectAttr := schema.ObjectAttribute{
 		AttributeTypes: map[string]attr.Type{
-			"s": types.StringType,
+			"s": basetypes.StringType{},
 		},
 	}
 	shimmed := &attrSchema{"key", pfutils.FromAttrLike(objectAttr)}
@@ -44,7 +44,7 @@ func TestObjectAttribute(t *testing.T) {
 
 func TestTypeSchemaDescriptionIsEmpty(t *testing.T) {
 	shimmedType := &typeSchema{
-		t:      types.StringType,
+		t:      basetypes.StringType{},
 		nested: nil,
 	}
 	assert.Equal(t, shimmedType.Description(), "")

--- a/pf/internal/schemashim/type_schema.go
+++ b/pf/internal/schemashim/type_schema.go
@@ -16,7 +16,6 @@ package schemashim
 
 import (
 	pfattr "github.com/hashicorp/terraform-plugin-framework/attr"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 
@@ -62,16 +61,12 @@ func (s *typeSchema) Elem() interface{} {
 	case basetypes.ObjectTypable:
 		var pseudoResource shim.Resource = newObjectPseudoResource(tt, s.nested, nil)
 		return pseudoResource
-	case basetypes.SetTypable, basetypes.ListTypable:
+	case basetypes.SetTypable, basetypes.ListTypable, basetypes.MapTypable:
 		typeWithElementType, ok := s.t.(pfattr.TypeWithElementType)
-		contract.Assertf(ok, "List or Set type %T expect to implement TypeWithElementType", s.t)
+		contract.Assertf(ok, "List, Set or Map type %T expect to implement TypeWithElementType", s.t)
 		contract.Assertf(s.nested == nil || len(s.nested) == 0,
-			"s.t==SetTypable should not have any s.nested attrs")
+			"s.t==%T should not have any s.nested attrs", s.t)
 		return newTypeSchema(typeWithElementType.ElementType(), nil)
-	case types.MapType:
-		contract.Assertf(s.nested == nil || len(s.nested) == 0,
-			"s.t==MapType should not have any s.nested attrs")
-		return newTypeSchema(tt.ElemType, nil)
 	case pfattr.TypeWithElementTypes:
 		var pseudoResource shim.Resource = newTuplePseudoResource(tt)
 		return pseudoResource

--- a/pf/internal/schemashim/type_schema_test.go
+++ b/pf/internal/schemashim/type_schema_test.go
@@ -1,11 +1,13 @@
 package schemashim
 
 import (
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	"github.com/stretchr/testify/assert"
-	"testing"
+
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
 func TestMapAttribute(t *testing.T) {

--- a/pf/internal/schemashim/type_schema_test.go
+++ b/pf/internal/schemashim/type_schema_test.go
@@ -1,0 +1,27 @@
+package schemashim
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestMapAttribute(t *testing.T) {
+	mapAttr := schema.MapAttribute{
+		Optional:    true,
+		ElementType: basetypes.StringType{},
+	}
+	shimmed := &typeSchema{mapAttr.GetType(), nil}
+	assertIsMapType(t, shimmed)
+	s := shimmed.Elem().(*typeSchema)
+	assert.Equal(t, shim.TypeString, s.Type())
+}
+
+func assertIsMapType(t *testing.T, shimmed shim.Schema) {
+	assert.Equal(t, shim.TypeMap, shimmed.Type())
+	assert.NotNil(t, shimmed.Elem())
+	schema, isTypeSchema := shimmed.Elem().(*typeSchema)
+	assert.Truef(t, isTypeSchema, "expected shim.Elem() to be of type %T", *schema)
+}

--- a/pf/tests/provider_checkconfig_test.go
+++ b/pf/tests/provider_checkconfig_test.go
@@ -18,10 +18,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hexops/autogold/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -104,7 +104,7 @@ func TestCheckConfig(t *testing.T) {
 				},
 				"scopes": schema.ListAttribute{
 					Optional:    true,
-					ElementType: types.StringType,
+					ElementType: basetypes.StringType{},
 				},
 			},
 		}
@@ -328,7 +328,7 @@ func TestCheckConfig(t *testing.T) {
 			Attributes: map[string]schema.Attribute{
 				"scopes": schema.ListAttribute{
 					Optional:    true,
-					ElementType: types.StringType,
+					ElementType: basetypes.StringType{},
 				},
 			},
 			Blocks: map[string]schema.Block{
@@ -405,7 +405,7 @@ func TestCheckConfig(t *testing.T) {
 			Attributes: map[string]schema.Attribute{
 				"scopes": schema.ListAttribute{
 					Optional:    true,
-					ElementType: types.StringType,
+					ElementType: basetypes.StringType{},
 				},
 			},
 			Blocks: map[string]schema.Block{

--- a/pf/tests/provider_nested_custom_types_test.go
+++ b/pf/tests/provider_nested_custom_types_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/pulumi/pulumi-terraform-bridge/pf/tests/internal/providerbuilder"
 	"github.com/pulumi/pulumi-terraform-bridge/pf/tfbridge"
@@ -41,7 +40,7 @@ func TestNestedCustomTypeEncoding(t *testing.T) {
 						Validators: []validator.List{
 							listvalidator.SizeAtMost(1),
 						},
-						ElementType: types.ObjectType{
+						ElementType: basetypes.ObjectType{
 							AttrTypes: AttributeTypesMust[promptOverrideConfigurationModel](context.Background()),
 						},
 					},
@@ -78,7 +77,7 @@ type promptOverrideConfigurationModel struct {
 }
 
 type promptConfigurationModel struct {
-	BasePromptTemplate types.String `tfsdk:"base_prompt_template"`
+	BasePromptTemplate basetypes.StringType `tfsdk:"base_prompt_template"`
 }
 
 // Implementation for set, list, and object typables.


### PR DESCRIPTION
This is mostly a migration/refactor from `github.com/hashicorp/terraform-plugin-framework/types/` to `github.com/hashicorp/terraform-plugin-framework/types/basetypes` library. The main functional change is in type_schema.go's Elem() function.

Resolves #2119. 
