### PR TITLE
Apply config encoding at the ProviderWithContext level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,12 @@
 *.iml
 .DS_Store
 bin
+go.work
+go.work.sum
+
+
 coverage.txt
 pkg/tests/coverage.txt
 testing/coverage.txt
-go.work
-go.work.sum
+pf/coverage.out
+pf/tests/coverage.out

--- a/dynamic/provider_test.go
+++ b/dynamic/provider_test.go
@@ -264,7 +264,17 @@ func TestCheckConfig(t *testing.T) {
 		}),
 	}, expect(autogold.Expect(`{
   "inputs": {
-    "endpoint": 123.456
+    "endpoint": "123.456"
+  }
+}`))))
+
+	t.Run("nested-config", assertGRPCCall(s.CheckConfig, &pulumirpc.CheckRequest{
+		News: marshal(resource.PropertyMap{
+			"nested": resource.NewProperty(`{"field1": "true", "field2": false}`),
+		}),
+	}, expect(autogold.Expect(`{
+  "inputs": {
+    "nested": "{\"field1\":\"true\",\"field2\":false}"
   }
 }`))))
 }

--- a/dynamic/provider_test.go
+++ b/dynamic/provider_test.go
@@ -268,7 +268,11 @@ func TestCheckConfig(t *testing.T) {
   }
 }`))))
 
-	t.Run("nested-config", assertGRPCCall(s.CheckConfig, &pulumirpc.CheckRequest{
+	// Check that we correctly handle JSON encoded config values sent by Pulumi.
+	//
+	// This will become unnecessary when https://github.com/pulumi/pulumi/pull/15032
+	// merges.
+	t.Run("json-encoded-nested-config", assertGRPCCall(s.CheckConfig, &pulumirpc.CheckRequest{
 		News: marshal(resource.PropertyMap{
 			"nested": resource.NewProperty(`{"field1": "true", "field2": false}`),
 		}),

--- a/pf/internal/configencoding/provider.go
+++ b/pf/internal/configencoding/provider.go
@@ -1,0 +1,120 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configencoding
+
+import (
+	"context"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+
+	pl "github.com/pulumi/pulumi-terraform-bridge/pf/internal/plugin"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+)
+
+type ProviderWithContextAndConfig interface {
+	pl.ProviderWithContext
+
+	Attach(address string) error
+
+	// GetConfigEncoding supplies the wrapping [Provider] with the (possibly unstable)
+	// encoding used by the wrapped ProviderWithContextAndConfig.
+	//
+	// This is necessary since dynamic providers change their encoding in response to
+	// gRPC calls.
+	GetConfigEncoding(context.Context) *tfbridge.ConfigEncoding
+}
+
+type provider[T any] struct{ ProviderWithContextAndConfig }
+
+type Provider[T any] interface {
+	pl.ProviderWithContext
+
+	Unwrap() T
+}
+
+// New creates a new [plugin.Provider] that wraps prov.
+//
+// The returned provider will correctly handle JSON encoded property values according to
+// the passed encoding.
+func New[T ProviderWithContextAndConfig](prov T) Provider[T] {
+	return &provider[T]{prov}
+}
+
+// Unwrap returns the original [pl.ProviderWithContext] used to create the [Provider].
+func (p *provider[T]) Unwrap() T { return p.ProviderWithContextAndConfig.(T) }
+
+func (p *provider[T]) CheckConfigWithContext(
+	ctx context.Context, urn resource.URN, olds, news resource.PropertyMap,
+	allowUnknowns bool,
+) (resource.PropertyMap, []plugin.CheckFailure, error) {
+	encoding := p.GetConfigEncoding(ctx)
+	olds, err := encoding.UnfoldProperties(olds)
+	if err != nil {
+		return nil, nil, err
+	}
+	news, err = encoding.UnfoldProperties(news)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	props, failures, err := p.ProviderWithContextAndConfig.
+		CheckConfigWithContext(ctx, urn, olds, news, allowUnknowns)
+	if err != nil {
+		return nil, nil, err
+	}
+	props, err = encoding.FoldProperties(props)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return props, failures, err
+}
+
+func (p *provider[T]) DiffConfigWithContext(
+	ctx context.Context, urn resource.URN, oldInputs, olds, news resource.PropertyMap,
+	allowUnknowns bool, ignoreChanges []string) (plugin.DiffResult, error) {
+	encoding := p.GetConfigEncoding(ctx)
+	oldInputs, err := encoding.UnfoldProperties(oldInputs)
+	if err != nil {
+		return plugin.DiffConfigResponse{}, err
+	}
+
+	olds, err = encoding.UnfoldProperties(olds)
+	if err != nil {
+		return plugin.DiffConfigResponse{}, err
+	}
+
+	news, err = encoding.UnfoldProperties(news)
+	if err != nil {
+		return plugin.DiffConfigResponse{}, err
+	}
+
+	return p.ProviderWithContextAndConfig.DiffConfigWithContext(
+		ctx, urn, oldInputs, olds, news, allowUnknowns, ignoreChanges)
+}
+
+func (p *provider[T]) ConfigureWithContext(ctx context.Context, inputs resource.PropertyMap) error {
+	inputs, err := p.GetConfigEncoding(ctx).UnfoldProperties(inputs)
+	if err != nil {
+		return err
+	}
+
+	return p.ProviderWithContextAndConfig.ConfigureWithContext(ctx, inputs)
+}
+
+func (p *provider[T]) Attach(address string) error {
+	return p.ProviderWithContextAndConfig.Attach(address)
+}

--- a/pf/internal/configencoding/provider.go
+++ b/pf/internal/configencoding/provider.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2024, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -113,8 +113,4 @@ func (p *provider[T]) ConfigureWithContext(ctx context.Context, inputs resource.
 	}
 
 	return p.ProviderWithContextAndConfig.ConfigureWithContext(ctx, inputs)
-}
-
-func (p *provider[T]) Attach(address string) error {
-	return p.ProviderWithContextAndConfig.Attach(address)
 }

--- a/pf/tests/internal/testprovider/cmd/pulumi-resource-testbridge/schema.json
+++ b/pf/tests/internal/testprovider/cmd/pulumi-resource-testbridge/schema.json
@@ -26,6 +26,27 @@
             "boolConfigProp": {
                 "type": "boolean"
             },
+            "listNestedProps": {
+                "type": "array",
+                "items": {
+                    "type": "boolean"
+                }
+            },
+            "listNesteds": {
+                "type": "array",
+                "items": {
+                    "$ref": "#/types/testbridge:config/listNesteds:listNesteds"
+                }
+            },
+            "mapNestedProp": {
+                "type": "object",
+                "additionalProperties": {
+                    "type": "integer"
+                }
+            },
+            "singleNested": {
+                "$ref": "#/types/testbridge:config/singleNested:singleNested"
+            },
             "skipMetadataApiCheck": {
                 "type": "boolean",
                 "description": "Example taken from pulumi-aws; used to validate string properties remapped to bool type during briding\n",
@@ -38,10 +59,106 @@
                 "type": "string",
                 "description": "Used for testing DefaultInfo default application support\n",
                 "default": "DEFAULT"
+            },
+            "validateNested": {
+                "type": "boolean",
+                "description": "Validate that nested values are received as expected.\n"
             }
         }
     },
     "types": {
+        "testbridge:config/listNesteds:listNesteds": {
+            "properties": {
+                "boolProp": {
+                    "type": "boolean"
+                },
+                "listNestedProps": {
+                    "type": "array",
+                    "items": {
+                        "type": "boolean"
+                    }
+                },
+                "mapNestedProp": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "integer"
+                    }
+                },
+                "stringProp": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "testbridge:config/singleNested:singleNested": {
+            "properties": {
+                "boolProp": {
+                    "type": "boolean"
+                },
+                "listNestedProps": {
+                    "type": "array",
+                    "items": {
+                        "type": "boolean"
+                    }
+                },
+                "mapNestedProp": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "integer"
+                    }
+                },
+                "stringProp": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "testbridge:index/ProviderListNested:ProviderListNested": {
+            "properties": {
+                "boolProp": {
+                    "type": "boolean"
+                },
+                "listNestedProps": {
+                    "type": "array",
+                    "items": {
+                        "type": "boolean"
+                    }
+                },
+                "mapNestedProp": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "integer"
+                    }
+                },
+                "stringProp": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "testbridge:index/ProviderSingleNested:ProviderSingleNested": {
+            "properties": {
+                "boolProp": {
+                    "type": "boolean"
+                },
+                "listNestedProps": {
+                    "type": "array",
+                    "items": {
+                        "type": "boolean"
+                    }
+                },
+                "mapNestedProp": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "integer"
+                    }
+                },
+                "stringProp": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "testbridge:index/TestnestRule:TestnestRule": {
             "properties": {
                 "actionParameters": {
@@ -249,6 +366,27 @@
             "boolConfigProp": {
                 "type": "boolean"
             },
+            "listNestedProps": {
+                "type": "array",
+                "items": {
+                    "type": "boolean"
+                }
+            },
+            "listNesteds": {
+                "type": "array",
+                "items": {
+                    "$ref": "#/types/testbridge:index/ProviderListNested:ProviderListNested"
+                }
+            },
+            "mapNestedProp": {
+                "type": "object",
+                "additionalProperties": {
+                    "type": "integer"
+                }
+            },
+            "singleNested": {
+                "$ref": "#/types/testbridge:index/ProviderSingleNested:ProviderSingleNested"
+            },
             "skipMetadataApiCheck": {
                 "type": "boolean",
                 "description": "Example taken from pulumi-aws; used to validate string properties remapped to bool type during briding\n"
@@ -259,11 +397,36 @@
             "stringDefaultinfoConfigProp": {
                 "type": "string",
                 "description": "Used for testing DefaultInfo default application support\n"
+            },
+            "validateNested": {
+                "type": "boolean",
+                "description": "Validate that nested values are received as expected.\n"
             }
         },
         "inputProperties": {
             "boolConfigProp": {
                 "type": "boolean"
+            },
+            "listNestedProps": {
+                "type": "array",
+                "items": {
+                    "type": "boolean"
+                }
+            },
+            "listNesteds": {
+                "type": "array",
+                "items": {
+                    "$ref": "#/types/testbridge:index/ProviderListNested:ProviderListNested"
+                }
+            },
+            "mapNestedProp": {
+                "type": "object",
+                "additionalProperties": {
+                    "type": "integer"
+                }
+            },
+            "singleNested": {
+                "$ref": "#/types/testbridge:index/ProviderSingleNested:ProviderSingleNested"
             },
             "skipMetadataApiCheck": {
                 "type": "boolean",
@@ -277,6 +440,10 @@
                 "type": "string",
                 "description": "Used for testing DefaultInfo default application support\n",
                 "default": "DEFAULT"
+            },
+            "validateNested": {
+                "type": "boolean",
+                "description": "Validate that nested values are received as expected.\n"
             }
         }
     },

--- a/pf/tfbridge/main.go
+++ b/pf/tfbridge/main.go
@@ -44,7 +44,7 @@ func Main(ctx context.Context, pkg string, prov tfbridge.ProviderInfo, meta Prov
 			if err != nil {
 				return nil, err
 			}
-			return pp.marshalProviderInfo(ctx), nil
+			return pp.Unwrap().marshalProviderInfo(ctx), nil
 		})
 	// TODO[pulumi/pulumi-terraform-bridge#820]
 	// prov.P.InitLogging()

--- a/pf/tfbridge/provider.go
+++ b/pf/tfbridge/provider.go
@@ -32,6 +32,7 @@ import (
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 
 	"github.com/pulumi/pulumi-terraform-bridge/pf"
+	"github.com/pulumi/pulumi-terraform-bridge/pf/internal/configencoding"
 	pl "github.com/pulumi/pulumi-terraform-bridge/pf/internal/plugin"
 	"github.com/pulumi/pulumi-terraform-bridge/pf/internal/runtypes"
 	"github.com/pulumi/pulumi-terraform-bridge/pf/internal/schemashim"
@@ -92,7 +93,7 @@ func ShimProviderWithContext(ctx context.Context, p pfprovider.Provider) shim.Pr
 }
 
 func newProviderWithContext(ctx context.Context, info tfbridge.ProviderInfo,
-	meta ProviderMetadata) (*provider, error) {
+	meta ProviderMetadata) (configencoding.Provider[*provider], error) {
 	const infoPErrMSg string = "info.P must be constructed with ShimProvider or ShimProviderWithContext"
 
 	if info.P == nil {
@@ -146,7 +147,7 @@ func newProviderWithContext(ctx context.Context, info tfbridge.ProviderInfo,
 		}
 	}
 
-	return &provider{
+	p := &provider{
 		tfServer:           server6,
 		info:               info,
 		resources:          resources,
@@ -158,7 +159,13 @@ func newProviderWithContext(ctx context.Context, info tfbridge.ProviderInfo,
 		version:            semverVersion,
 		schemaOnlyProvider: info.P,
 		parameterize:       meta.XParamaterize,
-	}, nil
+	}
+
+	return configencoding.New(p), nil
+}
+
+func (p *provider) GetConfigEncoding(context.Context) *tfbridge.ConfigEncoding {
+	return tfbridge.NewConfigEncoding(p.schemaOnlyProvider.Schema(), p.info.Config)
 }
 
 // Internal. The signature of this function can change between major releases. Exposed to facilitate testing.
@@ -173,9 +180,8 @@ func NewProviderServer(
 		return nil, err
 	}
 
-	p.logSink = logSink
-	configEnc := tfbridge.NewConfigEncoding(p.schemaOnlyProvider.Schema(), p.info.Config)
-	return pl.NewProviderServerWithContext(p, configEnc), nil
+	p.Unwrap().logSink = logSink
+	return pl.NewProviderServerWithContext(p), nil
 }
 
 // Closer closes any underlying OS resources associated with this provider (like processes, RPC channels, etc).
@@ -214,7 +220,7 @@ func (p *provider) ParameterizeWithContext(
 			if err != nil {
 				return err
 			}
-			*p = *pp
+			*p = *pp.Unwrap()
 			return nil
 		})
 

--- a/pkg/convert/map.go
+++ b/pkg/convert/map.go
@@ -53,7 +53,7 @@ func (enc *mapEncoder) fromPropertyValue(p resource.PropertyValue) (tftypes.Valu
 	}
 	if !p.IsObject() {
 		return tftypes.NewValue(mapTy, nil),
-			fmt.Errorf("Expected an Object PropertyValue")
+			fmt.Errorf("Expected an Object PropertyValue, found %s (%q)", p.TypeString(), p.String())
 	}
 	values := map[string]tftypes.Value{}
 	for key, pv := range p.ObjectValue() {

--- a/pkg/convert/object.go
+++ b/pkg/convert/object.go
@@ -65,7 +65,7 @@ func (enc *objectEncoder) fromPropertyValue(p resource.PropertyValue) (tftypes.V
 	}
 	if !p.IsObject() {
 		return tftypes.NewValue(enc.objectType, nil),
-			fmt.Errorf("Expected an Object PropertyValue")
+			fmt.Errorf("Expected an Object PropertyValue, found %s (%q)", p.TypeString(), p.String())
 	}
 	pulumiMap := p.ObjectValue()
 	values := map[string]tftypes.Value{}

--- a/pkg/tfbridge/config_encoding.go
+++ b/pkg/tfbridge/config_encoding.go
@@ -17,7 +17,6 @@ package tfbridge
 import (
 	"encoding/json"
 	"fmt"
-	"sort"
 
 	"github.com/golang/protobuf/ptypes/struct"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -43,11 +42,8 @@ func NewConfigEncoding(config shim.SchemaMap, configInfos map[string]*SchemaInfo
 		pulumiKey := resource.PropertyKey(TerraformToPulumiNameV2(tfKey, config, configInfos))
 		schema := config.Get(tfKey)
 		fieldTypes[pulumiKey] = schema.Type()
-
 	}
-	return &ConfigEncoding{
-		fieldTypes: fieldTypes,
-	}
+	return &ConfigEncoding{fieldTypes}
 }
 
 func (*ConfigEncoding) tryUnwrapSecret(encoded any) (any, bool) {
@@ -87,8 +83,6 @@ func (enc *ConfigEncoding) convertStringToPropertyValue(s string, typ shim.Value
 		return resource.PropertyValue{}, err
 	}
 
-	opts := enc.unmarshalOpts()
-
 	// Instead of using resource.NewPropertyValue, specialize it to detect nested json-encoded secrets.
 	var replv func(encoded any) (resource.PropertyValue, bool)
 	replv = func(encoded any) (resource.PropertyValue, bool) {
@@ -98,9 +92,6 @@ func (enc *ConfigEncoding) convertStringToPropertyValue(s string, typ shim.Value
 		}
 
 		v := resource.NewPropertyValueRepl(encodedSecret, nil, replv)
-		if opts.KeepSecrets {
-			v = resource.MakeSecret(v)
-		}
 
 		return v, true
 	}
@@ -121,126 +112,90 @@ func (*ConfigEncoding) zeroValue(typ shim.ValueType) resource.PropertyValue {
 	}
 }
 
-func (enc *ConfigEncoding) unmarshalOpts() plugin.MarshalOptions {
-	return plugin.MarshalOptions{
+func (enc *ConfigEncoding) UnmarshalProperties(props *structpb.Struct) (resource.PropertyMap, error) {
+	m, err := plugin.UnmarshalProperties(props, plugin.MarshalOptions{
 		Label:        "config",
 		KeepUnknowns: true,
 		SkipNulls:    true,
 		RejectAssets: true,
-	}
-}
-
-// Like plugin.UnmarshalPropertyValue but overrides string parsing with convertStringToPropertyValue.
-func (enc *ConfigEncoding) unmarshalPropertyValue(key resource.PropertyKey,
-	v *structpb.Value) (*resource.PropertyValue, error) {
-
-	opts := enc.unmarshalOpts()
-
-	pv, err := plugin.UnmarshalPropertyValue(key, v, enc.unmarshalOpts())
+	})
 	if err != nil {
-		return nil, fmt.Errorf("error unmarshalling property %q: %w", key, err)
-	}
-	shimType, gotShimType := enc.fieldTypes[key]
-
-	// Only apply JSON-encoded recognition for known fields.
-	if !gotShimType {
-		return pv, nil
+		return nil, fmt.Errorf("failed to unmarshal to provider values: %w", err)
 	}
 
-	var jsonString string
-	var jsonStringDetected, jsonStringSecret bool
-
-	if pv.IsString() {
-		jsonString = pv.StringValue()
-		jsonStringDetected = true
-	}
-
-	if opts.KeepSecrets && pv.IsSecret() && pv.SecretValue().Element.IsString() {
-		jsonString = pv.SecretValue().Element.StringValue()
-		jsonStringDetected = true
-		jsonStringSecret = true
-	}
-
-	if jsonStringDetected {
-		v, err := enc.convertStringToPropertyValue(jsonString, shimType)
-		if err != nil {
-			return nil, fmt.Errorf("error unmarshalling property %q: %w", key, err)
-		}
-		if jsonStringSecret {
-			s := resource.MakeSecret(v)
-			return &s, nil
-		}
-		return &v, nil
-	}
-
-	// Computed sentinels are coming in as always having an empty string, but the encoding coerses them to a zero
-	// value of the appropriate type.
-	if pv.IsComputed() && gotShimType {
-		el := pv.V.(resource.Computed).Element
-		if el.IsString() && el.StringValue() == "" {
-			res := resource.MakeComputed(enc.zeroValue(shimType))
-			return &res, nil
-		}
-	}
-
-	return pv, nil
+	return enc.UnfoldProperties(m)
 }
 
-// Inline from plugin.UnmarshalProperties substituting plugin.UnmarshalPropertyValue.
-func (enc *ConfigEncoding) UnmarshalProperties(props *structpb.Struct) (resource.PropertyMap, error) {
-	opts := enc.unmarshalOpts()
+func (enc *ConfigEncoding) UnfoldProperties(m resource.PropertyMap) (resource.PropertyMap, error) {
+	result := make(resource.PropertyMap, len(m))
+	for _, pk := range m.StableKeys() {
+		v := m[pk]
 
-	result := make(resource.PropertyMap)
-
-	// First sort the keys so we enumerate them in order (in case errors happen, we want determinism).
-	var keys []string
-	if props != nil {
-		for k := range props.Fields {
-			keys = append(keys, k)
+		// If we don't have type information on the field, we don't attempt to do
+		// anything with it.
+		typ, hasType := enc.fieldTypes[pk]
+		if !hasType {
+			result[pk] = v
+			continue
 		}
-		sort.Strings(keys)
-	}
 
-	// And now unmarshal every field it into the map.
-	for _, key := range keys {
-		pk := resource.PropertyKey(key)
-		v, err := enc.unmarshalPropertyValue(pk, props.Fields[key])
-		if err != nil {
-			return nil, err
-		} else if v != nil {
-			if opts.SkipNulls && v.IsNull() {
-				continue
-			}
-			if opts.SkipInternalKeys && resource.IsInternalPropertyKey(pk) {
-				continue
-			}
-			result[pk] = *v
+		var isSecret bool
+		if v.IsSecret() {
+			isSecret = true
+			v = v.SecretValue().Element
 		}
+
+		if v.IsString() {
+			prop, err := enc.convertStringToPropertyValue(v.StringValue(), typ)
+			if err != nil {
+				return nil, err
+			}
+			v = prop
+		}
+
+		if v.IsComputed() && v.V.(resource.Computed).Element.V == "" {
+			v = resource.MakeComputed(enc.zeroValue(enc.fieldTypes[pk]))
+		}
+
+		if isSecret {
+			v = resource.MakeSecret(v)
+		}
+
+		result[pk] = v
 	}
 
 	return result, nil
 }
 
+// Inverse of [ConfigEncoding.UnfoldProperties], with additional support for
+// secrets. Since the encoding cannot represent nested secrets, any nested secrets will be
+// approximated by making the entire top-level property secret.
+func (enc *ConfigEncoding) FoldProperties(props resource.PropertyMap) (resource.PropertyMap, error) {
+	dst := make(resource.PropertyMap, len(props))
+	for k, v := range props {
+		var err error
+		dst[k], err = enc.jsonEncodePropertyValue(k, v)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return dst, nil
+}
+
 // Inverse of UnmarshalProperties, with additional support for secrets. Since the encoding cannot represent nested
 // secrets, any nested secrets will be approximated by making the entire top-level property secret.
 func (enc *ConfigEncoding) MarshalProperties(props resource.PropertyMap) (*structpb.Struct, error) {
-	opts := plugin.MarshalOptions{
+	copy, err := enc.FoldProperties(props)
+	if err != nil {
+		return nil, err
+	}
+	return plugin.MarshalProperties(copy, plugin.MarshalOptions{
 		Label:        "config",
 		KeepUnknowns: true,
 		SkipNulls:    true,
 		RejectAssets: true,
 		KeepSecrets:  true,
-	}
-
-	copy := make(resource.PropertyMap)
-	for k, v := range props {
-		var err error
-		copy[k], err = enc.jsonEncodePropertyValue(k, v)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return plugin.MarshalProperties(copy, opts)
+	})
 }
 
 func (enc *ConfigEncoding) jsonEncodePropertyValue(k resource.PropertyKey,

--- a/pkg/tfbridge/config_encoding_test.go
+++ b/pkg/tfbridge/config_encoding_test.go
@@ -34,7 +34,7 @@ func TestConfigEncoding(t *testing.T) {
 		pv resource.PropertyValue
 	}
 
-	knownKey := "mykey"
+	const knownKey = "mykey"
 
 	makeEnc := func(ty shim.ValueType) *ConfigEncoding {
 		return NewConfigEncoding(
@@ -74,10 +74,14 @@ func TestConfigEncoding(t *testing.T) {
 
 	checkUnmarshal := func(t *testing.T, tc testCase) {
 		enc := makeEnc(tc.ty)
-		pv, err := enc.unmarshalPropertyValue(resource.PropertyKey(knownKey), tc.v)
+		pv, err := enc.UnmarshalProperties(&structpb.Struct{
+			Fields: map[string]*structpb.Value{
+				knownKey: tc.v,
+			},
+		})
 		assert.NoError(t, err)
 		assert.NotNil(t, pv)
-		assert.Equal(t, tc.pv, *pv)
+		assert.Equal(t, tc.pv, pv[knownKey])
 	}
 
 	turnaroundTestCases := []testCase{


### PR DESCRIPTION
This allows dynamic providers to benefit from the same code that handles provider config for PF and SDKv2 based providers.

Fixes https://github.com/pulumi/pulumi-terraform-provider/issues/4

This borrows some code from <https://github.com/pulumi/pulumi-terraform-bridge/pull/2195>,
converted to still work with `plugin.ProviderWithContext`.

---

### Why the old design was problematic

The current design of provider encoding for the PF is:

``` go
type providerServer struct {
	pulumirpc.UnsafeResourceProviderServer // opt out of forward compat
	provider      ProviderWithContext
	keepSecrets   bool
	keepResources bool

	configEncoding tfbridge.ConfigEncoding
}
```
([src](https://github.com/pulumi/pulumi-terraform-bridge/blob/b40324a6a05cb68fbb61d29bdf2b7d7e5899e766/pf/internal/plugin/provider_server.go#L36-L44))

`*providerServer` directly implements `pulumirpc.ResourceProviderServer`. `providerServer`
is in charge of translating between `grpc` level constructs and `plugin.Provider` level
constructs. One method on `pulumirpc.ResourceProviderServer` is `Parameterize`:

``` go
type ResourceProviderServer interface {
	...
    Parameterize(context.Context, *ParameterizeRequest) (*ParameterizeResponse, error)
}
```
([src](https://github.com/pulumi/pulumi/blob/cfd74eaf031b7005f6d2b7887a3e6676e8b6a993/sdk/proto/go/provider_grpc.pb.go#L322))

This request is forwarded to `providerServer.provider`:

``` go
func (p *providerServer) Parameterize(
	ctx context.Context, req *pulumirpc.ParameterizeRequest,
) (*pulumirpc.ParameterizeResponse, error) {
	return plugin.NewProviderServer(&forwardServer{
		parameterize: p.provider.ParameterizeWithContext,
	}).Parameterize(ctx, req)
}
```
([src](https://github.com/pulumi/pulumi-terraform-bridge/blob/b40324a6a05cb68fbb61d29bdf2b7d7e5899e766/pf/internal/plugin/provider_server.go#L157-L163))

The problem is that `Parameterize` changes the set of acceptable configuration inputs, and
thus the encoding. With the old design, `Parameterize` would need a hook to change the
encoding used by `providerServer`.

### Why the new design

By moving `configEncoding` into `ProviderWithContext`, we allow `ProviderWithContext` to
change the encoding as calls to `Parameterize` come in. This is the change that fixes
<https://github.com/pulumi/pulumi-terraform-provider/issues/4>.


The new code also moves us in the direction of #2148, but #2148 does not motivate the
change.

### Why not <SOMETHING ELSE> instead

#### [pulumi/pulumi: [sdk-gen] Don't JSON-encode provider config #15032](https://github.com/pulumi/pulumi/pull/15032)

This would be a better fix, however the core team has shown little apatite for merging
[#15032](https://github.com/pulumi/pulumi/pull/15032).  I don't want to wait on them to become interested and leave this unfixed
indefinitely.