### PR TITLE
Simplify using MuxWith with PF

### DIFF
--- a/pf/tests/muxwith_test.go
+++ b/pf/tests/muxwith_test.go
@@ -1,0 +1,67 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfbridgetests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	pb "github.com/pulumi/pulumi-terraform-bridge/pf/tests/internal/providerbuilder"
+	"github.com/stretchr/testify/require"
+)
+
+// Add coverage for pf.NewMuxProvider.
+func TestNewMuxProvider(t *testing.T) {
+	createCallCount := 0
+
+	r := pb.Resource{
+		Name: "r",
+		CreateFunc: func(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+			t.Logf("CREATE called: %v", req.Plan.Raw.String())
+			diags := resp.State.SetAttribute(ctx, path.Root("id"), "id0")
+			resp.Diagnostics = append(resp.Diagnostics, diags...)
+			createCallCount++
+		},
+		ResourceSchema: schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"p": schema.StringAttribute{
+					Optional: true,
+				},
+			},
+		},
+	}
+
+	p := pb.NewProvider(pb.NewProviderArgs{
+		AllResources: []pb.Resource{r},
+	})
+
+	// Providers using newPulumiTest utilize NewMuxProvider and MuxWith to connect up a PF provider.
+	pt := newPulumiTest(t, p, `
+		name: test-program
+		runtime: yaml
+		resources:
+		  my-res:
+		    type: testprovider:index:R
+		    properties:
+		      p: "FOO"
+		`)
+
+	pt.Up()
+
+	require.Equal(t, 1, createCallCount)
+}

--- a/pf/tests/pulumi_test.go
+++ b/pf/tests/pulumi_test.go
@@ -1,0 +1,71 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfbridgetests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	sdkv2schema "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/pulumi/providertest/pulumitest"
+	pf "github.com/pulumi/pulumi-terraform-bridge/pf/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/pulcheck"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/tokens"
+	sdkv2shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
+	"github.com/stretchr/testify/require"
+)
+
+// Quick setup for integration-testing PF-based providers.
+func newPulumiTest(t *testing.T, p provider.Provider, testProgramYAML string) *pulumitest.PulumiTest {
+	ctx := context.Background()
+
+	// Due to some historical limitations it is not yet possible to directly pass a PF-based provider to the main
+	// [info.Provider.P] parameter, but the same effect can be achieved by passing it to [info.Provider.MuxWith] and
+	// using a dummy empty provider for [info.Provider.P].
+	dummyProvider := &sdkv2schema.Provider{}
+
+	var providerName string = "testprovider"
+
+	muxProviderInfo := info.Provider{
+		Name:         providerName,
+		P:            pf.ShimProvider(p),
+		Version:      "0.0.1",
+		MetadataInfo: info.NewProviderMetadata([]byte(`{}`)),
+	}
+
+	makeToken := func(module, name string) (string, error) {
+		return tokens.MakeStandard(providerName)(module, name)
+	}
+
+	muxProviderInfo.MustComputeTokens(tokens.SingleModule(providerName, "index", makeToken))
+
+	muxProvider, err := pf.NewMuxProvider(ctx, muxProviderInfo, nil)
+	require.NoError(t, err)
+
+	providerInfo := info.Provider{
+		P:                              sdkv2shim.NewProvider(dummyProvider),
+		Name:                           providerName,
+		Version:                        "0.0.1",
+		MetadataInfo:                   info.NewProviderMetadata([]byte(`{}`)),
+		EnableZeroDefaultSchemaVersion: true,
+		MuxWith:                        []info.MuxProvider{muxProvider},
+	}
+
+	providerInfo.MustComputeTokens(tokens.SingleModule(providerName, "index", makeToken))
+
+	return pulcheck.PulCheck(t, providerInfo, testProgramYAML)
+}

--- a/pf/tests/pulumi_test.go
+++ b/pf/tests/pulumi_test.go
@@ -38,7 +38,7 @@ func newPulumiTest(t *testing.T, p provider.Provider, testProgramYAML string) *p
 	// using a dummy empty provider for [info.Provider.P].
 	dummyProvider := &sdkv2schema.Provider{}
 
-	var providerName string = "testprovider"
+	providerName := "testprovider"
 
 	muxProviderInfo := info.Provider{
 		Name:         providerName,

--- a/pf/tfbridge/provider_mux.go
+++ b/pf/tfbridge/provider_mux.go
@@ -19,13 +19,14 @@ import (
 	"encoding/json"
 	"io"
 
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	rprovider "github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen"
 )
 
 // Adapts a provider to be usable as a mix-in, see [info.Provider.MuxWith].

--- a/pf/tfbridge/provider_mux.go
+++ b/pf/tfbridge/provider_mux.go
@@ -1,0 +1,79 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfbridge
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	rprovider "github.com/pulumi/pulumi/pkg/v3/resource/provider"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+)
+
+// Adapts a provider to be usable as a mix-in, see [info.Provider.MuxWith].
+//
+// info.P must be constructed with ShimProvider or ShimProviderWithContext.
+func NewMuxProvider(ctx context.Context, providerInfo info.Provider, meta *ProviderMetadata) (info.MuxProvider, error) {
+	// If schema is not pre-built, generate the schema on the fly.
+	if meta == nil || meta.PackageSchema == nil {
+		noSink := diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never})
+		spec, err := tfgen.GenerateSchema(providerInfo, noSink)
+		if err != nil {
+			return nil, err
+		}
+		bytes, err := json.Marshal(spec)
+		if err != nil {
+			return nil, err
+		}
+		meta = &ProviderMetadata{PackageSchema: bytes}
+	}
+	return &pfProviderAsMuxProvider{
+		providerInfo: providerInfo,
+		meta:         *meta,
+	}, nil
+}
+
+type pfProviderAsMuxProvider struct {
+	providerInfo info.Provider
+	meta         ProviderMetadata
+}
+
+func (p *pfProviderAsMuxProvider) GetSpec(_ context.Context, _, _ string) (schema.PackageSpec, error) {
+	return p.getSpec()
+}
+
+func (p *pfProviderAsMuxProvider) getSpec() (schema.PackageSpec, error) {
+	var res schema.PackageSpec
+	if err := json.Unmarshal(p.meta.PackageSchema, &res); err != nil {
+		return schema.PackageSpec{}, nil
+	}
+	return res, nil
+}
+
+func (p *pfProviderAsMuxProvider) GetInstance(
+	ctx context.Context,
+	name, version string,
+	host *rprovider.HostClient,
+) (pulumirpc.ResourceProviderServer, error) {
+	return NewProviderServer(ctx, host, p.providerInfo, p.meta)
+}
+
+var _ info.MuxProvider = (*pfProviderAsMuxProvider)(nil)

--- a/pkg/tests/pulcheck/pulcheck.go
+++ b/pkg/tests/pulcheck/pulcheck.go
@@ -19,7 +19,6 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/tokens"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen"
-	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
 	pulumidiag "github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
@@ -147,15 +146,13 @@ func BridgedProvider(t T, providerName string, tfp *schema.Provider, opts ...Bri
 	for _, opt := range opts {
 		opt(options)
 	}
+
 	EnsureProviderValid(t, tfp)
+
 	shimProvider := shimv2.NewProvider(tfp, shimv2.WithPlanResourceChange(
 		func(tfResourceType string) bool { return !options.DisablePlanResourceChange },
 	))
-	return QuickProvider(t, providerName, shimProvider)
-}
 
-// Help quickly setting up a reasonable info.Provider.
-func QuickProvider(t T, providerName string, shimProvider shim.Provider) info.Provider {
 	provider := tfbridge.ProviderInfo{
 		P:                              shimProvider,
 		Name:                           providerName,
@@ -167,6 +164,7 @@ func QuickProvider(t T, providerName string, shimProvider shim.Provider) info.Pr
 		return tokens.MakeStandard(providerName)(module, name)
 	}
 	provider.MustComputeTokens(tokens.SingleModule(providerName, "index", makeToken))
+
 	return provider
 }
 
@@ -176,10 +174,6 @@ func skipUnlessLinux(t T) {
 	}
 }
 
-// Set up an integration test against a given in-process provider stood up from bridgedProvider.
-//
-// Specify verbatim Pulumi.yaml in the program parameter.
-//
 // This is an experimental API.
 func PulCheck(t T, bridgedProvider info.Provider, program string) *pulumitest.PulumiTest {
 	skipUnlessLinux(t)


### PR DESCRIPTION
Currently `info.Provider` allows overriding resource or function implementations by specifying `MuxWith` section with a
list of `MuxProvider` instances. This PR adds a function to easily wrap a Plugin Framework based provider into a
`MuxProvider` instance:

    pf.NewMuxProvider(context.Context, info.Provider, *ProviderMetadata) (info.MuxProvider, error)

This also enables bridge developers to more easily create end-to-end tests against providers implemented with the Plugin
Framework.