### PR TITLE
Fixup dynamic schemas: URN properties and missing IDs

### DIFF
--- a/dynamic/internal/fixup/properties.go
+++ b/dynamic/internal/fixup/properties.go
@@ -1,0 +1,162 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// package fixup applies fixes to a [info.Provider] to ensure that it can generate a valid
+// schema and that the schema can generate valid SDKs in all all languages.
+//
+// package fixup is still in development and may expose breaking changes in minor
+// versions.
+package fixup
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+)
+
+// Default applies the default set of fixups to p.
+//
+// The set of fixups applied may expand over time, but it should not effect providers that
+// correctly compile in all languages.
+func Default(p *info.Provider) error {
+	return errors.Join(
+		fixPropertyConflict(p),
+		fixMissingIDs(p),
+	)
+}
+
+func fixMissingIDs(p *info.Provider) error {
+	getIDType := func(r *info.Resource) tokens.Type {
+		s := r.Fields["id"]
+		if s == nil {
+			return ""
+		}
+		return s.Type
+	}
+	return walkResources(p, func(r tfbridge.Resource) error {
+		id, hasID := r.TF.Schema().GetOk("id")
+		ok := hasID &&
+			(id.Type() == shim.TypeString || getIDType(r.Schema) == "string") &&
+			id.Computed()
+		if !ok {
+			r.Schema.ComputeID = missingID
+		}
+		return nil
+	})
+}
+
+func missingID(context.Context, resource.PropertyMap) (resource.ID, error) {
+	return "missing ID", nil
+}
+
+func fixPropertyConflict(p *info.Provider) error {
+	if p.Name == "" {
+		return fmt.Errorf("must set p.Name")
+	}
+	return walkResources(p, func(r tfbridge.Resource) error {
+		var retError error
+		r.TF.Schema().Range(func(key string, value shim.Schema) bool {
+			if fix := badPropertyName(p.Name, key); fix != nil {
+				if r.Schema.Fields == nil {
+					r.Schema.Fields = map[string]*info.Schema{}
+				}
+
+				s, ok := r.Schema.Fields[key]
+				if !ok {
+					s = &info.Schema{}
+				}
+
+				if s.Name == "" {
+					var err error
+					s.Name, err = fix(r.TF)
+					if err != nil {
+						retError = fmt.Errorf("%q: %w", key, err)
+					}
+				}
+
+				if !ok {
+					r.Schema.Fields[key] = s
+				}
+			}
+
+			return true
+		})
+		return retError
+	})
+}
+
+func badPropertyName(providerName, key string) func(shim.Resource) (string, error) {
+	switch key {
+	case "urn":
+		return newName(providerName)
+	default:
+		return nil
+	}
+}
+
+func newName(providerName string) func(shim.Resource) (string, error) {
+	return func(r shim.Resource) (string, error) {
+		s := r.Schema()
+		v := providerName + "_urn"
+		if _, ok := s.GetOk(v); !ok {
+			return tfbridge.TerraformToPulumiNameV2(v, s, nil), nil
+		}
+		return "", fmt.Errorf("no available new name, tried %q", v)
+	}
+}
+
+func walkResources(p *info.Provider, f func(tfbridge.Resource) error) error {
+	var errs []error
+
+	if p.Resources == nil {
+		p.Resources = map[string]*info.Resource{}
+	}
+
+	p.P.ResourcesMap().Range(func(key string, tf shim.Resource) bool {
+		res, isPresent := p.Resources[key]
+		if !isPresent {
+			res = &info.Resource{}
+		}
+		if err := f(tfbridge.Resource{
+			Schema: res,
+			TF:     tf,
+			TFName: key,
+		}); err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", key, err))
+		}
+
+		// If the res wasn't already present in the map and f made some change to
+		// it, then we need to insert it back into p.Resources.
+		//
+		// If isPresent, then we don't need to make the insertion because res was
+		// already in the map.
+		//
+		// If IsZero, then inserting res doesn't have any effect, so we skip it.
+		if !isPresent && !reflect.ValueOf(*res).IsZero() {
+			p.Resources[key] = res
+		}
+
+		return true
+	})
+
+	return errors.Join(errs...)
+}

--- a/dynamic/internal/fixup/properties_test.go
+++ b/dynamic/internal/fixup/properties_test.go
@@ -1,0 +1,73 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fixup_test
+
+import (
+	"testing"
+
+	_ "github.com/hexops/autogold/v2" // autogold registers a flag for -update
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-terraform-bridge/dynamic/internal/fixup"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
+)
+
+func TestFixMissingID(t *testing.T) {
+	t.Parallel()
+
+	p := info.Provider{
+		Name: "test",
+		P: (&schema.Provider{
+			ResourcesMap: schema.ResourceMap{
+				"test_res": (&schema.Resource{
+					Schema: schema.SchemaMap{
+						"some_property": (&schema.Schema{
+							Type: shim.TypeString,
+						}).Shim(),
+					},
+				}).Shim(),
+			},
+		}).Shim(),
+	}
+
+	err := fixup.Default(&p)
+	require.NoError(t, err)
+	assert.NotNil(t, p.Resources["test_res"].ComputeID)
+}
+
+func TestFixURNProperty(t *testing.T) {
+	t.Parallel()
+	p := info.Provider{
+		Name: "test",
+		P: (&schema.Provider{
+			ResourcesMap: schema.ResourceMap{
+				"test_res": (&schema.Resource{
+					Schema: schema.SchemaMap{
+						"urn": (&schema.Schema{
+							Type: shim.TypeString,
+						}).Shim(),
+					},
+				}).Shim(),
+			},
+		}).Shim(),
+	}
+
+	err := fixup.Default(&p)
+	require.NoError(t, err)
+	assert.Equal(t, &info.Schema{Name: "testUrn"}, p.Resources["test_res"].Fields["urn"])
+}

--- a/dynamic/main.go
+++ b/dynamic/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 
+	"github.com/pulumi/pulumi-terraform-bridge/dynamic/internal/fixup"
 	"github.com/pulumi/pulumi-terraform-bridge/dynamic/parameterize"
 	"github.com/pulumi/pulumi-terraform-bridge/dynamic/version"
 	"github.com/pulumi/pulumi-terraform-bridge/pf/proto"
@@ -134,6 +135,10 @@ func initialSetup() (tfbridge.ProviderInfo, pfbridge.ProviderMetadata, func() er
 			tfServer = p
 			if tfServer != nil {
 				info = providerInfo(ctx, tfServer, value)
+				if err := fixup.Default(&info); err != nil {
+					return plugin.ParameterizeResponse{}, err
+				}
+
 			}
 
 			err = pfbridge.XParameterizeResetProvider(ctx, info, metadata)


### PR DESCRIPTION
Automatically fix dynamic provider schemas by applying known fixes. Currently, this includes 2 fixes:

- Renames properties called `"urn"` to `"resourceUrn"`.
- Sets `info.Resource.ComputeID` when an ID property is missing.

Fixes https://github.com/pulumi/pulumi-terraform-provider/issues/6