### PR TITLE
Update {pf,dynamic}/go.mod to v3.89.0

### DIFF
--- a/dynamic/go.mod
+++ b/dynamic/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/hexops/autogold/v2 v2.2.1
 	github.com/opentofu/opentofu/shim v0.0.0-00010101000000-000000000000
 	github.com/pulumi/pulumi-terraform-bridge/pf v0.0.0-00010101000000-000000000000
-	github.com/pulumi/pulumi-terraform-bridge/v3 v3.88.0
+	github.com/pulumi/pulumi-terraform-bridge/v3 v3.89.0
 	github.com/stretchr/testify v1.9.0
 	google.golang.org/protobuf v1.34.0
 )

--- a/pf/go.mod
+++ b/pf/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.22.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.33.0
-	github.com/pulumi/pulumi-terraform-bridge/v3 v3.88.0
+	github.com/pulumi/pulumi-terraform-bridge/v3 v3.89.0
 	github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.8
 	github.com/stretchr/testify v1.9.0
 	google.golang.org/grpc v1.63.2

--- a/pf/tests/go.mod
+++ b/pf/tests/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hexops/autogold/v2 v2.2.1
 	github.com/pulumi/providertest v0.0.14
 	github.com/pulumi/pulumi-terraform-bridge/pf v0.0.0
-	github.com/pulumi/pulumi-terraform-bridge/v3 v3.88.0
+	github.com/pulumi/pulumi-terraform-bridge/v3 v3.89.0
 	github.com/stretchr/testify v1.9.0
 	github.com/terraform-providers/terraform-provider-random/randomshim v0.0.0
 )


### PR DESCRIPTION
This PR is part of the bridge release process for v3.89.0.