### PR TITLE
Correctly map `pkg_index` tokens

### DIFF
--- a/dynamic/info.go
+++ b/dynamic/info.go
@@ -84,7 +84,11 @@ func providerInfo(ctx context.Context, p run.Provider, value parameterize.Value)
 		return prov, err
 	}
 
-	prov.MustComputeTokens(tokens.SingleModule(p.Name()+"_", "index", tokens.MakeStandard(p.Name())))
+	err := prov.ComputeTokens(tokens.SingleModule(p.Name()+"_", "index", tokens.MakeStandard(p.Name())))
+	if err != nil {
+		return prov, err
+	}
+
 	prov.SetAutonaming(255, "-")
 
 	return prov, nil

--- a/dynamic/info.go
+++ b/dynamic/info.go
@@ -84,7 +84,8 @@ func providerInfo(ctx context.Context, p run.Provider, value parameterize.Value)
 		return prov, err
 	}
 
-	err := prov.ComputeTokens(tokens.SingleModule(p.Name()+"_", "index", tokens.MakeStandard(p.Name())))
+	err := prov.ComputeTokens(tokens.SingleModule(
+		prov.GetResourcePrefix(), "index", tokens.MakeStandard(p.Name())))
 	if err != nil {
 		return prov, err
 	}

--- a/pkg/tfbridge/tokens/tokens.go
+++ b/pkg/tfbridge/tokens/tokens.go
@@ -48,6 +48,9 @@ type Make func(module, name string) (string, error)
 //	(pkg, module, name) => pkg:module/lowerFirst(name):name
 func MakeStandard(pkgName string) Make {
 	return func(module, name string) (string, error) {
+		if name == "" {
+			return "", fmt.Errorf("missing name for module %q", module)
+		}
 		lowerName := string(unicode.ToLower(rune(name[0]))) + name[1:]
 		return fmt.Sprintf("%s:%s/%s:%s", pkgName, module, lowerName, name), nil
 	}
@@ -168,7 +171,7 @@ func applyComputedTokens[T info.Resource | info.DataSource](
 		}
 		err := tks(k, v)
 		if err != nil {
-			errs.Errors = append(errs.Errors, err)
+			errs.Errors = append(errs.Errors, fmt.Errorf("%q: %w", k, err))
 			continue
 		}
 

--- a/pkg/tfbridge/tokens_test.go
+++ b/pkg/tfbridge/tokens_test.go
@@ -87,6 +87,24 @@ func TestTokensSingleModule(t *testing.T) {
 	}, info.Resources)
 }
 
+func TestTokenWithModuleName(t *testing.T) {
+	info := tfbridge.ProviderInfo{
+		Name: "foo",
+		P: (&schema.Provider{
+			ResourcesMap: schema.ResourceMap{
+				"foo_index": nil,
+			},
+		}).Shim(),
+	}
+
+	strategy := tokens.SingleModule(info.GetResourcePrefix(), "index", tokens.MakeStandard("bar"))
+	require.NoError(t, info.ComputeTokens(strategy))
+
+	assert.Equal(t, map[string]*tfbridge.ResourceInfo{
+		"foo_index": {Tok: "bar:index/index:Index"},
+	}, info.Resources)
+}
+
 func TestTokensKnownModules(t *testing.T) {
 	info := tfbridge.ProviderInfo{
 		P: (&schema.Provider{


### PR DESCRIPTION
This PR improves the error message when it fails to map tokens (first commit), then removes the `"_"` appended to the end of the prefix so tokens that are of the form `<pkg>_index` can be correctly mapped.

Fixes https://github.com/pulumi/pulumi-terraform-provider/issues/13