### PR TITLE
Correctly convert unknown and null values at any nesting

### DIFF
--- a/pkg/convert/adapter.go
+++ b/pkg/convert/adapter.go
@@ -50,7 +50,7 @@ func (d adaptedDecoder[T]) toPropertyValue(v tftypes.Value) (resource.PropertyVa
 	if err != nil {
 		return resource.PropertyValue{}, fmt.Errorf("failed to adapt for %T: %w", d.decoder, err)
 	}
-	return d.decoder.toPropertyValue(adapted)
+	return decode(d.decoder, adapted)
 }
 
 func newIntOverrideStringEncoder() Encoder {

--- a/pkg/convert/convert_test.go
+++ b/pkg/convert/convert_test.go
@@ -199,7 +199,7 @@ func TestConvertTurnaround(t *testing.T) {
 		t.Run(testcase.name+"/tf2pu", func(t *testing.T) {
 			t.Parallel()
 
-			actual, err := decoder.toPropertyValue(testcase.val)
+			actual, err := decode(decoder, testcase.val)
 			require.NoError(t, err)
 
 			if f := testcase.normProp; f != nil {

--- a/pkg/convert/encoding_test.go
+++ b/pkg/convert/encoding_test.go
@@ -673,7 +673,7 @@ func TestAdapter(t *testing.T) {
 					t.Logf("skipping since the encoder should error")
 					return
 				}
-				v, err := newStringOverIntDecoder().toPropertyValue(tt.expected)
+				v, err := decode(newStringOverIntDecoder(), tt.expected)
 				assert.NoError(t, err)
 				if !assert.True(t, v.DeepEquals(tt.input)) {
 					assert.Equal(t, v, tt.input)

--- a/pkg/convert/flattened.go
+++ b/pkg/convert/flattened.go
@@ -53,7 +53,7 @@ func (dec *flattenedDecoder) toPropertyValue(v tftypes.Value) (resource.Property
 	case 0:
 		return resource.NewNullProperty(), nil
 	case 1:
-		return dec.elementDecoder.toPropertyValue(list[0])
+		return decode(dec.elementDecoder, list[0])
 	default:
 		msg := "IsMaxItemsOne list or set has too many (%d) values"
 		err := fmt.Errorf(msg, len(list))

--- a/pkg/convert/list.go
+++ b/pkg/convert/list.go
@@ -70,12 +70,6 @@ func (enc *listEncoder) fromPropertyValue(p resource.PropertyValue) (tftypes.Val
 }
 
 func (dec *listDecoder) toPropertyValue(v tftypes.Value) (resource.PropertyValue, error) {
-	if !v.IsKnown() {
-		return unknownProperty(), nil
-	}
-	if v.IsNull() {
-		return resource.NewPropertyValue(nil), nil
-	}
 	var elements []tftypes.Value
 	if err := v.As(&elements); err != nil {
 		return resource.PropertyValue{},
@@ -83,7 +77,8 @@ func (dec *listDecoder) toPropertyValue(v tftypes.Value) (resource.PropertyValue
 	}
 	values := []resource.PropertyValue{}
 	for _, e := range elements {
-		ev, err := dec.elementDecoder.toPropertyValue(e)
+
+		ev, err := decode(dec.elementDecoder, e)
 		if err != nil {
 			return resource.PropertyValue{},
 				fmt.Errorf("decList fails with %s: %w", e.String(), err)

--- a/pkg/convert/map.go
+++ b/pkg/convert/map.go
@@ -68,12 +68,6 @@ func (enc *mapEncoder) fromPropertyValue(p resource.PropertyValue) (tftypes.Valu
 }
 
 func (dec *mapDecoder) toPropertyValue(v tftypes.Value) (resource.PropertyValue, error) {
-	if !v.IsKnown() {
-		return unknownProperty(), nil
-	}
-	if v.IsNull() {
-		return resource.NewPropertyValue(nil), nil
-	}
 	elements := map[string]tftypes.Value{}
 	if err := v.As(&elements); err != nil {
 		return resource.PropertyValue{},
@@ -82,7 +76,7 @@ func (dec *mapDecoder) toPropertyValue(v tftypes.Value) (resource.PropertyValue,
 
 	values := make(resource.PropertyMap)
 	for k, e := range elements {
-		ev, err := dec.elementDecoder.toPropertyValue(e)
+		ev, err := decode(dec.elementDecoder, e)
 		if err != nil {
 			return resource.PropertyValue{},
 				fmt.Errorf("decMap fails with %s: %w", e.String(), err)

--- a/pkg/convert/object.go
+++ b/pkg/convert/object.go
@@ -87,12 +87,6 @@ func (enc *objectEncoder) fromPropertyValue(p resource.PropertyValue) (tftypes.V
 }
 
 func (dec *objectDecoder) toPropertyValue(v tftypes.Value) (resource.PropertyValue, error) {
-	if !v.IsKnown() {
-		return unknownProperty(), nil
-	}
-	if v.IsNull() {
-		return resource.NewPropertyValue(nil), nil
-	}
 	elements := map[string]tftypes.Value{}
 	if err := v.As(&elements); err != nil {
 		return resource.PropertyValue{},
@@ -104,11 +98,11 @@ func (dec *objectDecoder) toPropertyValue(v tftypes.Value) (resource.PropertyVal
 		attrValue, gotAttrValue := elements[attr]
 		if gotAttrValue {
 			t := dec.objectType.AttributeTypes[attr]
-			pv, err := decoder.toPropertyValue(attrValue)
+			pv, err := decode(decoder, attrValue)
 			if err != nil {
 				return resource.PropertyValue{},
-					fmt.Errorf("objectDecoder fails on property %q (value %s): %w",
-						attr, attrValue, err)
+					fmt.Errorf("objectDecoder (%T) fails on property %q (value %s): %w",
+						decoder, attr, attrValue, err)
 			}
 			key := dec.propertyNames.PropertyKey(attr, t)
 			if !pv.IsNull() {

--- a/pkg/convert/secret.go
+++ b/pkg/convert/secret.go
@@ -32,7 +32,7 @@ func newSecretDecoder(elementDecoder Decoder) (Decoder, error) {
 }
 
 func (dec *secretDecoder) toPropertyValue(v tftypes.Value) (resource.PropertyValue, error) {
-	encoded, err := dec.elementDecoder.toPropertyValue(v)
+	encoded, err := decode(dec.elementDecoder, v)
 	if err != nil {
 		return resource.PropertyValue{}, err
 	}

--- a/pkg/convert/set.go
+++ b/pkg/convert/set.go
@@ -74,13 +74,6 @@ func (enc *setEncoder) fromPropertyValue(p resource.PropertyValue) (tftypes.Valu
 }
 
 func (dec *setDecoder) toPropertyValue(v tftypes.Value) (resource.PropertyValue, error) {
-	if !v.IsKnown() {
-		return unknownProperty(), nil
-	}
-	if v.IsNull() {
-		return resource.NewPropertyValue(nil), nil
-	}
-
 	retErr := func(msg string, args ...any) error {
 		return fmt.Errorf("set decoder failed: "+msg, args...)
 	}
@@ -92,7 +85,7 @@ func (dec *setDecoder) toPropertyValue(v tftypes.Value) (resource.PropertyValue,
 	}
 	values := []resource.PropertyValue{}
 	for i, e := range elements {
-		ev, err := dec.elementDecoder.toPropertyValue(e)
+		ev, err := decode(dec.elementDecoder, e)
 		if err != nil {
 			return resource.PropertyValue{},
 				retErr("could not decode element %d (%v): %w", i, ev, err)

--- a/pkg/convert/tuple.go
+++ b/pkg/convert/tuple.go
@@ -80,14 +80,6 @@ func (enc *tupleEncoder) fromPropertyValue(p resource.PropertyValue) (tftypes.Va
 }
 
 func (dec *tupleDecoder) toPropertyValue(v tftypes.Value) (resource.PropertyValue, error) {
-	if !v.IsKnown() {
-		zero := resource.NewArrayProperty([]resource.PropertyValue{})
-		return resource.MakeComputed(zero), nil
-	}
-	if v.IsNull() {
-		return resource.NewNullProperty(), nil
-	}
-
 	var elements []tftypes.Value
 	if err := v.As(&elements); err != nil {
 		return resource.PropertyValue{},
@@ -96,7 +88,7 @@ func (dec *tupleDecoder) toPropertyValue(v tftypes.Value) (resource.PropertyValu
 	values := make([]resource.PropertyValue, len(elements))
 	for i, e := range elements {
 		var err error
-		values[i], err = dec.decoders[i].toPropertyValue(e)
+		values[i], err = decode(dec.decoders[i], e)
 		if err != nil {
 			return resource.PropertyValue{},
 				fmt.Errorf("failed to decode tuple[%d] (%s): %w", i, v, err)


### PR DESCRIPTION
This allows `pkg/convert` to correctly decode flattened unknown or null values, such as those created in https://github.com/pulumi/pulumi-terraform-provider/issues/5.

Fixes https://github.com/pulumi/pulumi-terraform-provider/issues/5