### PR TITLE
Deprecate `tfplugin5`

### DIFF
--- a/pkg/tfshim/tfplugin5/package.go
+++ b/pkg/tfshim/tfplugin5/package.go
@@ -1,0 +1,20 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// tfplugin5 is an old attempt at consuming SDKv1 and SDKv2 providers at the gRPC level,
+// instead of linking in at the SDKv{1,2} level.
+//
+// Deprecated: This package is no longer used in the bridge and will be removed in a
+// future release.
+package tfplugin5


### PR DESCRIPTION
We don't use this library, nor do we maintain it. While it is ostensibly stable, we will not add bug fixes to the library.