### PR TITLE
Add default patterns to strip TF version references and tests

### DIFF
--- a/pkg/tfgen/installation_docs.go
+++ b/pkg/tfgen/installation_docs.go
@@ -376,7 +376,7 @@ func getDefaultHeadersToSkip() []*regexp.Regexp {
 func getTfVersionsToRemove() []*regexp.Regexp {
 	tfVersionsToRemove := []*regexp.Regexp{
 		regexp.MustCompile(`It requires [tT]erraform [v0-9]+\.?[0-9]?\.?[0-9]? or later.`),
-		regexp.MustCompile(`(?s)For [tT]erraform [v0-9]+\.?[0-9]?\.?[0-9]? and later:`),
+		regexp.MustCompile(`(?s)(For )?[tT]erraform [v0-9]+\.?[0-9]?\.?[0-9]? and later:`),
 	}
 	return tfVersionsToRemove
 }

--- a/pkg/tfgen/installation_docs.go
+++ b/pkg/tfgen/installation_docs.go
@@ -382,10 +382,11 @@ func getTfVersionsToRemove() []*regexp.Regexp {
 }
 
 func removeTfVersionMentions(docFile string) tfbridge.DocsEdit {
+	tfVersionsToRemove := getTfVersionsToRemove()
 	return tfbridge.DocsEdit{
 		Path: docFile,
 		Edit: func(_ string, content []byte) ([]byte, error) {
-			for _, tfVersion := range getTfVersionsToRemove() {
+			for _, tfVersion := range tfVersionsToRemove {
 				content = tfVersion.ReplaceAll(content, nil)
 			}
 			return content, nil

--- a/pkg/tfgen/installation_docs.go
+++ b/pkg/tfgen/installation_docs.go
@@ -376,7 +376,7 @@ func getDefaultHeadersToSkip() []*regexp.Regexp {
 func getTfVersionsToRemove() []*regexp.Regexp {
 	tfVersionsToRemove := []*regexp.Regexp{
 		regexp.MustCompile(`It requires [tT]erraform [v0-9]+\.?[0-9]?\.?[0-9]? or later.`),
-		regexp.MustCompile(`(?s)(For )?[tT]erraform [v0-9]+\.?[0-9]?\.?[0-9]? and later:`),
+		regexp.MustCompile(`(?s)(For )?[tT]erraform [v0-9]+\.?[0-9]?\.?[0-9]? and (later|earlier):`),
 	}
 	return tfVersionsToRemove
 }

--- a/pkg/tfgen/installation_docs_test.go
+++ b/pkg/tfgen/installation_docs_test.go
@@ -224,6 +224,13 @@ func TestApplyEditRules(t *testing.T) {
 			},
 			expected: []byte("This is a provider with an example.\nUse this code."),
 		},
+		{
+			name: "Strips mentions of Terraform version pattern 4",
+			docFile: DocFile{
+				Content: []byte("This is a provider with an example. Terraform 1.5 and later:\n Use this code."),
+			},
+			expected: []byte("This is a provider with an example.\nUse this code."),
+		},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/pkg/tfgen/installation_docs_test.go
+++ b/pkg/tfgen/installation_docs_test.go
@@ -231,6 +231,13 @@ func TestApplyEditRules(t *testing.T) {
 			},
 			expected: []byte("This is a provider with an example.\nUse this code."),
 		},
+		{
+			name: "Strips mentions of Terraform version pattern 5",
+			docFile: DocFile{
+				Content: []byte("This is a provider with an example. Terraform 1.5 and earlier:\n Use this code."),
+			},
+			expected: []byte("This is a provider with an example.\nUse this code."),
+		},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/pkg/tfgen/installation_docs_test.go
+++ b/pkg/tfgen/installation_docs_test.go
@@ -203,6 +203,27 @@ func TestApplyEditRules(t *testing.T) {
 			},
 			expected: []byte(readfile(t, "test_data/replace-links/actual.md")),
 		},
+		{
+			name: "Strips mentions of Terraform version pattern 1",
+			docFile: DocFile{
+				Content: []byte("This is a provider. It requires terraform 0.12 or later."),
+			},
+			expected: []byte("This is a provider."),
+		},
+		{
+			name: "Strips mentions of Terraform version pattern 2",
+			docFile: DocFile{
+				Content: []byte("This is a provider. It requires terraform v0.12 or later."),
+			},
+			expected: []byte("This is a provider."),
+		},
+		{
+			name: "Strips mentions of Terraform version pattern 3",
+			docFile: DocFile{
+				Content: []byte("This is a provider with an example. For Terraform v1.5 and later:\n Use this code."),
+			},
+			expected: []byte("This is a provider with an example.\nUse this code."),
+		},
 	}
 	for _, tt := range tests {
 		tt := tt


### PR DESCRIPTION
Adds a more pinpointed removal of TF version mentions, because a simple replace of "Terraform" --> "Pulumi" leaves these nonsensical.

There will likely be more patterns added here.

Contains relevant tests.