### PR TITLE
Set the root package name for go sdks

### DIFF
--- a/dynamic/info.go
+++ b/dynamic/info.go
@@ -69,7 +69,7 @@ func providerInfo(ctx context.Context, p run.Provider, value parameterize.Value)
 				p.Name(),
 				tfbridge.GetModuleMajorVersion(p.Version()),
 			),
-
+			RootPackageName:              p.Name(),
 			LiftSingleValueMethodReturns: true,
 			GenerateExtraInputTypes:      true,
 			RespectSchemaVersion:         true,

--- a/dynamic/testdata/TestSchemaGeneration/Azure/alz-0.11.1.golden
+++ b/dynamic/testdata/TestSchemaGeneration/Azure/alz-0.11.1.golden
@@ -15,6 +15,7 @@
         },
         "go": {
             "importBasePath": "github.com/pulumi/pulumi-terraform-provider/sdks/go/alz",
+            "rootPackageName": "alz",
             "liftSingleValueMethodReturns": true,
             "generateExtraInputTypes": true,
             "respectSchemaVersion": true

--- a/dynamic/testdata/TestSchemaGeneration/Backblaze/b2-0.8.9.golden
+++ b/dynamic/testdata/TestSchemaGeneration/Backblaze/b2-0.8.9.golden
@@ -15,6 +15,7 @@
         },
         "go": {
             "importBasePath": "github.com/pulumi/pulumi-terraform-provider/sdks/go/b2",
+            "rootPackageName": "b2",
             "liftSingleValueMethodReturns": true,
             "generateExtraInputTypes": true,
             "respectSchemaVersion": true

--- a/dynamic/testdata/TestSchemaGeneration/databricks/databricks-1.50.0.golden
+++ b/dynamic/testdata/TestSchemaGeneration/databricks/databricks-1.50.0.golden
@@ -15,6 +15,7 @@
         },
         "go": {
             "importBasePath": "github.com/pulumi/pulumi-terraform-provider/sdks/go/databricks",
+            "rootPackageName": "databricks",
             "liftSingleValueMethodReturns": true,
             "generateExtraInputTypes": true,
             "respectSchemaVersion": true

--- a/dynamic/testdata/TestSchemaGeneration/hashicorp/random-3.3.0.golden
+++ b/dynamic/testdata/TestSchemaGeneration/hashicorp/random-3.3.0.golden
@@ -15,6 +15,7 @@
         },
         "go": {
             "importBasePath": "github.com/pulumi/pulumi-terraform-provider/sdks/go/random/v3",
+            "rootPackageName": "random",
             "liftSingleValueMethodReturns": true,
             "generateExtraInputTypes": true,
             "respectSchemaVersion": true


### PR DESCRIPTION
The ImportBasePath for go SDKs can end in a version specificer. Set RootPackageName to the package’s name so that codegen generates a flat package instead of nesting it into a fodler for the package name or version.
