### PR TITLE
Handle legacy suffix in rawname when obtaining possible docs sources

### DIFF
--- a/pkg/tfbridge/info/rename.go
+++ b/pkg/tfbridge/info/rename.go
@@ -29,7 +29,6 @@ const RenamedEntitySuffix string = "_legacy"
 func (p *Provider) RenameResourceWithAlias(resourceName string, legacyTok tokens.Type, newTok tokens.Type,
 	legacyModule string, newModule string, info *Resource,
 ) {
-	resourcePrefix := p.Name + "_"
 	legacyResourceName := resourceName + RenamedEntitySuffix
 	if info == nil {
 		info = &Resource{}
@@ -49,12 +48,6 @@ func (p *Provider) RenameResourceWithAlias(resourceName string, legacyTok tokens
 		{Type: &legacyType},
 	}
 
-	if legacyInfo.Docs == nil {
-		legacyInfo.Docs = &Doc{
-			Source: resourceName[len(resourcePrefix):] + ".html.markdown",
-		}
-	}
-
 	legacyInfo.DeprecationMessage = fmt.Sprintf("%s has been deprecated in favor of %s",
 		generateResourceName(legacyInfo.Tok.Module().Package(), strings.ToLower(legacyModule),
 			legacyInfo.Tok.Name().String()),
@@ -69,7 +62,6 @@ func (p *Provider) RenameResourceWithAlias(resourceName string, legacyTok tokens
 func (p *Provider) RenameDataSource(resourceName string, legacyTok tokens.ModuleMember, newTok tokens.ModuleMember,
 	legacyModule string, newModule string, info *DataSource,
 ) {
-	resourcePrefix := p.Name + "_"
 	legacyResourceName := resourceName + RenamedEntitySuffix
 	if info == nil {
 		info = &DataSource{}
@@ -84,12 +76,6 @@ func (p *Provider) RenameDataSource(resourceName string, legacyTok tokens.Module
 	}
 
 	currentInfo.Tok = legacyTok
-
-	if legacyInfo.Docs == nil {
-		legacyInfo.Docs = &Doc{
-			Source: resourceName[len(resourcePrefix):] + ".html.markdown",
-		}
-	}
 
 	legacyInfo.DeprecationMessage = fmt.Sprintf("%s has been deprecated in favor of %s",
 		generateResourceName(legacyInfo.Tok.Module().Package(), strings.ToLower(legacyModule),

--- a/pkg/tfbridge/tokens_test.go
+++ b/pkg/tfbridge/tokens_test.go
@@ -17,6 +17,7 @@ package tfbridge_test
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
 	"testing"
 
 	"github.com/hexops/autogold/v2"
@@ -507,6 +508,13 @@ func testTokenAliasing(t *testing.T) {
 					"pkg_mod1_d1": nil,
 				},
 			}).Shim(),
+			Resources: map[string]*info.Resource{
+				"pkg_mod1_r1": {
+					Docs: &tfbridge.DocInfo{
+						Source: "manually_provided_docs_source.md",
+					},
+				},
+			},
 		}
 	}
 
@@ -521,7 +529,10 @@ func testTokenAliasing(t *testing.T) {
 	autoAliasing(simple, metadata)
 
 	assert.Equal(t, map[string]*tfbridge.ResourceInfo{
-		"pkg_mod1_r1": {Tok: "pkg:index/mod1R1:Mod1R1"},
+		"pkg_mod1_r1": {
+			Tok:  "pkg:index/mod1R1:Mod1R1",
+			Docs: &tfbridge.DocInfo{Source: "manually_provided_docs_source.md"},
+		},
 		"pkg_mod1_r2": {Tok: "pkg:index/mod1R2:Mod1R2"},
 		"pkg_mod2_r1": {Tok: "pkg:index/mod2R1:Mod2R1"},
 	}, simple.Resources)
@@ -544,11 +555,12 @@ func testTokenAliasing(t *testing.T) {
 		"pkg_mod1_r1": {
 			Tok:     "pkg:mod1/r1:R1",
 			Aliases: []tfbridge.AliasInfo{{Type: ref("pkg:index/mod1R1:Mod1R1")}},
+			Docs:    &tfbridge.DocInfo{Source: "manually_provided_docs_source.md"},
 		},
 		"pkg_mod1_r1_legacy": {
 			Tok:                "pkg:index/mod1R1:Mod1R1",
 			DeprecationMessage: "pkg.index/mod1r1.Mod1R1 has been deprecated in favor of pkg.mod1/r1.R1",
-			Docs:               &tfbridge.DocInfo{Source: "kg_mod1_r1.html.markdown"},
+			Docs:               &tfbridge.DocInfo{Source: "manually_provided_docs_source.md"},
 		},
 		"pkg_mod1_r2": {
 			Tok:     "pkg:mod1/r2:R2",
@@ -557,7 +569,7 @@ func testTokenAliasing(t *testing.T) {
 		"pkg_mod1_r2_legacy": {
 			Tok:                "pkg:index/mod1R2:Mod1R2",
 			DeprecationMessage: "pkg.index/mod1r2.Mod1R2 has been deprecated in favor of pkg.mod1/r2.R2",
-			Docs:               &tfbridge.DocInfo{Source: "kg_mod1_r2.html.markdown"},
+			//Docs:               &tfbridge.DocInfo{Source: "kg_mod1_r2.html.markdown"},
 		},
 		"pkg_mod2_r1": {
 			Tok:     "pkg:mod2/r1:R1",
@@ -566,7 +578,7 @@ func testTokenAliasing(t *testing.T) {
 		"pkg_mod2_r1_legacy": {
 			Tok:                "pkg:index/mod2R1:Mod2R1",
 			DeprecationMessage: "pkg.index/mod2r1.Mod2R1 has been deprecated in favor of pkg.mod2/r1.R1",
-			Docs:               &tfbridge.DocInfo{Source: "kg_mod2_r1.html.markdown"},
+			//Docs:               &tfbridge.DocInfo{Source: "kg_mod2_r1.html.markdown"},
 		},
 	}, modules.Resources)
 	assert.Equal(t, map[string]*tfbridge.DataSourceInfo{
@@ -574,7 +586,7 @@ func testTokenAliasing(t *testing.T) {
 		"pkg_mod1_d1_legacy": {
 			Tok:                "pkg:index/getMod1D1:getMod1D1",
 			DeprecationMessage: "pkg.index/getmod1d1.getMod1D1 has been deprecated in favor of pkg.mod1/getd1.getD1",
-			Docs:               &tfbridge.DocInfo{Source: "kg_mod1_d1.html.markdown"},
+			//Docs:               &tfbridge.DocInfo{Source: "kg_mod1_d1.html.markdown"},
 		},
 	},
 		modules.DataSources)
@@ -613,6 +625,7 @@ func testTokenAliasing(t *testing.T) {
 		"pkg_mod1_r1": {
 			Tok:     "pkg:mod1/r1:R1",
 			Aliases: []tfbridge.AliasInfo{{Type: ref("pkg:index/mod1R1:Mod1R1")}},
+			Docs:    &tfbridge.DocInfo{Source: "manually_provided_docs_source.md"},
 		},
 		"pkg_mod1_r2": {
 			Tok:     "pkg:mod1/r2:R2",

--- a/pkg/tfbridge/tokens_test.go
+++ b/pkg/tfbridge/tokens_test.go
@@ -17,7 +17,6 @@ package tfbridge_test
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
 	"testing"
 
 	"github.com/hexops/autogold/v2"
@@ -26,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/tokens"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"

--- a/pkg/tfbridge/tokens_test.go
+++ b/pkg/tfbridge/tokens_test.go
@@ -569,7 +569,6 @@ func testTokenAliasing(t *testing.T) {
 		"pkg_mod1_r2_legacy": {
 			Tok:                "pkg:index/mod1R2:Mod1R2",
 			DeprecationMessage: "pkg.index/mod1r2.Mod1R2 has been deprecated in favor of pkg.mod1/r2.R2",
-			//Docs:               &tfbridge.DocInfo{Source: "kg_mod1_r2.html.markdown"},
 		},
 		"pkg_mod2_r1": {
 			Tok:     "pkg:mod2/r1:R1",
@@ -578,7 +577,6 @@ func testTokenAliasing(t *testing.T) {
 		"pkg_mod2_r1_legacy": {
 			Tok:                "pkg:index/mod2R1:Mod2R1",
 			DeprecationMessage: "pkg.index/mod2r1.Mod2R1 has been deprecated in favor of pkg.mod2/r1.R1",
-			//Docs:               &tfbridge.DocInfo{Source: "kg_mod2_r1.html.markdown"},
 		},
 	}, modules.Resources)
 	assert.Equal(t, map[string]*tfbridge.DataSourceInfo{
@@ -586,7 +584,6 @@ func testTokenAliasing(t *testing.T) {
 		"pkg_mod1_d1_legacy": {
 			Tok:                "pkg:index/getMod1D1:getMod1D1",
 			DeprecationMessage: "pkg.index/getmod1d1.getMod1D1 has been deprecated in favor of pkg.mod1/getd1.getD1",
-			//Docs:               &tfbridge.DocInfo{Source: "kg_mod1_d1.html.markdown"},
 		},
 	},
 		modules.DataSources)

--- a/pkg/tfbridge/x/token_test.go
+++ b/pkg/tfbridge/x/token_test.go
@@ -433,7 +433,6 @@ func TestTokenAliasing(t *testing.T) {
 		"pkg_mod1_r1_legacy": {
 			Tok:                "pkg:index/mod1R1:Mod1R1",
 			DeprecationMessage: "pkg.index/mod1r1.Mod1R1 has been deprecated in favor of pkg.mod1/r1.R1",
-			Docs:               &tfbridge.DocInfo{Source: "kg_mod1_r1.html.markdown"},
 		},
 		"pkg_mod1_r2": {
 			Tok:     "pkg:mod1/r2:R2",
@@ -442,7 +441,6 @@ func TestTokenAliasing(t *testing.T) {
 		"pkg_mod1_r2_legacy": {
 			Tok:                "pkg:index/mod1R2:Mod1R2",
 			DeprecationMessage: "pkg.index/mod1r2.Mod1R2 has been deprecated in favor of pkg.mod1/r2.R2",
-			Docs:               &tfbridge.DocInfo{Source: "kg_mod1_r2.html.markdown"},
 		},
 		"pkg_mod2_r1": {
 			Tok:     "pkg:mod2/r1:R1",
@@ -451,7 +449,6 @@ func TestTokenAliasing(t *testing.T) {
 		"pkg_mod2_r1_legacy": {
 			Tok:                "pkg:index/mod2R1:Mod2R1",
 			DeprecationMessage: "pkg.index/mod2r1.Mod2R1 has been deprecated in favor of pkg.mod2/r1.R1",
-			Docs:               &tfbridge.DocInfo{Source: "kg_mod2_r1.html.markdown"},
 		},
 	}, modules.Resources)
 

--- a/pkg/tfgen/source.go
+++ b/pkg/tfgen/source.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
@@ -182,6 +183,11 @@ func getRepoPath(gitHost string, org string, provider string, version string) (_
 }
 
 func getMarkdownNames(packagePrefix, rawName string, globalInfo *tfbridge.DocRuleInfo) []string {
+
+	// Handle resources/datasources renamed with the tfbridge.RenamedEntitySuffix, `_legacy_`
+	// We want to be finding docs for the rawName _without_ the suffix, so we trim it if present.
+	rawName = strings.TrimSuffix(rawName, tfbridge.RenamedEntitySuffix)
+
 	possibleMarkdownNames := []string{
 		// Most frequently, docs leave off the provider prefix
 		withoutPackageName(packagePrefix, rawName) + ".html.markdown",

--- a/pkg/tfgen/source.go
+++ b/pkg/tfgen/source.go
@@ -186,19 +186,19 @@ func getMarkdownNames(packagePrefix, rawName string, globalInfo *tfbridge.DocRul
 
 	// Handle resources/datasources renamed with the tfbridge.RenamedEntitySuffix, `_legacy_`
 	// We want to be finding docs for the rawName _without_ the suffix, so we trim it if present.
-	rawName = strings.TrimSuffix(rawName, tfbridge.RenamedEntitySuffix)
+	trimmedName := strings.TrimSuffix(rawName, tfbridge.RenamedEntitySuffix)
 
 	possibleMarkdownNames := []string{
 		// Most frequently, docs leave off the provider prefix
-		withoutPackageName(packagePrefix, rawName) + ".html.markdown",
-		withoutPackageName(packagePrefix, rawName) + ".markdown",
-		withoutPackageName(packagePrefix, rawName) + ".html.md",
-		withoutPackageName(packagePrefix, rawName) + ".md",
+		withoutPackageName(packagePrefix, trimmedName) + ".html.markdown",
+		withoutPackageName(packagePrefix, trimmedName) + ".markdown",
+		withoutPackageName(packagePrefix, trimmedName) + ".html.md",
+		withoutPackageName(packagePrefix, trimmedName) + ".md",
 		// But for some providers, the prefix is included in the name of the doc file
-		rawName + ".html.markdown",
-		rawName + ".markdown",
-		rawName + ".html.md",
-		rawName + ".md",
+		trimmedName + ".html.markdown",
+		trimmedName + ".markdown",
+		trimmedName + ".html.md",
+		trimmedName + ".md",
 	}
 
 	if globalInfo != nil && globalInfo.AlternativeNames != nil {
@@ -207,7 +207,6 @@ func getMarkdownNames(packagePrefix, rawName string, globalInfo *tfbridge.DocRul
 			TfToken: rawName,
 		}), possibleMarkdownNames...)
 	}
-
 	return possibleMarkdownNames
 }
 

--- a/pkg/tfgen/source_test.go
+++ b/pkg/tfgen/source_test.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 )
 
 func TestGetDocsPath(t *testing.T) {
@@ -88,6 +90,58 @@ func TestGetDocsPath(t *testing.T) {
 
 			actualDataSource, err := getDocsPath(repo, DataSourceDocs)
 			check(tt.expectedDataSource, actualDataSource, err)
+		})
+	}
+}
+
+func TestGetNarkdownNames(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name          string
+		packagePrefix string
+		rawName       string
+		globalInfo    *tfbridge.DocRuleInfo
+		expectedNames []string
+	}{{
+		name:          "Generates collection of possible markdown names",
+		packagePrefix: "mongodbatlas",
+		rawName:       "mongodbatlas_x509_authentication_database_user",
+		globalInfo:    nil,
+		expectedNames: []string{
+			"x509_authentication_database_user.html.markdown",
+			"x509_authentication_database_user.markdown",
+			"x509_authentication_database_user.html.md",
+			"x509_authentication_database_user.md",
+			"mongodbatlas_x509_authentication_database_user.html.markdown",
+			"mongodbatlas_x509_authentication_database_user.markdown",
+			"mongodbatlas_x509_authentication_database_user.html.md",
+			"mongodbatlas_x509_authentication_database_user.md",
+		},
+	},
+		{
+			name:          "Trims tfbridge.RenamedEntitySuffix from possible markdown names",
+			packagePrefix: "mongodbatlas",
+			rawName:       "mongodbatlas_x509_authentication_database_user_legacy",
+			globalInfo:    nil,
+			expectedNames: []string{
+				"x509_authentication_database_user.html.markdown",
+				"x509_authentication_database_user.markdown",
+				"x509_authentication_database_user.html.md",
+				"x509_authentication_database_user.md",
+				"mongodbatlas_x509_authentication_database_user.html.markdown",
+				"mongodbatlas_x509_authentication_database_user.markdown",
+				"mongodbatlas_x509_authentication_database_user.html.md",
+				"mongodbatlas_x509_authentication_database_user.md",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actualNames := getMarkdownNames(tt.packagePrefix, tt.rawName, tt.globalInfo)
+			assert.Equal(t, tt.expectedNames, actualNames)
 		})
 	}
 }


### PR DESCRIPTION
Fixes #2228.

Removes the potentially incorrect setting of `DocInfo.Source` in `renames.go` and instead trims the `RenamedEntitySuffix` before generating possible docs names in `getMarkdownNames`.

edit: interesting test failure; this should not affect token aliasing itself. 

edit2: because `renames.go` no longer sets a possible docs source, the test in `tokens_test` had to be adjusted. It now shows that the bridge honors provided docs sources as well as default ones for renamed resources.

