### PR TITLE
feat: run validate during import and drop invalid inputs

### DIFF
--- a/pkg/tests/go.mod
+++ b/pkg/tests/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.33.0
 	github.com/hexops/autogold/v2 v2.2.1
 	github.com/hexops/valast v1.4.4
-	github.com/pulumi/providertest v0.0.14
+	github.com/pulumi/providertest v0.0.15
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.80.0
 	github.com/pulumi/pulumi/sdk v1.14.1
 	github.com/stretchr/testify v1.9.0

--- a/pkg/tests/go.sum
+++ b/pkg/tests/go.sum
@@ -1977,6 +1977,8 @@ github.com/pulumi/inflector v0.1.1 h1:dvlxlWtXwOJTUUtcYDvwnl6Mpg33prhK+7mzeF+Sob
 github.com/pulumi/inflector v0.1.1/go.mod h1:HUFCjcPTz96YtTuUlwG3i3EZG4WlniBvR9bd+iJxCUY=
 github.com/pulumi/providertest v0.0.14 h1:5QlAPAAs82jkQraHsJvq1xgVfC7xtW8sFJwv2pHgxQ8=
 github.com/pulumi/providertest v0.0.14/go.mod h1:GcsqEGgSngwaNOD+kICJPIUQlnA911fGBU8HDlJvVL0=
+github.com/pulumi/providertest v0.0.15 h1:nvpEHVvcAkiq3NguPUutB+si3sjU2PmFqkV8yw9QFhQ=
+github.com/pulumi/providertest v0.0.15/go.mod h1:GcsqEGgSngwaNOD+kICJPIUQlnA911fGBU8HDlJvVL0=
 github.com/pulumi/pulumi-java/pkg v0.11.0 h1:Jw9gBvyfmfOMq/EkYDm9+zGPxsDAA8jfeMpHmtZ+1oA=
 github.com/pulumi/pulumi-java/pkg v0.11.0/go.mod h1:sXAk25P47AQVQL6ilAbFmRNgZykC7og/+87ihnqzFTc=
 github.com/pulumi/pulumi-yaml v1.9.1 h1:JPeI80M23SPactxgnCFS1casZlSr7ZhAXwSx4H55QQ4=

--- a/pkg/tests/schema_pulumi_test.go
+++ b/pkg/tests/schema_pulumi_test.go
@@ -2,11 +2,13 @@ package tests
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hexops/autogold/v2"
@@ -14,7 +16,9 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/internal/tfcheck"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optpreview"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optrefresh"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestBasic(t *testing.T) {
@@ -1768,4 +1772,361 @@ resource "prov_test" "test" {
 	test = "val"
 }`)
 	})
+}
+
+func TestFailedValidatorOnReadHandling(t *testing.T) {
+	type PulumiResources struct {
+		Type       string                 `yaml:"type"`
+		Properties map[string]interface{} `yaml:"properties"`
+	}
+	type PulumiYaml struct {
+		Runtime   string                     `yaml:"runtime,omitempty"`
+		Name      string                     `yaml:"name,omitempty"`
+		Resources map[string]PulumiResources `yaml:"resources"`
+	}
+
+	tests := []struct {
+		name          string
+		schema        schema.Schema
+		cloudVal      interface{}
+		expectedProps map[string]interface{}
+		expectFailure bool
+	}{
+		{
+			name:     "TypeString no validate",
+			cloudVal: "ABC",
+			schema: schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+			expectedProps: map[string]interface{}{
+				// input not dropped
+				"collectionProp": "ABC",
+			},
+		},
+		{
+			name:     "TypeString ValidateFunc does not error",
+			cloudVal: "ABC",
+			schema: schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateFunc: func(i interface{}, s string) ([]string, []error) {
+					return []string{}, []error{}
+				},
+			},
+			expectedProps: map[string]interface{}{
+				// input not dropped
+				"collectionProp": "ABC",
+			},
+		},
+		{
+			name:     "TypeString ValidateDiagFunc does not error",
+			cloudVal: "ABC",
+			schema: schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateDiagFunc: func(i interface{}, p cty.Path) diag.Diagnostics {
+					return nil
+				},
+			},
+			expectedProps: map[string]interface{}{
+				// input not dropped
+				"collectionProp": "ABC",
+			},
+		},
+		{
+			name:     "TypeString ValidateDiagFunc returns error",
+			cloudVal: "ABC",
+			schema: schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateDiagFunc: func(i interface{}, p cty.Path) diag.Diagnostics {
+					return diag.Errorf("Error")
+				},
+			},
+			// input dropped
+			expectedProps: map[string]interface{}{},
+		},
+		{
+			name: "TypeMap ValidateDiagFunc returns error",
+			cloudVal: map[string]string{
+				"nested_prop":       "ABC",
+				"nested_other_prop": "value",
+			},
+			schema: schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				ValidateDiagFunc: func(i interface{}, p cty.Path) diag.Diagnostics {
+					return diag.Errorf("Error")
+				},
+				Elem: &schema.Schema{
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			},
+			// input dropped
+			expectedProps: map[string]interface{}{},
+		},
+		{
+			name: "Non-Computed TypeMap ValidateDiagFunc does not drop",
+			cloudVal: map[string]string{
+				"nested_prop":       "ABC",
+				"nested_other_prop": "value",
+			},
+			schema: schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: false,
+				ValidateDiagFunc: func(i interface{}, p cty.Path) diag.Diagnostics {
+					return diag.Errorf("Error")
+				},
+				Elem: &schema.Schema{
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			},
+			// input not dropped
+			expectedProps: map[string]interface{}{
+				"collectionProp": map[string]interface{}{
+					"nested_prop":       "ABC",
+					"nested_other_prop": "value",
+				},
+			},
+			// we don't drop computed: false attributes, so they will
+			// still fail
+			expectFailure: true,
+		},
+		{
+			name: "Required TypeMap ValidateDiagFunc does not drop",
+			cloudVal: map[string]string{
+				"nested_prop":       "ABC",
+				"nested_other_prop": "value",
+			},
+			schema: schema.Schema{
+				Type:     schema.TypeMap,
+				Required: true,
+				ValidateDiagFunc: func(i interface{}, p cty.Path) diag.Diagnostics {
+					return diag.Errorf("Error")
+				},
+				Elem: &schema.Schema{
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			},
+			expectedProps: map[string]interface{}{
+				"collectionProp": map[string]interface{}{
+					"nested_prop":       "ABC",
+					"nested_other_prop": "value",
+				},
+			},
+			expectFailure: true,
+		},
+		{
+			name:     "TypeString ValidateFunc returns error",
+			cloudVal: "ABC",
+			schema: schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateFunc: func(i interface{}, s string) ([]string, []error) {
+					return []string{}, []error{errors.New("Error")}
+				},
+			},
+			// input dropped
+			expectedProps: map[string]interface{}{},
+		},
+		{
+			name:     "TypeString ValidateFunc does not drop required fields",
+			cloudVal: "ABC",
+			schema: schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: func(i interface{}, s string) ([]string, []error) {
+					return []string{}, []error{errors.New("Error")}
+				},
+			},
+			expectedProps: map[string]interface{}{
+				// input not dropped
+				"collectionProp": "ABC",
+			},
+			expectFailure: true,
+		},
+		{
+			name: "TypeSet ValidateDiagFunc returns error",
+			cloudVal: []interface{}{
+				"ABC", "value",
+			},
+			schema: schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					ValidateDiagFunc: func(i interface{}, p cty.Path) diag.Diagnostics {
+						if val, ok := i.(string); ok && val != "ABC" {
+							return diag.Errorf("Error")
+						}
+						return nil
+					},
+				},
+			},
+			// if one element of the list fails validation
+			// the entire list is removed. Terraform does not return
+			// list indexes as part of the diagnostic attribute path
+			expectedProps: map[string]interface{}{},
+		},
+
+		// ValidateDiagFunc & ValidateFunc are not supported for TypeList & TypeSet, but they
+		// are supported on the nested elements. For now we are not processing the results of those with `schema.Resource` elements
+		// since it can get complicated. Nothing will get dropped and the validation error will pass through
+		{
+			name: "TypeList do not validate nested fields",
+			cloudVal: []interface{}{
+				map[string]interface{}{
+					"nested_prop":       "ABC",
+					"nested_other_prop": "ABC",
+				},
+			},
+			schema: schema.Schema{
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"nested_prop": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ValidateDiagFunc: func(i interface{}, p cty.Path) diag.Diagnostics {
+								return diag.Errorf("Error")
+							},
+						},
+						"nested_other_prop": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ValidateDiagFunc: func(i interface{}, p cty.Path) diag.Diagnostics {
+								return nil
+							},
+						},
+					},
+				},
+			},
+			expectedProps: map[string]interface{}{
+				"collectionProp": map[string]interface{}{
+					"nestedOtherProp": "ABC",
+					"nestedProp":      "ABC",
+				},
+			},
+			expectFailure: true,
+		},
+		{
+			name: "TypeSet Do not validate nested fields",
+			cloudVal: []interface{}{
+				map[string]interface{}{
+					"nested_prop": "ABC",
+				},
+			},
+			schema: schema.Schema{
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"nested_prop": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: func(i interface{}, s string) ([]string, []error) {
+								return []string{}, []error{errors.New("Error")}
+							},
+						},
+					},
+				},
+			},
+			expectedProps: map[string]interface{}{
+				"collectionProps": []interface{}{
+					map[string]interface{}{
+						"nestedProp": "ABC",
+					},
+				},
+			},
+			expectFailure: true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			resMap := map[string]*schema.Resource{
+				"prov_test": {
+					Schema: map[string]*schema.Schema{
+						"collection_prop": &tc.schema,
+						"other_prop": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+					Importer: &schema.ResourceImporter{
+						StateContext: func(ctx context.Context, rd *schema.ResourceData, i interface{}) ([]*schema.ResourceData, error) {
+							err := rd.Set("collection_prop", tc.cloudVal)
+							assert.NoError(t, err)
+							err = rd.Set("other_prop", "test")
+							assert.NoError(t, err)
+							return []*schema.ResourceData{rd}, nil
+						},
+					},
+					ReadContext: func(ctx context.Context, rd *schema.ResourceData, i interface{}) diag.Diagnostics {
+						err := rd.Set("collection_prop", tc.cloudVal)
+						assert.NoError(t, err)
+						err = rd.Set("other_prop", "test")
+						assert.NoError(t, err)
+						return nil
+					},
+				},
+			}
+			tfp := &schema.Provider{ResourcesMap: resMap}
+			bridgedProvider := pulcheck.BridgedProvider(t, "prov", tfp, pulcheck.DisablePlanResourceChange())
+			program := `
+name: test
+runtime: yaml
+`
+			pt := pulcheck.PulCheck(t, bridgedProvider, program)
+			outPath := filepath.Join(pt.CurrentStack().Workspace().WorkDir(), "out.yaml")
+
+			imp := pt.Import("prov:index/test:Test", "mainRes", "mainRes", "", "--out", outPath)
+			tc.expectedProps["otherProp"] = "test"
+
+			contents, err := os.ReadFile(outPath)
+			assert.NoError(t, err)
+			expected := PulumiYaml{
+				Resources: map[string]PulumiResources{
+					"mainRes": {
+						Type:       "prov:Test",
+						Properties: tc.expectedProps,
+					},
+				},
+			}
+			var actual PulumiYaml
+			err = yaml.Unmarshal(contents, &actual)
+			assert.NoError(t, err)
+
+			assert.Equal(t, expected, actual)
+			if tc.expectFailure {
+				assert.Contains(t, imp.Stdout, "One or more imported inputs failed to validate")
+			} else {
+				assert.NotContains(t, imp.Stdout, "One or more imported inputs failed to validate")
+
+				f, err := os.OpenFile(filepath.Join(pt.CurrentStack().Workspace().WorkDir(), "Pulumi.yaml"), os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
+				assert.NoError(t, err)
+				defer f.Close()
+				_, err = f.WriteString(string(contents))
+				assert.NoError(t, err)
+
+				// run preview using the generated file
+				pt.Preview(optpreview.Diff(), optpreview.ExpectNoChanges())
+			}
+		})
+	}
 }

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -1484,6 +1484,11 @@ func (p *Provider) processImportValidationErrors(
 
 		schemaAtPath, err := walk.LookupSchemaMapPath(path.schemaPath, schema)
 		if err != nil {
+			logger.Debug(fmt.Sprintf(
+				"could not find schema for validation error at path %s: %s",
+				path.schemaPath.GoString(),
+				err.Error(),
+			))
 			continue
 		}
 
@@ -1495,6 +1500,7 @@ func (p *Provider) processImportValidationErrors(
 		}
 		pp, err := resource.ParsePropertyPath(path.valuePath)
 		if err != nil {
+			logger.Debug(fmt.Sprintf("could not parse property path %q for validation error: %s", path.valuePath, err.Error()))
 			continue
 		}
 		logger.Warn(fmt.Sprintf("property at path %q failed validation and was dropped from generated input", pp.String()))


### PR DESCRIPTION
During an import operation property values are read from the cloud and
turned into inputs which then becomes part of the generated code. For
some properties (Computed & Optional) the cloud can return values that
fail validation. Since these are computed & optional the provider will
allow the user to not specify a value. In these cases the import would
succeed, but if the user took the generated code as is and attempted to
run `pulumi up` it would fail due to the validation errors.

Rather than generate invalid inputs we will instead run `Validate` during import
and then processes any resulting validation errors. If any properties
fail validation (and they match our other cases) then we remove those
inputs so that the generated program code will not contain the invalid
inputs

NOTE: we want to (for now at least) scope this as narrowly as possible because we do not want to
create a scenario where the resulting inputs create a different error
(e.g. removing an invalid required property). In these cases we will just allow the invalid configuration
through and the user will have to decide what to do.

fixes https://github.com/pulumi/pulumi-aws/issues/4054