### PR TITLE
PF extract inputs from outputs tests

### DIFF
--- a/pf/tests/extract_inputs_test.go
+++ b/pf/tests/extract_inputs_test.go
@@ -544,6 +544,27 @@ func TestExtractInputsFromOutputsPF(t *testing.T) {
 			}}),
 		},
 		{
+			name: "object attribute computed",
+			props: resource.NewPropertyMapFromMap(map[string]interface{}{
+				"foo": map[string]interface{}{
+					"bar": "baz",
+				},
+			}),
+			resSchema: rschema.Schema{
+				Attributes: map[string]rschema.Attribute{
+					"foo": rschema.ObjectAttribute{
+						Computed: true,
+						AttributeTypes: map[string]attr.Type{
+							"bar": types.StringType,
+						},
+					},
+				},
+			},
+			expect: autogold.Expect(resource.PropertyMap{resource.PropertyKey("__defaults"): resource.PropertyValue{
+				V: []resource.PropertyValue{},
+			}}),
+		},
+		{
 			name: "single nested attribute",
 			props: resource.NewPropertyMapFromMap(map[string]interface{}{
 				"foo": map[string]interface{}{
@@ -572,6 +593,49 @@ func TestExtractInputsFromOutputsPF(t *testing.T) {
 				}},
 			}),
 		},
+		{
+			name: "single nested attribute computed",
+			props: resource.NewPropertyMapFromMap(map[string]interface{}{
+				"foo": map[string]interface{}{
+					"bar": "baz",
+				},
+			}),
+			resSchema: rschema.Schema{
+				Attributes: map[string]rschema.Attribute{
+					"foo": rschema.SingleNestedAttribute{
+						Computed: true,
+						Attributes: map[string]rschema.Attribute{
+							"bar": rschema.StringAttribute{Optional: true},
+						},
+					},
+				},
+			},
+			expect: autogold.Expect(resource.PropertyMap{resource.PropertyKey("__defaults"): resource.PropertyValue{
+				V: []resource.PropertyValue{},
+			}}),
+		},
+		{
+			name: "single nested attribute nested computed",
+			props: resource.NewPropertyMapFromMap(map[string]interface{}{
+				"foo": map[string]interface{}{
+					"bar": "baz",
+				},
+			}),
+			resSchema: rschema.Schema{
+				Attributes: map[string]rschema.Attribute{
+					"foo": rschema.SingleNestedAttribute{
+						Optional: true,
+						Attributes: map[string]rschema.Attribute{
+							"bar": rschema.StringAttribute{Computed: true},
+						},
+					},
+				},
+			},
+			expect: autogold.Expect(resource.PropertyMap{resource.PropertyKey("__defaults"): resource.PropertyValue{
+				V: []resource.PropertyValue{},
+			}}),
+		},
+		// TODO[pulumi/pulumi-terraform-bridge#2218]: Add default tests here.
 		// BLOCKS
 		// {
 		// 	name: "list nested block",

--- a/pf/tests/extract_inputs_test.go
+++ b/pf/tests/extract_inputs_test.go
@@ -638,6 +638,7 @@ func TestExtractInputsFromOutputsPF(t *testing.T) {
 		},
 		// TODO[pulumi/pulumi-terraform-bridge#2218]: Add missing defaults tests here once defaults are fixed.
 		// BLOCKS
+		// TODO[pulumi/pulumi-terraform-bridge#2180]: This should not yield values for computed properties
 		{
 			name: "list nested block not extracted",
 			props: resource.NewPropertyMapFromMap(map[string]interface{}{
@@ -665,7 +666,7 @@ func TestExtractInputsFromOutputsPF(t *testing.T) {
 						resource.PropertyKey("__defaults"): resource.PropertyValue{
 							V: []resource.PropertyValue{},
 						},
-						resource.PropertyKey("nested_field"): resource.PropertyValue{V: "nested_value"},
+						resource.PropertyKey("nested_field"): resource.PropertyValue{V: "nested_value"}, // wrong
 					},
 				}}},
 			}),
@@ -698,11 +699,12 @@ func TestExtractInputsFromOutputsPF(t *testing.T) {
 						resource.PropertyKey("__defaults"): resource.PropertyValue{
 							V: []resource.PropertyValue{},
 						},
-						resource.PropertyKey("nested_field"): resource.PropertyValue{V: "nested_value"},
+						resource.PropertyKey("nested_field"): resource.PropertyValue{V: "nested_value"}, // wrong
 					},
 				}}},
 			}),
 		},
+		// TODO[pulumi/pulumi-terraform-bridge#2180]: This should not yield values for computed properties
 		{
 			name: "list nested block computed not extracted",
 			props: resource.NewPropertyMapFromMap(map[string]interface{}{
@@ -730,7 +732,7 @@ func TestExtractInputsFromOutputsPF(t *testing.T) {
 						resource.PropertyKey("__defaults"): resource.PropertyValue{
 							V: []resource.PropertyValue{},
 						},
-						resource.PropertyKey("nested_field"): resource.PropertyValue{V: "nested_value"},
+						resource.PropertyKey("nested_field"): resource.PropertyValue{V: "nested_value"}, // wrong
 					},
 				}}},
 			}),
@@ -795,7 +797,7 @@ func TestExtractInputsFromOutputsPF(t *testing.T) {
 						resource.PropertyKey("__defaults"): resource.PropertyValue{
 							V: []resource.PropertyValue{},
 						},
-						resource.PropertyKey("nested_field"): resource.PropertyValue{V: "nested_value"},
+						resource.PropertyKey("nested_field"): resource.PropertyValue{V: "nested_value"}, // wrong
 					},
 				}}},
 			}),
@@ -881,7 +883,7 @@ func TestExtractInputsFromOutputsPF(t *testing.T) {
 					resource.PropertyKey("__defaults"): resource.PropertyValue{
 						V: []resource.PropertyValue{},
 					},
-					resource.PropertyKey("nested_field"): resource.PropertyValue{V: "nested_value"},
+					resource.PropertyKey("nested_field"): resource.PropertyValue{V: "nested_value"}, // wrong
 				}},
 			}),
 		},

--- a/pf/tests/extract_inputs_test.go
+++ b/pf/tests/extract_inputs_test.go
@@ -638,9 +638,8 @@ func TestExtractInputsFromOutputsPF(t *testing.T) {
 		},
 		// TODO[pulumi/pulumi-terraform-bridge#2218]: Add missing defaults tests here once defaults are fixed.
 		// BLOCKS
-		// TODO[pulumi/pulumi-terraform-bridge#2180]: This should not yield values for computed properties
 		{
-			name: "list nested block not extracted",
+			name: "list nested block extracted",
 			props: resource.NewPropertyMapFromMap(map[string]interface{}{
 				"block_field": []interface{}{
 					map[string]interface{}{"nested_field": "nested_value"},
@@ -666,7 +665,7 @@ func TestExtractInputsFromOutputsPF(t *testing.T) {
 						resource.PropertyKey("__defaults"): resource.PropertyValue{
 							V: []resource.PropertyValue{},
 						},
-						resource.PropertyKey("nested_field"): resource.PropertyValue{V: "nested_value"}, // wrong
+						resource.PropertyKey("nested_field"): resource.PropertyValue{V: "nested_value"},
 					},
 				}}},
 			}),
@@ -802,6 +801,7 @@ func TestExtractInputsFromOutputsPF(t *testing.T) {
 				}}},
 			}),
 		},
+		// TODO[pulumi/pulumi-terraform-bridge#2180]: This should not yield values for computed properties
 		{
 			name: "set nested block computed not extracted",
 			props: resource.NewPropertyMapFromMap(map[string]interface{}{
@@ -829,7 +829,7 @@ func TestExtractInputsFromOutputsPF(t *testing.T) {
 						resource.PropertyKey("__defaults"): resource.PropertyValue{
 							V: []resource.PropertyValue{},
 						},
-						resource.PropertyKey("nested_field"): resource.PropertyValue{V: "nested_value"},
+						resource.PropertyKey("nested_field"): resource.PropertyValue{V: "nested_value"}, //wrong
 					},
 				}}},
 			}),

--- a/pf/tests/extract_inputs_test.go
+++ b/pf/tests/extract_inputs_test.go
@@ -1,0 +1,421 @@
+package tfbridgetests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hexops/autogold/v2"
+	"github.com/pulumi/pulumi-terraform-bridge/pf/internal/schemashim"
+	pb "github.com/pulumi/pulumi-terraform-bridge/pf/tests/internal/providerbuilder"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractInputsFromOutputsPF(t *testing.T) {
+	type testCase struct {
+		name      string
+		props     resource.PropertyMap
+		resSchema rschema.Schema
+		expect    autogold.Value
+	}
+
+	testCases := []testCase{
+		{
+			name:  "string",
+			props: resource.NewPropertyMapFromMap(map[string]interface{}{"foo": "bar"}),
+			resSchema: rschema.Schema{
+				Attributes: map[string]rschema.Attribute{
+					"foo": rschema.StringAttribute{Optional: true},
+				},
+			},
+			expect: autogold.Expect(resource.PropertyMap{
+				resource.PropertyKey("__defaults"): resource.PropertyValue{
+					V: []resource.PropertyValue{},
+				},
+				resource.PropertyKey("foo"): resource.PropertyValue{V: "bar"},
+			}),
+		},
+		// TODO[pulumi/pulumi-terraform-bridge#2218]: This should not yield values for foo in the inputs.
+		{
+			name:  "string with default",
+			props: resource.NewPropertyMapFromMap(map[string]interface{}{"foo": "bar"}),
+			resSchema: rschema.Schema{
+				Attributes: map[string]rschema.Attribute{
+					"foo": rschema.StringAttribute{Optional: true, Default: stringdefault.StaticString("bar")},
+				},
+			},
+			expect: autogold.Expect(resource.PropertyMap{
+				resource.PropertyKey("__defaults"): resource.PropertyValue{
+					V: []resource.PropertyValue{},
+				},
+				resource.PropertyKey("foo"): resource.PropertyValue{V: "bar"},
+			}),
+		},
+		{
+			name:  "string with empty value",
+			props: resource.NewPropertyMapFromMap(map[string]interface{}{"foo": ""}),
+			resSchema: rschema.Schema{
+				Attributes: map[string]rschema.Attribute{
+					"foo": rschema.StringAttribute{Optional: true},
+				},
+			},
+			expect: autogold.Expect(resource.PropertyMap{resource.PropertyKey("__defaults"): resource.PropertyValue{
+				V: []resource.PropertyValue{},
+			}}),
+		},
+		{
+			name:  "string computed",
+			props: resource.NewPropertyMapFromMap(map[string]interface{}{"foo": "bar"}),
+			resSchema: rschema.Schema{
+				Attributes: map[string]rschema.Attribute{
+					"foo": rschema.StringAttribute{Computed: true},
+				},
+			},
+			expect: autogold.Expect(resource.PropertyMap{resource.PropertyKey("__defaults"): resource.PropertyValue{
+				V: []resource.PropertyValue{},
+			}}),
+		},
+		{
+			name:  "list attribute",
+			props: resource.NewPropertyMapFromMap(map[string]interface{}{"foo": []interface{}{"bar"}}),
+			resSchema: rschema.Schema{
+				Attributes: map[string]rschema.Attribute{
+					"foo": rschema.ListAttribute{
+						Optional:    true,
+						ElementType: types.StringType,
+					},
+				},
+			},
+			expect: autogold.Expect(resource.PropertyMap{
+				resource.PropertyKey("__defaults"): resource.PropertyValue{
+					V: []resource.PropertyValue{},
+				},
+				resource.PropertyKey("foo"): resource.PropertyValue{V: []resource.PropertyValue{{
+					V: "bar",
+				}}},
+			}),
+		},
+		// TODO[pulumi/pulumi-terraform-bridge#2218]: This should not yield values for foo in the inputs.
+		{
+			name: "list attribute with default",
+			props: resource.NewPropertyMapFromMap(map[string]interface{}{
+				"foo": []interface{}{"bar"},
+			}),
+			resSchema: rschema.Schema{
+				Attributes: map[string]rschema.Attribute{
+					"foo": rschema.ListAttribute{
+						Optional:    true,
+						ElementType: types.StringType,
+						Default:     listdefault.StaticValue(types.ListValueMust(types.StringType, []attr.Value{types.StringValue("bar")})),
+					},
+				},
+			},
+			expect: autogold.Expect(resource.PropertyMap{
+				resource.PropertyKey("__defaults"): resource.PropertyValue{
+					V: []resource.PropertyValue{},
+				},
+				resource.PropertyKey("foo"): resource.PropertyValue{V: []resource.PropertyValue{{
+					V: "bar",
+				}}},
+			}),
+		},
+		{
+			name: "list attribute computed",
+			props: resource.NewPropertyMapFromMap(map[string]interface{}{
+				"foo": []interface{}{"bar"},
+			}),
+			resSchema: rschema.Schema{
+				Attributes: map[string]rschema.Attribute{
+					"foo": rschema.ListAttribute{
+						ElementType: types.StringType,
+						Computed:    true,
+					},
+				},
+			},
+			expect: autogold.Expect(resource.PropertyMap{resource.PropertyKey("__defaults"): resource.PropertyValue{
+				V: []resource.PropertyValue{},
+			}}),
+		},
+		{
+			name: "list nested attribute",
+			props: resource.NewPropertyMapFromMap(map[string]interface{}{
+				"foo": []interface{}{
+					map[string]interface{}{"bar": "baz"},
+				},
+			}),
+			resSchema: rschema.Schema{
+				Attributes: map[string]rschema.Attribute{
+					"foo": rschema.ListNestedAttribute{
+						Optional: true,
+						NestedObject: rschema.NestedAttributeObject{
+							Attributes: map[string]rschema.Attribute{
+								"bar": rschema.StringAttribute{Optional: true},
+							},
+						},
+					},
+				},
+			},
+			expect: autogold.Expect(resource.PropertyMap{
+				resource.PropertyKey("__defaults"): resource.PropertyValue{
+					V: []resource.PropertyValue{},
+				},
+				resource.PropertyKey("foo"): resource.PropertyValue{V: []resource.PropertyValue{{
+					V: resource.PropertyMap{
+						resource.PropertyKey("__defaults"): resource.PropertyValue{
+							V: []resource.PropertyValue{},
+						},
+						resource.PropertyKey("bar"): resource.PropertyValue{V: "baz"},
+					},
+				}}},
+			}),
+		},
+		// TODO[pulumi/pulumi-terraform-bridge#2218]: This should not yield values for foo in the inputs.
+		{
+			name: "list nested attribute with defaults",
+			props: resource.NewPropertyMapFromMap(map[string]interface{}{
+				"foo": []interface{}{
+					map[string]interface{}{"bar": "baz"},
+				},
+			}),
+			resSchema: rschema.Schema{
+				Attributes: map[string]rschema.Attribute{
+					"foo": rschema.ListNestedAttribute{
+						Optional: true,
+						NestedObject: rschema.NestedAttributeObject{
+							Attributes: map[string]rschema.Attribute{
+								"bar": rschema.StringAttribute{Optional: true},
+							},
+						},
+						Default: listdefault.StaticValue(types.ListValueMust(types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"bar": types.StringType,
+							},
+						}, []attr.Value{types.ObjectValueMust(
+							map[string]attr.Type{
+								"bar": types.StringType,
+							},
+							map[string]attr.Value{
+								"bar": types.StringValue("baz"),
+							},
+						)})),
+					},
+				},
+			},
+			expect: autogold.Expect(resource.PropertyMap{
+				resource.PropertyKey("__defaults"): resource.PropertyValue{
+					V: []resource.PropertyValue{},
+				},
+				resource.PropertyKey("foo"): resource.PropertyValue{V: []resource.PropertyValue{{
+					V: resource.PropertyMap{
+						resource.PropertyKey("__defaults"): resource.PropertyValue{
+							V: []resource.PropertyValue{},
+						},
+						resource.PropertyKey("bar"): resource.PropertyValue{V: "baz"},
+					},
+				}}},
+			}),
+		},
+		{
+			name: "list nested attribute computed",
+			props: resource.NewPropertyMapFromMap(map[string]interface{}{
+				"foo": []interface{}{
+					map[string]interface{}{"bar": "baz"},
+				},
+			}),
+			resSchema: rschema.Schema{
+				Attributes: map[string]rschema.Attribute{
+					"foo": rschema.ListNestedAttribute{
+						Computed: true,
+						NestedObject: rschema.NestedAttributeObject{
+							Attributes: map[string]rschema.Attribute{
+								"bar": rschema.StringAttribute{Optional: true},
+							},
+						},
+					},
+				},
+			},
+			expect: autogold.Expect(resource.PropertyMap{resource.PropertyKey("__defaults"): resource.PropertyValue{
+				V: []resource.PropertyValue{},
+			}}),
+		},
+		{
+			name: "list nested attribute nested computed",
+			props: resource.NewPropertyMapFromMap(map[string]interface{}{
+				"foo": []interface{}{
+					map[string]interface{}{"bar": "baz"},
+				},
+			}),
+			resSchema: rschema.Schema{
+				Attributes: map[string]rschema.Attribute{
+					"foo": rschema.ListNestedAttribute{
+						Optional: true,
+						NestedObject: rschema.NestedAttributeObject{
+							Attributes: map[string]rschema.Attribute{
+								"bar": rschema.StringAttribute{Computed: true},
+							},
+						},
+					},
+				},
+			},
+			expect: autogold.Expect(resource.PropertyMap{
+				resource.PropertyKey("__defaults"): resource.PropertyValue{
+					V: []resource.PropertyValue{},
+				},
+				resource.PropertyKey("foo"): resource.PropertyValue{V: []resource.PropertyValue{{
+					V: resource.PropertyMap{resource.PropertyKey("__defaults"): resource.PropertyValue{
+						V: []resource.PropertyValue{},
+					}},
+				}}},
+			}),
+		},
+		{
+			name: "set nested attribute",
+			props: resource.NewPropertyMapFromMap(map[string]interface{}{
+				"foo": []interface{}{
+					map[string]interface{}{"bar": "baz"},
+				},
+			}),
+			resSchema: rschema.Schema{
+				Attributes: map[string]rschema.Attribute{
+					"foo": rschema.SetNestedAttribute{
+						Optional: true,
+						NestedObject: rschema.NestedAttributeObject{
+							Attributes: map[string]rschema.Attribute{
+								"bar": rschema.StringAttribute{Optional: true},
+							},
+						},
+					},
+				},
+			},
+			expect: autogold.Expect(resource.PropertyMap{
+				resource.PropertyKey("__defaults"): resource.PropertyValue{
+					V: []resource.PropertyValue{},
+				},
+				resource.PropertyKey("foo"): resource.PropertyValue{V: []resource.PropertyValue{{
+					V: resource.PropertyMap{
+						resource.PropertyKey("__defaults"): resource.PropertyValue{
+							V: []resource.PropertyValue{},
+						},
+						resource.PropertyKey("bar"): resource.PropertyValue{V: "baz"},
+					},
+				}}},
+			}),
+		},
+		{
+			name: "map nested attribute",
+			props: resource.NewPropertyMapFromMap(map[string]interface{}{
+				"foo": map[string]interface{}{
+					"bar": "baz",
+				},
+			}),
+			resSchema: rschema.Schema{
+				Attributes: map[string]rschema.Attribute{
+					"foo": rschema.MapNestedAttribute{
+						Optional: true,
+						NestedObject: rschema.NestedAttributeObject{
+							Attributes: map[string]rschema.Attribute{
+								"bar": rschema.StringAttribute{Optional: true},
+							},
+						},
+					},
+				},
+			},
+			expect: autogold.Expect(resource.PropertyMap{
+				resource.PropertyKey("__defaults"): resource.PropertyValue{
+					V: []resource.PropertyValue{},
+				},
+				resource.PropertyKey("foo"): resource.PropertyValue{V: resource.PropertyMap{
+					resource.PropertyKey("__defaults"): resource.PropertyValue{
+						V: []resource.PropertyValue{},
+					},
+					resource.PropertyKey("bar"): resource.PropertyValue{V: "baz"},
+				}},
+			}),
+		},
+		{
+			name: "object attribute",
+			props: resource.NewPropertyMapFromMap(map[string]interface{}{
+				"foo": map[string]interface{}{
+					"bar": "baz",
+				},
+			}),
+			resSchema: rschema.Schema{
+				Attributes: map[string]rschema.Attribute{
+					"foo": rschema.ObjectAttribute{
+						Optional: true,
+						AttributeTypes: map[string]attr.Type{
+							"bar": types.StringType,
+						},
+					},
+				},
+			},
+			expect: autogold.Expect(resource.PropertyMap{resource.PropertyKey("__defaults"): resource.PropertyValue{
+				V: []resource.PropertyValue{},
+			}}),
+		},
+		{
+			name: "single nested attribute",
+			props: resource.NewPropertyMapFromMap(map[string]interface{}{
+				"foo": map[string]interface{}{
+					"bar": "baz",
+				},
+			}),
+			resSchema: rschema.Schema{
+				Attributes: map[string]rschema.Attribute{
+					"foo": rschema.SingleNestedAttribute{
+						Optional: true,
+						Attributes: map[string]rschema.Attribute{
+							"bar": rschema.StringAttribute{Optional: true},
+						},
+					},
+				},
+			},
+			expect: autogold.Expect(resource.PropertyMap{
+				resource.PropertyKey("__defaults"): resource.PropertyValue{
+					V: []resource.PropertyValue{},
+				},
+				resource.PropertyKey("foo"): resource.PropertyValue{V: resource.PropertyMap{
+					resource.PropertyKey("__defaults"): resource.PropertyValue{
+						V: []resource.PropertyValue{},
+					},
+					resource.PropertyKey("bar"): resource.PropertyValue{V: "baz"},
+				}},
+			}),
+		},
+		// BLOCKS
+		// {
+		// 	name: "list nested block",
+		// },
+		// {
+		// 	name: "set nested block",
+		// },
+		// {
+		// 	name: "single nested block",
+		// },
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			prov := &pb.Provider{
+				AllResources: []pb.Resource{
+					{
+						Name:           "test",
+						ResourceSchema: tc.resSchema,
+					},
+				},
+			}
+
+			shimmedProvider := schemashim.ShimSchemaOnlyProvider(context.Background(), prov)
+			res := shimmedProvider.ResourcesMap().Get("_test")
+			result, err := tfbridge.ExtractInputsFromOutputs(nil, tc.props, res.Schema(), nil, false)
+			require.NoError(t, err)
+			tc.expect.Equal(t, result)
+		})
+	}
+}

--- a/pf/tests/extract_inputs_test.go
+++ b/pf/tests/extract_inputs_test.go
@@ -27,8 +27,9 @@ func TestExtractInputsFromOutputsPF(t *testing.T) {
 	}
 
 	testCases := []testCase{
+		// ATTRIBUTES
 		{
-			name:  "string",
+			name:  "string extracted",
 			props: resource.NewPropertyMapFromMap(map[string]interface{}{"foo": "bar"}),
 			resSchema: rschema.Schema{
 				Attributes: map[string]rschema.Attribute{
@@ -44,7 +45,7 @@ func TestExtractInputsFromOutputsPF(t *testing.T) {
 		},
 		// TODO[pulumi/pulumi-terraform-bridge#2218]: This should not yield values for foo in the inputs.
 		{
-			name:  "string with default",
+			name:  "string with default not extracted",
 			props: resource.NewPropertyMapFromMap(map[string]interface{}{"foo": "bar"}),
 			resSchema: rschema.Schema{
 				Attributes: map[string]rschema.Attribute{
@@ -55,11 +56,11 @@ func TestExtractInputsFromOutputsPF(t *testing.T) {
 				resource.PropertyKey("__defaults"): resource.PropertyValue{
 					V: []resource.PropertyValue{},
 				},
-				resource.PropertyKey("foo"): resource.PropertyValue{V: "bar"},
+				resource.PropertyKey("foo"): resource.PropertyValue{V: "bar"}, // wrong
 			}),
 		},
 		{
-			name:  "string with empty value",
+			name:  "string with empty value not extracted",
 			props: resource.NewPropertyMapFromMap(map[string]interface{}{"foo": ""}),
 			resSchema: rschema.Schema{
 				Attributes: map[string]rschema.Attribute{
@@ -71,7 +72,7 @@ func TestExtractInputsFromOutputsPF(t *testing.T) {
 			}}),
 		},
 		{
-			name:  "string computed",
+			name:  "string computed not extracted",
 			props: resource.NewPropertyMapFromMap(map[string]interface{}{"foo": "bar"}),
 			resSchema: rschema.Schema{
 				Attributes: map[string]rschema.Attribute{
@@ -83,7 +84,7 @@ func TestExtractInputsFromOutputsPF(t *testing.T) {
 			}}),
 		},
 		{
-			name:  "list attribute",
+			name:  "list attribute extracted",
 			props: resource.NewPropertyMapFromMap(map[string]interface{}{"foo": []interface{}{"bar"}}),
 			resSchema: rschema.Schema{
 				Attributes: map[string]rschema.Attribute{
@@ -104,7 +105,7 @@ func TestExtractInputsFromOutputsPF(t *testing.T) {
 		},
 		// TODO[pulumi/pulumi-terraform-bridge#2218]: This should not yield values for properties with defaults in the inputs.
 		{
-			name: "list attribute with default",
+			name: "list attribute with default not extracted",
 			props: resource.NewPropertyMapFromMap(map[string]interface{}{
 				"foo": []interface{}{"bar"},
 			}),
@@ -122,12 +123,12 @@ func TestExtractInputsFromOutputsPF(t *testing.T) {
 					V: []resource.PropertyValue{},
 				},
 				resource.PropertyKey("foo"): resource.PropertyValue{V: []resource.PropertyValue{{
-					V: "bar",
+					V: "bar", // wrong
 				}}},
 			}),
 		},
 		{
-			name: "list attribute computed",
+			name: "list attribute computed not extracted",
 			props: resource.NewPropertyMapFromMap(map[string]interface{}{
 				"foo": []interface{}{"bar"},
 			}),
@@ -144,7 +145,7 @@ func TestExtractInputsFromOutputsPF(t *testing.T) {
 			}}),
 		},
 		{
-			name: "list nested attribute",
+			name: "list nested attribute extracted",
 			props: resource.NewPropertyMapFromMap(map[string]interface{}{
 				"foo": []interface{}{
 					map[string]interface{}{"bar": "baz"},
@@ -178,7 +179,7 @@ func TestExtractInputsFromOutputsPF(t *testing.T) {
 		},
 		// TODO[pulumi/pulumi-terraform-bridge#2218]: This should not yield values for properties with defaults in the inputs.
 		{
-			name: "list nested attribute with defaults",
+			name: "list nested attribute with defaults not extracted",
 			props: resource.NewPropertyMapFromMap(map[string]interface{}{
 				"foo": []interface{}{
 					map[string]interface{}{"bar": "baz"},
@@ -217,14 +218,14 @@ func TestExtractInputsFromOutputsPF(t *testing.T) {
 						resource.PropertyKey("__defaults"): resource.PropertyValue{
 							V: []resource.PropertyValue{},
 						},
-						resource.PropertyKey("bar"): resource.PropertyValue{V: "baz"},
+						resource.PropertyKey("bar"): resource.PropertyValue{V: "baz"}, // wrong
 					},
 				}}},
 			}),
 		},
 		// TODO[pulumi/pulumi-terraform-bridge#2218]: This should not yield values for properties with defaults in the inputs.
 		{
-			name: "list nested attribute with nested defaults",
+			name: "list nested attribute with nested defaults not extracted",
 			props: resource.NewPropertyMapFromMap(map[string]interface{}{
 				"foo": []interface{}{
 					map[string]interface{}{"bar": "baz"},
@@ -251,13 +252,13 @@ func TestExtractInputsFromOutputsPF(t *testing.T) {
 						resource.PropertyKey("__defaults"): resource.PropertyValue{
 							V: []resource.PropertyValue{},
 						},
-						resource.PropertyKey("bar"): resource.PropertyValue{V: "baz"},
+						resource.PropertyKey("bar"): resource.PropertyValue{V: "baz"}, // wrong
 					},
 				}}},
 			}),
 		},
 		{
-			name: "list nested attribute computed",
+			name: "list nested attribute computed not extracted",
 			props: resource.NewPropertyMapFromMap(map[string]interface{}{
 				"foo": []interface{}{
 					map[string]interface{}{"bar": "baz"},
@@ -280,7 +281,7 @@ func TestExtractInputsFromOutputsPF(t *testing.T) {
 			}}),
 		},
 		{
-			name: "list nested attribute nested computed",
+			name: "list nested attribute nested computed not extracted",
 			props: resource.NewPropertyMapFromMap(map[string]interface{}{
 				"foo": []interface{}{
 					map[string]interface{}{"bar": "baz"},
@@ -310,7 +311,7 @@ func TestExtractInputsFromOutputsPF(t *testing.T) {
 			}),
 		},
 		{
-			name: "set nested attribute",
+			name: "set nested attribute extracted",
 			props: resource.NewPropertyMapFromMap(map[string]interface{}{
 				"foo": []interface{}{
 					map[string]interface{}{"bar": "baz"},
@@ -343,7 +344,7 @@ func TestExtractInputsFromOutputsPF(t *testing.T) {
 			}),
 		},
 		{
-			name: "map nested attribute",
+			name: "map nested attribute extracted",
 			props: resource.NewPropertyMapFromMap(map[string]interface{}{
 				"foo": map[string]interface{}{
 					"key1": map[string]interface{}{"bar": "baz"},
@@ -380,7 +381,7 @@ func TestExtractInputsFromOutputsPF(t *testing.T) {
 		},
 		// TODO[pulumi/pulumi-terraform-bridge#2218]: This should not yield values for properties with defaults in the inputs.
 		{
-			name: "map nested attribute with default",
+			name: "map nested attribute with default not extracted",
 			props: resource.NewPropertyMapFromMap(map[string]interface{}{
 				"foo": map[string]interface{}{
 					"key1": map[string]interface{}{"bar": "baz"},
@@ -404,7 +405,7 @@ func TestExtractInputsFromOutputsPF(t *testing.T) {
 										"bar": types.StringType,
 									},
 									map[string]attr.Value{
-										"bar": types.StringValue("baz"),
+										"bar": types.StringValue("baz"), // wrong
 									},
 								),
 							},
@@ -431,7 +432,7 @@ func TestExtractInputsFromOutputsPF(t *testing.T) {
 		},
 		// TODO[pulumi/pulumi-terraform-bridge#2218]: This should not yield values for properties with defaults in the inputs.
 		{
-			name: "map nested attribute with nested default",
+			name: "map nested attribute with nested default not extracted",
 			props: resource.NewPropertyMapFromMap(map[string]interface{}{
 				"foo": map[string]interface{}{
 					"key1": map[string]interface{}{"bar": "baz"},
@@ -461,13 +462,13 @@ func TestExtractInputsFromOutputsPF(t *testing.T) {
 						resource.PropertyKey("__defaults"): resource.PropertyValue{
 							V: []resource.PropertyValue{},
 						},
-						resource.PropertyKey("bar"): resource.PropertyValue{V: "baz"},
+						resource.PropertyKey("bar"): resource.PropertyValue{V: "baz"}, // wrong
 					}},
 				}},
 			}),
 		},
 		{
-			name: "map nested attribute computed",
+			name: "map nested attribute computed not extracted",
 			props: resource.NewPropertyMapFromMap(map[string]interface{}{
 				"foo": map[string]interface{}{
 					"key1": map[string]interface{}{"bar": "baz"},
@@ -490,7 +491,7 @@ func TestExtractInputsFromOutputsPF(t *testing.T) {
 			}}),
 		},
 		{
-			name: "map nested attribute nested computed",
+			name: "map nested attribute nested computed not extracted",
 			props: resource.NewPropertyMapFromMap(map[string]interface{}{
 				"foo": map[string]interface{}{
 					"key1": map[string]interface{}{"bar": "baz"},
@@ -523,7 +524,7 @@ func TestExtractInputsFromOutputsPF(t *testing.T) {
 			}),
 		},
 		{
-			name: "object attribute",
+			name: "object attribute extracted",
 			props: resource.NewPropertyMapFromMap(map[string]interface{}{
 				"foo": map[string]interface{}{
 					"bar": "baz",
@@ -544,7 +545,7 @@ func TestExtractInputsFromOutputsPF(t *testing.T) {
 			}}),
 		},
 		{
-			name: "object attribute computed",
+			name: "object attribute computed not extracted",
 			props: resource.NewPropertyMapFromMap(map[string]interface{}{
 				"foo": map[string]interface{}{
 					"bar": "baz",
@@ -565,7 +566,7 @@ func TestExtractInputsFromOutputsPF(t *testing.T) {
 			}}),
 		},
 		{
-			name: "single nested attribute",
+			name: "single nested attribute extracted",
 			props: resource.NewPropertyMapFromMap(map[string]interface{}{
 				"foo": map[string]interface{}{
 					"bar": "baz",
@@ -594,7 +595,7 @@ func TestExtractInputsFromOutputsPF(t *testing.T) {
 			}),
 		},
 		{
-			name: "single nested attribute computed",
+			name: "single nested attribute computed not extracted",
 			props: resource.NewPropertyMapFromMap(map[string]interface{}{
 				"foo": map[string]interface{}{
 					"bar": "baz",
@@ -615,7 +616,7 @@ func TestExtractInputsFromOutputsPF(t *testing.T) {
 			}}),
 		},
 		{
-			name: "single nested attribute nested computed",
+			name: "single nested attribute nested computed not extracted",
 			props: resource.NewPropertyMapFromMap(map[string]interface{}{
 				"foo": map[string]interface{}{
 					"bar": "baz",
@@ -635,17 +636,273 @@ func TestExtractInputsFromOutputsPF(t *testing.T) {
 				V: []resource.PropertyValue{},
 			}}),
 		},
-		// TODO[pulumi/pulumi-terraform-bridge#2218]: Add default tests here.
+		// TODO[pulumi/pulumi-terraform-bridge#2218]: Add missing defaults tests here once defaults are fixed.
 		// BLOCKS
-		// {
-		// 	name: "list nested block",
-		// },
-		// {
-		// 	name: "set nested block",
-		// },
-		// {
-		// 	name: "single nested block",
-		// },
+		{
+			name: "list nested block not extracted",
+			props: resource.NewPropertyMapFromMap(map[string]interface{}{
+				"block_field": []interface{}{
+					map[string]interface{}{"nested_field": "nested_value"},
+				},
+			}),
+			resSchema: rschema.Schema{
+				Blocks: map[string]rschema.Block{
+					"block_field": rschema.ListNestedBlock{
+						NestedObject: rschema.NestedBlockObject{
+							Attributes: map[string]rschema.Attribute{
+								"nested_field": rschema.StringAttribute{Optional: true},
+							},
+						},
+					},
+				},
+			},
+			expect: autogold.Expect(resource.PropertyMap{
+				resource.PropertyKey("__defaults"): resource.PropertyValue{
+					V: []resource.PropertyValue{},
+				},
+				resource.PropertyKey("block_field"): resource.PropertyValue{V: []resource.PropertyValue{{
+					V: resource.PropertyMap{
+						resource.PropertyKey("__defaults"): resource.PropertyValue{
+							V: []resource.PropertyValue{},
+						},
+						resource.PropertyKey("nested_field"): resource.PropertyValue{V: "nested_value"},
+					},
+				}}},
+			}),
+		},
+		// TODO[pulumi/pulumi-terraform-bridge#2218]: This should not yield values for properties with defaults in the inputs.
+		{
+			name: "list nested block with defaults not extracted",
+			props: resource.NewPropertyMapFromMap(map[string]interface{}{
+				"block_field": []interface{}{
+					map[string]interface{}{"nested_field": "nested_value"},
+				},
+			}),
+			resSchema: rschema.Schema{
+				Blocks: map[string]rschema.Block{
+					"block_field": rschema.ListNestedBlock{
+						NestedObject: rschema.NestedBlockObject{
+							Attributes: map[string]rschema.Attribute{
+								"nested_field": rschema.StringAttribute{Optional: true, Default: stringdefault.StaticString("nested_value")},
+							},
+						},
+					},
+				},
+			},
+			expect: autogold.Expect(resource.PropertyMap{
+				resource.PropertyKey("__defaults"): resource.PropertyValue{
+					V: []resource.PropertyValue{},
+				},
+				resource.PropertyKey("block_field"): resource.PropertyValue{V: []resource.PropertyValue{{
+					V: resource.PropertyMap{
+						resource.PropertyKey("__defaults"): resource.PropertyValue{
+							V: []resource.PropertyValue{},
+						},
+						resource.PropertyKey("nested_field"): resource.PropertyValue{V: "nested_value"},
+					},
+				}}},
+			}),
+		},
+		{
+			name: "list nested block computed not extracted",
+			props: resource.NewPropertyMapFromMap(map[string]interface{}{
+				"block_field": []interface{}{
+					map[string]interface{}{"nested_field": "nested_value"},
+				},
+			}),
+			resSchema: rschema.Schema{
+				Blocks: map[string]rschema.Block{
+					"block_field": rschema.ListNestedBlock{
+						NestedObject: rschema.NestedBlockObject{
+							Attributes: map[string]rschema.Attribute{
+								"nested_field": rschema.StringAttribute{Computed: true},
+							},
+						},
+					},
+				},
+			},
+			expect: autogold.Expect(resource.PropertyMap{
+				resource.PropertyKey("__defaults"): resource.PropertyValue{
+					V: []resource.PropertyValue{},
+				},
+				resource.PropertyKey("block_field"): resource.PropertyValue{V: []resource.PropertyValue{{
+					V: resource.PropertyMap{
+						resource.PropertyKey("__defaults"): resource.PropertyValue{
+							V: []resource.PropertyValue{},
+						},
+						resource.PropertyKey("nested_field"): resource.PropertyValue{V: "nested_value"},
+					},
+				}}},
+			}),
+		},
+		{
+			name: "set nested block extracted",
+			props: resource.NewPropertyMapFromMap(map[string]interface{}{
+				"block_field": []interface{}{
+					map[string]interface{}{"nested_field": "nested_value"},
+				},
+			}),
+			resSchema: rschema.Schema{
+				Blocks: map[string]rschema.Block{
+					"block_field": rschema.SetNestedBlock{
+						NestedObject: rschema.NestedBlockObject{
+							Attributes: map[string]rschema.Attribute{
+								"nested_field": rschema.StringAttribute{Optional: true},
+							},
+						},
+					},
+				},
+			},
+			expect: autogold.Expect(resource.PropertyMap{
+				resource.PropertyKey("__defaults"): resource.PropertyValue{
+					V: []resource.PropertyValue{},
+				},
+				resource.PropertyKey("block_field"): resource.PropertyValue{V: []resource.PropertyValue{{
+					V: resource.PropertyMap{
+						resource.PropertyKey("__defaults"): resource.PropertyValue{
+							V: []resource.PropertyValue{},
+						},
+						resource.PropertyKey("nested_field"): resource.PropertyValue{V: "nested_value"},
+					},
+				}}},
+			}),
+		},
+		// TODO[pulumi/pulumi-terraform-bridge#2218]: This should not yield values for properties with defaults in the inputs.
+		{
+			name: "set nested block with defaults not extracted",
+			props: resource.NewPropertyMapFromMap(map[string]interface{}{
+				"block_field": []interface{}{
+					map[string]interface{}{"nested_field": "nested_value"},
+				},
+			}),
+			resSchema: rschema.Schema{
+				Blocks: map[string]rschema.Block{
+					"block_field": rschema.SetNestedBlock{
+						NestedObject: rschema.NestedBlockObject{
+							Attributes: map[string]rschema.Attribute{
+								"nested_field": rschema.StringAttribute{Optional: true, Default: stringdefault.StaticString("nested_value")},
+							},
+						},
+					},
+				},
+			},
+			expect: autogold.Expect(resource.PropertyMap{
+				resource.PropertyKey("__defaults"): resource.PropertyValue{
+					V: []resource.PropertyValue{},
+				},
+				resource.PropertyKey("block_field"): resource.PropertyValue{V: []resource.PropertyValue{{
+					V: resource.PropertyMap{
+						resource.PropertyKey("__defaults"): resource.PropertyValue{
+							V: []resource.PropertyValue{},
+						},
+						resource.PropertyKey("nested_field"): resource.PropertyValue{V: "nested_value"},
+					},
+				}}},
+			}),
+		},
+		{
+			name: "set nested block computed not extracted",
+			props: resource.NewPropertyMapFromMap(map[string]interface{}{
+				"block_field": []interface{}{
+					map[string]interface{}{"nested_field": "nested_value"},
+				},
+			}),
+			resSchema: rschema.Schema{
+				Blocks: map[string]rschema.Block{
+					"block_field": rschema.SetNestedBlock{
+						NestedObject: rschema.NestedBlockObject{
+							Attributes: map[string]rschema.Attribute{
+								"nested_field": rschema.StringAttribute{Computed: true},
+							},
+						},
+					},
+				},
+			},
+			expect: autogold.Expect(resource.PropertyMap{
+				resource.PropertyKey("__defaults"): resource.PropertyValue{
+					V: []resource.PropertyValue{},
+				},
+				resource.PropertyKey("block_field"): resource.PropertyValue{V: []resource.PropertyValue{{
+					V: resource.PropertyMap{
+						resource.PropertyKey("__defaults"): resource.PropertyValue{
+							V: []resource.PropertyValue{},
+						},
+						resource.PropertyKey("nested_field"): resource.PropertyValue{V: "nested_value"},
+					},
+				}}},
+			}),
+		},
+		{
+			name: "single nested block extracted",
+			props: resource.NewPropertyMapFromMap(map[string]interface{}{
+				"block_field": map[string]interface{}{"nested_field": "nested_value"},
+			}),
+			resSchema: rschema.Schema{
+				Blocks: map[string]rschema.Block{
+					"block_field": rschema.SingleNestedBlock{
+						Attributes: map[string]rschema.Attribute{
+							"nested_field": rschema.StringAttribute{Optional: true},
+						},
+					},
+				},
+			},
+			expect: autogold.Expect(resource.PropertyMap{
+				resource.PropertyKey("__defaults"): resource.PropertyValue{
+					V: []resource.PropertyValue{},
+				},
+				resource.PropertyKey("block_field"): resource.PropertyValue{V: resource.PropertyMap{
+					resource.PropertyKey("__defaults"): resource.PropertyValue{
+						V: []resource.PropertyValue{},
+					},
+					resource.PropertyKey("nested_field"): resource.PropertyValue{V: "nested_value"},
+				}},
+			}),
+		},
+		// TODO[pulumi/pulumi-terraform-bridge#2218]: This should not yield values for properties with defaults in the inputs.
+		{
+			name: "single nested block with default not extracted",
+			props: resource.NewPropertyMapFromMap(map[string]interface{}{
+				"block_field": map[string]interface{}{"nested_field": "nested_value"},
+			}),
+			resSchema: rschema.Schema{
+				Blocks: map[string]rschema.Block{
+					"block_field": rschema.SingleNestedBlock{
+						Attributes: map[string]rschema.Attribute{
+							"nested_field": rschema.StringAttribute{Optional: true, Default: stringdefault.StaticString("nested_value")},
+						},
+					},
+				},
+			},
+			expect: autogold.Expect(resource.PropertyMap{
+				resource.PropertyKey("__defaults"): resource.PropertyValue{
+					V: []resource.PropertyValue{},
+				},
+				resource.PropertyKey("block_field"): resource.PropertyValue{V: resource.PropertyMap{
+					resource.PropertyKey("__defaults"): resource.PropertyValue{
+						V: []resource.PropertyValue{},
+					},
+					resource.PropertyKey("nested_field"): resource.PropertyValue{V: "nested_value"},
+				}},
+			}),
+		},
+		{
+			name: "single nested block computed not extracted",
+			props: resource.NewPropertyMapFromMap(map[string]interface{}{
+				"block_field": map[string]interface{}{"nested_field": "nested_value"},
+			}),
+			resSchema: rschema.Schema{
+				Blocks: map[string]rschema.Block{
+					"block_field": rschema.SingleNestedBlock{
+						Attributes: map[string]rschema.Attribute{
+							"nested_field": rschema.StringAttribute{Computed: true},
+						},
+					},
+				},
+			},
+			expect: autogold.Expect(resource.PropertyMap{resource.PropertyKey("__defaults"): resource.PropertyValue{
+				V: []resource.PropertyValue{},
+			}}),
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This adds adds missing test coverage for `ExtractInputsFromOutputs` for various PF schemas. `ExtractInputsFromOutputs` is a shared function so we should have coverage on both sides to make sure we don't cause regressions when fixing one.

Similar to https://github.com/pulumi/pulumi-terraform-bridge/pull/2224 but on the PF side.

This is in preparation for https://github.com/pulumi/pulumi-terraform-bridge/pull/2181 for https://github.com/pulumi/pulumi-terraform-bridge/issues/2180.

Seeing some more evidence of https://github.com/pulumi/pulumi-terraform-bridge/issues/2218 here.