### PR TITLE
Fill in Parameterization Value

### DIFF
--- a/dynamic/Makefile
+++ b/dynamic/Makefile
@@ -6,7 +6,7 @@ build: bin
 		${LDFLAGS} \
 		github.com/pulumi/pulumi-terraform-bridge/dynamic
 
-test.unit:
+test_unit:
 	cd internal/shim && go test ${LDFLAGS} ./...
 	go test -short ${LDFLAGS} ./...
 
@@ -14,7 +14,7 @@ test:
 	cd internal/shim && go test -v ${LDFLAGS} ./...
 	go test -v ${LDFLAGS} ./...
 
-test.update:
+test_accept:
 	go test -v ${LDFLAGS} ./... -update
 
 bin:

--- a/dynamic/main.go
+++ b/dynamic/main.go
@@ -26,12 +26,19 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 
+	"github.com/pulumi/pulumi-terraform-bridge/dynamic/parameterize"
 	"github.com/pulumi/pulumi-terraform-bridge/dynamic/version"
 	"github.com/pulumi/pulumi-terraform-bridge/pf/proto"
 	pfbridge "github.com/pulumi/pulumi-terraform-bridge/pf/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen"
+)
+
+const (
+	// The name of this *unparameterized* provider.
+	baseProviderName = "terraform-provider"
 )
 
 func initialSetup() (tfbridge.ProviderInfo, pfbridge.ProviderMetadata, func() error) {
@@ -40,7 +47,7 @@ func initialSetup() (tfbridge.ProviderInfo, pfbridge.ProviderMetadata, func() er
 	info := tfbridge.ProviderInfo{
 		DisplayName:  "Any Terraform Provider",
 		P:            proto.Empty(),
-		Name:         "terraform-provider",
+		Name:         baseProviderName,
 		Version:      version.Version(),
 		Description:  "Use any Terraform provider with Pulumi",
 		MetadataInfo: &tfbridge.MetadataInfo{Path: "", Data: tfbridge.ProviderMetadata(nil)},
@@ -76,9 +83,21 @@ func initialSetup() (tfbridge.ProviderInfo, pfbridge.ProviderMetadata, func() er
 				return plugin.ParameterizeResponse{},
 					newDoubleParameterizeErr(tfServer.Name(), tfServer.Version())
 			}
-			args, err := parseParamaterizeParameters(req)
-			if err != nil {
-				return plugin.ParameterizeResponse{}, err
+
+			var args parameterize.Args
+			switch params := req.Parameters.(type) {
+			case *plugin.ParameterizeValue:
+				value, err := parameterize.ParseValue(params.Value)
+				if err != nil {
+					return plugin.ParameterizeResponse{}, err
+				}
+				args = value.IntoArgs()
+			case *plugin.ParameterizeArgs:
+				var err error
+				args, err = parameterize.ParseArgs(params.Args)
+				if err != nil {
+					return plugin.ParameterizeResponse{}, err
+				}
 			}
 
 			p, err := getProvider(ctx, args)
@@ -91,9 +110,21 @@ func initialSetup() (tfbridge.ProviderInfo, pfbridge.ProviderMetadata, func() er
 				return plugin.ParameterizeResponse{}, err
 			}
 
+			var value parameterize.Value
+			if args.Local != nil {
+				value.Local = &parameterize.LocalValue{
+					Path: args.Local.Path,
+				}
+			} else {
+				value.Remote = &parameterize.RemoteValue{
+					URL:     p.URL(),
+					Version: p.Version(),
+				}
+			}
+
 			tfServer = p
 			if tfServer != nil {
-				info = providerInfo(ctx, tfServer)
+				info = providerInfo(ctx, tfServer, value)
 			}
 
 			err = pfbridge.XParameterizeResetProvider(ctx, info, metadata)
@@ -133,7 +164,8 @@ type doubleParameterizeErr struct {
 }
 
 func (d doubleParameterizeErr) Error() string {
-	return fmt.Sprintf("provider is already parameterized to (%s, %s)", d.existing.name, d.existing.version)
+	return fmt.Sprintf("provider is already parameterized to (%s, %s)",
+		d.existing.name, d.existing.version)
 }
 
 func main() {
@@ -147,13 +179,17 @@ func main() {
 		}
 	}()
 
-	pfbridge.Main(ctx, "terraform-bridge", defaultInfo, metadata)
+	pfbridge.Main(ctx, baseProviderName, defaultInfo, metadata)
 }
 
-func getProvider(ctx context.Context, args paramaterizeArgs) (run.Provider, error) {
-	if args.path != "" {
-		return run.LocalProvider(ctx, args.path)
+func getProvider(ctx context.Context, args parameterize.Args) (run.Provider, error) {
+	if local := args.Local; local != nil {
+		return run.LocalProvider(ctx, local.Path)
 	}
 
-	return run.NamedProvider(ctx, args.name, args.version)
+	remote := args.Remote
+	contract.Assertf(remote != nil,
+		"local or remote must be specified - and that should have already been validated")
+
+	return run.NamedProvider(ctx, remote.Name, remote.Version)
 }

--- a/dynamic/parameterize/args.go
+++ b/dynamic/parameterize/args.go
@@ -1,0 +1,66 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parameterize
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Args represents a parsed CLI argument from a parameterize call.
+type Args struct {
+	Remote *RemoteArgs
+	Local  *LocalArgs
+}
+
+// RemoteArgs represents a TF provider referenced by name.
+type RemoteArgs struct {
+	// Name is a (possibly qualified) name of the provider.
+	Name string
+	// Version is the (possibly empty) version constraint on the provider.
+	Version string
+}
+
+// LocalArgs represents a local TF provider referenced by path.
+type LocalArgs struct {
+	// Path is the path to the provider binary. It can be relative or absolute.
+	Path string
+}
+
+func ParseArgs(args []string) (Args, error) {
+	// Check for a leading '.' or '/' to indicate a path
+	if len(args) >= 1 &&
+		(strings.HasPrefix(args[0], "./") || strings.HasPrefix(args[0], "/")) {
+		if len(args) > 1 {
+			return Args{}, fmt.Errorf("path based providers are only parameterized by 1 argument: <path>")
+		}
+		return Args{Local: &LocalArgs{Path: args[0]}}, nil
+	}
+
+	// This is a registry based provider
+	var remote RemoteArgs
+	switch len(args) {
+	// The second argument, if any is the version
+	case 2:
+		remote.Version = args[1]
+		fallthrough
+	// The first argument is the provider name
+	case 1:
+		remote.Name = args[0]
+		return Args{Remote: &remote}, nil
+	default:
+		return Args{}, fmt.Errorf("expected to be parameterized by 1-2 arguments: <name> [version]")
+	}
+}

--- a/dynamic/parameterize/args_test.go
+++ b/dynamic/parameterize/args_test.go
@@ -1,0 +1,75 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parameterize
+
+import (
+	"testing"
+
+	"github.com/hexops/autogold/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseArgs(t *testing.T) {
+	tests := []struct {
+		name   string
+		args   []string
+		expect Args
+		errMsg autogold.Value
+	}{
+		{
+			name:   "local",
+			args:   []string{"./my-provider"},
+			expect: Args{Local: &LocalArgs{Path: "./my-provider"}},
+		},
+		{
+			name:   "remote",
+			args:   []string{"my-registry.io/typ"},
+			expect: Args{Remote: &RemoteArgs{Name: "my-registry.io/typ"}},
+		},
+		{
+			name: "remote with version",
+			args: []string{"my-registry.io/typ", "v1.2.3"},
+			expect: Args{Remote: &RemoteArgs{
+				Name:    "my-registry.io/typ",
+				Version: "v1.2.3",
+			}},
+		},
+		{
+			name:   "no args",
+			args:   []string{},
+			errMsg: autogold.Expect("expected to be parameterized by 1-2 arguments: <name> [version]"),
+		},
+		{
+			name:   "too many args",
+			args:   []string{"arg1", "arg2", "arg3"},
+			errMsg: autogold.Expect("expected to be parameterized by 1-2 arguments: <name> [version]"),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := ParseArgs(tt.args)
+			if tt.errMsg == nil {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expect, actual)
+			} else {
+				require.Error(t, err)
+				tt.errMsg.Equal(t, err.Error())
+			}
+		})
+	}
+}

--- a/dynamic/parameterize/package.go
+++ b/dynamic/parameterize/package.go
@@ -1,0 +1,19 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// parameterize encapsulates parsing parameterize args as well as marshaling and
+// unmarshaling parameterize values. It only handles transforming from untyped
+// [github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin.ParameterizeRequest] to
+// typed values, and does not validate that described providers exist.
+package parameterize

--- a/dynamic/parameterize/value.go
+++ b/dynamic/parameterize/value.go
@@ -1,0 +1,106 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parameterize
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+// Value represents a fully qualified provider reference suitable to be embedded in
+// generated SDKs.
+//
+// It is conceptually an either, and only Remote or Local will be non-nil.
+type Value struct {
+	Remote *RemoteValue `json:"remote,omitempty"`
+	Local  *LocalValue  `json:"local,omitempty"`
+}
+
+type RemoteValue struct {
+	// The fully qualified URL of the remote value.
+	URL string `json:"url"`
+	// The fully specified version of the remote value.
+	Version string `json:"version"`
+}
+
+type LocalValue struct {
+	// The local or absolute path to the Terraform provider on disk.
+	Path string `json:"path"`
+}
+
+func (p Value) Marshal() []byte {
+	contract.Assertf((p.Remote == nil) != (p.Local == nil),
+		"cannot marshal an invalid value: p.Remote XOR p.Local must be set")
+	switch {
+	case p.Remote != nil:
+		contract.Assertf(p.Remote.URL != "", "Url cannot be empty")
+		contract.Assertf(p.Remote.Version != "", "Version cannot be empty")
+	case p.Local != nil:
+		contract.Assertf(p.Local.Path != "", "Path cannot be empty")
+	}
+	b, err := json.Marshal(p)
+	contract.AssertNoErrorf(err, "p is composed of basic and non-recursive types, so it must be marshalable")
+	return b
+}
+
+func (p *Value) Unmarshal(b []byte) error {
+	err := json.Unmarshal(b, p)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+	if p.Remote != nil && p.Local != nil {
+		return fmt.Errorf(`cannot specify both "remote" and "local"`)
+	}
+	switch {
+	case p.Remote != nil:
+		if p.Remote.URL == "" {
+			return fmt.Errorf("remote.url cannot be empty")
+		}
+		if p.Remote.Version == "" {
+			return fmt.Errorf("remote.version cannot be empty")
+		}
+	case p.Local != nil:
+		if p.Local.Path == "" {
+			return fmt.Errorf("local.path cannot be empty")
+		}
+	default:
+		return fmt.Errorf(`must specify either "remote" or "local"`)
+	}
+	return nil
+}
+
+func ParseValue(b []byte) (Value, error) {
+	var value Value
+	err := value.Unmarshal(b)
+	return value, err
+}
+
+// IntoArgs converts a [Value] into an [Args].
+//
+// We can do this because [Value] is a fully resolved [Args], and so it is always possible to
+// go from [Value] to [Args].
+func (p *Value) IntoArgs() Args {
+	if p.Local != nil {
+		return Args{Local: &LocalArgs{
+			Path: p.Local.Path,
+		}}
+	}
+	return Args{Remote: &RemoteArgs{
+		Name:    p.Remote.URL,
+		Version: p.Remote.Version,
+	}}
+}

--- a/dynamic/parameterize/value_test.go
+++ b/dynamic/parameterize/value_test.go
@@ -1,0 +1,159 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parameterize
+
+import (
+	"testing"
+
+	"github.com/hexops/autogold/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarshalValue(t *testing.T) {
+	t.Parallel()
+
+	t.Run("remote", func(t *testing.T) {
+		autogold.Expect(
+			`{"remote":{"url":"registry/owner/type","version":"1.2.3"}}`,
+		).Equal(t, string(Value{Remote: &RemoteValue{
+			URL:     "registry/owner/type",
+			Version: "1.2.3",
+		}}.Marshal()))
+	})
+
+	t.Run("local", func(t *testing.T) {
+		autogold.Expect(`{"local":{"path":"./path"}}`).Equal(t, string(Value{Local: &LocalValue{
+			Path: "./path",
+		}}.Marshal()))
+	})
+
+	// Invalid values of Value should panic to help catch bugs early.
+	shouldPanicOnMarshal := []struct {
+		name string
+		v    Value
+	}{
+		{name: "zero value"},
+		{"local missing path", Value{Local: new(LocalValue)}},
+		{"remote missing version", Value{Remote: &RemoteValue{URL: "url"}}},
+		{"remote missing url", Value{Remote: &RemoteValue{Version: "1.2.3"}}},
+		{"remote missing values", Value{Remote: new(RemoteValue)}},
+		{"local and remote", Value{Remote: new(RemoteValue), Local: new(LocalValue)}},
+	}
+	for _, tt := range shouldPanicOnMarshal {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Panics(t, func() { tt.v.Marshal() })
+		})
+	}
+}
+
+func TestUnmarshal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		input  string
+		expect Value
+		err    bool
+	}{
+		{
+			name:  "remote",
+			input: `{"remote":{"url":"registry/owner/type","version":"1.2.3"}}`,
+			expect: Value{Remote: &RemoteValue{
+				URL:     "registry/owner/type",
+				Version: "1.2.3",
+			}},
+		},
+		{
+			name:  "local",
+			input: `{"local":{"path":"./path"}}`,
+			expect: Value{Local: &LocalValue{
+				Path: "./path",
+			}},
+		},
+		{
+			name:  "local and remote",
+			input: `{"remote":{"url":"registry/owner/type","version":"1.2.3"},"local":{"path":"./path"}}`,
+			err:   true,
+		},
+		{
+			name:  "invalid options",
+			input: `{"foo":{"url":"registry/owner/type","version":"1.2.3"}}`,
+			err:   true,
+		},
+		{
+			name:  "empty",
+			input: `{}`,
+			err:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, err := ParseValue([]byte(tt.input))
+			if tt.err {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expect, actual)
+			}
+		})
+	}
+}
+
+func TestValueIntoArgs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value Value
+		args  Args
+	}{
+		{
+			name: "remote",
+			value: Value{Remote: &RemoteValue{
+				URL:     "a/b/c",
+				Version: "1.2.3",
+			}},
+			args: Args{Remote: &RemoteArgs{
+				Name:    "a/b/c",
+				Version: "1.2.3",
+			}},
+		},
+		{
+			name: "local",
+			value: Value{Local: &LocalValue{
+				Path: "./a/b/c",
+			}},
+			args: Args{Local: &LocalArgs{
+				Path: "./a/b/c",
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.value.IntoArgs(), tt.args)
+		})
+	}
+}

--- a/dynamic/testdata/TestSchemaGeneration/Azure/alz-0.11.1.golden
+++ b/dynamic/testdata/TestSchemaGeneration/Azure/alz-0.11.1.golden
@@ -743,5 +743,12 @@
                 ]
             }
         }
+    },
+    "parameterization": {
+        "baseProvider": {
+            "name": "terraform-provider",
+            "version": "v0.0.0-dev"
+        },
+        "parameter": "eyJyZW1vdGUiOnsidXJsIjoicmVnaXN0cnkub3BlbnRvZnUub3JnL2F6dXJlL2FseiIsInZlcnNpb24iOiIwLjExLjEifX0="
     }
 }

--- a/dynamic/testdata/TestSchemaGeneration/Backblaze/b2-0.8.9.golden
+++ b/dynamic/testdata/TestSchemaGeneration/Backblaze/b2-0.8.9.golden
@@ -1395,5 +1395,12 @@
                 ]
             }
         }
+    },
+    "parameterization": {
+        "baseProvider": {
+            "name": "terraform-provider",
+            "version": "v0.0.0-dev"
+        },
+        "parameter": "eyJyZW1vdGUiOnsidXJsIjoicmVnaXN0cnkub3BlbnRvZnUub3JnL2JhY2tibGF6ZS9iMiIsInZlcnNpb24iOiIwLjguOSJ9fQ=="
     }
 }

--- a/dynamic/testdata/TestSchemaGeneration/hashicorp/random-3.3.0.golden
+++ b/dynamic/testdata/TestSchemaGeneration/hashicorp/random-3.3.0.golden
@@ -807,5 +807,12 @@
                 "type": "object"
             }
         }
+    },
+    "parameterization": {
+        "baseProvider": {
+            "name": "terraform-provider",
+            "version": "v0.0.0-dev"
+        },
+        "parameter": "eyJyZW1vdGUiOnsidXJsIjoicmVnaXN0cnkub3BlbnRvZnUub3JnL2hhc2hpY29ycC9yYW5kb20iLCJ2ZXJzaW9uIjoiMy4zLjAifX0="
     }
 }


### PR DESCRIPTION
This commit adds support for the new `.Parameterization` field on the schema. As part of
doing so, I have moved parsing parameterization into it's own package.

Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/2149