### PR TITLE
Expand diff cross tests

### DIFF
--- a/pkg/tests/cross-tests/diff_check.go
+++ b/pkg/tests/cross-tests/diff_check.go
@@ -47,7 +47,7 @@ type diffTestCase struct {
 	DeleteBeforeReplace bool
 }
 
-func runDiffCheck(t T, tc diffTestCase) {
+func runDiffCheck(t T, tc diffTestCase) []string {
 	tfwd := t.TempDir()
 
 	lifecycleArgs := lifecycleArgs{CreateBeforeDestroy: !tc.DeleteBeforeReplace}
@@ -90,6 +90,8 @@ func runDiffCheck(t T, tc diffTestCase) {
 		}
 	}
 	tc.verifyBasicDiffAgreement(t, tfAction, x.Summary, diffResponse)
+
+	return tfAction
 }
 
 func (tc *diffTestCase) verifyBasicDiffAgreement(t T, tfActions []string, us auto.UpdateSummary, diffResponse map[string]interface{}) {

--- a/pkg/tests/cross-tests/diff_check.go
+++ b/pkg/tests/cross-tests/diff_check.go
@@ -15,6 +15,7 @@
 package crosstests
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -41,19 +42,25 @@ type diffTestCase struct {
 	Config1, Config2 any
 
 	// Optional object type for the resource. If left nil will be inferred from Resource schema.
-	ObjectType *tftypes.Object
+	ObjectType          *tftypes.Object
+	DeleteBeforeReplace bool
 }
 
 func runDiffCheck(t T, tc diffTestCase) {
 	tfwd := t.TempDir()
 
+	lifecycleArgs := lifecycleArgs{CreateBeforeDestroy: !tc.DeleteBeforeReplace}
+
 	tfd := newTFResDriver(t, tfwd, defProviderShortName, defRtype, tc.Resource)
-	_ = tfd.writePlanApply(t, tc.Resource.Schema, defRtype, "example", tc.Config1)
-	tfDiffPlan := tfd.writePlanApply(t, tc.Resource.Schema, defRtype, "example", tc.Config2)
+	_ = tfd.writePlanApply(t, tc.Resource.Schema, defRtype, "example", tc.Config1, lifecycleArgs)
+	tfDiffPlan := tfd.writePlanApply(t, tc.Resource.Schema, defRtype, "example", tc.Config2, lifecycleArgs)
 
 	resMap := map[string]*schema.Resource{defRtype: tc.Resource}
 	tfp := &schema.Provider{ResourcesMap: resMap}
 	bridgedProvider := pulcheck.BridgedProvider(t, defProviderShortName, tfp)
+	if tc.DeleteBeforeReplace {
+		bridgedProvider.Resources[defRtype].DeleteBeforeReplace = true
+	}
 
 	pd := &pulumiDriver{
 		name:                defProviderShortName,
@@ -77,21 +84,58 @@ func runDiffCheck(t T, tc diffTestCase) {
 	tc.verifyBasicDiffAgreement(t, tfAction, x.Summary)
 }
 
-func (tc *diffTestCase) verifyBasicDiffAgreement(t T, tfAction string, us auto.UpdateSummary) {
+func (tc *diffTestCase) verifyBasicDiffAgreement(t T, tfActions []string, us auto.UpdateSummary) {
 	t.Logf("UpdateSummary.ResourceChanges: %#v", us.ResourceChanges)
-	switch tfAction {
-	case "update":
-		require.NotNilf(t, us.ResourceChanges, "UpdateSummary.ResourceChanges should not be nil")
-		rc := *us.ResourceChanges
-		assert.Equalf(t, 1, rc[string(apitype.OpSame)], "expected one resource to stay the same - the stack")
-		assert.Equalf(t, 1, rc[string(apitype.Update)], "expected the test resource to get an update plan")
-		assert.Equalf(t, 2, len(rc), "expected two entries in UpdateSummary.ResourceChanges")
-	case "no-op":
-		require.NotNilf(t, us.ResourceChanges, "UpdateSummary.ResourceChanges should not be nil")
-		rc := *us.ResourceChanges
-		assert.Equalf(t, 2, rc[string(apitype.OpSame)], "expected the test resource and stack to stay the same")
-		assert.Equalf(t, 1, len(rc), "expected one entry in UpdateSummary.ResourceChanges")
-	default:
-		panic("TODO: do not understand this TF action yet: " + tfAction)
+	// Action list from https://github.com/opentofu/opentofu/blob/main/internal/plans/action.go#L11
+	if len(tfActions) == 0 {
+		require.FailNow(t, "No TF actions found")
+	}
+	if len(tfActions) == 1 {
+		switch tfActions[0] {
+		case "no-op":
+			require.NotNilf(t, us.ResourceChanges, "UpdateSummary.ResourceChanges should not be nil")
+			rc := *us.ResourceChanges
+			assert.Equalf(t, 2, rc[string(apitype.OpSame)], "expected the test resource and stack to stay the same")
+			assert.Equalf(t, 1, len(rc), "expected one entry in UpdateSummary.ResourceChanges")
+		case "create":
+			require.NotNilf(t, us.ResourceChanges, "UpdateSummary.ResourceChanges should not be nil")
+			rc := *us.ResourceChanges
+			assert.Equalf(t, 1, rc[string(apitype.OpSame)], "expected the stack to stay the same")
+			assert.Equalf(t, 1, rc[string(apitype.OpCreate)], "expected the test resource to get a create plan")
+		case "read":
+			require.FailNow(t, "Unexpected TF action: read")
+		case "update":
+			require.NotNilf(t, us.ResourceChanges, "UpdateSummary.ResourceChanges should not be nil")
+			rc := *us.ResourceChanges
+			assert.Equalf(t, 1, rc[string(apitype.OpSame)], "expected one resource to stay the same - the stack")
+			assert.Equalf(t, 1, rc[string(apitype.Update)], "expected the test resource to get an update plan")
+			assert.Equalf(t, 2, len(rc), "expected two entries in UpdateSummary.ResourceChanges")
+		case "delete":
+			require.NotNilf(t, us.ResourceChanges, "UpdateSummary.ResourceChanges should not be nil")
+			rc := *us.ResourceChanges
+			assert.Equalf(t, 1, rc[string(apitype.OpSame)], "expected the stack to stay the same")
+			assert.Equalf(t, 1, rc[string(apitype.OpDelete)], "expected the test resource to get a delete plan")
+		default:
+			panic("TODO: do not understand this TF action yet: " + tfActions[0])
+		}
+	} else if len(tfActions) == 2 {
+		if tfActions[0] == "create" && tfActions[1] == "delete" {
+			require.NotNilf(t, us.ResourceChanges, "UpdateSummary.ResourceChanges should not be nil")
+			rc := *us.ResourceChanges
+			assert.Equalf(t, 1, rc[string(apitype.OpSame)], "expected the stack to stay the same")
+			assert.Equalf(t, 1, rc[string(apitype.OpReplace)], "expected the test resource to get a replace plan")
+			// TODO: verify order matches
+		} else if tfActions[0] == "delete" && tfActions[1] == "create" {
+			require.NotNilf(t, us.ResourceChanges, "UpdateSummary.ResourceChanges should not be nil")
+			rc := *us.ResourceChanges
+			t.Logf("UpdateSummary.ResourceChanges: %#v", rc)
+			assert.Equalf(t, 1, rc[string(apitype.OpSame)], "expected the stack to stay the same")
+			assert.Equalf(t, 1, rc[string(apitype.OpReplace)], "expected the test resource to get a replace plan")
+			// TODO: verify order matches
+		} else {
+			panic("TODO: do not understand this TF action yet: " + fmt.Sprint(tfActions))
+		}
+	} else {
+		panic("TODO: do not understand this TF action yet: " + fmt.Sprint(tfActions))
 	}
 }

--- a/pkg/tests/cross-tests/diff_cross_test.go
+++ b/pkg/tests/cross-tests/diff_cross_test.go
@@ -111,7 +111,7 @@ func TestSimple(t *testing.T) {
 		res.Schema["name"].ForceNew = true
 		runDiffCheck(t, diffTestCase{
 			Resource:            res,
-			Config1:             nil,
+			Config1:             config1,
 			Config2:             config2,
 			DeleteBeforeReplace: true,
 		})

--- a/pkg/tests/cross-tests/input_check.go
+++ b/pkg/tests/cross-tests/input_check.go
@@ -53,7 +53,7 @@ func runCreateInputCheck(t T, tc inputTestCase) {
 	tfwd := t.TempDir()
 
 	tfd := newTFResDriver(t, tfwd, defProviderShortName, defRtype, tc.Resource)
-	tfd.writePlanApply(t, tc.Resource.Schema, defRtype, "example", tc.Config)
+	tfd.writePlanApply(t, tc.Resource.Schema, defRtype, "example", tc.Config, lifecycleArgs{})
 
 	resMap := map[string]*schema.Resource{defRtype: tc.Resource}
 	tfp := &schema.Provider{ResourcesMap: resMap}

--- a/pkg/tests/cross-tests/tf_driver.go
+++ b/pkg/tests/cross-tests/tf_driver.go
@@ -94,6 +94,9 @@ func (d *TfResDriver) write(
 	ctyConfig := fromValue(config).ToCty()
 	if lifecycle.CreateBeforeDestroy {
 		ctyMap := ctyConfig.AsValueMap()
+		if ctyMap == nil {
+			ctyMap = make(map[string]cty.Value)
+		}
 		ctyMap["lifecycle"] = cty.ObjectVal(
 			map[string]cty.Value{
 				"create_before_destroy": cty.True,

--- a/pkg/tests/cross-tests/tfwrite.go
+++ b/pkg/tests/cross-tests/tfwrite.go
@@ -84,6 +84,18 @@ func writeBlock(body *hclwrite.Body, schemas map[string]*schema.Schema, values m
 		}
 	}
 
+	// lifecycle block
+	if _, ok := values["lifecycle"]; ok {
+		newBlock := body.AppendNewBlock("lifecycle", nil)
+		lifecycleSchema := map[string]*schema.Schema{
+			"create_before_destroy": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+		}
+		writeBlock(newBlock.Body(), lifecycleSchema, values["lifecycle"].AsValueMap())
+	}
+
 	attrKeys := make([]string, 0, len(coreConfigSchema.Attributes))
 	for key := range coreConfigSchema.Attributes {
 		attrKeys = append(attrKeys, key)

--- a/pkg/tests/cross-tests/upgrade_state_check.go
+++ b/pkg/tests/cross-tests/upgrade_state_check.go
@@ -134,10 +134,10 @@ func runUpgradeStateInputCheck(t T, tc upgradeStateTestCase) {
 	tfwd := t.TempDir()
 
 	tfd := newTFResDriver(t, tfwd, defProviderShortName, defRtype, tc.Resource)
-	_ = tfd.writePlanApply(t, tc.Resource.Schema, defRtype, "example", tc.Config1)
+	_ = tfd.writePlanApply(t, tc.Resource.Schema, defRtype, "example", tc.Config1, lifecycleArgs{})
 
 	tfd2 := newTFResDriver(t, tfwd, defProviderShortName, defRtype, &upgradeRes)
-	_ = tfd2.writePlanApply(t, tc.Resource.Schema, defRtype, "example", tc.Config2)
+	_ = tfd2.writePlanApply(t, tc.Resource.Schema, defRtype, "example", tc.Config2, lifecycleArgs{})
 
 	schemaVersion1, schemaVersion2 := runPulumiUpgrade(t, tc.Resource, &upgradeRes, tc.Config1, tc.Config2, tc.DisablePlanResourceChange)
 


### PR DESCRIPTION
This PR expands the diff cross-tests for SDKv2 and adds test cases for all TF attribute and block types.

The cross-tests can now match the following against TF:
- creates
- deletes
- replaces with deleteBeforeReplace
- replaces without deleteBeforeReplace

Note that the last two required some workarounds in the cross-tests as TF and pulumi differ on the order of operations here: TF deletes first and creates after, while Pulumi defaults to create first and delete after. This means that in order to match the behaviour we now use the TF `lifecycle`'s `create_before_destroy` (https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#create_before_destroy) by default and remove it for `deleteBeforeReplace` cases.

This also adds test cases for:
- Create
- Delete
- Update without a diff
- Update with a diff
- Replace
- Replace with deleteBeforeReplace

Each of these is handled for the following TF types
- string
- int
- float
- bool
- list attributes
- set attributes
- maps
- list blocks
- set blocks

fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/2298