### PR TITLE
Display invalid values when error checking

### DIFF
--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -1202,7 +1202,7 @@ func TestCheckWarnings(t *testing.T) {
 		},
 	}
 
-	// we need the pschema for type checking
+	// we need the schema for type checking
 	pulumiSchemaSpec := &pschema.PackageSpec{
 		Resources: map[string]pschema.ResourceSpec{
 			"ExampleResource": {
@@ -1298,7 +1298,7 @@ func TestCheckWarnings(t *testing.T) {
 	// run 'go test  -run=TestCheckWarnings -v ./pkg/tfbridge/ -update' to update
 	autogold.Expect(`warning: Type checking failed:
 warning: Unexpected type at field "networkConfiguration":
-           expected object type, got [] type
+           expected object type, got {[{map[securityGroups:{[out... of type []
 warning: Type checking is still experimental. If you believe that a warning is incorrect,
 please let us know by creating an issue at https://github.com/pulumi/pulumi-terraform-bridge/issues.
 This will become a hard error in the future.

--- a/pkg/tfbridge/tests/provider_test.go
+++ b/pkg/tfbridge/tests/provider_test.go
@@ -825,7 +825,7 @@ func TestTypeCheckingMistypedBooleansWithUnknowns(t *testing.T) {
 		},
 	}, newTestProviderOptions{})
 
-	reason := "expected boolean type, got string type. " +
+	reason := `expected boolean type, got \"DISABLED\" of type string. ` +
 		"Examine values at 'my-ecs-service.networkConfiguration.assignPublicIp'."
 
 	// networkConfiguration.assignPublicIp has the wrong type intentionally.

--- a/pkg/tfbridge/validate_input_types_test.go
+++ b/pkg/tfbridge/validate_input_types_test.go
@@ -266,7 +266,7 @@ func TestValidateInputType_objects(t *testing.T) {
 				})),
 			}),
 			failures: autogold.Expect([]TypeFailure{{
-				Reason:       "expected object type, got [] type",
+				Reason:       "expected object type, got {[{map[prop:{[{foo}]}]}]} of type []",
 				ResourcePath: "top_level_type_failure",
 			}}),
 			types: map[string]pschema.ComplexTypeSpec{
@@ -321,7 +321,7 @@ func TestValidateInputType_objects(t *testing.T) {
 				"objectStringProp": map[string]string{"foo": "bar"},
 			})),
 			failures: autogold.Expect([]TypeFailure{{
-				Reason:       "expected string type, got object type",
+				Reason:       "expected string type, got {map[foo:{bar}]} of type object",
 				ResourcePath: "object_string_type_failure.objectStringProp",
 			}}),
 			types: map[string]pschema.ComplexTypeSpec{
@@ -377,7 +377,7 @@ func TestValidateInputType_objects(t *testing.T) {
 				},
 			})),
 			failures: autogold.Expect([]TypeFailure{{
-				Reason:       "expected object type, got [] type",
+				Reason:       "expected object type, got {[{map[foo:{bar}]}]} of type []",
 				ResourcePath: "object_nested_object_type_failure.prop",
 			}}),
 			types: map[string]pschema.ComplexTypeSpec{
@@ -455,7 +455,7 @@ func TestValidateInputType_objects(t *testing.T) {
 				},
 			})),
 			failures: autogold.Expect([]TypeFailure{{
-				Reason:       "expected object type, got string type",
+				Reason:       `expected object type, got "foo" of type string`,
 				ResourcePath: "object_double_nested_object_type_failure.prop.objectStringProp",
 			}}),
 			types: map[string]pschema.ComplexTypeSpec{
@@ -528,7 +528,7 @@ func TestValidateInputType_objects(t *testing.T) {
 				"prop": map[string]string{"foo": "bar"},
 			})),
 			failures: autogold.Expect([]TypeFailure{{
-				Reason:       "expected array type, got object type",
+				Reason:       "expected array type, got {map[foo:{bar}]} of type object",
 				ResourcePath: "object_nested_array_type_failure.prop",
 			}}),
 			types: map[string]pschema.ComplexTypeSpec{
@@ -602,7 +602,7 @@ func TestValidateInputType_objects(t *testing.T) {
 				},
 			})),
 			failures: autogold.Expect([]TypeFailure{{
-				Reason:       "expected string type, got [] type",
+				Reason:       "expected string type, got {[{foo}]} of type []",
 				ResourcePath: "object_nested_array_object_type_failure.prop[0].objectStringProp",
 			}}),
 			types: map[string]pschema.ComplexTypeSpec{
@@ -953,11 +953,11 @@ func TestValidateInputType_arrays(t *testing.T) {
 			}),
 			failures: autogold.Expect([]TypeFailure{
 				{
-					Reason:       "expected string type, got [] type",
+					Reason:       "expected string type, got {[{1}]} of type []",
 					ResourcePath: "object_string_type_failure[1].objectStringProp",
 				},
 				{
-					Reason:       "expected object type, got string type",
+					Reason:       `expected object type, got "foo" of type string`,
 					ResourcePath: "object_string_type_failure[2]",
 				},
 			}),
@@ -1022,12 +1022,10 @@ func TestValidateInputType_arrays(t *testing.T) {
 					},
 				})),
 			}),
-			failures: autogold.Expect([]TypeFailure{
-				{
-					Reason:       "expected string type, got [] type",
-					ResourcePath: "object_nested_object_type_failure[1].prop.foo",
-				},
-			}),
+			failures: autogold.Expect([]TypeFailure{{
+				Reason:       "expected string type, got {[{1}]} of type []",
+				ResourcePath: "object_nested_object_type_failure[1].prop.foo",
+			}}),
 			types: map[string]pschema.ComplexTypeSpec{
 				"pkg:index/type:ObjectNestedObjectType": {
 					ObjectTypeSpec: pschema.ObjectTypeSpec{
@@ -1124,11 +1122,11 @@ func TestValidateInputType_arrays(t *testing.T) {
 			}),
 			failures: autogold.Expect([]TypeFailure{
 				{
-					Reason:       "expected string type, got object type",
+					Reason:       "expected string type, got {map[foo:{bar}]} of type object",
 					ResourcePath: "object_nested_array_type_failure[0].prop[1]",
 				},
 				{
-					Reason:       "expected string type, got [] type",
+					Reason:       "expected string type, got {[{bar}]} of type []",
 					ResourcePath: "object_nested_array_type_failure[0].prop[2]",
 				},
 			}),
@@ -1214,12 +1212,10 @@ func TestValidateInputType_arrays(t *testing.T) {
 					},
 				})),
 			}),
-			failures: autogold.Expect([]TypeFailure{
-				{
-					Reason:       "expected string type, got [] type",
-					ResourcePath: "object_nested_array_object_type_failure[0].prop[1].objectStringProp",
-				},
-			}),
+			failures: autogold.Expect([]TypeFailure{{
+				Reason:       "expected string type, got {[{foo}]} of type []",
+				ResourcePath: "object_nested_array_object_type_failure[0].prop[1].objectStringProp",
+			}}),
 			types: map[string]pschema.ComplexTypeSpec{
 				"pkg:index/type:ObjectStringType": {
 					ObjectTypeSpec: pschema.ObjectTypeSpec{
@@ -1366,9 +1362,10 @@ func TestValidateInputType_toplevel(t *testing.T) {
 		{
 			name:  "string_type_failure",
 			input: resource.NewArrayProperty([]resource.PropertyValue{resource.NewNumberProperty(1)}),
-			failures: autogold.Expect([]TypeFailure{
-				{Reason: "expected string type, got [] type", ResourcePath: "string_type_failure"},
-			}),
+			failures: autogold.Expect([]TypeFailure{{
+				Reason:       "expected string type, got {[{1}]} of type []",
+				ResourcePath: "string_type_failure",
+			}}),
 			inputProperties: map[string]pschema.PropertySpec{
 				"string_type_failure": {
 					TypeSpec: pschema.TypeSpec{
@@ -1451,9 +1448,10 @@ func TestValidateInputType_toplevel(t *testing.T) {
 			input: resource.NewObjectProperty(
 				resource.NewPropertyMapFromMap(map[string]interface{}{"foo": []string{"bar"}}),
 			),
-			failures: autogold.Expect([]TypeFailure{
-				{Reason: "expected boolean type, got [] type", ResourcePath: "object_type_failure.foo"},
-			}),
+			failures: autogold.Expect([]TypeFailure{{
+				Reason:       "expected boolean type, got {[{bar}]} of type []",
+				ResourcePath: "object_type_failure.foo",
+			}}),
 			inputProperties: map[string]pschema.PropertySpec{
 				"object_type_failure": {
 					TypeSpec: pschema.TypeSpec{

--- a/pkg/tfbridge/validate_input_types_test.go
+++ b/pkg/tfbridge/validate_input_types_test.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hexops/autogold/v2"
 	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/stretchr/testify/assert"
 )
 
-// TestValidateInputTypesV2 tests the validateInputTypesV2 function
 func TestValidateInputType_objects(t *testing.T) {
 	testCases := []struct {
 		name     string
@@ -18,7 +18,7 @@ func TestValidateInputType_objects(t *testing.T) {
 		typeName string
 		input    resource.PropertyValue
 		types    map[string]pschema.ComplexTypeSpec
-		failures []TypeFailure
+		failures autogold.Value
 	}{
 		{
 			name:     "enum_string_success",
@@ -265,9 +265,10 @@ func TestValidateInputType_objects(t *testing.T) {
 					"prop": []string{"foo"},
 				})),
 			}),
-			failures: []TypeFailure{
-				{Reason: "expected object type, got [] type", ResourcePath: "top_level_type_failure"},
-			},
+			failures: autogold.Expect([]TypeFailure{{
+				Reason:       "expected object type, got [] type",
+				ResourcePath: "top_level_type_failure",
+			}}),
 			types: map[string]pschema.ComplexTypeSpec{
 				"pkg:index/type:ObjectMultiType": {
 					ObjectTypeSpec: pschema.ObjectTypeSpec{
@@ -319,12 +320,10 @@ func TestValidateInputType_objects(t *testing.T) {
 			input: resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
 				"objectStringProp": map[string]string{"foo": "bar"},
 			})),
-			failures: []TypeFailure{
-				{
-					Reason:       "expected string type, got object type",
-					ResourcePath: "object_string_type_failure.objectStringProp",
-				},
-			},
+			failures: autogold.Expect([]TypeFailure{{
+				Reason:       "expected string type, got object type",
+				ResourcePath: "object_string_type_failure.objectStringProp",
+			}}),
 			types: map[string]pschema.ComplexTypeSpec{
 				"pkg:index/type:ObjectStringType": {
 					ObjectTypeSpec: pschema.ObjectTypeSpec{
@@ -377,12 +376,10 @@ func TestValidateInputType_objects(t *testing.T) {
 					{"foo": "bar"},
 				},
 			})),
-			failures: []TypeFailure{
-				{
-					Reason:       "expected object type, got [] type",
-					ResourcePath: "object_nested_object_type_failure.prop",
-				},
-			},
+			failures: autogold.Expect([]TypeFailure{{
+				Reason:       "expected object type, got [] type",
+				ResourcePath: "object_nested_object_type_failure.prop",
+			}}),
 			types: map[string]pschema.ComplexTypeSpec{
 				"pkg:index/type:ObjectNestedObjectType": {
 					ObjectTypeSpec: pschema.ObjectTypeSpec{
@@ -457,12 +454,10 @@ func TestValidateInputType_objects(t *testing.T) {
 					"objectStringProp": "foo",
 				},
 			})),
-			failures: []TypeFailure{
-				{
-					Reason:       "expected object type, got string type",
-					ResourcePath: "object_double_nested_object_type_failure.prop.objectStringProp",
-				},
-			},
+			failures: autogold.Expect([]TypeFailure{{
+				Reason:       "expected object type, got string type",
+				ResourcePath: "object_double_nested_object_type_failure.prop.objectStringProp",
+			}}),
 			types: map[string]pschema.ComplexTypeSpec{
 				"pkg:index/type:ObjectStringType": {
 					ObjectTypeSpec: pschema.ObjectTypeSpec{
@@ -532,12 +527,10 @@ func TestValidateInputType_objects(t *testing.T) {
 			input: resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
 				"prop": map[string]string{"foo": "bar"},
 			})),
-			failures: []TypeFailure{
-				{
-					Reason:       "expected array type, got object type",
-					ResourcePath: "object_nested_array_type_failure.prop",
-				},
-			},
+			failures: autogold.Expect([]TypeFailure{{
+				Reason:       "expected array type, got object type",
+				ResourcePath: "object_nested_array_type_failure.prop",
+			}}),
 			types: map[string]pschema.ComplexTypeSpec{
 				"pkg:index/type:ObjectNestedArrayType": {
 					ObjectTypeSpec: pschema.ObjectTypeSpec{
@@ -608,12 +601,10 @@ func TestValidateInputType_objects(t *testing.T) {
 					{"objectStringProp": []string{"foo"}},
 				},
 			})),
-			failures: []TypeFailure{
-				{
-					Reason:       "expected string type, got [] type",
-					ResourcePath: "object_nested_array_object_type_failure.prop[0].objectStringProp",
-				},
-			},
+			failures: autogold.Expect([]TypeFailure{{
+				Reason:       "expected string type, got [] type",
+				ResourcePath: "object_nested_array_object_type_failure.prop[0].objectStringProp",
+			}}),
 			types: map[string]pschema.ComplexTypeSpec{
 				"pkg:index/type:ObjectStringType": {
 					ObjectTypeSpec: pschema.ObjectTypeSpec{
@@ -805,15 +796,10 @@ func TestValidateInputType_objects(t *testing.T) {
 			failures := v.ValidateInputs(tokens.Type("pkg:mod:ResA"), resource.PropertyMap{
 				resource.PropertyKey(tc.name): tc.input,
 			})
-			if failures != nil && len(failures) != len(tc.failures) {
-				t.Fatalf("%d failures, got %d: %v", len(tc.failures), len(failures), failures)
-			}
-			if len(tc.failures) > 0 {
-				if failures == nil {
-					t.Fatalf("expected failures, got none")
-				} else {
-					assert.Equal(t, tc.failures, failures)
-				}
+			if tc.failures == nil {
+				assert.Empty(t, failures)
+			} else {
+				tc.failures.Equal(t, failures)
 			}
 		})
 	}
@@ -825,7 +811,7 @@ func TestValidateInputType_arrays(t *testing.T) {
 		typeRef  string
 		typeName string
 		input    resource.PropertyValue
-		failures []TypeFailure
+		failures autogold.Value
 		types    map[string]pschema.ComplexTypeSpec
 	}{
 		{
@@ -965,7 +951,7 @@ func TestValidateInputType_arrays(t *testing.T) {
 				})),
 				resource.NewStringProperty("foo"),
 			}),
-			failures: []TypeFailure{
+			failures: autogold.Expect([]TypeFailure{
 				{
 					Reason:       "expected string type, got [] type",
 					ResourcePath: "object_string_type_failure[1].objectStringProp",
@@ -974,7 +960,7 @@ func TestValidateInputType_arrays(t *testing.T) {
 					Reason:       "expected object type, got string type",
 					ResourcePath: "object_string_type_failure[2]",
 				},
-			},
+			}),
 			types: map[string]pschema.ComplexTypeSpec{
 				"pkg:index/type:ObjectStringType": {
 					ObjectTypeSpec: pschema.ObjectTypeSpec{
@@ -1036,12 +1022,12 @@ func TestValidateInputType_arrays(t *testing.T) {
 					},
 				})),
 			}),
-			failures: []TypeFailure{
+			failures: autogold.Expect([]TypeFailure{
 				{
 					Reason:       "expected string type, got [] type",
 					ResourcePath: "object_nested_object_type_failure[1].prop.foo",
 				},
-			},
+			}),
 			types: map[string]pschema.ComplexTypeSpec{
 				"pkg:index/type:ObjectNestedObjectType": {
 					ObjectTypeSpec: pschema.ObjectTypeSpec{
@@ -1136,7 +1122,7 @@ func TestValidateInputType_arrays(t *testing.T) {
 					},
 				})),
 			}),
-			failures: []TypeFailure{
+			failures: autogold.Expect([]TypeFailure{
 				{
 					Reason:       "expected string type, got object type",
 					ResourcePath: "object_nested_array_type_failure[0].prop[1]",
@@ -1145,7 +1131,7 @@ func TestValidateInputType_arrays(t *testing.T) {
 					Reason:       "expected string type, got [] type",
 					ResourcePath: "object_nested_array_type_failure[0].prop[2]",
 				},
-			},
+			}),
 			types: map[string]pschema.ComplexTypeSpec{
 				"pkg:index/type:ObjectNestedArrayType": {
 					ObjectTypeSpec: pschema.ObjectTypeSpec{
@@ -1228,12 +1214,12 @@ func TestValidateInputType_arrays(t *testing.T) {
 					},
 				})),
 			}),
-			failures: []TypeFailure{
+			failures: autogold.Expect([]TypeFailure{
 				{
 					Reason:       "expected string type, got [] type",
 					ResourcePath: "object_nested_array_object_type_failure[0].prop[1].objectStringProp",
 				},
-			},
+			}),
 			types: map[string]pschema.ComplexTypeSpec{
 				"pkg:index/type:ObjectStringType": {
 					ObjectTypeSpec: pschema.ObjectTypeSpec{
@@ -1305,15 +1291,11 @@ func TestValidateInputType_arrays(t *testing.T) {
 			failures := v.ValidateInputs(tokens.Type("pkg:mod:ResA"), resource.PropertyMap{
 				resource.PropertyKey(tc.name): tc.input,
 			})
-			if failures != nil && len(failures) != len(tc.failures) {
-				t.Fatalf("%d failures, got %d: %v", len(tc.failures), len(failures), failures)
-			}
-			if len(tc.failures) > 0 {
-				if failures == nil {
-					t.Fatalf("expected failures, got none")
-				} else {
-					assert.Equal(t, tc.failures, failures)
-				}
+
+			if tc.failures == nil {
+				assert.Empty(t, failures)
+			} else {
+				tc.failures.Equal(t, failures)
 			}
 		})
 	}
@@ -1324,7 +1306,7 @@ func TestValidateInputType_toplevel(t *testing.T) {
 		name            string
 		inputProperties map[string]pschema.PropertySpec
 		input           resource.PropertyValue
-		failures        []TypeFailure
+		failures        autogold.Value
 	}{
 		{
 			name:  "string_type_success",
@@ -1384,9 +1366,9 @@ func TestValidateInputType_toplevel(t *testing.T) {
 		{
 			name:  "string_type_failure",
 			input: resource.NewArrayProperty([]resource.PropertyValue{resource.NewNumberProperty(1)}),
-			failures: []TypeFailure{
+			failures: autogold.Expect([]TypeFailure{
 				{Reason: "expected string type, got [] type", ResourcePath: "string_type_failure"},
-			},
+			}),
 			inputProperties: map[string]pschema.PropertySpec{
 				"string_type_failure": {
 					TypeSpec: pschema.TypeSpec{
@@ -1469,9 +1451,9 @@ func TestValidateInputType_toplevel(t *testing.T) {
 			input: resource.NewObjectProperty(
 				resource.NewPropertyMapFromMap(map[string]interface{}{"foo": []string{"bar"}}),
 			),
-			failures: []TypeFailure{
+			failures: autogold.Expect([]TypeFailure{
 				{Reason: "expected boolean type, got [] type", ResourcePath: "object_type_failure.foo"},
-			},
+			}),
 			inputProperties: map[string]pschema.PropertySpec{
 				"object_type_failure": {
 					TypeSpec: pschema.TypeSpec{
@@ -1629,15 +1611,10 @@ func TestValidateInputType_toplevel(t *testing.T) {
 			failures := v.ValidateInputs(tokens.Type("pkg:mod:ResA"), resource.PropertyMap{
 				resource.PropertyKey(tc.name): tc.input,
 			})
-			if failures != nil && len(failures) != len(tc.failures) {
-				t.Fatalf("%d failures, got %d: %v", len(tc.failures), len(failures), failures)
-			}
-			if len(tc.failures) > 0 {
-				if failures == nil {
-					t.Fatalf("expected failures, got none")
-				} else {
-					assert.Equal(t, tc.failures, failures)
-				}
+			if tc.failures == nil {
+				assert.Empty(t, failures)
+			} else {
+				tc.failures.Equal(t, failures)
 			}
 		})
 	}
@@ -1648,15 +1625,15 @@ func TestValidateConfigType(t *testing.T) {
 		name      string
 		inputName string
 		input     resource.PropertyValue
-		failures  []TypeFailure
+		failures  autogold.Value
 	}{
 		{
 			name:      "unexpected_argument",
 			inputName: "endpoints",
-			failures: []TypeFailure{{
+			failures: autogold.Expect([]TypeFailure{{
 				Reason:       "an unexpected argument \"wxyz\" was provided",
 				ResourcePath: "endpoints[0]",
-			}},
+			}}),
 			input: resource.NewArrayProperty([]resource.PropertyValue{
 				resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
 					"wxyz": "foo",
@@ -1666,7 +1643,6 @@ func TestValidateConfigType(t *testing.T) {
 		{
 			name:      "no_error_for_extra_inputs",
 			inputName: "doesnt_exist",
-			failures:  []TypeFailure{},
 			input: resource.NewArrayProperty([]resource.PropertyValue{
 				resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
 					"wxyz": "foo",
@@ -1722,7 +1698,11 @@ func TestValidateConfigType(t *testing.T) {
 			failures := v.ValidateConfig(resource.PropertyMap{
 				resource.PropertyKey(tc.inputName): tc.input,
 			})
-			assert.Equal(t, tc.failures, failures)
+			if tc.failures == nil {
+				assert.Empty(t, failures)
+			} else {
+				tc.failures.Equal(t, failures)
+			}
 		})
 	}
 }


### PR DESCRIPTION
This makes it much easier to understand type errors. This is motivated by https://github.com/pulumi/pulumi-terraform-bridge/issues/2339. 

The `.Reason` section of `TypeFailures` used to look like this:

```
expected boolean type, got string type
```

They now look like this:

```
expected boolean type, got "true" of type string
```

Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/2307.