### PR TITLE
Add tf as a code identifier to isHCL func

### DIFF
--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -2347,6 +2347,6 @@ func guessIsHCL(code string) bool {
 }
 
 func isHCL(fenceLanguage, code string) bool {
-	return fenceLanguage == "```terraform\n" || fenceLanguage == "```hcl\n" ||
+	return fenceLanguage == "```terraform\n" || fenceLanguage == "```hcl\n" || fenceLanguage == "```tf\n" ||
 		(fenceLanguage == "```\n" && guessIsHCL(code))
 }


### PR DESCRIPTION
Some provider docs like Artifactory use ```tf as a code block identifier. 

This PR adds that so the bridge can recognize it for example translation.