### PR TITLE
feat: run validate during import and drop invalid inputs

### DIFF
--- a/pkg/tests/schema_pulumi_test.go
+++ b/pkg/tests/schema_pulumi_test.go
@@ -3,11 +3,13 @@ package tests
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hexops/autogold/v2"
@@ -16,7 +18,9 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optpreview"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optrefresh"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestBasic(t *testing.T) {
@@ -2589,6 +2593,363 @@ Resources:
 			res := pt.Preview(optpreview.Diff())
 			t.Logf(res.StdOut)
 			tc.expected.Equal(t, res.StdOut)
+		})
+	}
+}
+
+func TestFailedValidatorOnReadHandling(t *testing.T) {
+	type PulumiResources struct {
+		Type       string                 `yaml:"type"`
+		Properties map[string]interface{} `yaml:"properties"`
+	}
+	type PulumiYaml struct {
+		Runtime   string                     `yaml:"runtime,omitempty"`
+		Name      string                     `yaml:"name,omitempty"`
+		Resources map[string]PulumiResources `yaml:"resources"`
+	}
+
+	tests := []struct {
+		name          string
+		schema        schema.Schema
+		cloudVal      interface{}
+		expectedProps map[string]interface{}
+		expectFailure bool
+	}{
+		{
+			name:     "TypeString no validate",
+			cloudVal: "ABC",
+			schema: schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+			expectedProps: map[string]interface{}{
+				// input not dropped
+				"collectionProp": "ABC",
+			},
+		},
+		{
+			name:     "TypeString ValidateFunc does not error",
+			cloudVal: "ABC",
+			schema: schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateFunc: func(i interface{}, s string) ([]string, []error) {
+					return []string{}, []error{}
+				},
+			},
+			expectedProps: map[string]interface{}{
+				// input not dropped
+				"collectionProp": "ABC",
+			},
+		},
+		{
+			name:     "TypeString ValidateDiagFunc does not error",
+			cloudVal: "ABC",
+			schema: schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateDiagFunc: func(i interface{}, p cty.Path) diag.Diagnostics {
+					return nil
+				},
+			},
+			expectedProps: map[string]interface{}{
+				// input not dropped
+				"collectionProp": "ABC",
+			},
+		},
+		{
+			name:     "TypeString ValidateDiagFunc returns error",
+			cloudVal: "ABC",
+			schema: schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateDiagFunc: func(i interface{}, p cty.Path) diag.Diagnostics {
+					return diag.Errorf("Error")
+				},
+			},
+			// input dropped
+			expectedProps: map[string]interface{}{},
+		},
+		{
+			name: "TypeMap ValidateDiagFunc returns error",
+			cloudVal: map[string]string{
+				"nested_prop":       "ABC",
+				"nested_other_prop": "value",
+			},
+			schema: schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				ValidateDiagFunc: func(i interface{}, p cty.Path) diag.Diagnostics {
+					return diag.Errorf("Error")
+				},
+				Elem: &schema.Schema{
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			},
+			// input dropped
+			expectedProps: map[string]interface{}{},
+		},
+		{
+			name: "Non-Computed TypeMap ValidateDiagFunc does not drop",
+			cloudVal: map[string]string{
+				"nested_prop":       "ABC",
+				"nested_other_prop": "value",
+			},
+			schema: schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: false,
+				ValidateDiagFunc: func(i interface{}, p cty.Path) diag.Diagnostics {
+					return diag.Errorf("Error")
+				},
+				Elem: &schema.Schema{
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			},
+			// input not dropped
+			expectedProps: map[string]interface{}{
+				"collectionProp": map[string]interface{}{
+					"nested_prop":       "ABC",
+					"nested_other_prop": "value",
+				},
+			},
+			// we don't drop computed: false attributes, so they will
+			// still fail
+			expectFailure: true,
+		},
+		{
+			name: "Required TypeMap ValidateDiagFunc does not drop",
+			cloudVal: map[string]string{
+				"nested_prop":       "ABC",
+				"nested_other_prop": "value",
+			},
+			schema: schema.Schema{
+				Type:     schema.TypeMap,
+				Required: true,
+				ValidateDiagFunc: func(i interface{}, p cty.Path) diag.Diagnostics {
+					return diag.Errorf("Error")
+				},
+				Elem: &schema.Schema{
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			},
+			expectedProps: map[string]interface{}{
+				"collectionProp": map[string]interface{}{
+					"nested_prop":       "ABC",
+					"nested_other_prop": "value",
+				},
+			},
+			expectFailure: true,
+		},
+		{
+			name:     "TypeString ValidateFunc returns error",
+			cloudVal: "ABC",
+			schema: schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateFunc: func(i interface{}, s string) ([]string, []error) {
+					return []string{}, []error{errors.New("Error")}
+				},
+			},
+			// input dropped
+			expectedProps: map[string]interface{}{},
+		},
+		{
+			name:     "TypeString ValidateFunc does not drop required fields",
+			cloudVal: "ABC",
+			schema: schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: func(i interface{}, s string) ([]string, []error) {
+					return []string{}, []error{errors.New("Error")}
+				},
+			},
+			expectedProps: map[string]interface{}{
+				// input not dropped
+				"collectionProp": "ABC",
+			},
+			expectFailure: true,
+		},
+		{
+			name: "TypeSet ValidateDiagFunc returns error",
+			cloudVal: []interface{}{
+				"ABC", "value",
+			},
+			schema: schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					ValidateDiagFunc: func(i interface{}, p cty.Path) diag.Diagnostics {
+						if val, ok := i.(string); ok && val != "ABC" {
+							return diag.Errorf("Error")
+						}
+						return nil
+					},
+				},
+			},
+			// if one element of the list fails validation
+			// the entire list is removed. Terraform does not return
+			// list indexes as part of the diagnostic attribute path
+			expectedProps: map[string]interface{}{},
+		},
+
+		// ValidateDiagFunc & ValidateFunc are not supported for TypeList & TypeSet, but they
+		// are supported on the nested elements. For now we are not processing the results of those with `schema.Resource` elements
+		// since it can get complicated. Nothing will get dropped and the validation error will pass through
+		{
+			name: "TypeList do not validate nested fields",
+			cloudVal: []interface{}{
+				map[string]interface{}{
+					"nested_prop":       "ABC",
+					"nested_other_prop": "ABC",
+				},
+			},
+			schema: schema.Schema{
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"nested_prop": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ValidateDiagFunc: func(i interface{}, p cty.Path) diag.Diagnostics {
+								return diag.Errorf("Error")
+							},
+						},
+						"nested_other_prop": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ValidateDiagFunc: func(i interface{}, p cty.Path) diag.Diagnostics {
+								return nil
+							},
+						},
+					},
+				},
+			},
+			expectedProps: map[string]interface{}{
+				"collectionProp": map[string]interface{}{
+					"nestedOtherProp": "ABC",
+					"nestedProp":      "ABC",
+				},
+			},
+			expectFailure: true,
+		},
+		{
+			name: "TypeSet Do not validate nested fields",
+			cloudVal: []interface{}{
+				map[string]interface{}{
+					"nested_prop": "ABC",
+				},
+			},
+			schema: schema.Schema{
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"nested_prop": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: func(i interface{}, s string) ([]string, []error) {
+								return []string{}, []error{errors.New("Error")}
+							},
+						},
+					},
+				},
+			},
+			expectedProps: map[string]interface{}{
+				"collectionProps": []interface{}{
+					map[string]interface{}{
+						"nestedProp": "ABC",
+					},
+				},
+			},
+			expectFailure: true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			resMap := map[string]*schema.Resource{
+				"prov_test": {
+					Schema: map[string]*schema.Schema{
+						"collection_prop": &tc.schema,
+						"other_prop": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+					Importer: &schema.ResourceImporter{
+						StateContext: func(ctx context.Context, rd *schema.ResourceData, i interface{}) ([]*schema.ResourceData, error) {
+							err := rd.Set("collection_prop", tc.cloudVal)
+							assert.NoError(t, err)
+							err = rd.Set("other_prop", "test")
+							assert.NoError(t, err)
+							return []*schema.ResourceData{rd}, nil
+						},
+					},
+					ReadContext: func(ctx context.Context, rd *schema.ResourceData, i interface{}) diag.Diagnostics {
+						err := rd.Set("collection_prop", tc.cloudVal)
+						assert.NoError(t, err)
+						err = rd.Set("other_prop", "test")
+						assert.NoError(t, err)
+						return nil
+					},
+				},
+			}
+			tfp := &schema.Provider{ResourcesMap: resMap}
+			bridgedProvider := pulcheck.BridgedProvider(t, "prov", tfp, pulcheck.DisablePlanResourceChange())
+			program := `
+name: test
+runtime: yaml
+`
+			pt := pulcheck.PulCheck(t, bridgedProvider, program)
+			outPath := filepath.Join(pt.CurrentStack().Workspace().WorkDir(), "out.yaml")
+
+			imp := pt.Import("prov:index/test:Test", "mainRes", "mainRes", "", "--out", outPath)
+			tc.expectedProps["otherProp"] = "test"
+
+			contents, err := os.ReadFile(outPath)
+			assert.NoError(t, err)
+			expected := PulumiYaml{
+				Resources: map[string]PulumiResources{
+					"mainRes": {
+						Type:       "prov:Test",
+						Properties: tc.expectedProps,
+					},
+				},
+			}
+			var actual PulumiYaml
+			err = yaml.Unmarshal(contents, &actual)
+			assert.NoError(t, err)
+
+			assert.Equal(t, expected, actual)
+			if tc.expectFailure {
+				assert.Contains(t, imp.Stdout, "One or more imported inputs failed to validate")
+			} else {
+				assert.NotContains(t, imp.Stdout, "One or more imported inputs failed to validate")
+
+				f, err := os.OpenFile(filepath.Join(pt.CurrentStack().Workspace().WorkDir(), "Pulumi.yaml"), os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
+				assert.NoError(t, err)
+				defer f.Close()
+				_, err = f.WriteString(string(contents))
+				assert.NoError(t, err)
+
+				// run preview using the generated file
+				pt.Preview(optpreview.Diff(), optpreview.ExpectNoChanges())
+			}
 		})
 	}
 }

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -47,6 +47,7 @@ import (
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/walk"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/logging"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/metadata"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/propertyvalue"
@@ -1360,9 +1361,11 @@ func (p *Provider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*pulum
 		return nil, errors.Wrapf(err, "unmarshaling %s's instance state", urn)
 	}
 
+	var isImportOrGet bool
 	// If we are in a "get" rather than a "refresh", we should call the Terraform importer, if one is defined.
 	isRefresh := len(req.GetProperties().GetFields()) != 0
 	if !isRefresh && res.TF.Importer() != nil {
+		isImportOrGet = true
 		glog.V(9).Infof("%s has TF Importer", res.TFName)
 
 		state, err = res.runTerraformImporter(ctx, id, p)
@@ -1418,6 +1421,14 @@ func (p *Provider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*pulum
 
 		cleanInputs := deconflict(ctx, res.TF.Schema(), res.Schema.Fields, inputs)
 
+		// TODO: https://github.com/pulumi/pulumi/issues/16886
+		// It is currently not possible to differentiate between an import and a .get request
+		// Ideally we only want to run this during import, but since we will only be modifying input
+		// properties (which .get requests don't care about) we are ok running this during .get requests
+		if isImportOrGet {
+			p.processImportValidationErrors(ctx, urn, res.TFName, inputs, res.TF.Schema(), res.Schema.GetFields())
+		}
+
 		minputs, err := plugin.MarshalProperties(cleanInputs, plugin.MarshalOptions{
 			Label:       label + ".inputs",
 			KeepSecrets: p.supportsSecrets,
@@ -1431,6 +1442,73 @@ func (p *Provider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*pulum
 
 	// The resource is gone.
 	return &pulumirpc.ReadResponse{}, nil
+}
+
+// processImportValidationErrors runs `Validate` and then processes any resulting validation errors.
+// This only needs to run during an `Import` operation because the values read from the cloud
+// during import will be turned into the inputs in the generated code. Sometimes the cloud returns invalid
+// input values which will cause the next `up` to fail.
+//
+// To try and avoid this failure case, we run the validate functions for the generated inputs and
+// if any fail (and they match our other cases) then we remove those inputs so that the generated
+// program code will not contain the invalid inputs
+//
+// NOTE: we want to (for now at least) scope this as narrowly as possible because we do not want to
+// create a scenario where the resulting inputs create a different error
+// (e.g. removing an invalid required property). In these cases we will just allow the invalid configuration
+// through and the user will have to decide what to do.
+func (p *Provider) processImportValidationErrors(
+	ctx context.Context,
+	urn resource.URN,
+	tfName string,
+	inputs resource.PropertyMap,
+	schema shim.SchemaMap,
+	schemaInfos map[string]*info.Schema,
+) {
+	logger := GetLogger(ctx)
+	tfInputs, _, err := makeTerraformInputsWithOptions(ctx,
+		&PulumiResource{URN: urn, Properties: inputs},
+		p.configValues, inputs, inputs, schema, schemaInfos,
+		makeTerraformInputsOptions{DisableTFDefaults: true, UnknownCollectionsSupported: p.tf.SupportsUnknownCollections()})
+	if err != nil {
+		return
+	}
+
+	rescfg := MakeTerraformConfigFromInputs(ctx, p.tf, tfInputs)
+	_, errs := p.tf.ValidateResource(ctx, tfName, rescfg)
+	for _, e := range errs {
+
+		path, _, _ := parseCheckError(schema, schemaInfos, e)
+
+		// do not process errors on nested types
+		if path == nil || len(path.schemaPath) > 1 {
+			continue
+		}
+
+		schemaAtPath, err := walk.LookupSchemaMapPath(path.schemaPath, schema)
+		if err != nil {
+			logger.Debug(fmt.Sprintf(
+				"could not find schema for validation error at path %s: %s",
+				path.schemaPath.GoString(),
+				err.Error(),
+			))
+			continue
+		}
+
+		// only drop optional computed properties since:
+		// - dropping required properties will cause it's own error.
+		// - dropping non-computed properties will cause a diff on the next preview
+		if !schemaAtPath.Optional() || !schemaAtPath.Computed() {
+			continue
+		}
+		pp, err := resource.ParsePropertyPath(path.valuePath)
+		if err != nil {
+			logger.Debug(fmt.Sprintf("could not parse property path %q for validation error: %s", path.valuePath, err.Error()))
+			continue
+		}
+		logger.Warn(fmt.Sprintf("property at path %q failed validation and was dropped from generated input", pp.String()))
+		pp.Delete(resource.NewObjectProperty(inputs))
+	}
 }
 
 // Update updates an existing resource with new values.  Only those values in the provided property bag are updated

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	schemav2 "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hexops/autogold/v2"
+	"github.com/pkg/errors"
 	testutils "github.com/pulumi/providertest/replay"
 	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
@@ -42,6 +43,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/internal/testprovider"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	shimv1 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v1"
 	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
@@ -5710,4 +5712,345 @@ func TestSetDuplicatedDiffEntries(t *testing.T) {
         "name": "snowflake"
     }
 }`)
+}
+
+func TestProcessImportValidationErrors(t *testing.T) {
+	tests := []struct {
+		name          string
+		schema        schemav2.Schema
+		cloudVal      interface{}
+		expectedProps resource.PropertyMap
+		expectFailure bool
+	}{
+		{
+			name:     "TypeString no validate",
+			cloudVal: "ABC",
+			schema: schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+			expectedProps: resource.NewPropertyMapFromMap(map[string]interface{}{
+				// input not dropped
+				"collectionProp": "ABC",
+			}),
+		},
+		{
+			name: "Secret value",
+			schema: schema.Schema{
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+				Computed:  true,
+			},
+			cloudVal: "ABC",
+			expectedProps: resource.PropertyMap{
+				// input not dropped
+				"collectionProp": resource.NewSecretProperty(
+					&resource.Secret{Element: resource.NewPropertyValue("ABC")},
+				),
+			},
+		},
+		{
+			name:     "TypeString ValidateFunc does not error",
+			cloudVal: "ABC",
+			schema: schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateFunc: func(i interface{}, s string) ([]string, []error) {
+					return []string{}, []error{}
+				},
+			},
+			expectedProps: resource.NewPropertyMapFromMap(map[string]interface{}{
+				// input not dropped
+				"collectionProp": "ABC",
+			}),
+		},
+		{
+			name:     "TypeString ValidateDiagFunc does not error",
+			cloudVal: "ABC",
+			schema: schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateDiagFunc: func(i interface{}, p cty.Path) diag.Diagnostics {
+					return nil
+				},
+			},
+			expectedProps: resource.NewPropertyMapFromMap(map[string]interface{}{
+				// input not dropped
+				"collectionProp": "ABC",
+			}),
+		},
+		{
+			name:     "TypeString ValidateDiagFunc returns error",
+			cloudVal: "ABC",
+			schema: schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateDiagFunc: func(i interface{}, p cty.Path) diag.Diagnostics {
+					return diag.Errorf("Error")
+				},
+			},
+			// input dropped
+			expectedProps: resource.NewPropertyMapFromMap(map[string]interface{}{}),
+		},
+		{
+			name: "TypeMap ValidateDiagFunc returns error",
+			cloudVal: map[string]string{
+				"nestedProp":      "ABC",
+				"nestedOtherProp": "value",
+			},
+			schema: schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				ValidateDiagFunc: func(i interface{}, p cty.Path) diag.Diagnostics {
+					return diag.Errorf("Error")
+				},
+				Elem: &schema.Schema{
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			},
+			// input dropped
+			expectedProps: resource.NewPropertyMapFromMap(map[string]interface{}{}),
+		},
+		{
+			name: "Non-Computed TypeMap ValidateDiagFunc does not drop",
+			cloudVal: map[string]string{
+				"nestedProp":      "ABC",
+				"nestedOtherProp": "value",
+			},
+			schema: schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: false,
+				ValidateDiagFunc: func(i interface{}, p cty.Path) diag.Diagnostics {
+					return diag.Errorf("Error")
+				},
+				Elem: &schema.Schema{
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			},
+			// input not dropped
+			expectedProps: resource.NewPropertyMapFromMap(map[string]interface{}{
+				"collectionProp": map[string]interface{}{
+					"nestedProp":      "ABC",
+					"nestedOtherProp": "value",
+				},
+			}),
+			// we don't drop computed: false attributes, so they will
+			// still fail
+			expectFailure: true,
+		},
+		{
+			name: "Required TypeMap ValidateDiagFunc does not drop",
+			cloudVal: map[string]string{
+				"nestedProp":      "ABC",
+				"nestedOtherProp": "value",
+			},
+			schema: schema.Schema{
+				Type:     schema.TypeMap,
+				Required: true,
+				ValidateDiagFunc: func(i interface{}, p cty.Path) diag.Diagnostics {
+					return diag.Errorf("Error")
+				},
+				Elem: &schema.Schema{
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			},
+			expectedProps: resource.NewPropertyMapFromMap(map[string]interface{}{
+				"collectionProp": map[string]interface{}{
+					"nestedProp":      "ABC",
+					"nestedOtherProp": "value",
+				},
+			}),
+			expectFailure: true,
+		},
+		{
+			name:     "TypeString ValidateFunc returns error",
+			cloudVal: "ABC",
+			schema: schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateFunc: func(i interface{}, s string) ([]string, []error) {
+					return []string{}, []error{errors.New("Error")}
+				},
+			},
+			// input dropped
+			expectedProps: resource.NewPropertyMapFromMap(map[string]interface{}{}),
+		},
+		{
+			name:     "TypeString ValidateFunc does not drop required fields",
+			cloudVal: "ABC",
+			schema: schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: func(i interface{}, s string) ([]string, []error) {
+					return []string{}, []error{errors.New("Error")}
+				},
+			},
+			expectedProps: resource.NewPropertyMapFromMap(map[string]interface{}{
+				// input not dropped
+				"collectionProp": "ABC",
+			}),
+			expectFailure: true,
+		},
+		{
+			name: "TypeSet ValidateDiagFunc returns error",
+			cloudVal: []interface{}{
+				"ABC", "value",
+			},
+			schema: schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					ValidateDiagFunc: func(i interface{}, p cty.Path) diag.Diagnostics {
+						if val, ok := i.(string); ok && val != "ABC" {
+							return diag.Errorf("Error")
+						}
+						return nil
+					},
+				},
+			},
+			// if one element of the list fails validation
+			// the entire list is removed. Terraform does not return
+			// list indexes as part of the diagnostic attribute path
+			expectedProps: resource.NewPropertyMapFromMap(map[string]interface{}{}),
+		},
+
+		// ValidateDiagFunc & ValidateFunc are not supported for TypeList &
+		// TypeSet, but they are supported on the nested elements. For now we are
+		// not processing the results of those with `schema.Resource` elements
+		// since it can get complicated. Nothing will get dropped and the
+		// validation error will pass through
+		{
+			name: "TypeList do not validate nested fields",
+			cloudVal: []interface{}{
+				map[string]interface{}{
+					"nestedProp":      "ABC",
+					"nestedOtherProp": "ABC",
+				},
+			},
+			schema: schema.Schema{
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"nested_prop": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ValidateDiagFunc: func(i interface{}, p cty.Path) diag.Diagnostics {
+								return diag.Errorf("Error")
+							},
+						},
+						"nested_other_prop": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ValidateDiagFunc: func(i interface{}, p cty.Path) diag.Diagnostics {
+								return nil
+							},
+						},
+					},
+				},
+			},
+			expectedProps: resource.NewPropertyMapFromMap(map[string]interface{}{
+				"collectionProp": []map[string]interface{}{
+					{
+						"nestedOtherProp": "ABC",
+						"nestedProp":      "ABC",
+					},
+				},
+			}),
+			expectFailure: true,
+		},
+		{
+			name: "TypeSet Do not validate nested fields",
+			cloudVal: []interface{}{
+				map[string]interface{}{
+					"nestedProp": "ABC",
+				},
+			},
+			schema: schema.Schema{
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"nested_prop": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: func(i interface{}, s string) ([]string, []error) {
+								return []string{}, []error{errors.New("Error")}
+							},
+						},
+					},
+				},
+			},
+			expectedProps: resource.NewPropertyMapFromMap(map[string]interface{}{
+				"collectionProps": []interface{}{
+					map[string]interface{}{
+						"nestedProp": "ABC",
+					},
+				},
+			}),
+			expectFailure: true,
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			urn, err := resource.ParseURN("urn:pulumi:test::test::prov:index/test:Test::mainRes")
+			assert.NoError(t, err)
+			tfName := "prov_test"
+			sch := map[string]*schemav2.Schema{
+				"collection_prop": &tc.schema,
+				"other_prop": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			}
+			schemaMap := shimv2.NewSchemaMap(sch)
+			tfProvider := shimv2.NewProvider(&schema.Provider{
+				Schema: map[string]*schema.Schema{},
+				ResourcesMap: map[string]*schemav2.Resource{
+					"prov_test": {
+						Schema: sch,
+					},
+				},
+			})
+			var inputs resource.PropertyValue
+			if tc.schema.Sensitive {
+				inputs = resource.NewSecretProperty(&resource.Secret{Element: resource.NewPropertyValue(tc.cloudVal)})
+			} else {
+				inputs = resource.NewPropertyValue(tc.cloudVal)
+			}
+			plural := ""
+			if (tc.schema.Type == schema.TypeList || tc.schema.Type == schema.TypeSet) && tc.schema.MaxItems != 1 {
+				plural = "s"
+			}
+			inputsMap := resource.PropertyMap{
+				resource.PropertyKey("collectionProp" + plural): inputs,
+			}
+
+			schemaInfos := map[string]*info.Schema{}
+			p := Provider{
+				configValues: resource.PropertyMap{},
+				tf:           tfProvider,
+			}
+			ctx := context.Background()
+			ctx = p.loggingContext(ctx, urn)
+
+			p.processImportValidationErrors(ctx, urn, tfName, inputsMap, schemaMap, schemaInfos)
+			assert.Equal(t, tc.expectedProps, inputsMap)
+		})
+	}
 }

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -351,6 +351,12 @@ func (ctx *conversionContext) makeTerraformInput(
 	tfs shim.Schema,
 	ps *SchemaInfo,
 ) (interface{}, error) {
+
+	if v.IsSecret() {
+		// We shouldn't see secrets, but if we do then we should ignore them
+		return ctx.makeTerraformInput(name, old, v.SecretValue().Element, tfs, ps)
+	}
+
 	// For TypeList or TypeSet with MaxItems==1, we will have projected as a scalar
 	// nested value, and need to wrap it into a single-element array before passing to
 	// Terraform.


### PR DESCRIPTION
> This is a reroll of #2277 which was reverted in #2299
> I've added additional handing for secret values

During an import operation property values are read from the cloud and
turned into inputs which then becomes part of the generated code. For
some properties (Computed & Optional) the cloud can return values that
fail validation. Since these are computed & optional the provider will
allow the user to not specify a value. In these cases the import would
succeed, but if the user took the generated code as is and attempted to
run pulumi up it would fail due to the validation errors.

Rather than generate invalid inputs we will instead run Validate during import
and then processes any resulting validation errors. If any properties
fail validation (and they match our other cases) then we remove those
inputs so that the generated program code will not contain the invalid
inputs

NOTE: we want to (for now at least) scope this as narrowly as possible because we do not want to
create a scenario where the resulting inputs create a different error
(e.g. removing an invalid required property). In these cases we will just allow the invalid configuration
through and the user will have to decide what to do.

fixes pulumi/pulumi-aws#4054