### PR TITLE
Fix flaky tests by disabling automatic plugin acquisition for all tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL            := sh
 PROJECT          := github.com/pulumi/pulumi-terraform-bridge
 TESTPARALLELISM  := 10
-PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION := true
+export PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION := true
 
 PROJECT_DIR := $(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,17 @@
 SHELL            := sh
 PROJECT          := github.com/pulumi/pulumi-terraform-bridge
 TESTPARALLELISM  := 10
+PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION := true
 
 PROJECT_DIR := $(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
+
+install_plugins::
+	pulumi plugin install converter terraform 1.0.18
+	pulumi plugin install resource random 4.16.3
+	pulumi plugin install resource aws 6.22.2
+	pulumi plugin install resource archive 0.0.4
+	pulumi plugin install resource wavefront 3.0.0
+	pulumi plugin install resource equinix 0.6.0 --server github://api.github.com/equinix
 
 build::
 	go mod tidy
@@ -19,7 +28,7 @@ lint:
 lint_fix:
 	go run scripts/build.go fix-lint
 
-test::
+test:: install_plugins
 	@mkdir -p bin
 	go build -o bin ./internal/testing/pulumi-terraform-bridge-test-provider
 	PULUMI_TERRAFORM_BRIDGE_TEST_PROVIDER=$(shell pwd)/bin/pulumi-terraform-bridge-test-provider \

--- a/pf/Makefile
+++ b/pf/Makefile
@@ -1,5 +1,5 @@
 TESTPARALLELISM := 10
-PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION := true
+export PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION := true
 
 install_plugins::
 	pulumi plugin install resource random 4.16.3

--- a/pf/Makefile
+++ b/pf/Makefile
@@ -1,6 +1,10 @@
 TESTPARALLELISM := 10
+PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION := true
 
-build.tests::
+install_plugins::
+	pulumi plugin install resource random 4.16.3
+
+build.tests:: install_plugins
 	go test -test.run NONE
 	cd tests && go test -test.run NONE
 	cd tests/integration && go test -test.run NONE

--- a/pf/tests/integration/program_test.go
+++ b/pf/tests/integration/program_test.go
@@ -215,15 +215,15 @@ func TestTracePropagation(t *testing.T) {
 // Note that random_bytes is an interesting resource that does not specify an ID where Pulumi requires it. Add a test
 // for it to make sure this continues working.
 func TestResourceWithoutID(t *testing.T) {
-	t.Skipf("Flaky due to GH rate limits [pulumi/pulumi-terraform-bridge#2191]")
 	wd, err := os.Getwd()
 	assert.NoError(t, err)
 
 	bin := filepath.Join(wd, "..", "bin")
 
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
-		Env: []string{fmt.Sprintf("PATH=%s", bin)},
-		Dir: filepath.Join("..", "testdata", "resource-without-id"),
+		Env:       []string{fmt.Sprintf("PATH=%s", bin), "PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=true"},
+		Dir:       filepath.Join("..", "testdata", "resource-without-id"),
+		Overrides: map[string]string{"random": "4.16.3"},
 	})
 }
 

--- a/pf/tests/integration/program_test.go
+++ b/pf/tests/integration/program_test.go
@@ -215,6 +215,7 @@ func TestTracePropagation(t *testing.T) {
 // Note that random_bytes is an interesting resource that does not specify an ID where Pulumi requires it. Add a test
 // for it to make sure this continues working.
 func TestResourceWithoutID(t *testing.T) {
+	t.Skipf("Flaky due to GH rate limits [pulumi/pulumi-terraform-bridge#2191]")
 	wd, err := os.Getwd()
 	assert.NoError(t, err)
 

--- a/pf/tests/integration/program_test.go
+++ b/pf/tests/integration/program_test.go
@@ -221,9 +221,9 @@ func TestResourceWithoutID(t *testing.T) {
 	bin := filepath.Join(wd, "..", "bin")
 
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
-		Env:       []string{fmt.Sprintf("PATH=%s", bin), "PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=true"},
+		Env:       []string{fmt.Sprintf("PATH=%s", bin)},
 		Dir:       filepath.Join("..", "testdata", "resource-without-id"),
-		Overrides: map[string]string{"random": "4.16.3"},
+		Overrides: map[string]string{"random": "v4.16.3"},
 	})
 }
 

--- a/pf/tests/integration/program_test.go
+++ b/pf/tests/integration/program_test.go
@@ -30,6 +30,8 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 	"github.com/stretchr/testify/require"
 	"sourcegraph.com/sourcegraph/appdash"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/testutil"
 )
 
 func TestBasicProgram(t *testing.T) {
@@ -221,9 +223,11 @@ func TestResourceWithoutID(t *testing.T) {
 	bin := filepath.Join(wd, "..", "bin")
 
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
-		Env:       []string{fmt.Sprintf("PATH=%s", bin)},
-		Dir:       filepath.Join("..", "testdata", "resource-without-id"),
-		Overrides: map[string]string{"random": "v4.16.3"},
+		Env: []string{fmt.Sprintf("PATH=%s", bin)},
+		Dir: filepath.Join("..", "testdata", "resource-without-id"),
+		LocalProviders: []integration.LocalDependency{
+			testutil.RandomProvider(t),
+		},
 	})
 }
 

--- a/pkg/tests/acc_provider_config_test.go
+++ b/pkg/tests/acc_provider_config_test.go
@@ -24,11 +24,12 @@ import (
 func TestAccProviderConfig(t *testing.T) {
 	opts := accTestOptions(t).With(integration.ProgramTestOptions{
 		Dir: "provider-config",
-
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 			assert.Equal(t, stack.Outputs["generatedRandomString"],
 				stack.Outputs["providerRandomString"])
 		},
+		Env:       []string{"PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=true"},
+		Overrides: map[string]string{"random": "4.16.3"},
 	})
 	integration.ProgramTest(t, &opts)
 }

--- a/pkg/tests/acc_provider_config_test.go
+++ b/pkg/tests/acc_provider_config_test.go
@@ -28,8 +28,7 @@ func TestAccProviderConfig(t *testing.T) {
 			assert.Equal(t, stack.Outputs["generatedRandomString"],
 				stack.Outputs["providerRandomString"])
 		},
-		Env:       []string{"PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=true"},
-		Overrides: map[string]string{"random": "4.16.3"},
+		Overrides: map[string]string{"random": "v4.16.3"},
 	})
 	integration.ProgramTest(t, &opts)
 }

--- a/pkg/tests/acc_provider_config_test.go
+++ b/pkg/tests/acc_provider_config_test.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/testutil"
 )
 
 func TestAccProviderConfig(t *testing.T) {
@@ -27,6 +29,9 @@ func TestAccProviderConfig(t *testing.T) {
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 			assert.Equal(t, stack.Outputs["generatedRandomString"],
 				stack.Outputs["providerRandomString"])
+		},
+		LocalProviders: []integration.LocalDependency{
+			testutil.RandomProvider(t),
 		},
 	})
 	integration.ProgramTest(t, &opts)

--- a/pkg/tests/acc_provider_config_test.go
+++ b/pkg/tests/acc_provider_config_test.go
@@ -28,7 +28,6 @@ func TestAccProviderConfig(t *testing.T) {
 			assert.Equal(t, stack.Outputs["generatedRandomString"],
 				stack.Outputs["providerRandomString"])
 		},
-		Overrides: map[string]string{"random": "v4.16.3"},
 	})
 	integration.ProgramTest(t, &opts)
 }

--- a/pkg/tests/internal/pulcheck/pulcheck.go
+++ b/pkg/tests/internal/pulcheck/pulcheck.go
@@ -163,7 +163,7 @@ func PulCheck(t T, bridgedProvider info.Provider, program string) *pulumitest.Pu
 	require.NoError(t, err)
 
 	opts := []opttest.Option{
-		opttest.Env("DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "true"),
+		opttest.Env("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "true"),
 		opttest.TestInPlace(),
 		opttest.SkipInstall(),
 		opttest.AttachProvider(

--- a/pkg/tests/main_test.go
+++ b/pkg/tests/main_test.go
@@ -28,6 +28,8 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 )
 
+var localTestProviders []integration.LocalDependency
+
 func TestMain(m *testing.M) {
 	if err := setupIntegrationTests(); err != nil {
 		log.Fatal(err)
@@ -53,15 +55,12 @@ func accTestOptions(t *testing.T) *integration.ProgramTestOptions {
 		t.Error("%w", err)
 	}
 
-	pathVal := os.Getenv("PATH")
-	t.Logf("PATH=%s:%s", filepath.Join(cwd, "..", "..", "bin"), pathVal)
-
 	return &integration.ProgramTestOptions{
 		Env: []string{
-			fmt.Sprintf("PATH=%s:%s", filepath.Join(cwd, "..", "..", "bin"), pathVal),
+			fmt.Sprintf("PATH=%s", filepath.Join(cwd, "..", "..", "bin")),
 			"PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=true",
-			"PULUMI_IGNORE_AMBIENT_PLUGINS=false",
 		},
+		LocalProviders: localTestProviders,
 	}
 }
 
@@ -77,16 +76,21 @@ func ensureCompiledTestProviders(wd string) error {
 
 	internalErrorMsg := "Internal validation of the provider failed"
 
+	internal := func(segments ...string) string {
+		return filepath.Join(append([]string{wd, "..", "..", "internal"}, segments...)...)
+	}
 	testProviders := []testProvider{
 		{
 			"tpsdkv2",
-			filepath.Join(wd, "..", "..", "internal", "testprovider_sdkv2",
-				"cmd", "pulumi-resource-tpsdkv2"),
-			filepath.Join(wd, "..", "..", "internal", "testprovider_sdkv2",
-				"cmd", "pulumi-tfgen-tpsdkv2"), nil,
+			internal("testprovider_sdkv2", "cmd", "pulumi-resource-tpsdkv2"),
+			internal("testprovider_sdkv2", "cmd", "pulumi-tfgen-tpsdkv2"),
+			nil,
 		},
 		{
-			"testprovider_invschema", filepath.Join(wd, "..", "..", "internal", "testprovider_invalid_schema", "cmd", "pulumi-resource-tpinvschema"), filepath.Join(wd, "..", "..", "internal", "testprovider_invalid_schema", "cmd", "pulumi-tfgen-tpinvschema"), &internalErrorMsg,
+			"testprovider_invschema",
+			internal("testprovider_invalid_schema", "cmd", "pulumi-resource-tpinvschema"),
+			internal("testprovider_invalid_schema", "cmd", "pulumi-tfgen-tpinvschema"),
+			&internalErrorMsg,
 		},
 	}
 
@@ -148,6 +152,10 @@ func ensureCompiledTestProviders(wd string) error {
 				fmt.Println(stderr)
 				return fmt.Errorf("provider build failed for %s: %w", p.name, err)
 			}
+			localTestProviders = append(localTestProviders, integration.LocalDependency{
+				Package: p.name,
+				Path:    bin, // The path to the directory that contains the binary, not the binary
+			})
 		}
 	}
 

--- a/pkg/tests/main_test.go
+++ b/pkg/tests/main_test.go
@@ -57,6 +57,7 @@ func accTestOptions(t *testing.T) *integration.ProgramTestOptions {
 	return &integration.ProgramTestOptions{
 		Env: []string{
 			fmt.Sprintf("PATH=%s:%s", filepath.Join(cwd, "..", "..", "bin"), pathVal),
+			"PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=true",
 		},
 	}
 }

--- a/pkg/tests/main_test.go
+++ b/pkg/tests/main_test.go
@@ -60,6 +60,7 @@ func accTestOptions(t *testing.T) *integration.ProgramTestOptions {
 		Env: []string{
 			fmt.Sprintf("PATH=%s:%s", filepath.Join(cwd, "..", "..", "bin"), pathVal),
 			"PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=true",
+			"PULUMI_IGNORE_AMBIENT_PLUGINS=false",
 		},
 	}
 }

--- a/pkg/tests/main_test.go
+++ b/pkg/tests/main_test.go
@@ -54,6 +54,8 @@ func accTestOptions(t *testing.T) *integration.ProgramTestOptions {
 	}
 
 	pathVal := os.Getenv("PATH")
+	t.Logf("PATH=%s:%s", filepath.Join(cwd, "..", "..", "bin"), pathVal)
+
 	return &integration.ProgramTestOptions{
 		Env: []string{
 			fmt.Sprintf("PATH=%s:%s", filepath.Join(cwd, "..", "..", "bin"), pathVal),

--- a/pkg/tests/main_test.go
+++ b/pkg/tests/main_test.go
@@ -53,9 +53,10 @@ func accTestOptions(t *testing.T) *integration.ProgramTestOptions {
 		t.Error("%w", err)
 	}
 
+	pathVal := os.Getenv("PATH")
 	return &integration.ProgramTestOptions{
 		Env: []string{
-			fmt.Sprintf("PATH=%s:$PATH", filepath.Join(cwd, "..", "..", "bin")),
+			fmt.Sprintf("PATH=%s:%s", filepath.Join(cwd, "..", "..", "bin"), pathVal),
 		},
 	}
 }

--- a/pkg/tests/main_test.go
+++ b/pkg/tests/main_test.go
@@ -55,7 +55,7 @@ func accTestOptions(t *testing.T) *integration.ProgramTestOptions {
 
 	return &integration.ProgramTestOptions{
 		Env: []string{
-			fmt.Sprintf("PATH=%s", filepath.Join(cwd, "..", "..", "bin")),
+			fmt.Sprintf("PATH=%s:$PATH", filepath.Join(cwd, "..", "..", "bin")),
 		},
 	}
 }

--- a/pkg/tfgen/convert_cli_test.go
+++ b/pkg/tfgen/convert_cli_test.go
@@ -89,7 +89,7 @@ func TestConvertViaPulumiCLI(t *testing.T) {
 			}
 		}
 		if !found {
-			t.Logf("pulumi plugin install resource terraform v1.0.18")
+			t.Logf("pulumi plugin install converter terraform v1.0.18")
 			err := exec.Command(pulumi, "plugin", "install", "converter", "terraform", "v1.0.18").Run()
 			require.NoError(t, err)
 		}

--- a/pkg/tfgen/convert_cli_test.go
+++ b/pkg/tfgen/convert_cli_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -57,43 +56,6 @@ func TestConvertViaPulumiCLI(t *testing.T) {
 		t.Skipf("Skipping on Windows due to a test setup issue")
 	}
 	t.Setenv("PULUMI_CONVERT", "1")
-	t.Setenv("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "true")
-
-	t.Run("setup", func(t *testing.T) {
-		// Minimize number of GH API calls by manually installing the plugin.
-		pulumi, err := exec.LookPath("pulumi")
-		require.NoError(t, err)
-
-		t.Logf("pulumi plugin ls --json")
-		cmd := exec.Command(pulumi, "plugin", "ls", "--json")
-		var buf bytes.Buffer
-		cmd.Stdout = &buf
-		err = cmd.Run()
-		require.NoError(t, err)
-
-		type plugin struct {
-			Name    string `json:"name"`
-			Version string `json:"version"`
-		}
-
-		var installedPlugins []plugin
-		err = json.Unmarshal(buf.Bytes(), &installedPlugins)
-		require.NoError(t, err)
-
-		// Ensure the converter plugin is installed pulumi-converter-terraform
-		found := false
-		for _, p := range installedPlugins {
-			if p.Name == "terraform" && p.Version == "1.0.18" {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Logf("pulumi plugin install converter terraform 1.0.18")
-			err := exec.Command(pulumi, "plugin", "install", "converter", "terraform", "1.0.18").Run()
-			require.NoError(t, err)
-		}
-	})
 
 	simpleResourceTF := `
 resource "simple_resource" "a_resource" {

--- a/pkg/tfgen/convert_cli_test.go
+++ b/pkg/tfgen/convert_cli_test.go
@@ -48,6 +48,7 @@ import (
 )
 
 func TestConvertViaPulumiCLI(t *testing.T) {
+	t.Skipf("Very flaky [pulumi/pulumi#16469]")
 	if runtime.GOOS == "windows" {
 		// Currently there is a test issue in CI/test setup:
 		//

--- a/pkg/tfgen/convert_cli_test.go
+++ b/pkg/tfgen/convert_cli_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -57,6 +58,42 @@ func TestConvertViaPulumiCLI(t *testing.T) {
 	}
 	t.Setenv("PULUMI_CONVERT", "1")
 	t.Setenv("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "true")
+
+	t.Run("setup", func(t *testing.T) {
+		// Minimize number of GH API calls by manually installing the plugin.
+		pulumi, err := exec.LookPath("pulumi")
+		require.NoError(t, err)
+
+		t.Logf("pulumi plugin ls --json")
+		cmd := exec.Command(pulumi, "plugin", "ls", "--json")
+		var buf bytes.Buffer
+		cmd.Stdout = &buf
+		err = cmd.Run()
+		require.NoError(t, err)
+
+		type plugin struct {
+			Name    string `json:"name"`
+			Version string `json:"version"`
+		}
+
+		var installedPlugins []plugin
+		err = json.Unmarshal(buf.Bytes(), &installedPlugins)
+		require.NoError(t, err)
+
+		// Ensure the converter plugin is installed pulumi-converter-terraform
+		found := false
+		for _, p := range installedPlugins {
+			if p.Name == "terraform" && p.Version == "1.0.18" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Logf("pulumi plugin install resource terraform v1.0.18")
+			err := exec.Command(pulumi, "plugin", "install", "converter", "terraform", "v1.0.18").Run()
+			require.NoError(t, err)
+		}
+	})
 
 	simpleResourceTF := `
 resource "simple_resource" "a_resource" {

--- a/pkg/tfgen/convert_cli_test.go
+++ b/pkg/tfgen/convert_cli_test.go
@@ -89,8 +89,8 @@ func TestConvertViaPulumiCLI(t *testing.T) {
 			}
 		}
 		if !found {
-			t.Logf("pulumi plugin install converter terraform v1.0.18")
-			err := exec.Command(pulumi, "plugin", "install", "converter", "terraform", "v1.0.18").Run()
+			t.Logf("pulumi plugin install converter terraform 1.0.18")
+			err := exec.Command(pulumi, "plugin", "install", "converter", "terraform", "1.0.18").Run()
 			require.NoError(t, err)
 		}
 	})

--- a/pkg/tfgen/convert_cli_test.go
+++ b/pkg/tfgen/convert_cli_test.go
@@ -48,7 +48,6 @@ import (
 )
 
 func TestConvertViaPulumiCLI(t *testing.T) {
-	t.Skipf("Very flaky [pulumi/pulumi#16469]")
 	if runtime.GOOS == "windows" {
 		// Currently there is a test issue in CI/test setup:
 		//
@@ -57,7 +56,7 @@ func TestConvertViaPulumiCLI(t *testing.T) {
 		t.Skipf("Skipping on Windows due to a test setup issue")
 	}
 	t.Setenv("PULUMI_CONVERT", "1")
-	t.Setenv("DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "true")
+	t.Setenv("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "true")
 
 	simpleResourceTF := `
 resource "simple_resource" "a_resource" {

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -1285,6 +1285,7 @@ func TestConvertExamples(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skipf("Skipping on windows to avoid failing on incorrect newline handling")
 	}
+	t.Setenv("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "true")
 
 	type testCase struct {
 		name string

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -1385,8 +1385,8 @@ func TestConvertExamplesInner(t *testing.T) {
 	assert.NoError(t, err)
 
 	type testCase struct {
-		name           string
-		path           examplePath
+		name string
+		path examplePath
 	}
 
 	testCases := []testCase{

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -1284,7 +1284,6 @@ func TestConvertExamples(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skipf("Skipping on windows to avoid failing on incorrect newline handling")
 	}
-	t.Setenv("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "true")
 
 	type testCase struct {
 		name string

--- a/unstable/testutil/installed_providers.go
+++ b/unstable/testutil/installed_providers.go
@@ -1,0 +1,46 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/stretchr/testify/require"
+)
+
+// RandomProvider returns a [integration.LocalDependency] reference to the random provider
+// installed via `make install_plugins`.
+func RandomProvider(t *testing.T) integration.LocalDependency {
+	randomPath, err := workspace.GetPluginPath(
+		diag.DefaultSink(os.Stdout, os.Stderr, diag.FormatOptions{
+			Color: colors.Never,
+		}),
+		apitype.ResourcePlugin, "random",
+		&semver.Version{Major: 4, Minor: 16, Patch: 3}, nil)
+	require.NoError(t, err,
+		`The random provider at this version should have been installed by "make install_plugins"`)
+	return integration.LocalDependency{
+		Package: "random",
+		Path:    filepath.Dir(randomPath),
+	}
+}

--- a/unstable/testutil/installed_providers.go
+++ b/unstable/testutil/installed_providers.go
@@ -31,16 +31,19 @@ import (
 // RandomProvider returns a [integration.LocalDependency] reference to the random provider
 // installed via `make install_plugins`.
 func RandomProvider(t *testing.T) integration.LocalDependency {
-	randomPath, err := workspace.GetPluginPath(
+	return pluginDependency(t, "random", semver.Version{Major: 4, Minor: 16, Patch: 3})
+}
+
+func pluginDependency(t *testing.T, name string, version semver.Version) integration.LocalDependency {
+	path, err := workspace.GetPluginPath(
 		diag.DefaultSink(os.Stdout, os.Stderr, diag.FormatOptions{
 			Color: colors.Never,
 		}),
-		apitype.ResourcePlugin, "random",
-		&semver.Version{Major: 4, Minor: 16, Patch: 3}, nil)
+		apitype.ResourcePlugin, name, &version, nil)
 	require.NoError(t, err,
-		`The random provider at this version should have been installed by "make install_plugins"`)
+		`The %s provider at this version should have been installed by "make install_plugins"`, name)
 	return integration.LocalDependency{
-		Package: "random",
-		Path:    filepath.Dir(randomPath),
+		Package: name,
+		Path:    filepath.Dir(path),
 	}
 }


### PR DESCRIPTION
Disable automatic acquisition globally in the repository - this should ensure we do not use the GH API during tests and make our tests here a lot more robust.

Instead manually install all required plugins in the Makefile as a dependency of the tests. This ensures we only do it once and do not spam the GH API with redundant requests causing test flakes.

I've hit this more than 5 times on separate PRs in the last few days. It's seriously slowing down progress in the repo.

When we do hit the GH rate limit, we have to wait for up to an hour for it to reset.

~Skip `TestConvertViaPulumiCLI` until https://github.com/pulumi/pulumi/issues/16469 is addressed.~
~Skip `TestResourceWithoutID` until https://github.com/pulumi/pulumi-terraform-bridge/issues/2191 is addressed.~

Looks like we were using the wrong env variable name...

One of the tests was also absolutely spamming the GH API: https://github.com/pulumi/pulumi-terraform-bridge/actions/runs/9973182117/job/27557985796?pr=2190

Latest failures: https://github.com/pulumi/pulumi-terraform-bridge/actions/runs/9972810153/job/27556840950?pr=2186

fixes #2191 