### PR TITLE
Typos and simplified logic

### DIFF
--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -510,7 +510,7 @@ func (p *tfMarkdownParser) parseSupplementaryExamples() (string, error) {
 	}
 	fileBytes, err := os.ReadFile(absPath)
 	if err != nil {
-		p.sink.error("explicitly marked resource documention for replacement, but found no file at %q", examplesFileName)
+		p.sink.error("explicitly marked resource documentation for replacement, but found no file at %q", examplesFileName)
 		return "", err
 	}
 

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -477,7 +477,7 @@ func (g *Generator) makeObjectPropertyType(typePath paths.TypePath,
 		propertyInfos = info.Fields
 	}
 
-	// Look up the parent path and prepend it to the docs path, to allow for precise lookup in the entityDOcs.
+	// Look up the parent path and prepend it to the docs path, to allow for precise lookup in the entityDocs.
 	fullDocsPath := ""
 	currentPath := typePath
 	for {

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -397,14 +397,8 @@ func (g *Generator) makePropertyType(typePath paths.TypePath,
 		return g.makeObjectPropertyType(typePath, blockType, elemInfo, out, entityDocs)
 	}
 
-	// IsMaxItemOne lists and sets are flattened, transforming List[T] to T. Detect if this is the case.
-	flatten := false
-	switch sch.Type() {
-	case shim.TypeList, shim.TypeSet:
-		if tfbridge.IsMaxItemsOne(sch, info) {
-			flatten = true
-		}
-	}
+	// IsMaxItemOne lists and sets are flattened, transforming List[T] or Set[T] to T. Detect if this is the case.
+	flatten := tfbridge.IsMaxItemsOne(sch, info)
 
 	// The remaining cases are collections, List[T], Set[T] or Map[T], and recursion needs NewElementPath except for
 	// flattening that stays at the current path.


### PR DESCRIPTION
This PR fixes 2 typos and removes a redundant check. 372e0ba0d5ec253830ba9bdb3c4c519366c96a15 contains a message explaining why it is safe.

Refactored out of https://github.com/pulumi/pulumi-terraform-bridge/pull/2309.