### PR TITLE
fix(pf): remove __defaults entry from inputs

### DIFF
--- a/pf/tests/provider_read_test.go
+++ b/pf/tests/provider_read_test.go
@@ -217,6 +217,41 @@ func TestImportingResourcesWithBlocks(t *testing.T) {
 	testutils.Replay(t, server, testCase)
 }
 
+func TestImportingResourcesWithoutDefaults(t *testing.T) {
+	// Importing a resource that has blocks used to add a `__defaults: []` entry to the `response.inputs`
+	// ensure that it no longer does so
+	server := newProviderServer(t, testprovider.SyntheticTestBridgeProvider())
+	testCase := `
+	{
+          "method": "/pulumirpc.ResourceProvider/Read",
+          "request": {
+            "id": "zone/929e99f1a4152bfe415bbb3b29d1a227/my-ruleset-id",
+            "urn": "urn:pulumi:testing::testing::testbridge:index/testnest:Testnest::myresource",
+            "properties": {}
+          },
+          "response": {
+            "id": "*",
+            "inputs": {
+              "rules": [
+                {
+                  "protocol": "some-string"
+                }
+              ]
+            },
+            "properties": {
+              "id": "*",
+              "rules": [
+                {
+                  "protocol": "some-string"
+                }
+              ],
+              "services": []
+            }
+          }
+        }`
+	testutils.Replay(t, server, testCase)
+}
+
 // Check that importing a resource that does not exist returns an empty property bag and
 // no ID.
 func TestImportingMissingResources(t *testing.T) {

--- a/pf/tfbridge/provider_read.go
+++ b/pf/tfbridge/provider_read.go
@@ -91,7 +91,7 @@ func (p *provider) ReadWithContext(
 		}
 
 		// __defaults is not needed for Plugin Framework bridged providers
-		deleteDefaultsKey(&result.Inputs)
+		deleteDefaultsKey(result.Inputs)
 	}
 
 	return result, ignoredStatus, err
@@ -100,11 +100,10 @@ func (p *provider) ReadWithContext(
 // deleteDefaultsKey removes the `__defaults: []` entry from all objects recursively
 // The `__defaults` key is something used in sdkv2 and is not handled here in pf. Because
 // of some code reuse between sdkv2 & pf the `__defaults` key is getting inserted
-func deleteDefaultsKey(inputs *resource.PropertyMap) {
-	i := *inputs
-	delete(i, "__defaults")
-	for _, key := range i.StableKeys() {
-		transformedValue, err := propertyvalue.TransformPropertyValue(
+func deleteDefaultsKey(inputs resource.PropertyMap) {
+	delete(inputs, "__defaults")
+	for key, value := range inputs {
+		newVal, err := propertyvalue.TransformPropertyValue(
 			resource.PropertyPath{},
 			func(pp resource.PropertyPath, pv resource.PropertyValue) (resource.PropertyValue, error) {
 				if pv.IsObject() {
@@ -112,12 +111,11 @@ func deleteDefaultsKey(inputs *resource.PropertyMap) {
 				}
 				return pv, nil
 			},
-			i[key],
+			value,
 		)
-		if err != nil {
-			return
+		if err == nil {
+			inputs[key] = newVal
 		}
-		i[key] = transformedValue
 	}
 }
 

--- a/pf/tfbridge/provider_read_test.go
+++ b/pf/tfbridge/provider_read_test.go
@@ -1,0 +1,106 @@
+package tfbridge
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeleteNestedDefaults(t *testing.T) {
+	tests := []struct {
+		name     string
+		inputs   resource.PropertyMap
+		expected resource.PropertyMap
+	}{
+		{
+			name: "top level __defaults",
+			inputs: resource.NewPropertyMapFromMap(map[string]interface{}{
+				"someProp":   "someVal",
+				"__defaults": []string{},
+			}),
+			expected: resource.NewPropertyMapFromMap(map[string]interface{}{
+				"someProp": "someVal",
+			}),
+		},
+		{
+			name: "nested level __defaults",
+			inputs: resource.NewPropertyMapFromMap(map[string]interface{}{
+				"someProp": map[string]interface{}{
+					"nestedProp": "nestedValue",
+					"__defaults": []interface{}{},
+				},
+				"__defaults": []interface{}{},
+			}),
+			expected: resource.NewPropertyMapFromMap(map[string]interface{}{
+				"someProp": map[string]interface{}{
+					"nestedProp": "nestedValue",
+				},
+			}),
+		},
+		{
+			name: "array __defaults",
+			inputs: resource.NewPropertyMapFromMap(map[string]interface{}{
+				"someProp": []map[string]interface{}{
+					{
+						"nestedProp": "nestedValue",
+						"__defaults": []interface{}{},
+					},
+				},
+				"__defaults": []interface{}{},
+			}),
+			expected: resource.NewPropertyMapFromMap(map[string]interface{}{
+				"someProp": []map[string]interface{}{
+					{
+						"nestedProp": "nestedValue",
+					},
+				},
+			}),
+		},
+		{
+			name: "super nested __defaults",
+			inputs: resource.NewPropertyMapFromMap(map[string]interface{}{
+				"someProp": []map[string]interface{}{
+					{
+						"nestedProp": map[string]interface{}{
+							"__defaults": []interface{}{},
+							"doubleNested": []map[string]interface{}{
+								{
+									"__defaults": []interface{}{},
+									"someProp": map[string]interface{}{
+										"__defaults": []interface{}{},
+										"otherProp":  "value",
+									},
+								},
+							},
+						},
+						"__defaults": []interface{}{},
+					},
+				},
+				"__defaults": []interface{}{},
+			}),
+			expected: resource.NewPropertyMapFromMap(map[string]interface{}{
+				"someProp": []map[string]interface{}{
+					{
+						"nestedProp": map[string]interface{}{
+							"doubleNested": []map[string]interface{}{
+								{
+									"someProp": map[string]interface{}{
+										"otherProp": "value",
+									},
+								},
+							},
+						},
+					},
+				},
+			}),
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			deleteDefaultsKey(&tc.inputs)
+			assert.Equal(t, tc.expected, tc.inputs)
+		})
+	}
+}

--- a/pf/tfbridge/provider_read_test.go
+++ b/pf/tfbridge/provider_read_test.go
@@ -99,7 +99,7 @@ func TestDeleteNestedDefaults(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			deleteDefaultsKey(&tc.inputs)
+			deleteDefaultsKey(tc.inputs)
 			assert.Equal(t, tc.expected, tc.inputs)
 		})
 	}

--- a/pkg/tests/schema_pulumi_test.go
+++ b/pkg/tests/schema_pulumi_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,8 +14,107 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/internal/pulcheck"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optpreview"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optrefresh"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestFailedValidatorOnReadHandling(t *testing.T) {
+
+	toString := func(p *string) (v string) {
+		if p == nil {
+			return v
+		}
+
+		return *p
+	}
+	flatten := func() []interface{} {
+		var tflist []interface{}
+		val := ""
+		tflist = append(tflist, &map[string]interface{}{
+			"value1": "abc",
+			"value2": toString(&val),
+		})
+
+		return tflist
+	}
+	resMap := map[string]*schema.Resource{
+		"prov_test": {
+			Schema: map[string]*schema.Schema{
+				"route": {
+					Type:       schema.TypeSet,
+					Computed:   true,
+					Optional:   true,
+					ConfigMode: schema.SchemaConfigModeAttr,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"value1": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"value2": {
+								Type:     schema.TypeString,
+								Optional: true,
+								ValidateFunc: func(i interface{}, s string) ([]string, []error) {
+									t.Error("here")
+									return []string{}, []error{errors.New("validation error")}
+								},
+							},
+						},
+					},
+				},
+			},
+			Importer: &schema.ResourceImporter{
+				StateContext: func(ctx context.Context, rd *schema.ResourceData, i interface{}) ([]*schema.ResourceData, error) {
+					err := rd.Set("route", flatten())
+					assert.NoError(t, err)
+					return []*schema.ResourceData{rd}, nil
+				},
+			},
+			ReadContext: func(ctx context.Context, rd *schema.ResourceData, i interface{}) diag.Diagnostics {
+				err := rd.Set("route", flatten())
+				assert.NoError(t, err)
+				return nil
+			},
+		},
+	}
+	bridgedProvider := pulcheck.BridgedProvider(t, "prov", resMap, pulcheck.DisablePlanResourceChange())
+	// 	program := `
+	// name: test
+	// runtime: yaml
+	// resources:
+	//   mainRes:
+	//     type: prov:index:Test
+	//     properties:
+	//       routes:
+	//         - value1: abcd
+	//     options:
+	//       ignoreChanges:
+	//         - routes
+	// outputs:
+	//   testOut: ${mainRes.routes}
+	// `
+	program := `
+name: test
+runtime: yaml
+`
+	pt := pulcheck.PulCheck(t, bridgedProvider, program)
+
+	ip := pt.Import("prov:index/test:Test", "mainRes", "mainRes", "")
+	es := pt.ExportStack()
+	state, err := es.Deployment.MarshalJSON()
+	assert.NoError(t, err)
+	t.Logf("State: %s", string(state))
+	t.Logf("import stdout: %s", ip.Stdout)
+	t.Logf("import stderr: %s", ip.Stderr)
+	// res := pt.Up(optup.Diff())
+	// t.Logf("stdout: %s", res.StdOut)
+	// t.Logf("stderr: %s", res.StdErr)
+	// es = pt.ExportStack()
+	// state, err = es.Deployment.MarshalJSON()
+	// assert.NoError(t, err)
+	// t.Logf("State: %s", string(state))
+	assert.Equal(t, "", 0)
+}
 
 func TestUnknownHandling(t *testing.T) {
 	resMap := map[string]*schema.Resource{


### PR DESCRIPTION
PF resources should not be injecting __defaults during
import as they do not support it, but it is happening through an
unintended side-effect of code reuse from sdkv2.

I could think of a couple other ways to handle this:

1. Duplicate the code in the pf and remove the code specific to
injecting __defaults
2. Removing where we inject an empty __defaults. See #2236

Decided to go with the simplest approach of just doing some post
processing since touching the `sdkv2` code seems to be a much bigger
effort.

fixes #2189, fixes pulumi/pulumi-aws#4204