### PR TITLE
Infer resource prefix for dynamic providers

### DIFF
--- a/dynamic/info.go
+++ b/dynamic/info.go
@@ -28,15 +28,20 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/pf/proto"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/tokens"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
 func providerInfo(ctx context.Context, p run.Provider, value parameterize.Value) (tfbridge.ProviderInfo, error) {
+
+	provider := proto.New(ctx, p)
 	prov := tfbridge.ProviderInfo{
-		P:           proto.New(ctx, p),
+		P:           provider,
 		Name:        p.Name(),
 		Version:     p.Version(),
 		Description: "A Pulumi provider dynamically bridged from " + p.Name() + ".",
 		Publisher:   "Pulumi",
+
+		ResourcePrefix: inferResourcePrefix(provider),
 
 		// To avoid bogging down schema generation speed, we skip all examples.
 		SkipExamples: func(tfbridge.SkipExamplesArgs) bool { return true },
@@ -93,4 +98,34 @@ func providerInfo(ctx context.Context, p run.Provider, value parameterize.Value)
 	prov.SetAutonaming(255, "-")
 
 	return prov, nil
+}
+
+// inferResourcePrefix makes a best attempt effort at finding the resource prefix for p.
+func inferResourcePrefix(p shim.Provider) string {
+	var canidate string
+	p.ResourcesMap().Range(func(key string, _ shim.Resource) bool {
+		parts := strings.Split(key, "_")
+		if len(parts) < 2 {
+			// This might not be a valid resource, just ignore it. Errors will
+			// be reported later as part of token mapping.
+			return true
+		}
+		// Set parts[0] as the candidate
+		if canidate == "" {
+			canidate = parts[0]
+			return true
+		}
+
+		// We already have a candidate, we are now checking if it's consistent.
+
+		if canidate == parts[0] {
+			// The candidate still holds, so keep iterating.
+			return true
+		}
+
+		// The candidate did not hold, so reset the candidate and give up.
+		canidate = ""
+		return false
+	})
+	return canidate
 }

--- a/dynamic/info_test.go
+++ b/dynamic/info_test.go
@@ -1,0 +1,101 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/opentofu/opentofu/shim/run"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-terraform-bridge/dynamic/parameterize"
+)
+
+func TestInferResourcePrefix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		tfNames        []string
+		expectedPrefix string
+	}{
+		{
+			name: "divergent-prefix",
+			tfNames: []string{
+				"prefix_res1",
+				"prefix_res2",
+			},
+			expectedPrefix: "prefix",
+		},
+		{
+			name: "expected-prefix",
+			tfNames: []string{
+				"test_res1",
+				"test_res2",
+			},
+			expectedPrefix: "test",
+		},
+		{
+			name: "ambiguous-prefix",
+			tfNames: []string{
+				"test_res1",
+				"test2_res",
+			},
+			// We expect "test" because that is the .Name of the provider.
+			expectedPrefix: "test",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			resourceSchemas := make(map[string]*tfprotov6.Schema, len(tt.tfNames))
+			for _, tf := range tt.tfNames {
+				resourceSchemas[tf] = &tfprotov6.Schema{Block: &tfprotov6.SchemaBlock{}}
+			}
+
+			info, err := providerInfo(context.Background(), schemaOnlyProvider{
+				name:    "test",
+				version: "1.0.0",
+				schema: &tfprotov6.GetProviderSchemaResponse{
+					ResourceSchemas: resourceSchemas,
+				},
+			}, parameterize.Value{})
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expectedPrefix, info.GetResourcePrefix())
+		})
+	}
+}
+
+type schemaOnlyProvider struct {
+	run.Provider
+	name, url, version string
+
+	schema *tfprotov6.GetProviderSchemaResponse
+}
+
+func (s schemaOnlyProvider) Name() string    { return s.name }
+func (s schemaOnlyProvider) URL() string     { return s.url }
+func (s schemaOnlyProvider) Version() string { return s.version }
+
+func (s schemaOnlyProvider) GetProviderSchema(
+	_ context.Context, req *tfprotov6.GetProviderSchemaRequest,
+) (*tfprotov6.GetProviderSchemaResponse, error) {
+	return s.schema, nil
+}


### PR DESCRIPTION
Instead of assuming that the resource prefix for `p` is `p.Name()`, we attempt to discover
it by iterating over the prefixes of the resources of `p`.

Fixes https://github.com/pulumi/pulumi-terraform-provider/issues/12