### PR TITLE
Add more shim layer tests for pf

### DIFF
--- a/pf/tests/schemashim_test.go
+++ b/pf/tests/schemashim_test.go
@@ -305,7 +305,7 @@ func TestSchemaShimRepresentations(t *testing.T) {
 						Blocks: map[string]schema.Block{
 							"single_nested_block": schema.SingleNestedBlock{
 								Attributes: map[string]schema.Attribute{
-									"a1": schema.Float64Attribute{
+									"a1": schema.StringAttribute{
 										Optional: true,
 									},
 								},
@@ -322,7 +322,7 @@ func TestSchemaShimRepresentations(t *testing.T) {
           "resource": {
             "a1": {
               "optional": true,
-              "type": 3
+              "type": 4
             }
           }
         },
@@ -342,7 +342,7 @@ func TestSchemaShimRepresentations(t *testing.T) {
 							"list_nested_block": schema.ListNestedBlock{
 								NestedObject: schema.NestedBlockObject{
 									Attributes: map[string]schema.Attribute{
-										"a1": schema.Float64Attribute{
+										"a1": schema.StringAttribute{
 											Optional: true,
 										},
 									},
@@ -352,6 +352,7 @@ func TestSchemaShimRepresentations(t *testing.T) {
 					},
 				}},
 			},
+			// TODO: Why is this different to list-nested-attribute? Should it be?
 			autogold.Expect(`{
   "resources": {
     "_": {
@@ -360,7 +361,7 @@ func TestSchemaShimRepresentations(t *testing.T) {
           "resource": {
             "a1": {
               "optional": true,
-              "type": 3
+              "type": 4
             }
           }
         },


### PR DESCRIPTION
Follow-up on https://github.com/pulumi/pulumi-terraform-bridge/pull/2187 with missing PF attribute/block types.

Looks like the shim layer does indeed lose information, unlike in sdkv2. Wondering how much of it is essential:

- the distinction between block and attribute seems to be lost. Perhaps intentional but it is meaningful in PF (ex. blocks can't be `Computed`)
- `list-attribute-object-element` and `list-nested-attribute` are the same. As far as I can tell, these are pretty much the same thing on the PF side, so fair.
- `object-attribute`, `single-nested-attribute` and `single-nested-block` are identical in the shim layer.
- These are also identical to the nested object in a `map-nested-attribute`, `list-nested-attribute` and  - these are all roughly "Objects" so probably fair.
- Interestingly these are all different from the nested object in a `list-nested-block` - my intuition is that these should be "the same" for the shim layer. Any ideas here?