### PR TITLE
Generate only a single index file for installation docs

### DIFF
--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -28,12 +28,6 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tf2pulumi/il"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen/internal/paths"
-	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/metadata"
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	dotnetgen "github.com/pulumi/pulumi/pkg/v3/codegen/dotnet"
 	gogen "github.com/pulumi/pulumi/pkg/v3/codegen/go"
@@ -48,6 +42,13 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	schemaTools "github.com/pulumi/schema-tools/pkg"
 	"github.com/spf13/afero"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tf2pulumi/il"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen/internal/paths"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/metadata"
 )
 
 const (

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -28,6 +28,12 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tf2pulumi/il"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen/internal/paths"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/metadata"
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	dotnetgen "github.com/pulumi/pulumi/pkg/v3/codegen/dotnet"
 	gogen "github.com/pulumi/pulumi/pkg/v3/codegen/go"
@@ -42,15 +48,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	schemaTools "github.com/pulumi/schema-tools/pkg"
 	"github.com/spf13/afero"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
-
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tf2pulumi/il"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen/internal/paths"
-	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/metadata"
 )
 
 const (
@@ -987,16 +984,7 @@ func (g *Generator) UnstableGenerateFromSchema(genSchemaResult *GenerateSchemaRe
 		if err != nil {
 			return errors.Wrapf(err, "failed to parse installation docs")
 		}
-		files["installation-configuration.md"] = content
-		// Populate minimal _index.md file
-		displayName := g.info.DisplayName
-		if displayName == "" {
-			// Capitalize the package name
-			capitalize := cases.Title(language.English)
-			displayName = capitalize.String(g.info.Name)
-		}
-		indexContent := writeIndexFrontMatter(displayName)
-		files["_index.md"] = []byte(indexContent)
+		files["_index.md"] = content
 	case Schema:
 		// Omit the version so that the spec is stable if the version is e.g. derived from the current Git commit hash.
 		pulumiPackageSpec.Version = ""

--- a/pkg/tfgen/installation_docs.go
+++ b/pkg/tfgen/installation_docs.go
@@ -66,16 +66,6 @@ func writeFrontMatter(title string) string {
 		title)
 }
 
-func writeIndexFrontMatter(displayName string) string {
-	return fmt.Sprintf(delimiter+
-		"title: %[1]s\n"+
-		"meta_desc: The %[1]s provider for Pulumi "+
-		"can be used to provision any of the cloud resources available in %[1]s.\n"+
-		"layout: package\n"+
-		delimiter,
-		displayName)
-}
-
 func getBodyAndTitle(content string) (string, string) {
 	// The first header in `index.md` is the package name, of the format `# Foo Provider`.
 	titleIndex := strings.Index(content, "# ")

--- a/pkg/tfgen/installation_docs.go
+++ b/pkg/tfgen/installation_docs.go
@@ -56,10 +56,14 @@ func plainDocsParser(docFile *DocFile, g *Generator) ([]byte, error) {
 	return []byte(contentStr), nil
 }
 
-func writeFrontMatter(title string) string {
+func writeFrontMatter(providerName string) string {
+	// Capitalize the provider name for the title
+
+	capitalize := cases.Title(language.English)
+	title := capitalize.String(providerName)
 	return fmt.Sprintf(delimiter+
-		"title: %[1]s Installation & Configuration\n"+
-		"meta_desc: Provides an overview on how to configure the Pulumi %[1]s.\n"+
+		"title: %[1]s Provider\n"+
+		"meta_desc: Provides an overview on how to configure the Pulumi %[1]s provider.\n"+
 		"layout: package\n"+
 		delimiter+
 		"\n",

--- a/pkg/tfgen/installation_docs_test.go
+++ b/pkg/tfgen/installation_docs_test.go
@@ -94,17 +94,17 @@ func TestWriteFrontMatter(t *testing.T) {
 
 	type testCase struct {
 		// The name of the test case.
-		name     string
-		title    string
-		expected string
+		name         string
+		providerName string
+		expected     string
 	}
 
 	tc := testCase{
-		name:  "Generates Front Matter for installation-configuration.md",
-		title: "Testcase Provider",
+		name:         "Generates Front Matter for installation-configuration.md",
+		providerName: "Test",
 		expected: delimiter +
-			"title: Testcase Provider Installation & Configuration\n" +
-			"meta_desc: Provides an overview on how to configure the Pulumi Testcase Provider.\n" +
+			"title: Test Provider\n" +
+			"meta_desc: Provides an overview on how to configure the Pulumi Test provider.\n" +
 			"layout: package\n" +
 			delimiter +
 			"\n",
@@ -112,7 +112,7 @@ func TestWriteFrontMatter(t *testing.T) {
 
 	t.Run(tc.name, func(t *testing.T) {
 		t.Parallel()
-		actual := writeFrontMatter(tc.title)
+		actual := writeFrontMatter(tc.providerName)
 		require.Equal(t, tc.expected, actual)
 	})
 }

--- a/pkg/tfgen/installation_docs_test.go
+++ b/pkg/tfgen/installation_docs_test.go
@@ -117,34 +117,6 @@ func TestWriteFrontMatter(t *testing.T) {
 	})
 }
 
-func TestWriteIndexFrontMatter(t *testing.T) {
-	t.Parallel()
-
-	type testCase struct {
-		// The name of the test case.
-		name        string
-		displayName string
-		expected    string
-	}
-
-	tc := testCase{
-		name:        "Generates Front Matter for _index.md",
-		displayName: "Testcase",
-		expected: delimiter +
-			"title: Testcase\n" +
-			"meta_desc: The Testcase provider for Pulumi " +
-			"can be used to provision any of the cloud resources available in Testcase.\n" +
-			"layout: package\n" +
-			delimiter,
-	}
-
-	t.Run(tc.name, func(t *testing.T) {
-		t.Parallel()
-		actual := writeIndexFrontMatter(tc.displayName)
-		require.Equal(t, tc.expected, actual)
-	})
-}
-
 func TestApplyEditRules(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
- **Only generate a single _index.md file**
- **Adjust header to just read the provider name**
