### PR TITLE
Implement Dynamic type support

### DIFF
--- a/dynamic/go.mod
+++ b/dynamic/go.mod
@@ -144,7 +144,7 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/hcl/v2 v2.20.1 // indirect
 	github.com/hashicorp/hil v0.0.0-20190212132231-97b3a9cdfa93 // indirect
-	github.com/hashicorp/terraform-plugin-framework v1.6.0 // indirect
+	github.com/hashicorp/terraform-plugin-framework v1.7.0 // indirect
 	github.com/hashicorp/terraform-plugin-go v0.23.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0 // indirect
 	github.com/hashicorp/terraform-plugin-mux v0.16.0 // indirect

--- a/dynamic/go.sum
+++ b/dynamic/go.sum
@@ -583,8 +583,8 @@ github.com/hashicorp/hil v0.0.0-20190212132231-97b3a9cdfa93 h1:T1Q6ag9tCwun16AW+
 github.com/hashicorp/hil v0.0.0-20190212132231-97b3a9cdfa93/go.mod h1:n2TSygSNwsLJ76m8qFXTSc7beTb+auJxYdqrnoqwZWE=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
-github.com/hashicorp/terraform-plugin-framework v1.6.0 h1:hMPWoCiNGR+yzoDlXtZ/meGlUOCn8r1OFuPG84MkhWg=
-github.com/hashicorp/terraform-plugin-framework v1.6.0/go.mod h1:QRG6J+m5QBJum+lzKi0Ci2CB8a/xflS3T/aWoz8WD4Y=
+github.com/hashicorp/terraform-plugin-framework v1.7.0 h1:wOULbVmfONnJo9iq7/q+iBOBJul5vRovaYJIu2cY/Pw=
+github.com/hashicorp/terraform-plugin-framework v1.7.0/go.mod h1:jY9Id+3KbZ17OMpulgnWLSfwxNVYSoYBQFTgsx044CI=
 github.com/hashicorp/terraform-plugin-go v0.23.0 h1:AALVuU1gD1kPb48aPQUjug9Ir/125t+AAurhqphJ2Co=
 github.com/hashicorp/terraform-plugin-go v0.23.0/go.mod h1:1E3Cr9h2vMlahWMbsSEcNrOCxovCZhOOIXjFHbjc/lQ=
 github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9TFvymaRGZED3FCV0=

--- a/pf/go.mod
+++ b/pf/go.mod
@@ -11,9 +11,9 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/golang/protobuf v1.5.4
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/hashicorp/terraform-plugin-framework v1.6.0
+	github.com/hashicorp/terraform-plugin-framework v1.7.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
-	github.com/hashicorp/terraform-plugin-go v0.22.0
+	github.com/hashicorp/terraform-plugin-go v0.22.1
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.33.0
 	github.com/hexops/autogold/v2 v2.2.1

--- a/pf/go.sum
+++ b/pf/go.sum
@@ -1648,12 +1648,13 @@ github.com/hashicorp/terraform-exec v0.20.0/go.mod h1:ckKGkJWbsNqFKV1itgMnE0hY9I
 github.com/hashicorp/terraform-json v0.4.0/go.mod h1:eAbqb4w0pSlRmdvl8fOyHAi/+8jnkVYN28gJkSJrLhU=
 github.com/hashicorp/terraform-json v0.19.0/go.mod h1:qdeBs11ovMzo5puhrRibdD6d2Dq6TyE/28JiU4tIQxk=
 github.com/hashicorp/terraform-json v0.21.0/go.mod h1:qdeBs11ovMzo5puhrRibdD6d2Dq6TyE/28JiU4tIQxk=
-github.com/hashicorp/terraform-plugin-framework v1.6.0 h1:hMPWoCiNGR+yzoDlXtZ/meGlUOCn8r1OFuPG84MkhWg=
-github.com/hashicorp/terraform-plugin-framework v1.6.0/go.mod h1:QRG6J+m5QBJum+lzKi0Ci2CB8a/xflS3T/aWoz8WD4Y=
+github.com/hashicorp/terraform-plugin-framework v1.7.0 h1:wOULbVmfONnJo9iq7/q+iBOBJul5vRovaYJIu2cY/Pw=
+github.com/hashicorp/terraform-plugin-framework v1.7.0/go.mod h1:jY9Id+3KbZ17OMpulgnWLSfwxNVYSoYBQFTgsx044CI=
 github.com/hashicorp/terraform-plugin-framework-validators v0.12.0 h1:HOjBuMbOEzl7snOdOoUfE2Jgeto6JOjLVQ39Ls2nksc=
 github.com/hashicorp/terraform-plugin-framework-validators v0.12.0/go.mod h1:jfHGE/gzjxYz6XoUwi/aYiiKrJDeutQNUtGQXkaHklg=
-github.com/hashicorp/terraform-plugin-go v0.22.0 h1:1OS1Jk5mO0f5hrziWJGXXIxBrMe2j/B8E+DVGw43Xmc=
 github.com/hashicorp/terraform-plugin-go v0.22.0/go.mod h1:mPULV91VKss7sik6KFEcEu7HuTogMLLO/EvWCuFkRVE=
+github.com/hashicorp/terraform-plugin-go v0.22.1 h1:iTS7WHNVrn7uhe3cojtvWWn83cm2Z6ryIUDTRO0EV7w=
+github.com/hashicorp/terraform-plugin-go v0.22.1/go.mod h1:qrjnqRghvQ6KnDbB12XeZ4FluclYwptntoWCr9QaXTI=
 github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9TFvymaRGZED3FCV0=
 github.com/hashicorp/terraform-plugin-log v0.9.0/go.mod h1:rKL8egZQ/eXSyDqzLUuwUYLVdlYeamldAHSxjUFADow=
 github.com/hashicorp/terraform-plugin-sdk v1.7.0 h1:B//oq0ZORG+EkVrIJy0uPGSonvmXqxSzXe8+GhknoW0=

--- a/pf/tests/dynamic_types_test.go
+++ b/pf/tests/dynamic_types_test.go
@@ -1,0 +1,47 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfbridgetests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	pb "github.com/pulumi/pulumi-terraform-bridge/pf/tests/internal/providerbuilder"
+	br "github.com/pulumi/pulumi-terraform-bridge/pf/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/pulcheck"
+)
+
+func TestCreateResourceWithDynamicAttribute(t *testing.T) {
+	r := pb.Resource{
+		Name: "myres",
+		CreateFunc: func(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+			panic("!")
+		},
+		ResourceSchema: schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"manifest": schema.DynamicAttribute{},
+			},
+		},
+	}
+
+	p := pb.NewProvider(pb.NewProviderArgs{
+		AllResources: []pb.Resource{r},
+	})
+
+	bridgedProvider := pulcheck.QuickProvider(t, "testprovider", br.ShimProvider(p))
+	pulcheck.PulCheck(t, bridgedProvider, "program")
+}

--- a/pf/tests/dynamic_types_test.go
+++ b/pf/tests/dynamic_types_test.go
@@ -48,6 +48,12 @@ func TestCreateResourceWithDynamicAttribute(t *testing.T) {
 			expectedManifestOutput:   "FOO",
 		},
 		{
+			name:                     "empty-string",
+			manifestToSend:           "",
+			expectedManifestReceived: basetypes.NewDynamicValue(basetypes.NewStringValue("")),
+			expectedManifestOutput:   "",
+		},
+		{
 			name:                     "true",
 			manifestToSend:           true,
 			expectedManifestReceived: basetypes.NewDynamicValue(basetypes.NewBoolValue(true)),
@@ -88,6 +94,15 @@ func TestCreateResourceWithDynamicAttribute(t *testing.T) {
 			expectedManifestOutput: []any{"a", "b", "c"},
 		},
 		{
+			name:           "empty-array",
+			manifestToSend: []any{},
+			expectedManifestReceived: basetypes.NewDynamicValue(basetypes.NewListValueMust(
+				types.DynamicType,
+				[]attr.Value{},
+			)),
+			expectedManifestOutput: []any{},
+		},
+		{
 			name: "uniform-map",
 			manifestToSend: map[string]any{
 				"a": "1",
@@ -106,6 +121,19 @@ func TestCreateResourceWithDynamicAttribute(t *testing.T) {
 				"a": "1",
 				"b": "2",
 			},
+		},
+		{
+			name:           "empty-map",
+			manifestToSend: map[string]any{},
+			expectedManifestMatches: func(t *testing.T, v basetypes.DynamicValue) {
+				vv, err := v.ToTerraformValue(context.Background())
+				require.NoError(t, err)
+				var parts map[string]tftypes.Value
+				err = vv.As(&parts)
+				require.NoError(t, err)
+				assert.Equal(t, 0, len(parts))
+			},
+			expectedManifestOutput: map[string]any{},
 		},
 	}
 

--- a/pf/tests/dynamic_types_test.go
+++ b/pf/tests/dynamic_types_test.go
@@ -94,6 +94,14 @@ func TestCreateResourceWithDynamicAttribute(t *testing.T) {
 			expectedManifestOutput: []any{"a", "b", "c"},
 		},
 		{
+			name:           "heterogeneous-array",
+			manifestToSend: []any{"a", []any{"1", "2"}, map[string]any{"a": "1"}},
+			expectedManifestMatches: func(t *testing.T, v basetypes.DynamicValue) {
+				t.Logf("Received: %v", v)
+			},
+			expectedManifestOutput: []any{"a", []any{"1", "2"}, map[string]any{"a": "1"}},
+		},
+		{
 			name:           "empty-array",
 			manifestToSend: []any{},
 			expectedManifestReceived: basetypes.NewDynamicValue(basetypes.NewListValueMust(
@@ -134,6 +142,28 @@ func TestCreateResourceWithDynamicAttribute(t *testing.T) {
 				assert.Equal(t, 0, len(parts))
 			},
 			expectedManifestOutput: map[string]any{},
+		},
+		{
+			name: "heterogeneous-map",
+			manifestToSend: map[string]any{
+				"a": "1",
+				"b": []any{"x", "y"},
+				"c": map[string]any{
+					"aa": "1",
+					"bb": "2",
+				},
+			},
+			expectedManifestMatches: func(t *testing.T, v basetypes.DynamicValue) {
+				t.Logf("Received: %v", v)
+			},
+			expectedManifestOutput: map[string]any{
+				"a": "1",
+				"b": []any{"x", "y"},
+				"c": map[string]any{
+					"aa": "1",
+					"bb": "2",
+				},
+			},
 		},
 	}
 

--- a/pf/tests/dynamic_types_test.go
+++ b/pf/tests/dynamic_types_test.go
@@ -217,12 +217,12 @@ func TestCreateResourceWithDynamicAttribute(t *testing.T) {
 	}
 
 	type ResourceModel struct {
-		Id       types.String  `tfsdk:"id"`
+		ID       types.String  `tfsdk:"id"`
 		Manifest types.Dynamic `tfsdk:"manifest"`
 	}
 
 	type ResourceModelR0 struct {
-		Id types.String `tfsdk:"id"`
+		ID types.String `tfsdk:"id"`
 		U  types.String `tfsdk:"u"`
 	}
 
@@ -251,7 +251,7 @@ func TestCreateResourceWithDynamicAttribute(t *testing.T) {
 
 					t.Logf("Create called with manifest as: %+v", model.Manifest)
 
-					model.Id = basetypes.NewStringValue("id0")
+					model.ID = basetypes.NewStringValue("id0")
 
 					diags = resp.State.Set(ctx, &model)
 					resp.Diagnostics = append(resp.Diagnostics, diags...)
@@ -282,7 +282,7 @@ func TestCreateResourceWithDynamicAttribute(t *testing.T) {
 						panic("req.Config.Get failed")
 					}
 
-					model.Id = basetypes.NewStringValue("r00")
+					model.ID = basetypes.NewStringValue("r00")
 					model.U = basetypes.NewStringValue("U")
 
 					diags = resp.State.Set(ctx, &model)

--- a/pf/tests/dynamic_types_test.go
+++ b/pf/tests/dynamic_types_test.go
@@ -42,6 +42,15 @@ func TestCreateResourceWithDynamicAttribute(t *testing.T) {
 
 	testCases := []testCase{
 		{
+			name:           "null",
+			manifestToSend: nil,
+			expectedManifestMatches: func(t *testing.T, v basetypes.DynamicValue) {
+				// Somehow v.IsNull()==false, but v.IsUnderlyingValueNull()==true, probably OK.
+				require.True(t, v.IsUnderlyingValueNull())
+			},
+			expectedManifestOutput: nil,
+		},
+		{
 			name:                     "string",
 			manifestToSend:           "FOO",
 			expectedManifestReceived: basetypes.NewDynamicValue(basetypes.NewStringValue("FOO")),

--- a/pf/tests/go.mod
+++ b/pf/tests/go.mod
@@ -5,7 +5,7 @@ go 1.22
 replace github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests => ../../pkg/tests
 
 require (
-	github.com/hashicorp/terraform-plugin-framework v1.6.0
+	github.com/hashicorp/terraform-plugin-framework v1.7.0
 	github.com/hashicorp/terraform-plugin-go v0.23.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.33.0
 	github.com/hashicorp/terraform-provider-tls/shim v0.0.0-00010101000000-000000000000
@@ -266,7 +266,7 @@ require (
 	google.golang.org/grpc v1.63.2
 	google.golang.org/protobuf v1.34.0
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 	lukechampine.com/frand v1.4.2 // indirect
 	sourcegraph.com/sourcegraph/appdash v0.0.0-20211028080628-e2786a622600
 )

--- a/pf/tests/go.sum
+++ b/pf/tests/go.sum
@@ -1700,8 +1700,8 @@ github.com/hashicorp/terraform-json v0.4.0/go.mod h1:eAbqb4w0pSlRmdvl8fOyHAi/+8j
 github.com/hashicorp/terraform-json v0.19.0/go.mod h1:qdeBs11ovMzo5puhrRibdD6d2Dq6TyE/28JiU4tIQxk=
 github.com/hashicorp/terraform-json v0.21.0 h1:9NQxbLNqPbEMze+S6+YluEdXgJmhQykRyRNd+zTI05U=
 github.com/hashicorp/terraform-json v0.21.0/go.mod h1:qdeBs11ovMzo5puhrRibdD6d2Dq6TyE/28JiU4tIQxk=
-github.com/hashicorp/terraform-plugin-framework v1.6.0 h1:hMPWoCiNGR+yzoDlXtZ/meGlUOCn8r1OFuPG84MkhWg=
-github.com/hashicorp/terraform-plugin-framework v1.6.0/go.mod h1:QRG6J+m5QBJum+lzKi0Ci2CB8a/xflS3T/aWoz8WD4Y=
+github.com/hashicorp/terraform-plugin-framework v1.7.0 h1:wOULbVmfONnJo9iq7/q+iBOBJul5vRovaYJIu2cY/Pw=
+github.com/hashicorp/terraform-plugin-framework v1.7.0/go.mod h1:jY9Id+3KbZ17OMpulgnWLSfwxNVYSoYBQFTgsx044CI=
 github.com/hashicorp/terraform-plugin-framework-validators v0.12.0 h1:HOjBuMbOEzl7snOdOoUfE2Jgeto6JOjLVQ39Ls2nksc=
 github.com/hashicorp/terraform-plugin-framework-validators v0.12.0/go.mod h1:jfHGE/gzjxYz6XoUwi/aYiiKrJDeutQNUtGQXkaHklg=
 github.com/hashicorp/terraform-plugin-go v0.22.0/go.mod h1:mPULV91VKss7sik6KFEcEu7HuTogMLLO/EvWCuFkRVE=

--- a/pkg/convert/bool.go
+++ b/pkg/convert/bool.go
@@ -33,7 +33,7 @@ func newBoolDecoder() Decoder {
 }
 
 func (*boolEncoder) fromPropertyValue(p resource.PropertyValue) (tftypes.Value, error) {
-	if propertyValueIsUnkonwn(p) {
+	if propertyValueIsUnknown(p) {
 		return tftypes.NewValue(tftypes.Bool, tftypes.UnknownValue), nil
 	}
 	if p.IsNull() {

--- a/pkg/convert/dynamic.go
+++ b/pkg/convert/dynamic.go
@@ -1,0 +1,51 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package convert
+
+import (
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
+// To support DynamicPseudoType, perform a best-effort conversion at the data level without any type information.
+func newDynamicEncoder() Encoder {
+	return &dynamicEncoder{}
+}
+
+type dynamicEncoder struct{}
+
+func (*dynamicEncoder) fromPropertyValue(p resource.PropertyValue) (tftypes.Value, error) {
+	if propertyValueIsUnkonwn(p) {
+		return tftypes.NewValue(tftypes.Object{}, tftypes.UnknownValue), nil
+	}
+	if p.IsNull() {
+		return tftypes.NewValue(tftypes.Object{}, nil), nil
+	}
+	if p.IsString() {
+		return tftypes.NewValue(tftypes.String, p.StringValue()), nil
+	}
+
+	panic("TODO More types needed!")
+}
+
+type dynamicDecoder struct{}
+
+func newDynamicDecoder() Decoder {
+	return &dynamicDecoder{}
+}
+
+func (*dynamicDecoder) toPropertyValue(v tftypes.Value) (resource.PropertyValue, error) {
+	panic("TOOD implement dynamic decoder")
+}

--- a/pkg/convert/dynamic.go
+++ b/pkg/convert/dynamic.go
@@ -71,7 +71,9 @@ func (enc *dynamicEncoder) fromPropertyValue(p resource.PropertyValue) (tftypes.
 	case p.IsSecret() || p.IsOutput() && p.OutputValue().Secret:
 		return tftypes.Value{}, fmt.Errorf("Secrets inside dynamically typed blocks are not yet supported")
 	case p.IsOutput():
-		// Cannot be unknown at this point, or secret. Strip dependencies and send the value.
+		o := p.OutputValue()
+		contract.Assertf(o.Known && !o.Secret,
+		  "Cannot be unknown at this point, or secret.")
 		return enc.fromPropertyValue(p.OutputValue().Element)
 	case p.IsObject():
 		// Maps and objects are confused in this Pulumi representation, we cannot reliably tell them apart.

--- a/pkg/convert/dynamic.go
+++ b/pkg/convert/dynamic.go
@@ -30,8 +30,6 @@ func newDynamicEncoder() Encoder {
 
 type dynamicEncoder struct{}
 
-// Convert a PropertyValue to a tftypes.Value. If the optional ty parameter is specified, ensure that the resulting
-// tftypes.Value is constructed with the given type.
 func (enc *dynamicEncoder) fromPropertyValue(p resource.PropertyValue) (tftypes.Value, error) {
 	switch {
 	case propertyValueIsUnknown(p):
@@ -73,7 +71,7 @@ func (enc *dynamicEncoder) fromPropertyValue(p resource.PropertyValue) (tftypes.
 	case p.IsOutput():
 		o := p.OutputValue()
 		contract.Assertf(o.Known && !o.Secret,
-		  "Cannot be unknown at this point, or secret.")
+			"Cannot be unknown at this point, or secret.")
 		return enc.fromPropertyValue(p.OutputValue().Element)
 	case p.IsObject():
 		// Maps and objects are confused in this Pulumi representation, we cannot reliably tell them apart.

--- a/pkg/convert/dynamic.go
+++ b/pkg/convert/dynamic.go
@@ -15,8 +15,12 @@
 package convert
 
 import (
+	"fmt"
+	"math/big"
+
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 // To support DynamicPseudoType, perform a best-effort conversion at the data level without any type information.
@@ -26,18 +30,58 @@ func newDynamicEncoder() Encoder {
 
 type dynamicEncoder struct{}
 
-func (*dynamicEncoder) fromPropertyValue(p resource.PropertyValue) (tftypes.Value, error) {
-	if propertyValueIsUnkonwn(p) {
+func (enc *dynamicEncoder) fromPropertyValue(p resource.PropertyValue) (tftypes.Value, error) {
+	switch {
+	case propertyValueIsUnknown(p):
 		return tftypes.NewValue(tftypes.Object{}, tftypes.UnknownValue), nil
-	}
-	if p.IsNull() {
+	case p.IsNull():
 		return tftypes.NewValue(tftypes.Object{}, nil), nil
-	}
-	if p.IsString() {
+	case p.IsBool():
+		return tftypes.NewValue(tftypes.Bool, p.BoolValue()), nil
+	case p.IsNumber():
+		return tftypes.NewValue(tftypes.Number, p.NumberValue()), nil
+	case p.IsString():
 		return tftypes.NewValue(tftypes.String, p.StringValue()), nil
+	case p.IsArray():
+		var result []tftypes.Value
+		for _, e := range p.ArrayValue() {
+			te, err := enc.fromPropertyValue(e)
+			if err != nil {
+				return tftypes.Value{}, err
+			}
+			result = append(result, te)
+		}
+		// TODO will this work or elements need to be wrapped in DynamicPseudoType for this to work?
+		return tftypes.NewValue(tftypes.List{ElementType: tftypes.DynamicPseudoType}, result), nil
+	case p.IsAsset():
+		return tftypes.Value{}, fmt.Errorf("Assets inside dynamically typed blocks are not yet supported")
+	case p.IsArchive():
+		return tftypes.Value{}, fmt.Errorf("Archives inside dynamically typed blocks are not yet supported")
+	case p.IsSecret() || p.IsOutput() && p.OutputValue().Secret:
+		return tftypes.Value{}, fmt.Errorf("Secrets inside dynamically typed blocks are not yet supported")
+	case p.IsOutput():
+		// Cannot be unknown at this point, or secret. Strip dependencies and send the value.
+		return enc.fromPropertyValue(p.OutputValue().Element)
+	case p.IsObject():
+		// Maps and objects are confused in this Pulumi representation, we cannot reliably tell them apart.
+		// Assume this is an object, but do not inflect property names in any way.
+		result := map[string]tftypes.Value{}
+		ty := tftypes.Object{AttributeTypes: map[string]tftypes.Type{}}
+		for k, v := range p.ObjectValue() {
+			te, err := enc.fromPropertyValue(v)
+			if err != nil {
+				return tftypes.Value{}, err
+			}
+			result[string(k)] = te
+			ty.AttributeTypes[string(k)] = te.Type()
+		}
+		return tftypes.NewValue(ty, result), nil
+	case p.IsResourceReference():
+		return tftypes.Value{}, fmt.Errorf("Resource references inside dynamically typed blocks are not yet supported")
+	default:
+		contract.Failf("Unexpected PropertyValue case: %v", p)
+		panic("Unreachable")
 	}
-
-	panic("TODO More types needed!")
 }
 
 type dynamicDecoder struct{}
@@ -46,20 +90,68 @@ func newDynamicDecoder() Decoder {
 	return &dynamicDecoder{}
 }
 
-func (*dynamicDecoder) toPropertyValue(v tftypes.Value) (resource.PropertyValue, error) {
-	if !v.IsKnown() {
+func (dec *dynamicDecoder) toPropertyValue(v tftypes.Value) (resource.PropertyValue, error) {
+	switch {
+	case !v.IsKnown():
 		return unknownProperty(), nil
-	}
-	if v.IsNull() {
+	case v.IsNull():
 		return resource.NewPropertyValue(nil), nil
-	}
-	if v.Type().Is(tftypes.String) {
+	case v.Type().Is(tftypes.Bool):
+		var x bool
+		err := v.As(&x)
+		if err != nil {
+			return resource.PropertyValue{}, err
+		}
+		return resource.NewBoolProperty(x), nil
+	case v.Type().Is(tftypes.Number):
+		var x big.Float
+		err := v.As(&x)
+		if err != nil {
+			return resource.PropertyValue{}, err
+		}
+		f, _ := x.Float64()
+		return resource.NewNumberProperty(f), nil
+	case v.Type().Is(tftypes.String):
 		var s string
 		err := v.As(&s)
 		if err != nil {
 			return resource.PropertyValue{}, err
 		}
 		return resource.NewStringProperty(s), nil
+	case v.Type().Is(tftypes.List{}):
+		var elements []tftypes.Value
+		err := v.As(&elements)
+		if err != nil {
+			return resource.PropertyValue{}, err
+		}
+		var translated []resource.PropertyValue
+		for _, e := range elements {
+			te, err := dec.toPropertyValue(e)
+			if err != nil {
+				return resource.PropertyValue{}, err
+			}
+			translated = append(translated, te)
+		}
+		return resource.NewArrayProperty(translated), nil
+	case v.Type().Is(tftypes.Map{}), v.Type().Is(tftypes.Object{}):
+		var elements map[string]tftypes.Value
+		err := v.As(&elements)
+		if err != nil {
+			return resource.PropertyValue{}, err
+		}
+		translated := make(resource.PropertyMap)
+		for k, v := range elements {
+			tv, err := dec.toPropertyValue(v)
+			if err != nil {
+				return resource.PropertyValue{}, err
+			}
+			translated[resource.PropertyKey(k)] = tv
+		}
+		return resource.NewObjectProperty(translated), nil
+	case v.Type().Is(tftypes.Tuple{}):
+		return resource.PropertyValue{}, fmt.Errorf("Tuple types inside dynamically typed blocks are not yet supported")
+	default:
+		contract.Failf("Unexpected tftypes.Value case: %v", v.String())
+		panic("Unreachable")
 	}
-	panic("TODO More types needed!")
 }

--- a/pkg/convert/dynamic.go
+++ b/pkg/convert/dynamic.go
@@ -51,8 +51,10 @@ func (enc *dynamicEncoder) fromPropertyValue(p resource.PropertyValue) (tftypes.
 			}
 			result = append(result, te)
 		}
-		// tftypes.NewValue is pretty strict in that array elements must have the same type.
-		// Try to encode this as an array and fallback on a tuple if the types do not match.
+		// tftypes.NewValue is pretty strict in that array elements must have the same type. Try to encode this
+		// as an array and fallback on a tuple if the types do not match. Attempts to encode either the list or
+		// its element as DynamicPseudoType themselves to make the element type uniform trigger end-to-end
+		// errors, this approach seems to be the best workaround for now.
 		if commonTy, err := tftypes.TypeFromElements(result); err == nil {
 			return tftypes.NewValue(tftypes.List{ElementType: commonTy}, result), nil
 		} else {

--- a/pkg/convert/dynamic.go
+++ b/pkg/convert/dynamic.go
@@ -33,9 +33,9 @@ type dynamicEncoder struct{}
 func (enc *dynamicEncoder) fromPropertyValue(p resource.PropertyValue) (tftypes.Value, error) {
 	switch {
 	case propertyValueIsUnknown(p):
-		return tftypes.NewValue(tftypes.Object{}, tftypes.UnknownValue), nil
+		return tftypes.NewValue(tftypes.Object{} /* arbitrary type */, tftypes.UnknownValue), nil
 	case p.IsNull():
-		return tftypes.NewValue(tftypes.Object{}, nil), nil
+		return tftypes.NewValue(tftypes.Object{} /* arbitrary type */, nil), nil
 	case p.IsBool():
 		return tftypes.NewValue(tftypes.Bool, p.BoolValue()), nil
 	case p.IsNumber():

--- a/pkg/convert/dynamic.go
+++ b/pkg/convert/dynamic.go
@@ -47,5 +47,19 @@ func newDynamicDecoder() Decoder {
 }
 
 func (*dynamicDecoder) toPropertyValue(v tftypes.Value) (resource.PropertyValue, error) {
-	panic("TOOD implement dynamic decoder")
+	if !v.IsKnown() {
+		return unknownProperty(), nil
+	}
+	if v.IsNull() {
+		return resource.NewPropertyValue(nil), nil
+	}
+	if v.Type().Is(tftypes.String) {
+		var s string
+		err := v.As(&s)
+		if err != nil {
+			return resource.PropertyValue{}, err
+		}
+		return resource.NewStringProperty(s), nil
+	}
+	panic("TODO More types needed!")
 }

--- a/pkg/convert/encoding.go
+++ b/pkg/convert/encoding.go
@@ -175,6 +175,8 @@ func deriveEncoder(pctx *schemaPropContext, t tftypes.Type) (Encoder, error) {
 		}
 	case t.Is(tftypes.Bool):
 		return newBoolEncoder(), nil
+	case t.Is(tftypes.DynamicPseudoType):
+		return newDynamicEncoder(), nil
 	}
 
 	switch tt := t.(type) {
@@ -252,6 +254,8 @@ func deriveDecoder(pctx *schemaPropContext, t tftypes.Type) (Decoder, error) {
 		}
 	case t.Is(tftypes.Bool):
 		return newBoolDecoder(), nil
+	case t.Is(tftypes.DynamicPseudoType):
+		return newDynamicDecoder(), nil
 	}
 
 	if to := pctx.TypeInfo(); to != "" {

--- a/pkg/convert/list.go
+++ b/pkg/convert/list.go
@@ -46,7 +46,7 @@ func newListDecoder(elementDecoder Decoder) (Decoder, error) {
 func (enc *listEncoder) fromPropertyValue(p resource.PropertyValue) (tftypes.Value, error) {
 	listTy := tftypes.List{ElementType: enc.elementType}
 
-	if propertyValueIsUnkonwn(p) {
+	if propertyValueIsUnknown(p) {
 		return tftypes.NewValue(listTy, tftypes.UnknownValue), nil
 	}
 	if p.IsNull() {

--- a/pkg/convert/map.go
+++ b/pkg/convert/map.go
@@ -45,7 +45,7 @@ func newMapDecoder(elementDecoder Decoder) (Decoder, error) {
 
 func (enc *mapEncoder) fromPropertyValue(p resource.PropertyValue) (tftypes.Value, error) {
 	mapTy := tftypes.Map{ElementType: enc.elementType}
-	if propertyValueIsUnkonwn(p) {
+	if propertyValueIsUnknown(p) {
 		return tftypes.NewValue(mapTy, tftypes.UnknownValue), nil
 	}
 	if p.IsNull() {

--- a/pkg/convert/number.go
+++ b/pkg/convert/number.go
@@ -34,7 +34,7 @@ func newNumberDecoder() Decoder {
 }
 
 func (*numberEncoder) fromPropertyValue(p resource.PropertyValue) (tftypes.Value, error) {
-	if propertyValueIsUnkonwn(p) {
+	if propertyValueIsUnknown(p) {
 		return tftypes.NewValue(tftypes.Number, tftypes.UnknownValue), nil
 	}
 	if p.IsNull() {

--- a/pkg/convert/object.go
+++ b/pkg/convert/object.go
@@ -57,7 +57,7 @@ func newObjectDecoder(objectType tftypes.Object,
 }
 
 func (enc *objectEncoder) fromPropertyValue(p resource.PropertyValue) (tftypes.Value, error) {
-	if propertyValueIsUnkonwn(p) {
+	if propertyValueIsUnknown(p) {
 		return tftypes.NewValue(enc.objectType, tftypes.UnknownValue), nil
 	}
 	if p.IsNull() {

--- a/pkg/convert/property_value.go
+++ b/pkg/convert/property_value.go
@@ -23,6 +23,6 @@ func unknownProperty() resource.PropertyValue {
 }
 
 // This is how p.ContainsUnknowns checks if the value itself is unknown before recursing.
-func propertyValueIsUnkonwn(p resource.PropertyValue) bool {
+func propertyValueIsUnknown(p resource.PropertyValue) bool {
 	return p.IsComputed() || (p.IsOutput() && !p.OutputValue().Known)
 }

--- a/pkg/convert/set.go
+++ b/pkg/convert/set.go
@@ -46,7 +46,7 @@ func newSetDecoder(elementDecoder Decoder) (Decoder, error) {
 func (enc *setEncoder) fromPropertyValue(p resource.PropertyValue) (tftypes.Value, error) {
 	setTy := tftypes.Set{ElementType: enc.elementType}
 
-	if propertyValueIsUnkonwn(p) {
+	if propertyValueIsUnknown(p) {
 		return tftypes.NewValue(setTy, tftypes.UnknownValue), nil
 	}
 	if p.IsNull() {

--- a/pkg/convert/string.go
+++ b/pkg/convert/string.go
@@ -34,7 +34,7 @@ func newStringDecoder() Decoder {
 }
 
 func (*stringEncoder) fromPropertyValue(p resource.PropertyValue) (tftypes.Value, error) {
-	if propertyValueIsUnkonwn(p) {
+	if propertyValueIsUnknown(p) {
 		return tftypes.NewValue(tftypes.String, tftypes.UnknownValue), nil
 	}
 

--- a/pkg/convert/tuple.go
+++ b/pkg/convert/tuple.go
@@ -51,7 +51,7 @@ func tuplePropertyName(i int) string {
 
 func (enc *tupleEncoder) fromPropertyValue(p resource.PropertyValue) (tftypes.Value, error) {
 	typ := tftypes.Tuple{ElementTypes: enc.types}
-	if propertyValueIsUnkonwn(p) {
+	if propertyValueIsUnknown(p) {
 		return tftypes.NewValue(typ, tftypes.UnknownValue), nil
 	}
 	if p.IsNull() {

--- a/pkg/tests/pulcheck/pulcheck.go
+++ b/pkg/tests/pulcheck/pulcheck.go
@@ -19,7 +19,6 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/tokens"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen"
-	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
 	pulumidiag "github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
@@ -147,15 +146,13 @@ func BridgedProvider(t T, providerName string, tfp *schema.Provider, opts ...Bri
 	for _, opt := range opts {
 		opt(options)
 	}
+
 	EnsureProviderValid(t, tfp)
+
 	shimProvider := shimv2.NewProvider(tfp, shimv2.WithPlanResourceChange(
 		func(tfResourceType string) bool { return !options.DisablePlanResourceChange },
 	))
-	return QuickProvider(t, providerName, shimProvider)
-}
 
-// Help quickly setting up a reasonable info.Provider.
-func QuickProvider(t T, providerName string, shimProvider shim.Provider) info.Provider {
 	provider := tfbridge.ProviderInfo{
 		P:                              shimProvider,
 		Name:                           providerName,
@@ -167,6 +164,7 @@ func QuickProvider(t T, providerName string, shimProvider shim.Provider) info.Pr
 		return tokens.MakeStandard(providerName)(module, name)
 	}
 	provider.MustComputeTokens(tokens.SingleModule(providerName, "index", makeToken))
+
 	return provider
 }
 
@@ -176,10 +174,6 @@ func skipUnlessLinux(t T) {
 	}
 }
 
-// Set up an integration test against a given in-process provider stood up from bridgedProvider.
-//
-// Specify verbatim Pulumi.yaml in the program parameter.
-//
 // This is an experimental API.
 func PulCheck(t T, bridgedProvider info.Provider, program string) *pulumitest.PulumiTest {
 	skipUnlessLinux(t)

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -437,7 +437,7 @@ func (g *Generator) makePropertyType(typePath paths.TypePath,
 	case shim.TypeSet:
 		t.kind = kindSet
 	case shim.TypeDynamic:
-		return nil, errors.New("Error in schema generation: Dynamic types are not implemented")
+		return nil, nil // nil of type *propertyType represents the special <any> type
 	default:
 		contract.Failf(
 			"impossible: sch.Type() should be one of TypeMap, TypeList, TypeSet, TypeDynamic at this point path: "+

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -328,7 +328,9 @@ const (
 	kindObject
 )
 
-// propertyType represents a non-resource, non-datasource type. Property types may be simple
+// propertyType represents a non-resource, non-datasource type.
+//
+// Using nil for *propertyType implies catch-all any type (aka "pulumi.json#/Any" in Package Schema).
 type propertyType struct {
 	name       string
 	doc        string

--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -180,6 +180,12 @@ func (nt *schemaNestedTypes) gatherFromProperties(pathContext paths.TypePath,
 
 	for _, p := range ps {
 		name := p.name
+
+		// Skip the <any> type as it does not need recursive handling.
+		if p.typ == nil {
+			continue
+		}
+
 		if p.typ.kind == kindList || p.typ.kind == kindSet {
 			name = inflector.Singularize(name)
 		}

--- a/pkg/tfgen/generate_test.go
+++ b/pkg/tfgen/generate_test.go
@@ -169,11 +169,10 @@ func Test_makePropertyType(t *testing.T) {
 		assert.Equal(t, kindString, p.kind)
 	})
 
-	//TODO: change this test to assert typeKind when implementing
-	// https://github.com/pulumi/pulumi-terraform-bridge/issues/2127
 	t.Run("Dynamic Unimplemented", func(t *testing.T) {
-		_, err := g.makePropertyType(path, "obj", dynamicType, nil, false, entityDocs{})
-		assert.Error(t, err, "Error in schema generation: Dynamic types are not implemented")
+		pt, err := g.makePropertyType(path, "obj", dynamicType, nil, false, entityDocs{})
+		assert.NoError(t, err)
+		assert.Nilf(t, pt, "Expected nil *propertyType as that models the <any> type")
 	})
 
 	t.Run("ListString", func(t *testing.T) {


### PR DESCRIPTION
This PR adds support for the [Dynamic Type](https://developer.hashicorp.com/terraform/plugin/framework/handling-data/types/dynamic#) to Plugin Framework based bridged providers. 

One use case for these types is modeling K8S manifests. In HCL this permits users to specify manifests as verbatim trees. This PR makes it possible in the Pulumi projection as well.

Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/2127

Limitations:

- will fail if nested secrets are used inside a property of type Dynamic
- will fail if Assets, Archives, or Resource References are passed down through a property of type Dynamic
- there is a little guess-work involved in recovering the type of the passed value which might result in providers receiving a different recovered type under Pulumi compared to TF; specifically maps and objects may be confused, as can arrays and tuples; for most code this is not expected to be a problem, but might need to be revisited if users report issues

Dependencies: Plugin Framework updated to 1.7.0 to be able to test dynamic types (introduced in that version).