### PR TITLE
Fix typechecking booleans

### DIFF
--- a/pkg/tfbridge/tests/provider_test.go
+++ b/pkg/tfbridge/tests/provider_test.go
@@ -825,8 +825,11 @@ func TestTypeCheckingMistypedBooleansWithUnknowns(t *testing.T) {
 		},
 	}, newTestProviderOptions{})
 
+	reason := "expected boolean type, got string type. " +
+		"Examine values at 'my-ecs-service.networkConfiguration.assignPublicIp'."
+
 	// networkConfiguration.assignPublicIp has the wrong type intentionally.
-	replay.ReplaySequence(t, p, `
+	replay.ReplaySequence(t, p, fmt.Sprintf(`
 	[
 	  {
 	    "method": "/pulumirpc.ResourceProvider/Check",
@@ -843,10 +846,10 @@ func TestTypeCheckingMistypedBooleansWithUnknowns(t *testing.T) {
 	    },
 	    "response": {
               "inputs": "*",
-              "failures": [{"reason": "expected boolean type, got string type. Examine values at 'my-ecs-service.networkConfiguration.assignPublicIp'."}]
+              "failures": [{"reason": "%s"}]
 	    }
 	  }
-	]`)
+	]`, reason))
 }
 
 func nilSink() diag.Sink {

--- a/pkg/tfbridge/validate_input_types.go
+++ b/pkg/tfbridge/validate_input_types.go
@@ -157,9 +157,8 @@ func (v *PulumiInputValidator) validatePropertyValue(
 	}
 
 	switch typeSpec.Type {
-	case "bool":
-		// The bridge permits coalescing strings to booleans, hence skip strings.
-		if !propertyValue.IsBool() && !propertyValue.IsString() {
+	case "boolean":
+		if !propertyValue.IsBool() {
 			return []TypeFailure{{
 				ResourcePath: propertyPath.String(),
 				Reason: fmt.Sprintf(

--- a/pkg/tfbridge/validate_input_types_test.go
+++ b/pkg/tfbridge/validate_input_types_test.go
@@ -1477,7 +1477,7 @@ func TestValidateInputType_toplevel(t *testing.T) {
 					TypeSpec: pschema.TypeSpec{
 						Type: "object",
 						AdditionalProperties: &pschema.TypeSpec{
-							Type: "bool",
+							Type: "boolean",
 						},
 					},
 				},


### PR DESCRIPTION
The type-checking pass had a bug where it failed to flag passing a string to a slot of type boolean. This is now fixed so that appropriate warnings are generated.

Fixes  https://github.com/pulumi/pulumi-aws/issues/4342 P1
