### PR TITLE
Specify a license for dynamic providers

### DIFF
--- a/dynamic/main.go
+++ b/dynamic/main.go
@@ -53,6 +53,7 @@ func initialSetup() (info.Provider, pfbridge.ProviderMetadata, func() error) {
 		LogoURL:      "https://raw.githubusercontent.com/pulumi/pulumi-terraform-provider/main/assets/logo.png",
 		Version:      version.Version(),
 		Description:  "Use any Terraform provider with Pulumi",
+		License:      "Apache-2.0",
 		MetadataInfo: &info.Metadata{Path: "", Data: tfbridge.ProviderMetadata(nil)},
 		SchemaPostProcessor: func(spec *schema.PackageSpec) {
 			spec.Attribution = ""

--- a/dynamic/testdata/TestSchemaGeneration/unparameterized.golden
+++ b/dynamic/testdata/TestSchemaGeneration/unparameterized.golden
@@ -6,6 +6,7 @@
     "keywords": [
         "category/utility"
     ],
+    "license": "Apache-2.0",
     "logoUrl": "https://raw.githubusercontent.com/pulumi/pulumi-terraform-provider/main/assets/logo.png",
     "meta": {
         "moduleFormat": "(.*)(?:/[^/]*)"


### PR DESCRIPTION
This shows up in upstream documentation, so we should put something there.