### PR TITLE
Schema header translates to Configuration Reference

### DIFF
--- a/pkg/tfgen/installation_docs.go
+++ b/pkg/tfgen/installation_docs.go
@@ -137,7 +137,7 @@ func applyEditRules(contentBytes []byte, docFile string, g *Generator) ([]byte, 
 			`Configuration Reference`),
 		reReplace(`Schema`,
 			`Configuration Reference`),
-
+		reReplace("### Optional\n", ""),
 		reReplace(`block contains the following arguments`,
 			`input has the following nested fields`),
 	)

--- a/pkg/tfgen/installation_docs.go
+++ b/pkg/tfgen/installation_docs.go
@@ -135,6 +135,9 @@ func applyEditRules(contentBytes []byte, docFile string, g *Generator) ([]byte, 
 			`The following configuration inputs are supported`),
 		reReplace(`Argument Reference`,
 			`Configuration Reference`),
+		reReplace(`Schema`,
+			`Configuration Reference`),
+
 		reReplace(`block contains the following arguments`,
 			`input has the following nested fields`),
 	)


### PR DESCRIPTION
When transforming installation docs, the "Schema" header should transform the same way as "Argument Regerence". This PR adds that behavior.
