### PR TITLE
Refactor the SDKv2 Integration tests to take a TF provider instead of a resource map

### DIFF
--- a/pkg/tests/cross-tests/diff_check.go
+++ b/pkg/tests/cross-tests/diff_check.go
@@ -52,7 +52,8 @@ func runDiffCheck(t T, tc diffTestCase) {
 	tfDiffPlan := tfd.writePlanApply(t, tc.Resource.Schema, defRtype, "example", tc.Config2)
 
 	resMap := map[string]*schema.Resource{defRtype: tc.Resource}
-	bridgedProvider := pulcheck.BridgedProvider(t, defProviderShortName, resMap)
+	tfp := &schema.Provider{ResourcesMap: resMap}
+	bridgedProvider := pulcheck.BridgedProvider(t, defProviderShortName, tfp)
 
 	pd := &pulumiDriver{
 		name:                defProviderShortName,

--- a/pkg/tests/cross-tests/input_check.go
+++ b/pkg/tests/cross-tests/input_check.go
@@ -56,7 +56,8 @@ func runCreateInputCheck(t T, tc inputTestCase) {
 	tfd.writePlanApply(t, tc.Resource.Schema, defRtype, "example", tc.Config)
 
 	resMap := map[string]*schema.Resource{defRtype: tc.Resource}
-	bridgedProvider := pulcheck.BridgedProvider(t, defProviderShortName, resMap)
+	tfp := &schema.Provider{ResourcesMap: resMap}
+	bridgedProvider := pulcheck.BridgedProvider(t, defProviderShortName, tfp)
 	pd := &pulumiDriver{
 		name:                defProviderShortName,
 		pulumiResourceToken: defRtoken,

--- a/pkg/tests/cross-tests/upgrade_state_check.go
+++ b/pkg/tests/cross-tests/upgrade_state_check.go
@@ -60,8 +60,10 @@ func runPulumiUpgrade(t T, res1, res2 *schema.Resource, config1, config2 any, di
 		opts = append(opts, pulcheck.DisablePlanResourceChange())
 	}
 
-	prov1 := pulcheck.BridgedProvider(t, defProviderShortName, map[string]*schema.Resource{defRtype: res1}, opts...)
-	prov2 := pulcheck.BridgedProvider(t, defProviderShortName, map[string]*schema.Resource{defRtype: res2}, opts...)
+	tfp1 := &schema.Provider{ResourcesMap: map[string]*schema.Resource{defRtype: res1}}
+	prov1 := pulcheck.BridgedProvider(t, defProviderShortName, tfp1, opts...)
+	tfp2 := &schema.Provider{ResourcesMap: map[string]*schema.Resource{defRtype: res2}}
+	prov2 := pulcheck.BridgedProvider(t, defProviderShortName, tfp2, opts...)
 
 	pd := &pulumiDriver{
 		name:                defProviderShortName,

--- a/pkg/tests/internal/pulcheck/pulcheck.go
+++ b/pkg/tests/internal/pulcheck/pulcheck.go
@@ -141,13 +141,12 @@ func DisablePlanResourceChange() BridgedProviderOpt {
 }
 
 // This is an experimental API.
-func BridgedProvider(t T, providerName string, resMap map[string]*schema.Resource, opts ...BridgedProviderOpt) info.Provider {
+func BridgedProvider(t T, providerName string, tfp *schema.Provider, opts ...BridgedProviderOpt) info.Provider {
 	options := &bridgedProviderOpts{}
 	for _, opt := range opts {
 		opt(options)
 	}
 
-	tfp := &schema.Provider{ResourcesMap: resMap}
 	EnsureProviderValid(t, tfp)
 
 	shimProvider := shimv2.NewProvider(tfp, shimv2.WithPlanResourceChange(

--- a/pkg/tests/schema_pulumi_test.go
+++ b/pkg/tests/schema_pulumi_test.go
@@ -16,6 +16,35 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestBasic(t *testing.T) {
+	resMap := map[string]*schema.Resource{
+		"prov_test": {
+			Schema: map[string]*schema.Schema{
+				"test": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			},
+		},
+	}
+	tfp := &schema.Provider{ResourcesMap: resMap}
+	bridgedProvider := pulcheck.BridgedProvider(t, "prov", tfp)
+	program := `
+name: test
+runtime: yaml
+resources:
+  mainRes:
+    type: prov:index:Test
+	properties:
+	  test: "hello"
+outputs:
+  testOut: ${mainRes.test}
+`
+	pt := pulcheck.PulCheck(t, bridgedProvider, program)
+	res := pt.Up()
+	require.Equal(t, "hello", res.Outputs["testOut"].Value)
+}
+
 func TestUnknownHandling(t *testing.T) {
 	resMap := map[string]*schema.Resource{
 		"prov_test": {
@@ -42,7 +71,8 @@ func TestUnknownHandling(t *testing.T) {
 			},
 		},
 	}
-	bridgedProvider := pulcheck.BridgedProvider(t, "prov", resMap)
+	tfp := &schema.Provider{ResourcesMap: resMap}
+	bridgedProvider := pulcheck.BridgedProvider(t, "prov", tfp)
 	program := `
 name: test
 runtime: yaml
@@ -588,7 +618,8 @@ func TestCollectionsNullEmptyRefreshClean(t *testing.T) {
 					},
 				}
 
-				bridgedProvider := pulcheck.BridgedProvider(t, "prov", resMap, opts...)
+				tfp := &schema.Provider{ResourcesMap: resMap}
+				bridgedProvider := pulcheck.BridgedProvider(t, "prov", tfp, opts...)
 				program := fmt.Sprintf(`
 name: test
 runtime: yaml
@@ -658,7 +689,8 @@ outputs:
 					},
 				}
 
-				bridgedProvider := pulcheck.BridgedProvider(t, "prov", resMap, opts...)
+				tfp := &schema.Provider{ResourcesMap: resMap}
+				bridgedProvider := pulcheck.BridgedProvider(t, "prov", tfp, opts...)
 				program := fmt.Sprintf(`
 name: test
 runtime: yaml
@@ -796,7 +828,8 @@ func TestUnknownBlocks(t *testing.T) {
 			},
 		},
 	}
-	bridgedProvider := pulcheck.BridgedProvider(t, "prov", resMap)
+	tfp := &schema.Provider{ResourcesMap: resMap}
+	bridgedProvider := pulcheck.BridgedProvider(t, "prov", tfp)
 
 	provTestKnownProgram := `
 name: test
@@ -1440,7 +1473,8 @@ func TestFullyComputedNestedAttribute(t *testing.T) {
 			return []*schema.ResourceData{rd}, nil
 		}
 	}
-	bridgedProvider := pulcheck.BridgedProvider(t, "prov", resMap)
+	tfp := &schema.Provider{ResourcesMap: resMap}
+	bridgedProvider := pulcheck.BridgedProvider(t, "prov", tfp)
 
 	program := `
 name: test


### PR DESCRIPTION
This PR refactors the pulcheck integration test interface to take a provider instead of a resource map to allow more flexibility in tests - for example the user might want to specify a Schema on the provider or some other property of the provider.

I've also added a simple test example of this type of integration tests.