### PR TITLE
Fix the call to `logger.Error`

### DIFF
--- a/tools/pulumi-hcl-lint/main.go
+++ b/tools/pulumi-hcl-lint/main.go
@@ -55,7 +55,7 @@ func main() {
 
 	go func() {
 		if err := lint(ctx, ".", issues); err != nil {
-			logger.Error("Unexpected failure: %s", err)
+			logger.Error(fmt.Sprintf("Unexpected failure: %s", err.Error()))
 			os.Exit(1)
 		}
 		close(issues)


### PR DESCRIPTION
`slog.Logger.Error` expects to take a message string and then key-value pairs. It does not format on the message string.