### PR TITLE
Escape hyphens for tokens

### DIFF
--- a/dynamic/info_test.go
+++ b/dynamic/info_test.go
@@ -115,6 +115,35 @@ func TestFixTokenOverrides(t *testing.T) {
 	}, p.Resources)
 }
 
+func TestFixHyphenToken(t *testing.T) {
+	t.Parallel()
+
+	p, err := providerInfo(context.Background(), schemaOnlyProvider{
+		name:    "test",
+		version: "1.0.0",
+		schema: &tfprotov6.GetProviderSchemaResponse{
+			ResourceSchemas: map[string]*tfprotov6.Schema{
+				"test_my-token": {Block: &tfprotov6.SchemaBlock{
+					Attributes: []*tfprotov6.SchemaAttribute{
+						{Name: "id", Type: tftypes.String, Computed: true},
+					},
+				}},
+				"test_many-hyphenated-blocks": {Block: &tfprotov6.SchemaBlock{
+					Attributes: []*tfprotov6.SchemaAttribute{
+						{Name: "id", Type: tftypes.String, Computed: true},
+					},
+				}},
+			},
+		},
+	}, parameterize.Value{})
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]*info.Resource{
+		"test_my-token":               {Tok: "test:index/myToken:MyToken"},
+		"test_many-hyphenated-blocks": {Tok: "test:index/manyHyphenatedBlocks:ManyHyphenatedBlocks"},
+	}, p.Resources)
+}
+
 type schemaOnlyProvider struct {
 	run.Provider
 	name, url, version string

--- a/pkg/tfbridge/tokens/tokens.go
+++ b/pkg/tfbridge/tokens/tokens.go
@@ -56,10 +56,16 @@ func MakeStandard(pkgName string) Make {
 	}
 }
 
+// upperCamelCase converts a TF token to a valid Pulumi token segment in CamelCase format.
 func upperCamelCase(s string) string { return cgstrings.UppercaseFirst(camelCase(s)) }
 
+// camelCase converts a TF token a valid Pulumi token segment in camelCase format.
 func camelCase(s string) string {
-	return cgstrings.ModifyStringAroundDelimeter(s, "_", cgstrings.UppercaseFirst)
+	s = cgstrings.ModifyStringAroundDelimeter(s, "_", cgstrings.UppercaseFirst)
+
+	// Terraform allows both `-` and `_` in it's tokens, but Pulumi allows
+	// neither.
+	return cgstrings.ModifyStringAroundDelimeter(s, "-", cgstrings.UppercaseFirst)
 }
 
 func checkedApply[T comparable](dst *T, src T) {

--- a/pkg/tfbridge/tokens_test.go
+++ b/pkg/tfbridge/tokens_test.go
@@ -40,6 +40,7 @@ func TestTokensSingleModule(t *testing.T) {
 				"foo_fizz_buzz":       nil,
 				"foo_bar_hello_world": nil,
 				"foo_bar":             nil,
+				"foo_hyphen-ated":     nil,
 			},
 			DataSourcesMap: schema.ResourceMap{
 				"foo_source1":             nil,
@@ -62,6 +63,7 @@ func TestTokensSingleModule(t *testing.T) {
 		"foo_fizz_buzz":       {Tok: "foo:index:FizzBuzz"},
 		"foo_bar_hello_world": {Tok: "foo:index:BarHelloWorld"},
 		"foo_bar":             {Tok: "foo:index:Bar", Docs: &tfbridge.DocInfo{}},
+		"foo_hyphen-ated":     {Tok: "foo:index:HyphenAted"},
 	}
 	expectedDatasources := map[string]*tfbridge.DataSourceInfo{
 		"foo_source1":             {Tok: "foo:index:getSource1"},
@@ -84,6 +86,7 @@ func TestTokensSingleModule(t *testing.T) {
 		"foo_fizz_buzz":       {Tok: "foo:index:FizzBuzz"},
 		"foo_bar_hello_world": {Tok: "foo:index:BarHelloPulumi"},
 		"foo_bar":             {Tok: "foo:index:Bar"},
+		"foo_hyphen-ated":     {Tok: "foo:index:HyphenAted"},
 	}, info.Resources)
 }
 


### PR DESCRIPTION
This allows automatic mapping for valid providers that don't conform to TF's recommended snake_case naming convention.

Fixes https://github.com/pulumi/pulumi-terraform-provider/issues/17