### PR TITLE
Emit warning on example translation failure

### DIFF
--- a/pkg/tfgen/convert_cli.go
+++ b/pkg/tfgen/convert_cli.go
@@ -643,17 +643,17 @@ func (cc *cliConverter) singleExampleFromHCLToPCL(path, hclCode string) (transla
 
 // Function for one-off example conversions PCL --> supported language (nodejs, yaml, etc)
 func (cc *cliConverter) singleExampleFromPCLToLanguage(example translatedExample, lang string) (string, error) {
+	var err error
+
 	if example.PCL == "" {
 		return "", nil
 	}
 	source, diags, _ := cc.convertPCL(example.PCL, lang)
-	//if err != nil {
-	//	return "", err
-	//}
 	diags = cc.postProcessDiagnostics(diags.Extend(example.Diagnostics))
 	if diags.HasErrors() {
-		return "", fmt.Errorf("Failed to convert an example: %s", diags.Error())
+		source = "Example unavailable in this language\n"
+		err = fmt.Errorf("failed to convert an example: %s", diags.Error())
 	}
 	source = "```" + lang + "\n" + source + "```"
-	return source, nil
+	return source, err
 }

--- a/pkg/tfgen/convert_cli.go
+++ b/pkg/tfgen/convert_cli.go
@@ -651,7 +651,7 @@ func (cc *cliConverter) singleExampleFromPCLToLanguage(example translatedExample
 	source, diags, _ := cc.convertPCL(example.PCL, lang)
 	diags = cc.postProcessDiagnostics(diags.Extend(example.Diagnostics))
 	if diags.HasErrors() {
-		source = "Example unavailable in this language\n"
+		source = "Example currently unavailable in this language\n"
 		err = fmt.Errorf("failed to convert an example: %s", diags.Error())
 	}
 	source = "```" + lang + "\n" + source + "```"

--- a/pkg/tfgen/convert_cli.go
+++ b/pkg/tfgen/convert_cli.go
@@ -646,10 +646,10 @@ func (cc *cliConverter) singleExampleFromPCLToLanguage(example translatedExample
 	if example.PCL == "" {
 		return "", nil
 	}
-	source, diags, err := cc.convertPCL(example.PCL, lang)
-	if err != nil {
-		return "", err
-	}
+	source, diags, _ := cc.convertPCL(example.PCL, lang)
+	//if err != nil {
+	//	return "", err
+	//}
 	diags = cc.postProcessDiagnostics(diags.Extend(example.Diagnostics))
 	if diags.HasErrors() {
 		return "", fmt.Errorf("Failed to convert an example: %s", diags.Error())

--- a/pkg/tfgen/installation_docs.go
+++ b/pkg/tfgen/installation_docs.go
@@ -245,7 +245,7 @@ func convertExample(g *Generator, code string, exampleNumber int) (string, error
 		// Generate language example
 		convertedLang, err := converter.singleExampleFromPCLToLanguage(pclExample, lang)
 		if err != nil {
-			return "", err
+			g.warn(err.Error())
 		}
 		exampleContent += choosableStart + pulumiYAML + convertedLang + choosableEnd
 	}


### PR DESCRIPTION
Installation docs build failed for pulumi-alicloud and others when an example could not be translated. This PR continues on a failed example translation (just like for API docs) and emits a warning instead.

Additionally, we write a default message to the code field in the missing example.