### PR TITLE
Change Go's import path to a dynamic specific path with version

### DIFF
--- a/dynamic/info.go
+++ b/dynamic/info.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"path"
 	"strings"
 
@@ -60,10 +59,9 @@ func providerInfo(ctx context.Context, p run.Provider, value parameterize.Value)
 		Java: &tfbridge.JavaInfo{ /* Java does not have a RespectSchemaVersion flag */ },
 		Golang: &tfbridge.GolangInfo{
 			ImportBasePath: path.Join(
-				fmt.Sprintf("github.com/pulumi/pulumi-%[1]s/sdk/", p.Name()),
-				tfbridge.GetModuleMajorVersion("0.0.0"),
-				"go",
+				"github.com/pulumi/pulumi-terraform-provider/sdks/go",
 				p.Name(),
+				tfbridge.GetModuleMajorVersion(p.Version()),
 			),
 
 			LiftSingleValueMethodReturns: true,

--- a/dynamic/testdata/TestSchemaGeneration/Azure/alz-0.11.1.golden
+++ b/dynamic/testdata/TestSchemaGeneration/Azure/alz-0.11.1.golden
@@ -14,7 +14,7 @@
             "respectSchemaVersion": true
         },
         "go": {
-            "importBasePath": "github.com/pulumi/pulumi-alz/sdk/go/alz",
+            "importBasePath": "github.com/pulumi/pulumi-terraform-provider/sdks/go/alz",
             "liftSingleValueMethodReturns": true,
             "generateExtraInputTypes": true,
             "respectSchemaVersion": true

--- a/dynamic/testdata/TestSchemaGeneration/Backblaze/b2-0.8.9.golden
+++ b/dynamic/testdata/TestSchemaGeneration/Backblaze/b2-0.8.9.golden
@@ -14,7 +14,7 @@
             "respectSchemaVersion": true
         },
         "go": {
-            "importBasePath": "github.com/pulumi/pulumi-b2/sdk/go/b2",
+            "importBasePath": "github.com/pulumi/pulumi-terraform-provider/sdks/go/b2",
             "liftSingleValueMethodReturns": true,
             "generateExtraInputTypes": true,
             "respectSchemaVersion": true

--- a/dynamic/testdata/TestSchemaGeneration/hashicorp/random-3.3.0.golden
+++ b/dynamic/testdata/TestSchemaGeneration/hashicorp/random-3.3.0.golden
@@ -14,7 +14,7 @@
             "respectSchemaVersion": true
         },
         "go": {
-            "importBasePath": "github.com/pulumi/pulumi-random/sdk/go/random",
+            "importBasePath": "github.com/pulumi/pulumi-terraform-provider/sdks/go/random/v3",
             "liftSingleValueMethodReturns": true,
             "generateExtraInputTypes": true,
             "respectSchemaVersion": true


### PR DESCRIPTION
This change provides 2 benefits:

1. It prevents a static SDK from conflicting with a dynamic SDK.
2. It correctly includes the major version of the generated SDK in the path.