### PR TITLE
Respect versions for dynamic providers

### DIFF
--- a/dynamic/go.mod
+++ b/dynamic/go.mod
@@ -201,8 +201,8 @@ require (
 	github.com/pulumi/pulumi-java/pkg v0.11.0 // indirect
 	github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.8 // indirect
 	github.com/pulumi/pulumi-yaml v1.9.1 // indirect
-	github.com/pulumi/pulumi/pkg/v3 v3.125.0
-	github.com/pulumi/pulumi/sdk/v3 v3.125.0
+	github.com/pulumi/pulumi/pkg/v3 v3.125.1-0.20240720005025-a3aef6c6522f
+	github.com/pulumi/pulumi/sdk/v3 v3.125.1-0.20240720005025-a3aef6c6522f
 	github.com/pulumi/schema-tools v0.1.2 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect

--- a/dynamic/go.sum
+++ b/dynamic/go.sum
@@ -768,10 +768,10 @@ github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.8 h1:mav2tSitA9BPJPLLahKg
 github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.8/go.mod h1:qUYk2c9i/yqMGNj9/bQyXpS39BxNDSXYjVN1njnq0zY=
 github.com/pulumi/pulumi-yaml v1.9.1 h1:JPeI80M23SPactxgnCFS1casZlSr7ZhAXwSx4H55QQ4=
 github.com/pulumi/pulumi-yaml v1.9.1/go.mod h1:OH0R34yJxA5u6zjYBN4JXcWoEvfkRoOVWi6viu8buoA=
-github.com/pulumi/pulumi/pkg/v3 v3.125.0 h1:3iG071wxtmfthzcDbAvfSDUDSQngzL/eKylmz69+Njo=
-github.com/pulumi/pulumi/pkg/v3 v3.125.0/go.mod h1:L+M81tuBoWAk7lBRUxFoj1kGaLPVYA98/zmWkviUpEQ=
-github.com/pulumi/pulumi/sdk/v3 v3.125.0 h1:hou7x/qf9G3878g4+DmBU+IEMJz66w+ZhwJONymjANE=
-github.com/pulumi/pulumi/sdk/v3 v3.125.0/go.mod h1:p1U24en3zt51agx+WlNboSOV8eLlPWYAkxMzVEXKbnY=
+github.com/pulumi/pulumi/pkg/v3 v3.125.1-0.20240720005025-a3aef6c6522f h1:JCfNwxDGzQIljzmYN1tg22bDx6Z72avSboiBwKxOHgI=
+github.com/pulumi/pulumi/pkg/v3 v3.125.1-0.20240720005025-a3aef6c6522f/go.mod h1:L+M81tuBoWAk7lBRUxFoj1kGaLPVYA98/zmWkviUpEQ=
+github.com/pulumi/pulumi/sdk/v3 v3.125.1-0.20240720005025-a3aef6c6522f h1:dzLJOfB0DVtuX1yjLun3fqztDp0zq52hkYslOH2o7Bs=
+github.com/pulumi/pulumi/sdk/v3 v3.125.1-0.20240720005025-a3aef6c6522f/go.mod h1:p1U24en3zt51agx+WlNboSOV8eLlPWYAkxMzVEXKbnY=
 github.com/pulumi/schema-tools v0.1.2 h1:Fd9xvUjgck4NA+7/jSk7InqCUT4Kj940+EcnbQKpfZo=
 github.com/pulumi/schema-tools v0.1.2/go.mod h1:62lgj52Tzq11eqWTIaKd+EVyYAu5dEcDJxMhTjvMO/k=
 github.com/pulumi/terraform-diff-reader v0.0.2 h1:kTE4nEXU3/SYXESvAIem+wyHMI3abqkI3OhJ0G04LLI=

--- a/dynamic/info.go
+++ b/dynamic/info.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"strings"
 
 	"github.com/opentofu/opentofu/shim/run"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
@@ -35,6 +36,7 @@ func providerInfo(ctx context.Context, p run.Provider, value parameterize.Value)
 		Name:        p.Name(),
 		Version:     p.Version(),
 		Description: "A Pulumi provider dynamically bridged from " + p.Name() + ".",
+		Publisher:   "Pulumi",
 
 		// To avoid bogging down schema generation speed, we skip all examples.
 		SkipExamples: func(tfbridge.SkipExamplesArgs) bool { return true },
@@ -43,6 +45,19 @@ func providerInfo(ctx context.Context, p run.Provider, value parameterize.Value)
 			Path: "", Data: tfbridge.ProviderMetadata(nil),
 		},
 
+		Python: &tfbridge.PythonInfo{
+			PyProject:            struct{ Enabled bool }{true},
+			RespectSchemaVersion: true,
+		},
+		JavaScript: &tfbridge.JavaScriptInfo{
+			LiftSingleValueMethodReturns: true,
+			RespectSchemaVersion:         true,
+		},
+		CSharp: &tfbridge.CSharpInfo{
+			LiftSingleValueMethodReturns: true,
+			RespectSchemaVersion:         true,
+		},
+		Java: &tfbridge.JavaInfo{ /* Java does not have a RespectSchemaVersion flag */ },
 		Golang: &tfbridge.GolangInfo{
 			ImportBasePath: path.Join(
 				fmt.Sprintf("github.com/pulumi/pulumi-%[1]s/sdk/", p.Name()),
@@ -59,7 +74,7 @@ func providerInfo(ctx context.Context, p run.Provider, value parameterize.Value)
 			spec.Parameterization = &schema.ParameterizationSpec{
 				BaseProvider: schema.BaseProviderSpec{
 					Name:    baseProviderName,
-					Version: version.Version(),
+					Version: strings.TrimPrefix(version.Version(), "v"),
 				},
 				Parameter: value.Marshal(),
 			}

--- a/dynamic/internal/shim/grpcutil/translate.go
+++ b/dynamic/internal/shim/grpcutil/translate.go
@@ -1,0 +1,100 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpcutil
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"runtime"
+	"sync"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"google.golang.org/grpc"
+)
+
+var (
+	pulumiTFDebugGRPCLogs = os.Getenv("PULUMI_TF_DEBUG_GRPC")
+	grpcLogLock           sync.Mutex
+	grpcLogFileTarget     *os.File
+)
+
+type grpcLog struct {
+	Call     string   `json:"call"`
+	Request  string   `json:"request"`
+	Response string   `json:"response"`
+	Error    []string `json:"error,omitempty"`
+}
+
+func writeGRPCLog(log grpcLog) error {
+	if pulumiTFDebugGRPCLogs == "" {
+		return nil
+	}
+	grpcLogLock.Lock()
+	defer grpcLogLock.Unlock()
+
+	if grpcLogFileTarget == nil {
+		var err error
+		grpcLogFileTarget, err = os.Create(pulumiTFDebugGRPCLogs)
+		if err != nil {
+			return err
+		}
+	}
+
+	b, err := json.Marshal(log)
+	contract.AssertNoErrorf(err, "%T should always marshal", log)
+	_, err = grpcLogFileTarget.Write(append(b, '\n'))
+	if err != nil {
+		return err
+	}
+	return grpcLogFileTarget.Sync()
+}
+
+func Translate[
+	In, Out fmt.Stringer,
+	Final any,
+	Call func(context.Context, In, ...grpc.CallOption) (Out, error),
+	MapResult func(Out) Final,
+](
+	ctx context.Context,
+	call Call,
+	i In,
+	m MapResult,
+) (_ Final, err error) {
+	var log grpcLog
+	if pulumiTFDebugGRPCLogs != "" {
+		log.Request = i.String()
+		if _, line, num, ok := runtime.Caller(2); ok {
+			log.Call = fmt.Sprintf("%s:%d", line, num)
+		}
+		defer func() {
+			e := writeGRPCLog(log)
+			if err == nil {
+				err = e
+			}
+		}()
+	}
+	v, err := call(ctx, i)
+	if err != nil {
+		var tmp Final
+		log.Error = []string{err.Error()}
+		return tmp, err
+	}
+	if pulumiTFDebugGRPCLogs != "" {
+		log.Response = v.String()
+	}
+	return m(v), nil
+}

--- a/dynamic/internal/shim/protov5/provider.go
+++ b/dynamic/internal/shim/protov5/provider.go
@@ -24,8 +24,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/opentofu/opentofu/internal/tfplugin5"
+	"github.com/opentofu/opentofu/shim/grpcutil"
 	"github.com/opentofu/opentofu/shim/protov5/translate"
-	"google.golang.org/grpc"
 )
 
 var _ tfprotov5.ProviderServer = (*provider)(nil)
@@ -39,7 +39,7 @@ type provider struct{ remote tfplugin5.ProviderClient }
 func (p provider) GetMetadata(
 	ctx context.Context, req *tfprotov5.GetMetadataRequest,
 ) (*tfprotov5.GetMetadataResponse, error) {
-	return translateGRPC(ctx,
+	return grpcutil.Translate(ctx,
 		p.remote.GetMetadata,
 		translate.GetMetadataRequest(req),
 		translate.GetMetadataResponse)
@@ -48,7 +48,7 @@ func (p provider) GetMetadata(
 func (p provider) GetProviderSchema(
 	ctx context.Context, req *tfprotov5.GetProviderSchemaRequest,
 ) (*tfprotov5.GetProviderSchemaResponse, error) {
-	return translateGRPC(ctx,
+	return grpcutil.Translate(ctx,
 		p.remote.GetSchema,
 		translate.GetProviderSchemaRequest(req),
 		translate.GetProviderSchemaResponse)
@@ -57,7 +57,7 @@ func (p provider) GetProviderSchema(
 func (p provider) PrepareProviderConfig(
 	ctx context.Context, req *tfprotov5.PrepareProviderConfigRequest,
 ) (*tfprotov5.PrepareProviderConfigResponse, error) {
-	return translateGRPC(ctx,
+	return grpcutil.Translate(ctx,
 		p.remote.PrepareProviderConfig,
 		translate.PrepareProviderConfigRequest(req),
 		translate.PrepareProviderConfigResponse)
@@ -66,7 +66,7 @@ func (p provider) PrepareProviderConfig(
 func (p provider) ConfigureProvider(
 	ctx context.Context, req *tfprotov5.ConfigureProviderRequest,
 ) (*tfprotov5.ConfigureProviderResponse, error) {
-	return translateGRPC(ctx,
+	return grpcutil.Translate(ctx,
 		p.remote.Configure,
 		translate.ConfigureProviderRequest(req),
 		translate.ConfigureProviderResponse)
@@ -75,7 +75,7 @@ func (p provider) ConfigureProvider(
 func (p provider) StopProvider(
 	ctx context.Context, req *tfprotov5.StopProviderRequest,
 ) (*tfprotov5.StopProviderResponse, error) {
-	return translateGRPC(ctx,
+	return grpcutil.Translate(ctx,
 		p.remote.Stop,
 		translate.StopProviderRequest(req),
 		translate.StopProviderResponse)
@@ -84,7 +84,7 @@ func (p provider) StopProvider(
 func (p provider) ValidateResourceTypeConfig(
 	ctx context.Context, req *tfprotov5.ValidateResourceTypeConfigRequest,
 ) (*tfprotov5.ValidateResourceTypeConfigResponse, error) {
-	return translateGRPC(ctx,
+	return grpcutil.Translate(ctx,
 		p.remote.ValidateResourceTypeConfig,
 		translate.ValidateResourceTypeConfigRequest(req),
 		translate.ValidateResourceTypeConfigResponse)
@@ -93,7 +93,7 @@ func (p provider) ValidateResourceTypeConfig(
 func (p provider) UpgradeResourceState(
 	ctx context.Context, req *tfprotov5.UpgradeResourceStateRequest,
 ) (*tfprotov5.UpgradeResourceStateResponse, error) {
-	return translateGRPC(ctx,
+	return grpcutil.Translate(ctx,
 		p.remote.UpgradeResourceState,
 		translate.UpgradeResourceStateRequest(req),
 		translate.UpgradeResourceStateResponse)
@@ -102,7 +102,7 @@ func (p provider) UpgradeResourceState(
 func (p provider) ReadResource(
 	ctx context.Context, req *tfprotov5.ReadResourceRequest,
 ) (*tfprotov5.ReadResourceResponse, error) {
-	return translateGRPC(ctx,
+	return grpcutil.Translate(ctx,
 		p.remote.ReadResource,
 		translate.ReadResourceRequest(req),
 		translate.ReadResourceResponse)
@@ -111,7 +111,7 @@ func (p provider) ReadResource(
 func (p provider) PlanResourceChange(
 	ctx context.Context, req *tfprotov5.PlanResourceChangeRequest,
 ) (*tfprotov5.PlanResourceChangeResponse, error) {
-	return translateGRPC(ctx,
+	return grpcutil.Translate(ctx,
 		p.remote.PlanResourceChange,
 		translate.PlanResourceChangeRequest(req),
 		translate.PlanResourceChangeResponse)
@@ -120,7 +120,7 @@ func (p provider) PlanResourceChange(
 func (p provider) ApplyResourceChange(
 	ctx context.Context, req *tfprotov5.ApplyResourceChangeRequest,
 ) (*tfprotov5.ApplyResourceChangeResponse, error) {
-	return translateGRPC(ctx,
+	return grpcutil.Translate(ctx,
 		p.remote.ApplyResourceChange,
 		translate.ApplyResourceChangeRequest(req),
 		translate.ApplyResourceChangeResponse)
@@ -129,7 +129,7 @@ func (p provider) ApplyResourceChange(
 func (p provider) ImportResourceState(
 	ctx context.Context, req *tfprotov5.ImportResourceStateRequest,
 ) (*tfprotov5.ImportResourceStateResponse, error) {
-	return translateGRPC(ctx,
+	return grpcutil.Translate(ctx,
 		p.remote.ImportResourceState,
 		translate.ImportResourceStateRequest(req),
 		translate.ImportResourceStateResponse)
@@ -138,7 +138,7 @@ func (p provider) ImportResourceState(
 func (p provider) MoveResourceState(
 	ctx context.Context, req *tfprotov5.MoveResourceStateRequest,
 ) (*tfprotov5.MoveResourceStateResponse, error) {
-	return translateGRPC(ctx,
+	return grpcutil.Translate(ctx,
 		p.remote.MoveResourceState,
 		translate.MoveResourceStateRequest(req),
 		translate.MoveResourceStateResponse)
@@ -147,7 +147,7 @@ func (p provider) MoveResourceState(
 func (p provider) ValidateDataSourceConfig(
 	ctx context.Context, req *tfprotov5.ValidateDataSourceConfigRequest,
 ) (*tfprotov5.ValidateDataSourceConfigResponse, error) {
-	return translateGRPC(ctx,
+	return grpcutil.Translate(ctx,
 		p.remote.ValidateDataSourceConfig,
 		translate.ValidateDataSourceConfigRequest(req),
 		translate.ValidateDataSourceConfigResponse)
@@ -156,7 +156,7 @@ func (p provider) ValidateDataSourceConfig(
 func (p provider) ReadDataSource(
 	ctx context.Context, req *tfprotov5.ReadDataSourceRequest,
 ) (*tfprotov5.ReadDataSourceResponse, error) {
-	return translateGRPC(ctx,
+	return grpcutil.Translate(ctx,
 		p.remote.ReadDataSource,
 		translate.ReadDataSourceRequest(req),
 		translate.ReadDataSourceResponse)
@@ -165,7 +165,7 @@ func (p provider) ReadDataSource(
 func (p provider) CallFunction(
 	ctx context.Context, req *tfprotov5.CallFunctionRequest,
 ) (*tfprotov5.CallFunctionResponse, error) {
-	return translateGRPC(ctx,
+	return grpcutil.Translate(ctx,
 		p.remote.CallFunction,
 		translate.CallFunctionRequest(req),
 		translate.CallFunctionResponse)
@@ -174,26 +174,8 @@ func (p provider) CallFunction(
 func (p provider) GetFunctions(
 	ctx context.Context, req *tfprotov5.GetFunctionsRequest,
 ) (*tfprotov5.GetFunctionsResponse, error) {
-	return translateGRPC(ctx,
+	return grpcutil.Translate(ctx,
 		p.remote.GetFunctions,
 		translate.GetFunctionsRequest(req),
 		translate.GetFunctionsResponse)
-}
-
-func translateGRPC[
-	In, Out, Final any,
-	Call func(context.Context, In, ...grpc.CallOption) (Out, error),
-	MapResult func(Out) Final,
-](
-	ctx context.Context,
-	call Call,
-	i In,
-	m MapResult,
-) (Final, error) {
-	v, err := call(ctx, i)
-	if err != nil {
-		var tmp Final
-		return tmp, err
-	}
-	return m(v), nil
 }

--- a/dynamic/internal/shim/protov6/provider.go
+++ b/dynamic/internal/shim/protov6/provider.go
@@ -24,8 +24,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/opentofu/opentofu/internal/tfplugin6"
+	"github.com/opentofu/opentofu/shim/grpcutil"
 	"github.com/opentofu/opentofu/shim/protov6/translate"
-	grpc "google.golang.org/grpc"
 )
 
 var _ tfprotov6.ProviderServer = (*shimProvider)(nil)
@@ -39,7 +39,7 @@ type shimProvider struct{ remote tfplugin6.ProviderClient }
 func (p shimProvider) GetMetadata(
 	ctx context.Context, req *tfprotov6.GetMetadataRequest,
 ) (*tfprotov6.GetMetadataResponse, error) {
-	return translateGRPC(ctx,
+	return grpcutil.Translate(ctx,
 		p.remote.GetMetadata,
 		translate.GetMetadataRequest(req),
 		translate.GetMetadataResult)
@@ -48,7 +48,7 @@ func (p shimProvider) GetMetadata(
 func (p shimProvider) GetProviderSchema(
 	ctx context.Context, req *tfprotov6.GetProviderSchemaRequest,
 ) (*tfprotov6.GetProviderSchemaResponse, error) {
-	return translateGRPC(ctx,
+	return grpcutil.Translate(ctx,
 		p.remote.GetProviderSchema,
 		translate.GetProviderSchemaRequest(req),
 		translate.GetProviderSchemaResponse)
@@ -57,11 +57,13 @@ func (p shimProvider) GetProviderSchema(
 func (p shimProvider) ValidateProviderConfig(
 	ctx context.Context, req *tfprotov6.ValidateProviderConfigRequest,
 ) (*tfprotov6.ValidateProviderConfigResponse, error) {
-	v, err := p.remote.ValidateProviderConfig(ctx, translate.ValidateProviderConfigRequest(req))
+	resp, err := grpcutil.Translate(ctx,
+		p.remote.ValidateProviderConfig,
+		translate.ValidateProviderConfigRequest(req),
+		translate.ValidateProviderConfigResponse)
 	if err != nil {
 		return nil, err
 	}
-	resp := translate.ValidateProviderConfigResponse(v)
 
 	// From the docs on PreparedConfig:
 	//
@@ -82,7 +84,7 @@ func (p shimProvider) ValidateProviderConfig(
 func (p shimProvider) ConfigureProvider(
 	ctx context.Context, req *tfprotov6.ConfigureProviderRequest,
 ) (*tfprotov6.ConfigureProviderResponse, error) {
-	return translateGRPC(ctx,
+	return grpcutil.Translate(ctx,
 		p.remote.ConfigureProvider,
 		translate.ConfigureProviderRequest(req),
 		translate.ConfigureProviderResponse)
@@ -91,7 +93,7 @@ func (p shimProvider) ConfigureProvider(
 func (p shimProvider) StopProvider(
 	ctx context.Context, req *tfprotov6.StopProviderRequest,
 ) (*tfprotov6.StopProviderResponse, error) {
-	return translateGRPC(ctx,
+	return grpcutil.Translate(ctx,
 		p.remote.StopProvider,
 		translate.StopProviderRequest(req),
 		translate.StopProviderResponse)
@@ -100,7 +102,7 @@ func (p shimProvider) StopProvider(
 func (p shimProvider) ValidateResourceConfig(
 	ctx context.Context, req *tfprotov6.ValidateResourceConfigRequest,
 ) (*tfprotov6.ValidateResourceConfigResponse, error) {
-	return translateGRPC(ctx,
+	return grpcutil.Translate(ctx,
 		p.remote.ValidateResourceConfig,
 		translate.ValidateResourceConfigRequest(req),
 		translate.ValidateResourceConfigResponse)
@@ -109,7 +111,7 @@ func (p shimProvider) ValidateResourceConfig(
 func (p shimProvider) UpgradeResourceState(
 	ctx context.Context, req *tfprotov6.UpgradeResourceStateRequest,
 ) (*tfprotov6.UpgradeResourceStateResponse, error) {
-	return translateGRPC(ctx,
+	return grpcutil.Translate(ctx,
 		p.remote.UpgradeResourceState,
 		translate.UpgradeResourceStateRequest(req),
 		translate.UpgradeResourceStateResponse)
@@ -118,7 +120,7 @@ func (p shimProvider) UpgradeResourceState(
 func (p shimProvider) ReadResource(
 	ctx context.Context, req *tfprotov6.ReadResourceRequest,
 ) (*tfprotov6.ReadResourceResponse, error) {
-	return translateGRPC(ctx,
+	return grpcutil.Translate(ctx,
 		p.remote.ReadResource,
 		translate.ReadResourceRequest(req),
 		translate.ReadResourceResponse)
@@ -127,7 +129,7 @@ func (p shimProvider) ReadResource(
 func (p shimProvider) PlanResourceChange(
 	ctx context.Context, req *tfprotov6.PlanResourceChangeRequest,
 ) (*tfprotov6.PlanResourceChangeResponse, error) {
-	return translateGRPC(ctx,
+	return grpcutil.Translate(ctx,
 		p.remote.PlanResourceChange,
 		translate.PlanResourceChangeRequest(req),
 		translate.PlanResourceChangeResponse)
@@ -136,7 +138,7 @@ func (p shimProvider) PlanResourceChange(
 func (p shimProvider) ApplyResourceChange(
 	ctx context.Context, req *tfprotov6.ApplyResourceChangeRequest,
 ) (*tfprotov6.ApplyResourceChangeResponse, error) {
-	return translateGRPC(ctx,
+	return grpcutil.Translate(ctx,
 		p.remote.ApplyResourceChange,
 		translate.ApplyResourceChangeRequest(req),
 		translate.ApplyResourceChangeResponse)
@@ -145,7 +147,7 @@ func (p shimProvider) ApplyResourceChange(
 func (p shimProvider) ImportResourceState(
 	ctx context.Context, req *tfprotov6.ImportResourceStateRequest,
 ) (*tfprotov6.ImportResourceStateResponse, error) {
-	return translateGRPC(ctx,
+	return grpcutil.Translate(ctx,
 		p.remote.ImportResourceState,
 		translate.ImportResourceStateRequest(req),
 		translate.ImportResourceStateResponse)
@@ -154,7 +156,7 @@ func (p shimProvider) ImportResourceState(
 func (p shimProvider) ValidateDataResourceConfig(
 	ctx context.Context, req *tfprotov6.ValidateDataResourceConfigRequest,
 ) (*tfprotov6.ValidateDataResourceConfigResponse, error) {
-	return translateGRPC(ctx,
+	return grpcutil.Translate(ctx,
 		p.remote.ValidateDataResourceConfig,
 		translate.ValidateDataResourceConfigRequest(req),
 		translate.ValidateDataResourceConfigResponse)
@@ -163,7 +165,7 @@ func (p shimProvider) ValidateDataResourceConfig(
 func (p shimProvider) MoveResourceState(
 	ctx context.Context, req *tfprotov6.MoveResourceStateRequest,
 ) (*tfprotov6.MoveResourceStateResponse, error) {
-	return translateGRPC(ctx,
+	return grpcutil.Translate(ctx,
 		p.remote.MoveResourceState,
 		translate.MoveResourceStateRequest(req),
 		translate.MoveResourceStateResponse)
@@ -172,7 +174,7 @@ func (p shimProvider) MoveResourceState(
 func (p shimProvider) ReadDataSource(
 	ctx context.Context, req *tfprotov6.ReadDataSourceRequest,
 ) (*tfprotov6.ReadDataSourceResponse, error) {
-	return translateGRPC(ctx,
+	return grpcutil.Translate(ctx,
 		p.remote.ReadDataSource,
 		translate.ReadDataSourceRequest(req),
 		translate.ReadDataSourceResponse)
@@ -181,7 +183,7 @@ func (p shimProvider) ReadDataSource(
 func (p shimProvider) CallFunction(
 	ctx context.Context, req *tfprotov6.CallFunctionRequest,
 ) (*tfprotov6.CallFunctionResponse, error) {
-	return translateGRPC(ctx,
+	return grpcutil.Translate(ctx,
 		p.remote.CallFunction,
 		translate.CallFunctionRequest(req),
 		translate.CallFunctionResponse)
@@ -190,26 +192,8 @@ func (p shimProvider) CallFunction(
 func (p shimProvider) GetFunctions(
 	ctx context.Context, req *tfprotov6.GetFunctionsRequest,
 ) (*tfprotov6.GetFunctionsResponse, error) {
-	return translateGRPC(ctx,
+	return grpcutil.Translate(ctx,
 		p.remote.GetFunctions,
 		translate.GetFunctionsRequest(req),
 		translate.GetFunctionsResponse)
-}
-
-func translateGRPC[
-	In, Out, Final any,
-	Call func(context.Context, In, ...grpc.CallOption) (Out, error),
-	MapResult func(Out) Final,
-](
-	ctx context.Context,
-	call Call,
-	i In,
-	m MapResult,
-) (Final, error) {
-	v, err := call(ctx, i)
-	if err != nil {
-		var tmp Final
-		return tmp, err
-	}
-	return m(v), nil
 }

--- a/dynamic/internal/shim/run/loader.go
+++ b/dynamic/internal/shim/run/loader.go
@@ -224,9 +224,7 @@ func runProvider(ctx context.Context, meta *providercache.CachedProvider) (Provi
 		return nil, err
 	}
 
-	// store the client so that the plugin can kill the child process
-	protoVer := client.NegotiatedVersion()
-	switch protoVer {
+	switch client.NegotiatedVersion() {
 	case 5:
 		p := raw.(*tfplugin.GRPCProvider)
 		p.PluginClient = client
@@ -240,15 +238,13 @@ func runProvider(ctx context.Context, meta *providercache.CachedProvider) (Provi
 		if err != nil {
 			return nil, err
 		}
-		return provider{
-			v6,
+		return provider{v6,
 			meta.Provider.Type, meta.Version.String(), meta.Provider.String(),
 			rpcClient.Close,
 		}, nil
 	case 6:
 		p := tfplugin6.NewProviderClient(rpcClient.(*plugin.GRPCClient).Conn)
-		return provider{
-			v6shim.New(p),
+		return provider{v6shim.New(p),
 			meta.Provider.Type, meta.Version.String(), meta.Provider.String(),
 			rpcClient.Close,
 		}, nil

--- a/dynamic/internal/shim/run/loader.go
+++ b/dynamic/internal/shim/run/loader.go
@@ -206,7 +206,9 @@ func runProvider(ctx context.Context, meta *providercache.CachedProvider) (Provi
 		Logger:           logging.NewProviderLogger(""),
 		AllowedProtocols: []plugin.Protocol{plugin.ProtocolGRPC},
 		Managed:          true,
-		Cmd:              exec.CommandContext(ctx, execFile),
+		// We intentionally use [context.Background] so the lifetime of the
+		// provider can escape the lifetime of the parameterize call.
+		Cmd:              exec.CommandContext(context.Background(), execFile),
 		AutoMTLS:         true,
 		VersionedPlugins: tfplugin.VersionedPlugins,
 		SyncStdout:       logging.PluginOutputMonitor(fmt.Sprintf("%s:stdout", meta.Provider)),

--- a/dynamic/main.go
+++ b/dynamic/main.go
@@ -89,7 +89,16 @@ func initialSetup() (tfbridge.ProviderInfo, pfbridge.ProviderMetadata, func() er
 			case *plugin.ParameterizeValue:
 				value, err := parameterize.ParseValue(params.Value)
 				if err != nil {
-					return plugin.ParameterizeResponse{}, err
+					tfbridge.GetLogger(ctx).Error(fmt.Sprintf(
+						"%[1]s is unable to parse the parameter value "+
+							"embedded in the generated SDK.\nThis is always a bug in "+
+							"%[1]s and should be reported. \n"+
+							"The value passed was %[2]q.",
+						baseProviderName, string(params.Value),
+					))
+					return plugin.ParameterizeResponse{}, fmt.Errorf(
+						"failed to parse parameterized value: %w", err,
+					)
 				}
 				args = value.IntoArgs()
 			case *plugin.ParameterizeArgs:

--- a/dynamic/testdata/TestSchemaGeneration/Azure/alz-0.11.1.golden
+++ b/dynamic/testdata/TestSchemaGeneration/Azure/alz-0.11.1.golden
@@ -3,26 +3,43 @@
     "version": "0.11.1",
     "description": "A Pulumi provider dynamically bridged from alz.",
     "attribution": "This Pulumi package is based on the [`alz` Terraform Provider](https://github.com/terraform-providers/terraform-provider-alz).",
+    "publisher": "Pulumi",
     "meta": {
         "moduleFormat": "(.*)(?:/[^/]*)"
     },
     "language": {
+        "csharp": {
+            "compatibility": "tfbridge20",
+            "liftSingleValueMethodReturns": true,
+            "respectSchemaVersion": true
+        },
         "go": {
             "importBasePath": "github.com/pulumi/pulumi-alz/sdk/go/alz",
             "liftSingleValueMethodReturns": true,
             "generateExtraInputTypes": true,
             "respectSchemaVersion": true
         },
+        "java": {
+            "basePackage": "",
+            "buildFiles": "",
+            "gradleNexusPublishPluginVersion": "",
+            "gradleTest": ""
+        },
         "nodejs": {
             "packageDescription": "A Pulumi provider dynamically bridged from alz.",
             "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-alz)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-alz` repo](/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-alz` repo](https://github.com/terraform-providers/terraform-provider-alz/issues).",
             "compatibility": "tfbridge20",
-            "disableUnionOutputTypes": true
+            "disableUnionOutputTypes": true,
+            "liftSingleValueMethodReturns": true,
+            "respectSchemaVersion": true
         },
         "python": {
             "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-alz)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-alz` repo](/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-alz` repo](https://github.com/terraform-providers/terraform-provider-alz/issues).",
             "compatibility": "tfbridge20",
-            "pyproject": {}
+            "respectSchemaVersion": true,
+            "pyproject": {
+                "enabled": true
+            }
         }
     },
     "config": {
@@ -747,7 +764,7 @@
     "parameterization": {
         "baseProvider": {
             "name": "terraform-provider",
-            "version": "v0.0.0-dev"
+            "version": "0.0.0-dev"
         },
         "parameter": "eyJyZW1vdGUiOnsidXJsIjoicmVnaXN0cnkub3BlbnRvZnUub3JnL2F6dXJlL2FseiIsInZlcnNpb24iOiIwLjExLjEifX0="
     }

--- a/dynamic/testdata/TestSchemaGeneration/Backblaze/b2-0.8.9.golden
+++ b/dynamic/testdata/TestSchemaGeneration/Backblaze/b2-0.8.9.golden
@@ -3,26 +3,43 @@
     "version": "0.8.9",
     "description": "A Pulumi provider dynamically bridged from b2.",
     "attribution": "This Pulumi package is based on the [`b2` Terraform Provider](https://github.com/terraform-providers/terraform-provider-b2).",
+    "publisher": "Pulumi",
     "meta": {
         "moduleFormat": "(.*)(?:/[^/]*)"
     },
     "language": {
+        "csharp": {
+            "compatibility": "tfbridge20",
+            "liftSingleValueMethodReturns": true,
+            "respectSchemaVersion": true
+        },
         "go": {
             "importBasePath": "github.com/pulumi/pulumi-b2/sdk/go/b2",
             "liftSingleValueMethodReturns": true,
             "generateExtraInputTypes": true,
             "respectSchemaVersion": true
         },
+        "java": {
+            "basePackage": "",
+            "buildFiles": "",
+            "gradleNexusPublishPluginVersion": "",
+            "gradleTest": ""
+        },
         "nodejs": {
             "packageDescription": "A Pulumi provider dynamically bridged from b2.",
             "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-b2)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-b2` repo](/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-b2` repo](https://github.com/terraform-providers/terraform-provider-b2/issues).",
             "compatibility": "tfbridge20",
-            "disableUnionOutputTypes": true
+            "disableUnionOutputTypes": true,
+            "liftSingleValueMethodReturns": true,
+            "respectSchemaVersion": true
         },
         "python": {
             "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-b2)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-b2` repo](/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-b2` repo](https://github.com/terraform-providers/terraform-provider-b2/issues).",
             "compatibility": "tfbridge20",
-            "pyproject": {}
+            "respectSchemaVersion": true,
+            "pyproject": {
+                "enabled": true
+            }
         }
     },
     "config": {
@@ -1399,7 +1416,7 @@
     "parameterization": {
         "baseProvider": {
             "name": "terraform-provider",
-            "version": "v0.0.0-dev"
+            "version": "0.0.0-dev"
         },
         "parameter": "eyJyZW1vdGUiOnsidXJsIjoicmVnaXN0cnkub3BlbnRvZnUub3JnL2JhY2tibGF6ZS9iMiIsInZlcnNpb24iOiIwLjguOSJ9fQ=="
     }

--- a/dynamic/testdata/TestSchemaGeneration/hashicorp/random-3.3.0.golden
+++ b/dynamic/testdata/TestSchemaGeneration/hashicorp/random-3.3.0.golden
@@ -3,26 +3,43 @@
     "version": "3.3.0",
     "description": "A Pulumi provider dynamically bridged from random.",
     "attribution": "This Pulumi package is based on the [`random` Terraform Provider](https://github.com/terraform-providers/terraform-provider-random).",
+    "publisher": "Pulumi",
     "meta": {
         "moduleFormat": "(.*)(?:/[^/]*)"
     },
     "language": {
+        "csharp": {
+            "compatibility": "tfbridge20",
+            "liftSingleValueMethodReturns": true,
+            "respectSchemaVersion": true
+        },
         "go": {
             "importBasePath": "github.com/pulumi/pulumi-random/sdk/go/random",
             "liftSingleValueMethodReturns": true,
             "generateExtraInputTypes": true,
             "respectSchemaVersion": true
         },
+        "java": {
+            "basePackage": "",
+            "buildFiles": "",
+            "gradleNexusPublishPluginVersion": "",
+            "gradleTest": ""
+        },
         "nodejs": {
             "packageDescription": "A Pulumi provider dynamically bridged from random.",
             "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-random)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-random` repo](/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-random` repo](https://github.com/terraform-providers/terraform-provider-random/issues).",
             "compatibility": "tfbridge20",
-            "disableUnionOutputTypes": true
+            "disableUnionOutputTypes": true,
+            "liftSingleValueMethodReturns": true,
+            "respectSchemaVersion": true
         },
         "python": {
             "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-random)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-random` repo](/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-random` repo](https://github.com/terraform-providers/terraform-provider-random/issues).",
             "compatibility": "tfbridge20",
-            "pyproject": {}
+            "respectSchemaVersion": true,
+            "pyproject": {
+                "enabled": true
+            }
         }
     },
     "config": {},
@@ -811,7 +828,7 @@
     "parameterization": {
         "baseProvider": {
             "name": "terraform-provider",
-            "version": "v0.0.0-dev"
+            "version": "0.0.0-dev"
         },
         "parameter": "eyJyZW1vdGUiOnsidXJsIjoicmVnaXN0cnkub3BlbnRvZnUub3JnL2hhc2hpY29ycC9yYW5kb20iLCJ2ZXJzaW9uIjoiMy4zLjAifX0="
     }

--- a/pf/proto/schema.go
+++ b/pf/proto/schema.go
@@ -15,7 +15,7 @@
 package proto
 
 import (
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	// "github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
@@ -36,8 +36,16 @@ func (pseudoResource) DecodeTimeouts(config shim.ResourceConfig) (*shim.Resource
 func getSchemaMap[T any](m interface {
 	GetOk(string) (T, bool)
 }, key string) T {
-	v, ok := m.GetOk(key)
-	contract.Assertf(ok, "Could not find key %q", key)
+	v, _ := m.GetOk(key)
+	// Some functions (such as terraformToPulumiName; link: [1]) do not correctly use
+	// GetOk, so we can't panic on Get for a missing value, even though that is the
+	// point of Get.
+	//
+	// [^1]: https://github.com/pulumi/pulumi-terraform-bridge/blob/08338be75eedce29c4c2349109d72edc8a38930d/pkg/tfbridge/names.go#L154-L158
+	//
+	// contract.Assertf(ok, "Could not find key %q", key)
+	//
+	//nolint:lll
 	return v
 }
 

--- a/pf/tfbridge/provider.go
+++ b/pf/tfbridge/provider.go
@@ -203,6 +203,7 @@ func XParameterizeResetProvider(ctx context.Context, info tfbridge.ProviderInfo,
 func (p *provider) ParameterizeWithContext(
 	ctx context.Context, req plugin.ParameterizeRequest,
 ) (plugin.ParameterizeResponse, error) {
+	ctx = p.initLogging(ctx, p.logSink, "")
 	if p.parameterize == nil {
 		return (&plugin.UnimplementedProvider{}).Parameterize(ctx, req)
 	}
@@ -222,6 +223,7 @@ func (p *provider) ParameterizeWithContext(
 
 // GetSchema returns the schema for the provider.
 func (p *provider) GetSchemaWithContext(ctx context.Context, req plugin.GetSchemaRequest) ([]byte, error) {
+	ctx = p.initLogging(ctx, p.logSink, "")
 	return p.pulumiSchema(ctx, req)
 }
 

--- a/pf/tfbridge/provider_checkconfig.go
+++ b/pf/tfbridge/provider_checkconfig.go
@@ -197,6 +197,16 @@ func (p *provider) validateProviderConfig(
 		if k == "version" || k == "pluginDownloadURL" {
 			continue
 		}
+		// TODO[https://github.com/pulumi/pulumi/issues/16757] While #16757 is
+		// outstanding, we need to filter out the keys for parameterized providers
+		// from the top level namespace.
+		//
+		// We will need to remove this check before we GA dynamic providers.
+		if p.parameterize != nil {
+			if k == "name" || k == "parameterization" {
+				continue
+			}
+		}
 		n := tfbridge.PulumiToTerraformName(string(k), p.schemaOnlyProvider.Schema(), p.info.GetConfig())
 		_, known := p.configType.AttributeTypes[n]
 		if !known {

--- a/pf/tfbridge/provider_checkconfig.go
+++ b/pf/tfbridge/provider_checkconfig.go
@@ -161,10 +161,10 @@ func (p *provider) validateProviderConfig(
 		err = fmt.Errorf("cannot encode provider configuration to call ValidateProviderConfig: %w", err)
 		return nil, err
 	}
-	req := &tfprotov6.ValidateProviderConfigRequest{
+
+	resp, err := p.tfServer.ValidateProviderConfig(ctx, &tfprotov6.ValidateProviderConfigRequest{
 		Config: config,
-	}
-	resp, err := p.tfServer.ValidateProviderConfig(ctx, req)
+	})
 	if err != nil {
 		return nil, fmt.Errorf("error calling ValidateProviderConfig: %w", err)
 	}


### PR DESCRIPTION
This is necessary to generate easily consumable SDKs.