### PR TITLE
Make PULUMI_BOT_TOKEN and CODECOV_TOKEN optional

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,11 +5,9 @@ on:
     inputs: {}
     secrets:
       CODECOV_TOKEN:
-        required: true
-      PULUMI_BOT_TOKEN:
-        required: true
+        required: false
 env:
-  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   test:
@@ -47,6 +45,11 @@ jobs:
       - name: Test Dynamic
         run: cd dynamic && make test
       - name: Upload coverage reports to Codecov
+        # If we have a CODECOV_TOKEN secret, then we upload it to get a coverage report.
+        #
+        # Community contributors do not have access to the CODECOV_TOKEN, so we just skip
+        # this step.
+        if: ${{ env.CODECOV_TOKEN != '' }}
         uses: codecov/codecov-action@v4
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 env:
-  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 name: Pull Request
 


### PR DESCRIPTION
Community contributors don't have access to either of these tokens and we don't *need* them to run tests for them, so we make them optional. This should enable Pulumi Org members to approve CI runs for contributors.

Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/2179