### PR TITLE
Make regex link matching more strict

### DIFF
--- a/pkg/tfgen/edit_rules.go
+++ b/pkg/tfgen/edit_rules.go
@@ -31,7 +31,7 @@ func defaultEditRules() editRules {
 		boundedReplace("[tT]erraform [aA]pply", "pulumi up"),
 		reReplace(`"([mM])ade (by|with) [tT]erraform"`, `"Made $2 Pulumi"`),
 		// A markdown link that has terraform in the link component.
-		reReplace(`\[([^\]]*)\]\(.*terraform([^\)]*)\)`, "$1"),
+		reReplace(`\[([^\]]*)\]\([^\)]*terraform([^\)]*)\)`, "$1"),
 		fixupImports(),
 		// Replace content such as "jdoe@hashicorp.com" with "jdoe@example.com"
 		reReplace("@hashicorp.com", "@example.com"),

--- a/pkg/tfgen/installation_docs_test.go
+++ b/pkg/tfgen/installation_docs_test.go
@@ -196,6 +196,13 @@ func TestApplyEditRules(t *testing.T) {
 			},
 			expected: []byte("# I am a provider\n"),
 		},
+		{
+			name: "Strips Hashicorp links correctly",
+			docFile: DocFile{
+				Content: []byte(readfile(t, "test_data/replace-links/input.md")),
+			},
+			expected: []byte(readfile(t, "test_data/replace-links/actual.md")),
+		},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/pkg/tfgen/test_data/replace-links/actual.md
+++ b/pkg/tfgen/test_data/replace-links/actual.md
@@ -1,0 +1,1 @@
+The [Datadog](https://www.datadoghq.com) provider is used to interact with the resources supported by Datadog. The provider needs to be configured with the proper credentials before it can be used. Try the hands-on tutorial on the Datadog provider on the HashiCorp Learn site.

--- a/pkg/tfgen/test_data/replace-links/input.md
+++ b/pkg/tfgen/test_data/replace-links/input.md
@@ -1,0 +1,1 @@
+The [Datadog](https://www.datadoghq.com) provider is used to interact with the resources supported by Datadog. The provider needs to be configured with the proper credentials before it can be used. Try the [hands-on tutorial](https://developer.hashicorp.com/terraform/tutorials/use-case/datadog-provider) on the Datadog provider on the HashiCorp Learn site.


### PR DESCRIPTION
While rolling out https://github.com/pulumi/home/issues/3598 on Datadog, I noticed that the default edit rules stripped the following upstream text 
>The [Datadog](https://www.datadoghq.com) provider is used to interact with the resources supported by Datadog. The provider needs to be configured with the proper credentials before it can be used. It requires terraform 0.12 or later.
>Try the [hands-on tutorial](https://developer.hashicorp.com/terraform/tutorials/use-case/datadog-provider) on the Datadog provider on the HashiCorp Learn site.

to render

"The Datadog on the Datadog provider on the HashiCorp Learn site."

This is because the current regex matches _all_ characters before the `terraform` link string, leading to a nonsensical replacement of the entire match. With this change, we exclude `)` which selects for the matching link only.

Added a test to this effect.