### PR TITLE
Fix schema generation for dynamic bridged providers

### DIFF
--- a/dynamic/testdata/TestSchemaGeneration/Azure/alz-0.11.1.golden
+++ b/dynamic/testdata/TestSchemaGeneration/Azure/alz-0.11.1.golden
@@ -620,6 +620,9 @@
                         "additionalProperties": {
                             "$ref": "#/types/alz:index/getArchetypePolicyAssignmentsToModify:getArchetypePolicyAssignmentsToModify"
                         }
+                    },
+                    "timeouts": {
+                        "$ref": "#/types/alz:index/getArchetypeTimeouts:getArchetypeTimeouts"
                     }
                 },
                 "type": "object",
@@ -698,8 +701,7 @@
                     "baseArchetype",
                     "defaults",
                     "id",
-                    "parentId",
-                    "timeouts"
+                    "parentId"
                 ]
             }
         },

--- a/dynamic/testdata/TestSchemaGeneration/Backblaze/b2-0.8.9.golden
+++ b/dynamic/testdata/TestSchemaGeneration/Backblaze/b2-0.8.9.golden
@@ -133,10 +133,7 @@
                     "description": "If present, the boolean value specifies whether bucket is File Lock-enabled. Defaults to `false`.\n"
                 }
             },
-            "type": "object",
-            "required": [
-                "defaultRetention"
-            ]
+            "type": "object"
         },
         "b2:index/BucketFileLockConfigurationDefaultRetention:BucketFileLockConfigurationDefaultRetention": {
             "properties": {
@@ -151,8 +148,7 @@
             },
             "type": "object",
             "required": [
-                "mode",
-                "period"
+                "mode"
             ]
         },
         "b2:index/BucketFileLockConfigurationDefaultRetentionPeriod:BucketFileLockConfigurationDefaultRetentionPeriod": {
@@ -187,10 +183,7 @@
                     "description": "Server-side encryption mode.\n"
                 }
             },
-            "type": "object",
-            "required": [
-                "key"
-            ]
+            "type": "object"
         },
         "b2:index/BucketFileVersionServerSideEncryptionKey:BucketFileVersionServerSideEncryptionKey": {
             "properties": {
@@ -795,10 +788,6 @@
                 "bucketId",
                 "bucketName",
                 "bucketType",
-                "corsRules",
-                "defaultServerSideEncryption",
-                "fileLockConfigurations",
-                "lifecycleRules",
                 "options",
                 "revision"
             ],
@@ -817,6 +806,31 @@
                 "bucketType": {
                     "type": "string",
                     "description": "The bucket type. Either 'allPublic', meaning that files in this bucket can be downloaded by anybody, or 'allPrivate'.\n"
+                },
+                "corsRules": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/types/b2:index/BucketCorsRule:BucketCorsRule"
+                    },
+                    "description": "The initial list of CORS rules for this bucket.\n"
+                },
+                "defaultServerSideEncryption": {
+                    "$ref": "#/types/b2:index/BucketDefaultServerSideEncryption:BucketDefaultServerSideEncryption",
+                    "description": "The default server-side encryption settings for this bucket.\n"
+                },
+                "fileLockConfigurations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/types/b2:index/BucketFileLockConfiguration:BucketFileLockConfiguration"
+                    },
+                    "description": "File lock enabled flag, and default retention settings.\n"
+                },
+                "lifecycleRules": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/types/b2:index/BucketLifecycleRule:BucketLifecycleRule"
+                    },
+                    "description": "The initial list of lifecycle rules for this bucket.\n"
                 }
             },
             "requiredInputs": [
@@ -951,7 +965,6 @@
                 "fileId",
                 "fileInfo",
                 "fileName",
-                "serverSideEncryption",
                 "size",
                 "source",
                 "uploadTimestamp"
@@ -975,6 +988,10 @@
                 "fileName": {
                     "type": "string",
                     "description": "The name of the B2 file.\n"
+                },
+                "serverSideEncryption": {
+                    "$ref": "#/types/b2:index/BucketFileVersionServerSideEncryption:BucketFileVersionServerSideEncryption",
+                    "description": "Server-side encryption settings.\n"
                 },
                 "source": {
                     "type": "string",

--- a/dynamic/testdata/TestSchemaGeneration/databricks/databricks-1.50.0.golden
+++ b/dynamic/testdata/TestSchemaGeneration/databricks/databricks-1.50.0.golden
@@ -200,11 +200,7 @@
                     "type": "boolean"
                 }
             },
-            "type": "object",
-            "required": [
-                "enablementDetails",
-                "maintenanceWindow"
-            ]
+            "type": "object"
         },
         "databricks:index/AutomaticClusterUpdateWorkspaceSettingAutomaticClusterUpdateWorkspaceEnablementDetails:AutomaticClusterUpdateWorkspaceSettingAutomaticClusterUpdateWorkspaceEnablementDetails": {
             "properties": {
@@ -226,10 +222,7 @@
                     "$ref": "#/types/databricks:index/AutomaticClusterUpdateWorkspaceSettingAutomaticClusterUpdateWorkspaceMaintenanceWindowWeekDayBasedSchedule:AutomaticClusterUpdateWorkspaceSettingAutomaticClusterUpdateWorkspaceMaintenanceWindowWeekDayBasedSchedule"
                 }
             },
-            "type": "object",
-            "required": [
-                "weekDayBasedSchedule"
-            ]
+            "type": "object"
         },
         "databricks:index/AutomaticClusterUpdateWorkspaceSettingAutomaticClusterUpdateWorkspaceMaintenanceWindowWeekDayBasedSchedule:AutomaticClusterUpdateWorkspaceSettingAutomaticClusterUpdateWorkspaceMaintenanceWindowWeekDayBasedSchedule": {
             "properties": {
@@ -243,10 +236,7 @@
                     "$ref": "#/types/databricks:index/AutomaticClusterUpdateWorkspaceSettingAutomaticClusterUpdateWorkspaceMaintenanceWindowWeekDayBasedScheduleWindowStartTime:AutomaticClusterUpdateWorkspaceSettingAutomaticClusterUpdateWorkspaceMaintenanceWindowWeekDayBasedScheduleWindowStartTime"
                 }
             },
-            "type": "object",
-            "required": [
-                "windowStartTime"
-            ]
+            "type": "object"
         },
         "databricks:index/AutomaticClusterUpdateWorkspaceSettingAutomaticClusterUpdateWorkspaceMaintenanceWindowWeekDayBasedScheduleWindowStartTime:AutomaticClusterUpdateWorkspaceSettingAutomaticClusterUpdateWorkspaceMaintenanceWindowWeekDayBasedScheduleWindowStartTime": {
             "properties": {
@@ -320,10 +310,7 @@
                     "type": "number"
                 }
             },
-            "type": "object",
-            "required": [
-                "logAnalyticsInfo"
-            ]
+            "type": "object"
         },
         "databricks:index/ClusterAzureAttributesLogAnalyticsInfo:ClusterAzureAttributesLogAnalyticsInfo": {
             "properties": {
@@ -345,11 +332,7 @@
                     "$ref": "#/types/databricks:index/ClusterClusterLogConfS3:ClusterClusterLogConfS3"
                 }
             },
-            "type": "object",
-            "required": [
-                "dbfs",
-                "s3"
-            ]
+            "type": "object"
         },
         "databricks:index/ClusterClusterLogConfDbfs:ClusterClusterLogConfDbfs": {
             "properties": {
@@ -434,7 +417,6 @@
             },
             "type": "object",
             "required": [
-                "basicAuth",
                 "url"
             ]
         },
@@ -502,16 +484,7 @@
                     "$ref": "#/types/databricks:index/ClusterInitScriptWorkspace:ClusterInitScriptWorkspace"
                 }
             },
-            "type": "object",
-            "required": [
-                "abfss",
-                "dbfs",
-                "file",
-                "gcs",
-                "s3",
-                "volumes",
-                "workspace"
-            ]
+            "type": "object"
         },
         "databricks:index/ClusterInitScriptAbfss:ClusterInitScriptAbfss": {
             "properties": {
@@ -632,12 +605,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "cran",
-                "maven",
-                "pypi"
-            ]
+            "type": "object"
         },
         "databricks:index/ClusterLibraryCran:ClusterLibraryCran": {
             "properties": {
@@ -711,12 +679,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "cran",
-                "maven",
-                "pypi"
-            ]
+            "type": "object"
         },
         "databricks:index/ClusterPolicyLibraryCran:ClusterPolicyLibraryCran": {
             "properties": {
@@ -838,10 +801,7 @@
                     "$ref": "#/types/databricks:index/ExternalLocationEncryptionDetailsSseEncryptionDetails:ExternalLocationEncryptionDetailsSseEncryptionDetails"
                 }
             },
-            "type": "object",
-            "required": [
-                "sseEncryptionDetails"
-            ]
+            "type": "object"
         },
         "databricks:index/ExternalLocationEncryptionDetailsSseEncryptionDetails:ExternalLocationEncryptionDetailsSseEncryptionDetails": {
             "properties": {
@@ -919,10 +879,7 @@
                     "$ref": "#/types/databricks:index/InstancePoolDiskSpecDiskType:InstancePoolDiskSpecDiskType"
                 }
             },
-            "type": "object",
-            "required": [
-                "diskType"
-            ]
+            "type": "object"
         },
         "databricks:index/InstancePoolDiskSpecDiskType:InstancePoolDiskSpecDiskType": {
             "properties": {
@@ -974,8 +931,6 @@
             },
             "type": "object",
             "required": [
-                "fleetOnDemandOption",
-                "fleetSpotOption",
                 "launchTemplateOverrides"
             ]
         },
@@ -1033,7 +988,6 @@
             },
             "type": "object",
             "required": [
-                "basicAuth",
                 "url"
             ]
         },
@@ -1156,8 +1110,7 @@
             },
             "type": "object",
             "required": [
-                "environmentKey",
-                "spec"
+                "environmentKey"
             ]
         },
         "databricks:index/JobEnvironmentSpec:JobEnvironmentSpec": {
@@ -1203,8 +1156,6 @@
             },
             "type": "object",
             "required": [
-                "gitSnapshot",
-                "jobSource",
                 "url"
             ]
         },
@@ -1398,37 +1349,17 @@
             },
             "type": "object",
             "required": [
-                "autoscale",
-                "awsAttributes",
-                "azureAttributes",
-                "clusterLogConf",
-                "clusterMountInfos",
-                "dockerImage",
-                "gcpAttributes",
-                "initScripts",
-                "libraries",
-                "sparkVersion",
-                "workloadType"
+                "sparkVersion"
             ],
             "language": {
                 "nodejs": {
                     "requiredOutputs": [
-                        "autoscale",
-                        "awsAttributes",
-                        "azureAttributes",
-                        "clusterLogConf",
-                        "clusterMountInfos",
-                        "dockerImage",
                         "driverInstancePoolId",
                         "driverNodeTypeId",
                         "enableElasticDisk",
                         "enableLocalDiskEncryption",
-                        "gcpAttributes",
-                        "initScripts",
-                        "libraries",
                         "nodeTypeId",
-                        "sparkVersion",
-                        "workloadType"
+                        "sparkVersion"
                     ]
                 }
             }
@@ -1494,10 +1425,7 @@
                     "type": "number"
                 }
             },
-            "type": "object",
-            "required": [
-                "logAnalyticsInfo"
-            ]
+            "type": "object"
         },
         "databricks:index/JobJobClusterNewClusterAzureAttributesLogAnalyticsInfo:JobJobClusterNewClusterAzureAttributesLogAnalyticsInfo": {
             "properties": {
@@ -1519,11 +1447,7 @@
                     "$ref": "#/types/databricks:index/JobJobClusterNewClusterClusterLogConfS3:JobJobClusterNewClusterClusterLogConfS3"
                 }
             },
-            "type": "object",
-            "required": [
-                "dbfs",
-                "s3"
-            ]
+            "type": "object"
         },
         "databricks:index/JobJobClusterNewClusterClusterLogConfDbfs:JobJobClusterNewClusterClusterLogConfDbfs": {
             "properties": {
@@ -1608,7 +1532,6 @@
             },
             "type": "object",
             "required": [
-                "basicAuth",
                 "url"
             ]
         },
@@ -1676,16 +1599,7 @@
                     "$ref": "#/types/databricks:index/JobJobClusterNewClusterInitScriptWorkspace:JobJobClusterNewClusterInitScriptWorkspace"
                 }
             },
-            "type": "object",
-            "required": [
-                "abfss",
-                "dbfs",
-                "file",
-                "gcs",
-                "s3",
-                "volumes",
-                "workspace"
-            ]
+            "type": "object"
         },
         "databricks:index/JobJobClusterNewClusterInitScriptAbfss:JobJobClusterNewClusterInitScriptAbfss": {
             "properties": {
@@ -1806,12 +1720,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "cran",
-                "maven",
-                "pypi"
-            ]
+            "type": "object"
         },
         "databricks:index/JobJobClusterNewClusterLibraryCran:JobJobClusterNewClusterLibraryCran": {
             "properties": {
@@ -1907,12 +1816,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "cran",
-                "maven",
-                "pypi"
-            ]
+            "type": "object"
         },
         "databricks:index/JobLibraryCran:JobLibraryCran": {
             "properties": {
@@ -2078,37 +1982,17 @@
             },
             "type": "object",
             "required": [
-                "autoscale",
-                "awsAttributes",
-                "azureAttributes",
-                "clusterLogConf",
-                "clusterMountInfos",
-                "dockerImage",
-                "gcpAttributes",
-                "initScripts",
-                "libraries",
-                "sparkVersion",
-                "workloadType"
+                "sparkVersion"
             ],
             "language": {
                 "nodejs": {
                     "requiredOutputs": [
-                        "autoscale",
-                        "awsAttributes",
-                        "azureAttributes",
-                        "clusterLogConf",
-                        "clusterMountInfos",
-                        "dockerImage",
                         "driverInstancePoolId",
                         "driverNodeTypeId",
                         "enableElasticDisk",
                         "enableLocalDiskEncryption",
-                        "gcpAttributes",
-                        "initScripts",
-                        "libraries",
                         "nodeTypeId",
-                        "sparkVersion",
-                        "workloadType"
+                        "sparkVersion"
                     ]
                 }
             }
@@ -2174,10 +2058,7 @@
                     "type": "number"
                 }
             },
-            "type": "object",
-            "required": [
-                "logAnalyticsInfo"
-            ]
+            "type": "object"
         },
         "databricks:index/JobNewClusterAzureAttributesLogAnalyticsInfo:JobNewClusterAzureAttributesLogAnalyticsInfo": {
             "properties": {
@@ -2199,11 +2080,7 @@
                     "$ref": "#/types/databricks:index/JobNewClusterClusterLogConfS3:JobNewClusterClusterLogConfS3"
                 }
             },
-            "type": "object",
-            "required": [
-                "dbfs",
-                "s3"
-            ]
+            "type": "object"
         },
         "databricks:index/JobNewClusterClusterLogConfDbfs:JobNewClusterClusterLogConfDbfs": {
             "properties": {
@@ -2288,7 +2165,6 @@
             },
             "type": "object",
             "required": [
-                "basicAuth",
                 "url"
             ]
         },
@@ -2356,16 +2232,7 @@
                     "$ref": "#/types/databricks:index/JobNewClusterInitScriptWorkspace:JobNewClusterInitScriptWorkspace"
                 }
             },
-            "type": "object",
-            "required": [
-                "abfss",
-                "dbfs",
-                "file",
-                "gcs",
-                "s3",
-                "volumes",
-                "workspace"
-            ]
+            "type": "object"
         },
         "databricks:index/JobNewClusterInitScriptAbfss:JobNewClusterInitScriptAbfss": {
             "properties": {
@@ -2486,12 +2353,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "cran",
-                "maven",
-                "pypi"
-            ]
+            "type": "object"
         },
         "databricks:index/JobNewClusterLibraryCran:JobNewClusterLibraryCran": {
             "properties": {
@@ -2852,49 +2714,13 @@
             },
             "type": "object",
             "required": [
-                "conditionTask",
-                "dbtTask",
-                "dependsOns",
-                "emailNotifications",
-                "forEachTask",
-                "health",
-                "libraries",
-                "newCluster",
-                "notebookTask",
-                "notificationSettings",
-                "pipelineTask",
-                "pythonWheelTask",
-                "runJobTask",
-                "sparkJarTask",
-                "sparkPythonTask",
-                "sparkSubmitTask",
-                "sqlTask",
-                "taskKey",
-                "webhookNotifications"
+                "taskKey"
             ],
             "language": {
                 "nodejs": {
                     "requiredOutputs": [
-                        "conditionTask",
-                        "dbtTask",
-                        "dependsOns",
-                        "emailNotifications",
-                        "forEachTask",
-                        "health",
-                        "libraries",
-                        "newCluster",
-                        "notebookTask",
-                        "notificationSettings",
-                        "pipelineTask",
-                        "pythonWheelTask",
                         "retryOnTimeout",
-                        "runJobTask",
-                        "sparkJarTask",
-                        "sparkPythonTask",
-                        "sparkSubmitTask",
-                        "sqlTask",
-                        "taskKey",
-                        "webhookNotifications"
+                        "taskKey"
                     ]
                 }
             }
@@ -3115,47 +2941,13 @@
             },
             "type": "object",
             "required": [
-                "conditionTask",
-                "dbtTask",
-                "dependsOns",
-                "emailNotifications",
-                "health",
-                "libraries",
-                "newCluster",
-                "notebookTask",
-                "notificationSettings",
-                "pipelineTask",
-                "pythonWheelTask",
-                "runJobTask",
-                "sparkJarTask",
-                "sparkPythonTask",
-                "sparkSubmitTask",
-                "sqlTask",
-                "taskKey",
-                "webhookNotifications"
+                "taskKey"
             ],
             "language": {
                 "nodejs": {
                     "requiredOutputs": [
-                        "conditionTask",
-                        "dbtTask",
-                        "dependsOns",
-                        "emailNotifications",
-                        "health",
-                        "libraries",
-                        "newCluster",
-                        "notebookTask",
-                        "notificationSettings",
-                        "pipelineTask",
-                        "pythonWheelTask",
                         "retryOnTimeout",
-                        "runJobTask",
-                        "sparkJarTask",
-                        "sparkPythonTask",
-                        "sparkSubmitTask",
-                        "sqlTask",
-                        "taskKey",
-                        "webhookNotifications"
+                        "taskKey"
                     ]
                 }
             }
@@ -3320,12 +3112,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "cran",
-                "maven",
-                "pypi"
-            ]
+            "type": "object"
         },
         "databricks:index/JobTaskForEachTaskTaskLibraryCran:JobTaskForEachTaskTaskLibraryCran": {
             "properties": {
@@ -3491,37 +3278,17 @@
             },
             "type": "object",
             "required": [
-                "autoscale",
-                "awsAttributes",
-                "azureAttributes",
-                "clusterLogConf",
-                "clusterMountInfos",
-                "dockerImage",
-                "gcpAttributes",
-                "initScripts",
-                "libraries",
-                "sparkVersion",
-                "workloadType"
+                "sparkVersion"
             ],
             "language": {
                 "nodejs": {
                     "requiredOutputs": [
-                        "autoscale",
-                        "awsAttributes",
-                        "azureAttributes",
-                        "clusterLogConf",
-                        "clusterMountInfos",
-                        "dockerImage",
                         "driverInstancePoolId",
                         "driverNodeTypeId",
                         "enableElasticDisk",
                         "enableLocalDiskEncryption",
-                        "gcpAttributes",
-                        "initScripts",
-                        "libraries",
                         "nodeTypeId",
-                        "sparkVersion",
-                        "workloadType"
+                        "sparkVersion"
                     ]
                 }
             }
@@ -3587,10 +3354,7 @@
                     "type": "number"
                 }
             },
-            "type": "object",
-            "required": [
-                "logAnalyticsInfo"
-            ]
+            "type": "object"
         },
         "databricks:index/JobTaskForEachTaskTaskNewClusterAzureAttributesLogAnalyticsInfo:JobTaskForEachTaskTaskNewClusterAzureAttributesLogAnalyticsInfo": {
             "properties": {
@@ -3612,11 +3376,7 @@
                     "$ref": "#/types/databricks:index/JobTaskForEachTaskTaskNewClusterClusterLogConfS3:JobTaskForEachTaskTaskNewClusterClusterLogConfS3"
                 }
             },
-            "type": "object",
-            "required": [
-                "dbfs",
-                "s3"
-            ]
+            "type": "object"
         },
         "databricks:index/JobTaskForEachTaskTaskNewClusterClusterLogConfDbfs:JobTaskForEachTaskTaskNewClusterClusterLogConfDbfs": {
             "properties": {
@@ -3701,7 +3461,6 @@
             },
             "type": "object",
             "required": [
-                "basicAuth",
                 "url"
             ]
         },
@@ -3769,16 +3528,7 @@
                     "$ref": "#/types/databricks:index/JobTaskForEachTaskTaskNewClusterInitScriptWorkspace:JobTaskForEachTaskTaskNewClusterInitScriptWorkspace"
                 }
             },
-            "type": "object",
-            "required": [
-                "abfss",
-                "dbfs",
-                "file",
-                "gcs",
-                "s3",
-                "volumes",
-                "workspace"
-            ]
+            "type": "object"
         },
         "databricks:index/JobTaskForEachTaskTaskNewClusterInitScriptAbfss:JobTaskForEachTaskTaskNewClusterInitScriptAbfss": {
             "properties": {
@@ -3899,12 +3649,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "cran",
-                "maven",
-                "pypi"
-            ]
+            "type": "object"
         },
         "databricks:index/JobTaskForEachTaskTaskNewClusterLibraryCran:JobTaskForEachTaskTaskNewClusterLibraryCran": {
             "properties": {
@@ -4109,8 +3854,7 @@
             },
             "type": "object",
             "required": [
-                "jobId",
-                "pipelineParams"
+                "jobId"
             ]
         },
         "databricks:index/JobTaskForEachTaskTaskRunJobTaskPipelineParams:JobTaskForEachTaskTaskRunJobTaskPipelineParams": {
@@ -4195,10 +3939,6 @@
             },
             "type": "object",
             "required": [
-                "alert",
-                "dashboard",
-                "file",
-                "query",
                 "warehouseId"
             ]
         },
@@ -4254,8 +3994,7 @@
             },
             "type": "object",
             "required": [
-                "dashboardId",
-                "subscriptions"
+                "dashboardId"
             ]
         },
         "databricks:index/JobTaskForEachTaskTaskSqlTaskDashboardSubscription:JobTaskForEachTaskTaskSqlTaskDashboardSubscription": {
@@ -4327,14 +4066,7 @@
                     }
                 }
             },
-            "type": "object",
-            "required": [
-                "onDurationWarningThresholdExceededs",
-                "onFailures",
-                "onStarts",
-                "onStreamingBacklogExceededs",
-                "onSuccesses"
-            ]
+            "type": "object"
         },
         "databricks:index/JobTaskForEachTaskTaskWebhookNotificationsOnDurationWarningThresholdExceeded:JobTaskForEachTaskTaskWebhookNotificationsOnDurationWarningThresholdExceeded": {
             "properties": {
@@ -4448,12 +4180,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "cran",
-                "maven",
-                "pypi"
-            ]
+            "type": "object"
         },
         "databricks:index/JobTaskLibraryCran:JobTaskLibraryCran": {
             "properties": {
@@ -4619,37 +4346,17 @@
             },
             "type": "object",
             "required": [
-                "autoscale",
-                "awsAttributes",
-                "azureAttributes",
-                "clusterLogConf",
-                "clusterMountInfos",
-                "dockerImage",
-                "gcpAttributes",
-                "initScripts",
-                "libraries",
-                "sparkVersion",
-                "workloadType"
+                "sparkVersion"
             ],
             "language": {
                 "nodejs": {
                     "requiredOutputs": [
-                        "autoscale",
-                        "awsAttributes",
-                        "azureAttributes",
-                        "clusterLogConf",
-                        "clusterMountInfos",
-                        "dockerImage",
                         "driverInstancePoolId",
                         "driverNodeTypeId",
                         "enableElasticDisk",
                         "enableLocalDiskEncryption",
-                        "gcpAttributes",
-                        "initScripts",
-                        "libraries",
                         "nodeTypeId",
-                        "sparkVersion",
-                        "workloadType"
+                        "sparkVersion"
                     ]
                 }
             }
@@ -4715,10 +4422,7 @@
                     "type": "number"
                 }
             },
-            "type": "object",
-            "required": [
-                "logAnalyticsInfo"
-            ]
+            "type": "object"
         },
         "databricks:index/JobTaskNewClusterAzureAttributesLogAnalyticsInfo:JobTaskNewClusterAzureAttributesLogAnalyticsInfo": {
             "properties": {
@@ -4740,11 +4444,7 @@
                     "$ref": "#/types/databricks:index/JobTaskNewClusterClusterLogConfS3:JobTaskNewClusterClusterLogConfS3"
                 }
             },
-            "type": "object",
-            "required": [
-                "dbfs",
-                "s3"
-            ]
+            "type": "object"
         },
         "databricks:index/JobTaskNewClusterClusterLogConfDbfs:JobTaskNewClusterClusterLogConfDbfs": {
             "properties": {
@@ -4829,7 +4529,6 @@
             },
             "type": "object",
             "required": [
-                "basicAuth",
                 "url"
             ]
         },
@@ -4897,16 +4596,7 @@
                     "$ref": "#/types/databricks:index/JobTaskNewClusterInitScriptWorkspace:JobTaskNewClusterInitScriptWorkspace"
                 }
             },
-            "type": "object",
-            "required": [
-                "abfss",
-                "dbfs",
-                "file",
-                "gcs",
-                "s3",
-                "volumes",
-                "workspace"
-            ]
+            "type": "object"
         },
         "databricks:index/JobTaskNewClusterInitScriptAbfss:JobTaskNewClusterInitScriptAbfss": {
             "properties": {
@@ -5027,12 +4717,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "cran",
-                "maven",
-                "pypi"
-            ]
+            "type": "object"
         },
         "databricks:index/JobTaskNewClusterLibraryCran:JobTaskNewClusterLibraryCran": {
             "properties": {
@@ -5237,8 +4922,7 @@
             },
             "type": "object",
             "required": [
-                "jobId",
-                "pipelineParams"
+                "jobId"
             ]
         },
         "databricks:index/JobTaskRunJobTaskPipelineParams:JobTaskRunJobTaskPipelineParams": {
@@ -5323,10 +5007,6 @@
             },
             "type": "object",
             "required": [
-                "alert",
-                "dashboard",
-                "file",
-                "query",
                 "warehouseId"
             ]
         },
@@ -5382,8 +5062,7 @@
             },
             "type": "object",
             "required": [
-                "dashboardId",
-                "subscriptions"
+                "dashboardId"
             ]
         },
         "databricks:index/JobTaskSqlTaskDashboardSubscription:JobTaskSqlTaskDashboardSubscription": {
@@ -5455,14 +5134,7 @@
                     }
                 }
             },
-            "type": "object",
-            "required": [
-                "onDurationWarningThresholdExceededs",
-                "onFailures",
-                "onStarts",
-                "onStreamingBacklogExceededs",
-                "onSuccesses"
-            ]
+            "type": "object"
         },
         "databricks:index/JobTaskWebhookNotificationsOnDurationWarningThresholdExceeded:JobTaskWebhookNotificationsOnDurationWarningThresholdExceeded": {
             "properties": {
@@ -5548,13 +5220,7 @@
                     "$ref": "#/types/databricks:index/JobTriggerTableUpdate:JobTriggerTableUpdate"
                 }
             },
-            "type": "object",
-            "required": [
-                "fileArrival",
-                "periodic",
-                "table",
-                "tableUpdate"
-            ]
+            "type": "object"
         },
         "databricks:index/JobTriggerFileArrival:JobTriggerFileArrival": {
             "properties": {
@@ -5664,14 +5330,7 @@
                     }
                 }
             },
-            "type": "object",
-            "required": [
-                "onDurationWarningThresholdExceededs",
-                "onFailures",
-                "onStarts",
-                "onStreamingBacklogExceededs",
-                "onSuccesses"
-            ]
+            "type": "object"
         },
         "databricks:index/JobWebhookNotificationsOnDurationWarningThresholdExceeded:JobWebhookNotificationsOnDurationWarningThresholdExceeded": {
             "properties": {
@@ -5811,11 +5470,7 @@
                     "$ref": "#/types/databricks:index/LakehouseMonitorNotificationsOnNewClassificationTagDetected:LakehouseMonitorNotificationsOnNewClassificationTagDetected"
                 }
             },
-            "type": "object",
-            "required": [
-                "onFailure",
-                "onNewClassificationTagDetected"
-            ]
+            "type": "object"
         },
         "databricks:index/LakehouseMonitorNotificationsOnFailure:LakehouseMonitorNotificationsOnFailure": {
             "properties": {
@@ -6149,13 +5804,7 @@
                     "$ref": "#/types/databricks:index/ModelServingConfigTrafficConfig:ModelServingConfigTrafficConfig"
                 }
             },
-            "type": "object",
-            "required": [
-                "autoCaptureConfig",
-                "servedEntities",
-                "servedModels",
-                "trafficConfig"
-            ]
+            "type": "object"
         },
         "databricks:index/ModelServingConfigAutoCaptureConfig:ModelServingConfigAutoCaptureConfig": {
             "properties": {
@@ -6222,13 +5871,9 @@
                 }
             },
             "type": "object",
-            "required": [
-                "externalModel"
-            ],
             "language": {
                 "nodejs": {
                     "requiredOutputs": [
-                        "externalModel",
                         "name",
                         "workloadSize",
                         "workloadType"
@@ -6274,15 +5919,7 @@
             },
             "type": "object",
             "required": [
-                "ai21labsConfig",
-                "amazonBedrockConfig",
-                "anthropicConfig",
-                "cohereConfig",
-                "databricksModelServingConfig",
-                "googleCloudVertexAiConfig",
                 "name",
-                "openaiConfig",
-                "palmConfig",
                 "provider",
                 "task"
             ]
@@ -6490,10 +6127,7 @@
                     }
                 }
             },
-            "type": "object",
-            "required": [
-                "routes"
-            ]
+            "type": "object"
         },
         "databricks:index/ModelServingConfigTrafficConfigRoute:ModelServingConfigTrafficConfigRoute": {
             "properties": {
@@ -6763,11 +6397,7 @@
                     "$ref": "#/types/databricks:index/MwsNetworkConnectivityConfigEgressConfigTargetRules:MwsNetworkConnectivityConfigEgressConfigTargetRules"
                 }
             },
-            "type": "object",
-            "required": [
-                "defaultRules",
-                "targetRules"
-            ]
+            "type": "object"
         },
         "databricks:index/MwsNetworkConnectivityConfigEgressConfigDefaultRules:MwsNetworkConnectivityConfigEgressConfigDefaultRules": {
             "properties": {
@@ -6778,11 +6408,7 @@
                     "$ref": "#/types/databricks:index/MwsNetworkConnectivityConfigEgressConfigDefaultRulesAzureServiceEndpointRule:MwsNetworkConnectivityConfigEgressConfigDefaultRulesAzureServiceEndpointRule"
                 }
             },
-            "type": "object",
-            "required": [
-                "awsStableIpRule",
-                "azureServiceEndpointRule"
-            ]
+            "type": "object"
         },
         "databricks:index/MwsNetworkConnectivityConfigEgressConfigDefaultRulesAwsStableIpRule:MwsNetworkConnectivityConfigEgressConfigDefaultRulesAwsStableIpRule": {
             "properties": {
@@ -6824,10 +6450,7 @@
                     }
                 }
             },
-            "type": "object",
-            "required": [
-                "azurePrivateEndpointRules"
-            ]
+            "type": "object"
         },
         "databricks:index/MwsNetworkConnectivityConfigEgressConfigTargetRulesAzurePrivateEndpointRule:MwsNetworkConnectivityConfigEgressConfigTargetRulesAzurePrivateEndpointRule": {
             "properties": {
@@ -7096,14 +6719,7 @@
                     "$ref": "#/types/databricks:index/NotificationDestinationConfigSlack:NotificationDestinationConfigSlack"
                 }
             },
-            "type": "object",
-            "required": [
-                "email",
-                "genericWebhook",
-                "microsoftTeams",
-                "pagerduty",
-                "slack"
-            ]
+            "type": "object"
         },
         "databricks:index/NotificationDestinationConfigEmail:NotificationDestinationConfigEmail": {
             "properties": {
@@ -7236,16 +6852,10 @@
                 }
             },
             "type": "object",
-            "required": [
-                "runContinuously",
-                "runTriggered"
-            ],
             "language": {
                 "nodejs": {
                     "requiredOutputs": [
-                        "pipelineId",
-                        "runContinuously",
-                        "runTriggered"
+                        "pipelineId"
                     ]
                 }
             }
@@ -7557,25 +7167,11 @@
                 }
             },
             "type": "object",
-            "required": [
-                "autoscale",
-                "awsAttributes",
-                "azureAttributes",
-                "clusterLogConf",
-                "gcpAttributes",
-                "initScripts"
-            ],
             "language": {
                 "nodejs": {
                     "requiredOutputs": [
-                        "autoscale",
-                        "awsAttributes",
-                        "azureAttributes",
-                        "clusterLogConf",
                         "driverNodeTypeId",
                         "enableLocalDiskEncryption",
-                        "gcpAttributes",
-                        "initScripts",
                         "nodeTypeId"
                     ]
                 }
@@ -7649,10 +7245,7 @@
                     "type": "number"
                 }
             },
-            "type": "object",
-            "required": [
-                "logAnalyticsInfo"
-            ]
+            "type": "object"
         },
         "databricks:index/PipelineClusterAzureAttributesLogAnalyticsInfo:PipelineClusterAzureAttributesLogAnalyticsInfo": {
             "properties": {
@@ -7674,11 +7267,7 @@
                     "$ref": "#/types/databricks:index/PipelineClusterClusterLogConfS3:PipelineClusterClusterLogConfS3"
                 }
             },
-            "type": "object",
-            "required": [
-                "dbfs",
-                "s3"
-            ]
+            "type": "object"
         },
         "databricks:index/PipelineClusterClusterLogConfDbfs:PipelineClusterClusterLogConfDbfs": {
             "properties": {
@@ -7762,16 +7351,7 @@
                     "$ref": "#/types/databricks:index/PipelineClusterInitScriptWorkspace:PipelineClusterInitScriptWorkspace"
                 }
             },
-            "type": "object",
-            "required": [
-                "abfss",
-                "dbfs",
-                "file",
-                "gcs",
-                "s3",
-                "volumes",
-                "workspace"
-            ]
+            "type": "object"
         },
         "databricks:index/PipelineClusterInitScriptAbfss:PipelineClusterInitScriptAbfss": {
             "properties": {
@@ -7931,11 +7511,7 @@
                     "$ref": "#/types/databricks:index/PipelineIngestionDefinitionTableConfiguration:PipelineIngestionDefinitionTableConfiguration"
                 }
             },
-            "type": "object",
-            "required": [
-                "objects",
-                "tableConfiguration"
-            ]
+            "type": "object"
         },
         "databricks:index/PipelineIngestionDefinitionObject:PipelineIngestionDefinitionObject": {
             "properties": {
@@ -7946,11 +7522,7 @@
                     "$ref": "#/types/databricks:index/PipelineIngestionDefinitionObjectTable:PipelineIngestionDefinitionObjectTable"
                 }
             },
-            "type": "object",
-            "required": [
-                "schema",
-                "table"
-            ]
+            "type": "object"
         },
         "databricks:index/PipelineIngestionDefinitionObjectSchema:PipelineIngestionDefinitionObjectSchema": {
             "properties": {
@@ -7970,10 +7542,7 @@
                     "$ref": "#/types/databricks:index/PipelineIngestionDefinitionObjectSchemaTableConfiguration:PipelineIngestionDefinitionObjectSchemaTableConfiguration"
                 }
             },
-            "type": "object",
-            "required": [
-                "tableConfiguration"
-            ]
+            "type": "object"
         },
         "databricks:index/PipelineIngestionDefinitionObjectSchemaTableConfiguration:PipelineIngestionDefinitionObjectSchemaTableConfiguration": {
             "properties": {
@@ -8016,10 +7585,7 @@
                     "$ref": "#/types/databricks:index/PipelineIngestionDefinitionObjectTableTableConfiguration:PipelineIngestionDefinitionObjectTableTableConfiguration"
                 }
             },
-            "type": "object",
-            "required": [
-                "tableConfiguration"
-            ]
+            "type": "object"
         },
         "databricks:index/PipelineIngestionDefinitionObjectTableTableConfiguration:PipelineIngestionDefinitionObjectTableTableConfiguration": {
             "properties": {
@@ -8088,12 +7654,7 @@
                     "deprecationMessage": "Deprecated"
                 }
             },
-            "type": "object",
-            "required": [
-                "file",
-                "maven",
-                "notebook"
-            ]
+            "type": "object"
         },
         "databricks:index/PipelineLibraryFile:PipelineLibraryFile": {
             "properties": {
@@ -8165,11 +7726,7 @@
                     "$ref": "#/types/databricks:index/PipelineTriggerManual:PipelineTriggerManual"
                 }
             },
-            "type": "object",
-            "required": [
-                "cron",
-                "manual"
-            ]
+            "type": "object"
         },
         "databricks:index/PipelineTriggerCron:PipelineTriggerCron": {
             "properties": {
@@ -8268,11 +7825,7 @@
                     "$ref": "#/types/databricks:index/QualityMonitorNotificationsOnNewClassificationTagDetected:QualityMonitorNotificationsOnNewClassificationTagDetected"
                 }
             },
-            "type": "object",
-            "required": [
-                "onFailure",
-                "onNewClassificationTagDetected"
-            ]
+            "type": "object"
         },
         "databricks:index/QualityMonitorNotificationsOnFailure:QualityMonitorNotificationsOnFailure": {
             "properties": {
@@ -8498,8 +8051,7 @@
             "type": "object",
             "required": [
                 "dataObjectType",
-                "name",
-                "partitions"
+                "name"
             ],
             "language": {
                 "nodejs": {
@@ -8508,7 +8060,6 @@
                         "addedBy",
                         "dataObjectType",
                         "name",
-                        "partitions",
                         "status"
                     ]
                 }
@@ -8675,10 +8226,7 @@
                     }
                 }
             },
-            "type": "object",
-            "required": [
-                "customTags"
-            ]
+            "type": "object"
         },
         "databricks:index/SqlEndpointTagsCustomTag:SqlEndpointTagsCustomTag": {
             "properties": {
@@ -8762,17 +8310,7 @@
             },
             "type": "object",
             "required": [
-                "date",
-                "dateRange",
-                "datetime",
-                "datetimeRange",
-                "datetimesec",
-                "datetimesecRange",
-                "enum",
-                "name",
-                "number",
-                "query",
-                "text"
+                "name"
             ]
         },
         "databricks:index/SqlQueryParameterDate:SqlQueryParameterDate": {
@@ -8795,10 +8333,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "range"
-            ]
+            "type": "object"
         },
         "databricks:index/SqlQueryParameterDateRangeRange:SqlQueryParameterDateRangeRange": {
             "properties": {
@@ -8835,10 +8370,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "range"
-            ]
+            "type": "object"
         },
         "databricks:index/SqlQueryParameterDatetimeRangeRange:SqlQueryParameterDatetimeRangeRange": {
             "properties": {
@@ -8875,10 +8407,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "range"
-            ]
+            "type": "object"
         },
         "databricks:index/SqlQueryParameterDatetimesecRangeRange:SqlQueryParameterDatetimesecRangeRange": {
             "properties": {
@@ -8918,7 +8447,6 @@
             },
             "type": "object",
             "required": [
-                "multiple",
                 "options"
             ]
         },
@@ -8970,7 +8498,6 @@
             },
             "type": "object",
             "required": [
-                "multiple",
                 "queryId"
             ]
         },
@@ -9014,12 +8541,7 @@
                     "$ref": "#/types/databricks:index/SqlQueryScheduleWeekly:SqlQueryScheduleWeekly"
                 }
             },
-            "type": "object",
-            "required": [
-                "continuous",
-                "daily",
-                "weekly"
-            ]
+            "type": "object"
         },
         "databricks:index/SqlQueryScheduleContinuous:SqlQueryScheduleContinuous": {
             "properties": {
@@ -9382,15 +8904,9 @@
                 }
             },
             "type": "object",
-            "required": [
-                "embeddingSourceColumns",
-                "embeddingVectorColumns"
-            ],
             "language": {
                 "nodejs": {
                     "requiredOutputs": [
-                        "embeddingSourceColumns",
-                        "embeddingVectorColumns",
                         "pipelineId"
                     ]
                 }
@@ -9436,11 +8952,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "embeddingSourceColumns",
-                "embeddingVectorColumns"
-            ]
+            "type": "object"
         },
         "databricks:index/VectorSearchIndexDirectAccessIndexSpecEmbeddingSourceColumn:VectorSearchIndexDirectAccessIndexSpecEmbeddingSourceColumn": {
             "properties": {
@@ -9576,16 +9088,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "effectivePredictiveOptimizationFlag",
-                "provisioningInfo"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getCatalogCatalogInfoEffectivePredictiveOptimizationFlag:getCatalogCatalogInfoEffectivePredictiveOptimizationFlag": {
             "properties": {
@@ -9602,12 +9105,7 @@
             "type": "object",
             "required": [
                 "value"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getCatalogCatalogInfoProvisioningInfo:getCatalogCatalogInfoProvisioningInfo": {
             "properties": {
@@ -9776,27 +9274,7 @@
                     "$ref": "#/types/databricks:index/getClusterClusterInfoWorkloadType:getClusterClusterInfoWorkloadType"
                 }
             },
-            "type": "object",
-            "required": [
-                "autoscale",
-                "awsAttributes",
-                "azureAttributes",
-                "clusterLogConf",
-                "clusterLogStatus",
-                "dockerImage",
-                "driver",
-                "executors",
-                "gcpAttributes",
-                "initScripts",
-                "spec",
-                "terminationReason",
-                "workloadType"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getClusterClusterInfoAutoscale:getClusterClusterInfoAutoscale": {
             "properties": {
@@ -9859,15 +9337,7 @@
                     "type": "number"
                 }
             },
-            "type": "object",
-            "required": [
-                "logAnalyticsInfo"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getClusterClusterInfoAzureAttributesLogAnalyticsInfo:getClusterClusterInfoAzureAttributesLogAnalyticsInfo": {
             "properties": {
@@ -9889,16 +9359,7 @@
                     "$ref": "#/types/databricks:index/getClusterClusterInfoClusterLogConfS3:getClusterClusterInfoClusterLogConfS3"
                 }
             },
-            "type": "object",
-            "required": [
-                "dbfs",
-                "s3"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getClusterClusterInfoClusterLogConfDbfs:getClusterClusterInfoClusterLogConfDbfs": {
             "properties": {
@@ -9909,12 +9370,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getClusterClusterInfoClusterLogConfS3:getClusterClusterInfoClusterLogConfS3": {
             "properties": {
@@ -9943,12 +9399,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getClusterClusterInfoClusterLogStatus:getClusterClusterInfoClusterLogStatus": {
             "properties": {
@@ -9970,15 +9421,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "basicAuth"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getClusterClusterInfoDockerImageBasicAuth:getClusterClusterInfoDockerImageBasicAuth": {
             "properties": {
@@ -10015,15 +9458,7 @@
                     "type": "number"
                 }
             },
-            "type": "object",
-            "required": [
-                "nodeAwsAttributes"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getClusterClusterInfoDriverNodeAwsAttributes:getClusterClusterInfoDriverNodeAwsAttributes": {
             "properties": {
@@ -10057,15 +9492,7 @@
                     "type": "number"
                 }
             },
-            "type": "object",
-            "required": [
-                "nodeAwsAttributes"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getClusterClusterInfoExecutorNodeAwsAttributes:getClusterClusterInfoExecutorNodeAwsAttributes": {
             "properties": {
@@ -10122,21 +9549,7 @@
                     "$ref": "#/types/databricks:index/getClusterClusterInfoInitScriptWorkspace:getClusterClusterInfoInitScriptWorkspace"
                 }
             },
-            "type": "object",
-            "required": [
-                "abfss",
-                "dbfs",
-                "file",
-                "gcs",
-                "s3",
-                "volumes",
-                "workspace"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getClusterClusterInfoInitScriptAbfss:getClusterClusterInfoInitScriptAbfss": {
             "properties": {
@@ -10147,12 +9560,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getClusterClusterInfoInitScriptDbfs:getClusterClusterInfoInitScriptDbfs": {
             "properties": {
@@ -10163,12 +9571,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getClusterClusterInfoInitScriptFile:getClusterClusterInfoInitScriptFile": {
             "properties": {
@@ -10179,12 +9582,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getClusterClusterInfoInitScriptGcs:getClusterClusterInfoInitScriptGcs": {
             "properties": {
@@ -10195,12 +9593,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getClusterClusterInfoInitScriptS3:getClusterClusterInfoInitScriptS3": {
             "properties": {
@@ -10229,12 +9622,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getClusterClusterInfoInitScriptVolumes:getClusterClusterInfoInitScriptVolumes": {
             "properties": {
@@ -10245,12 +9633,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getClusterClusterInfoInitScriptWorkspace:getClusterClusterInfoInitScriptWorkspace": {
             "properties": {
@@ -10261,12 +9644,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getClusterClusterInfoSpec:getClusterClusterInfoSpec": {
             "properties": {
@@ -10384,27 +9762,19 @@
             },
             "type": "object",
             "required": [
-                "autoscale",
-                "awsAttributes",
-                "azureAttributes",
                 "clusterId",
-                "clusterLogConf",
-                "clusterMountInfos",
-                "dockerImage",
                 "driverInstancePoolId",
                 "driverNodeTypeId",
                 "enableElasticDisk",
                 "enableLocalDiskEncryption",
-                "gcpAttributes",
-                "initScripts",
-                "libraries",
                 "nodeTypeId",
-                "sparkVersion",
-                "workloadType"
+                "sparkVersion"
             ],
             "language": {
                 "nodejs": {
-                    "requiredInputs": []
+                    "requiredInputs": [
+                        "sparkVersion"
+                    ]
                 }
             }
         },
@@ -10469,15 +9839,7 @@
                     "type": "number"
                 }
             },
-            "type": "object",
-            "required": [
-                "logAnalyticsInfo"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getClusterClusterInfoSpecAzureAttributesLogAnalyticsInfo:getClusterClusterInfoSpecAzureAttributesLogAnalyticsInfo": {
             "properties": {
@@ -10499,16 +9861,7 @@
                     "$ref": "#/types/databricks:index/getClusterClusterInfoSpecClusterLogConfS3:getClusterClusterInfoSpecClusterLogConfS3"
                 }
             },
-            "type": "object",
-            "required": [
-                "dbfs",
-                "s3"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getClusterClusterInfoSpecClusterLogConfDbfs:getClusterClusterInfoSpecClusterLogConfDbfs": {
             "properties": {
@@ -10519,12 +9872,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getClusterClusterInfoSpecClusterLogConfS3:getClusterClusterInfoSpecClusterLogConfS3": {
             "properties": {
@@ -10553,12 +9901,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getClusterClusterInfoSpecClusterMountInfo:getClusterClusterInfoSpecClusterMountInfo": {
             "properties": {
@@ -10576,12 +9919,7 @@
             "required": [
                 "localMountDirPath",
                 "networkFilesystemInfo"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getClusterClusterInfoSpecClusterMountInfoNetworkFilesystemInfo:getClusterClusterInfoSpecClusterMountInfoNetworkFilesystemInfo": {
             "properties": {
@@ -10595,12 +9933,7 @@
             "type": "object",
             "required": [
                 "serverAddress"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getClusterClusterInfoSpecDockerImage:getClusterClusterInfoSpecDockerImage": {
             "properties": {
@@ -10613,14 +9946,8 @@
             },
             "type": "object",
             "required": [
-                "basicAuth",
                 "url"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getClusterClusterInfoSpecDockerImageBasicAuth:getClusterClusterInfoSpecDockerImageBasicAuth": {
             "properties": {
@@ -10636,12 +9963,7 @@
             "required": [
                 "password",
                 "username"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getClusterClusterInfoSpecGcpAttributes:getClusterClusterInfoSpecGcpAttributes": {
             "properties": {
@@ -10691,21 +10013,7 @@
                     "$ref": "#/types/databricks:index/getClusterClusterInfoSpecInitScriptWorkspace:getClusterClusterInfoSpecInitScriptWorkspace"
                 }
             },
-            "type": "object",
-            "required": [
-                "abfss",
-                "dbfs",
-                "file",
-                "gcs",
-                "s3",
-                "volumes",
-                "workspace"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getClusterClusterInfoSpecInitScriptAbfss:getClusterClusterInfoSpecInitScriptAbfss": {
             "properties": {
@@ -10716,12 +10024,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getClusterClusterInfoSpecInitScriptDbfs:getClusterClusterInfoSpecInitScriptDbfs": {
             "properties": {
@@ -10732,12 +10035,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getClusterClusterInfoSpecInitScriptFile:getClusterClusterInfoSpecInitScriptFile": {
             "properties": {
@@ -10748,12 +10046,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getClusterClusterInfoSpecInitScriptGcs:getClusterClusterInfoSpecInitScriptGcs": {
             "properties": {
@@ -10764,12 +10057,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getClusterClusterInfoSpecInitScriptS3:getClusterClusterInfoSpecInitScriptS3": {
             "properties": {
@@ -10798,12 +10086,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getClusterClusterInfoSpecInitScriptVolumes:getClusterClusterInfoSpecInitScriptVolumes": {
             "properties": {
@@ -10814,12 +10097,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getClusterClusterInfoSpecInitScriptWorkspace:getClusterClusterInfoSpecInitScriptWorkspace": {
             "properties": {
@@ -10830,12 +10108,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getClusterClusterInfoSpecLibrary:getClusterClusterInfoSpecLibrary": {
             "properties": {
@@ -10861,17 +10134,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "cran",
-                "maven",
-                "pypi"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getClusterClusterInfoSpecLibraryCran:getClusterClusterInfoSpecLibraryCran": {
             "properties": {
@@ -10885,12 +10148,7 @@
             "type": "object",
             "required": [
                 "package"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getClusterClusterInfoSpecLibraryMaven:getClusterClusterInfoSpecLibraryMaven": {
             "properties": {
@@ -10910,12 +10168,7 @@
             "type": "object",
             "required": [
                 "coordinates"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getClusterClusterInfoSpecLibraryPypi:getClusterClusterInfoSpecLibraryPypi": {
             "properties": {
@@ -10929,12 +10182,7 @@
             "type": "object",
             "required": [
                 "package"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getClusterClusterInfoSpecWorkloadType:getClusterClusterInfoSpecWorkloadType": {
             "properties": {
@@ -10945,12 +10193,7 @@
             "type": "object",
             "required": [
                 "clients"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getClusterClusterInfoSpecWorkloadTypeClients:getClusterClusterInfoSpecWorkloadTypeClients": {
             "properties": {
@@ -10989,12 +10232,7 @@
             "type": "object",
             "required": [
                 "clients"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getClusterClusterInfoWorkloadTypeClients:getClusterClusterInfoWorkloadTypeClients": {
             "properties": {
@@ -11137,15 +10375,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "encryptionDetails"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getExternalLocationExternalLocationInfoEncryptionDetails:getExternalLocationExternalLocationInfoEncryptionDetails": {
             "properties": {
@@ -11153,15 +10383,7 @@
                     "$ref": "#/types/databricks:index/getExternalLocationExternalLocationInfoEncryptionDetailsSseEncryptionDetails:getExternalLocationExternalLocationInfoEncryptionDetailsSseEncryptionDetails"
                 }
             },
-            "type": "object",
-            "required": [
-                "sseEncryptionDetails"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getExternalLocationExternalLocationInfoEncryptionDetailsSseEncryptionDetails:getExternalLocationExternalLocationInfoEncryptionDetailsSseEncryptionDetails": {
             "properties": {
@@ -11248,21 +10470,17 @@
             },
             "type": "object",
             "required": [
-                "awsAttributes",
-                "azureAttributes",
                 "defaultTags",
-                "diskSpec",
-                "gcpAttributes",
                 "idleInstanceAutoterminationMinutes",
-                "instancePoolFleetAttributes",
                 "instancePoolId",
-                "instancePoolName",
-                "preloadedDockerImages",
-                "stats"
+                "instancePoolName"
             ],
             "language": {
                 "nodejs": {
-                    "requiredInputs": []
+                    "requiredInputs": [
+                        "idleInstanceAutoterminationMinutes",
+                        "instancePoolName"
+                    ]
                 }
             }
         },
@@ -11311,15 +10529,7 @@
                     "$ref": "#/types/databricks:index/getInstancePoolPoolInfoDiskSpecDiskType:getInstancePoolPoolInfoDiskSpecDiskType"
                 }
             },
-            "type": "object",
-            "required": [
-                "diskType"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getInstancePoolPoolInfoDiskSpecDiskType:getInstancePoolPoolInfoDiskSpecDiskType": {
             "properties": {
@@ -11372,15 +10582,8 @@
             },
             "type": "object",
             "required": [
-                "fleetOnDemandOption",
-                "fleetSpotOption",
                 "launchTemplateOverrides"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getInstancePoolPoolInfoInstancePoolFleetAttributeFleetOnDemandOption:getInstancePoolPoolInfoInstancePoolFleetAttributeFleetOnDemandOption": {
             "properties": {
@@ -11394,12 +10597,7 @@
             "type": "object",
             "required": [
                 "allocationStrategy"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getInstancePoolPoolInfoInstancePoolFleetAttributeFleetSpotOption:getInstancePoolPoolInfoInstancePoolFleetAttributeFleetSpotOption": {
             "properties": {
@@ -11413,12 +10611,7 @@
             "type": "object",
             "required": [
                 "allocationStrategy"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getInstancePoolPoolInfoInstancePoolFleetAttributeLaunchTemplateOverride:getInstancePoolPoolInfoInstancePoolFleetAttributeLaunchTemplateOverride": {
             "properties": {
@@ -11433,12 +10626,7 @@
             "required": [
                 "availabilityZone",
                 "instanceType"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getInstancePoolPoolInfoPreloadedDockerImage:getInstancePoolPoolInfoPreloadedDockerImage": {
             "properties": {
@@ -11451,14 +10639,8 @@
             },
             "type": "object",
             "required": [
-                "basicAuth",
                 "url"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getInstancePoolPoolInfoPreloadedDockerImageBasicAuth:getInstancePoolPoolInfoPreloadedDockerImageBasicAuth": {
             "properties": {
@@ -11474,12 +10656,7 @@
             "required": [
                 "password",
                 "username"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getInstancePoolPoolInfoStats:getInstancePoolPoolInfoStats": {
             "properties": {
@@ -11546,8 +10723,7 @@
             },
             "type": "object",
             "required": [
-                "runAsUserName",
-                "settings"
+                "runAsUserName"
             ],
             "language": {
                 "nodejs": {
@@ -11686,32 +10862,7 @@
             },
             "type": "object",
             "required": [
-                "continuous",
-                "dbtTask",
-                "deployment",
-                "emailNotifications",
-                "environments",
-                "format",
-                "gitSource",
-                "health",
-                "jobClusters",
-                "libraries",
-                "newCluster",
-                "notebookTask",
-                "notificationSettings",
-                "parameters",
-                "pipelineTask",
-                "pythonWheelTask",
-                "queue",
-                "runAs",
-                "runJobTask",
-                "schedule",
-                "sparkJarTask",
-                "sparkPythonTask",
-                "sparkSubmitTask",
-                "tasks",
-                "trigger",
-                "webhookNotifications"
+                "format"
             ],
             "language": {
                 "nodejs": {
@@ -11757,12 +10908,7 @@
             "type": "object",
             "required": [
                 "commands"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsDeployment:getJobJobSettingsSettingsDeployment": {
             "properties": {
@@ -11776,12 +10922,7 @@
             "type": "object",
             "required": [
                 "kind"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsEmailNotifications:getJobJobSettingsSettingsEmailNotifications": {
             "properties": {
@@ -11832,14 +10973,8 @@
             },
             "type": "object",
             "required": [
-                "environmentKey",
-                "spec"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+                "environmentKey"
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsEnvironmentSpec:getJobJobSettingsSettingsEnvironmentSpec": {
             "properties": {
@@ -11856,12 +10991,7 @@
             "type": "object",
             "required": [
                 "client"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsGitSource:getJobJobSettingsSettingsGitSource": {
             "properties": {
@@ -11886,14 +11016,8 @@
             },
             "type": "object",
             "required": [
-                "jobSource",
                 "url"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsGitSourceJobSource:getJobJobSettingsSettingsGitSourceJobSource": {
             "properties": {
@@ -11911,12 +11035,7 @@
             "required": [
                 "importFromGitBranch",
                 "jobConfigPath"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsHealth:getJobJobSettingsSettingsHealth": {
             "properties": {
@@ -11930,12 +11049,7 @@
             "type": "object",
             "required": [
                 "rules"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsHealthRule:getJobJobSettingsSettingsHealthRule": {
             "properties": {
@@ -11954,12 +11068,7 @@
                 "metric",
                 "op",
                 "value"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsJobCluster:getJobJobSettingsSettingsJobCluster": {
             "properties": {
@@ -11974,12 +11083,7 @@
             "required": [
                 "jobClusterKey",
                 "newCluster"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsJobClusterNewCluster:getJobJobSettingsSettingsJobClusterNewCluster": {
             "properties": {
@@ -12094,26 +11198,20 @@
             },
             "type": "object",
             "required": [
-                "autoscale",
-                "awsAttributes",
-                "azureAttributes",
-                "clusterLogConf",
-                "clusterMountInfos",
-                "dockerImage",
                 "driverInstancePoolId",
                 "driverNodeTypeId",
                 "enableElasticDisk",
                 "enableLocalDiskEncryption",
-                "gcpAttributes",
-                "initScripts",
                 "nodeTypeId",
                 "numWorkers",
-                "sparkVersion",
-                "workloadType"
+                "sparkVersion"
             ],
             "language": {
                 "nodejs": {
-                    "requiredInputs": []
+                    "requiredInputs": [
+                        "numWorkers",
+                        "sparkVersion"
+                    ]
                 }
             }
         },
@@ -12180,16 +11278,7 @@
                     "$ref": "#/types/databricks:index/getJobJobSettingsSettingsJobClusterNewClusterClusterLogConfS3:getJobJobSettingsSettingsJobClusterNewClusterClusterLogConfS3"
                 }
             },
-            "type": "object",
-            "required": [
-                "dbfs",
-                "s3"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getJobJobSettingsSettingsJobClusterNewClusterClusterLogConfDbfs:getJobJobSettingsSettingsJobClusterNewClusterClusterLogConfDbfs": {
             "properties": {
@@ -12200,12 +11289,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsJobClusterNewClusterClusterLogConfS3:getJobJobSettingsSettingsJobClusterNewClusterClusterLogConfS3": {
             "properties": {
@@ -12234,12 +11318,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsJobClusterNewClusterClusterMountInfo:getJobJobSettingsSettingsJobClusterNewClusterClusterMountInfo": {
             "properties": {
@@ -12257,12 +11336,7 @@
             "required": [
                 "localMountDirPath",
                 "networkFilesystemInfo"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsJobClusterNewClusterClusterMountInfoNetworkFilesystemInfo:getJobJobSettingsSettingsJobClusterNewClusterClusterMountInfoNetworkFilesystemInfo": {
             "properties": {
@@ -12276,12 +11350,7 @@
             "type": "object",
             "required": [
                 "serverAddress"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsJobClusterNewClusterDockerImage:getJobJobSettingsSettingsJobClusterNewClusterDockerImage": {
             "properties": {
@@ -12294,14 +11363,8 @@
             },
             "type": "object",
             "required": [
-                "basicAuth",
                 "url"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsJobClusterNewClusterDockerImageBasicAuth:getJobJobSettingsSettingsJobClusterNewClusterDockerImageBasicAuth": {
             "properties": {
@@ -12317,12 +11380,7 @@
             "required": [
                 "password",
                 "username"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsJobClusterNewClusterGcpAttributes:getJobJobSettingsSettingsJobClusterNewClusterGcpAttributes": {
             "properties": {
@@ -12371,21 +11429,7 @@
                     "$ref": "#/types/databricks:index/getJobJobSettingsSettingsJobClusterNewClusterInitScriptWorkspace:getJobJobSettingsSettingsJobClusterNewClusterInitScriptWorkspace"
                 }
             },
-            "type": "object",
-            "required": [
-                "abfss",
-                "dbfs",
-                "file",
-                "gcs",
-                "s3",
-                "volumes",
-                "workspace"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getJobJobSettingsSettingsJobClusterNewClusterInitScriptAbfss:getJobJobSettingsSettingsJobClusterNewClusterInitScriptAbfss": {
             "properties": {
@@ -12396,12 +11440,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsJobClusterNewClusterInitScriptDbfs:getJobJobSettingsSettingsJobClusterNewClusterInitScriptDbfs": {
             "properties": {
@@ -12412,12 +11451,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsJobClusterNewClusterInitScriptFile:getJobJobSettingsSettingsJobClusterNewClusterInitScriptFile": {
             "properties": {
@@ -12428,12 +11462,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsJobClusterNewClusterInitScriptGcs:getJobJobSettingsSettingsJobClusterNewClusterInitScriptGcs": {
             "properties": {
@@ -12444,12 +11473,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsJobClusterNewClusterInitScriptS3:getJobJobSettingsSettingsJobClusterNewClusterInitScriptS3": {
             "properties": {
@@ -12478,12 +11502,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsJobClusterNewClusterInitScriptVolumes:getJobJobSettingsSettingsJobClusterNewClusterInitScriptVolumes": {
             "properties": {
@@ -12494,12 +11513,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsJobClusterNewClusterInitScriptWorkspace:getJobJobSettingsSettingsJobClusterNewClusterInitScriptWorkspace": {
             "properties": {
@@ -12510,12 +11524,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsJobClusterNewClusterWorkloadType:getJobJobSettingsSettingsJobClusterNewClusterWorkloadType": {
             "properties": {
@@ -12526,12 +11535,7 @@
             "type": "object",
             "required": [
                 "clients"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsJobClusterNewClusterWorkloadTypeClients:getJobJobSettingsSettingsJobClusterNewClusterWorkloadTypeClients": {
             "properties": {
@@ -12568,17 +11572,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "cran",
-                "maven",
-                "pypi"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getJobJobSettingsSettingsLibraryCran:getJobJobSettingsSettingsLibraryCran": {
             "properties": {
@@ -12592,12 +11586,7 @@
             "type": "object",
             "required": [
                 "package"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsLibraryMaven:getJobJobSettingsSettingsLibraryMaven": {
             "properties": {
@@ -12617,12 +11606,7 @@
             "type": "object",
             "required": [
                 "coordinates"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsLibraryPypi:getJobJobSettingsSettingsLibraryPypi": {
             "properties": {
@@ -12636,12 +11620,7 @@
             "type": "object",
             "required": [
                 "package"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsNewCluster:getJobJobSettingsSettingsNewCluster": {
             "properties": {
@@ -12756,26 +11735,20 @@
             },
             "type": "object",
             "required": [
-                "autoscale",
-                "awsAttributes",
-                "azureAttributes",
-                "clusterLogConf",
-                "clusterMountInfos",
-                "dockerImage",
                 "driverInstancePoolId",
                 "driverNodeTypeId",
                 "enableElasticDisk",
                 "enableLocalDiskEncryption",
-                "gcpAttributes",
-                "initScripts",
                 "nodeTypeId",
                 "numWorkers",
-                "sparkVersion",
-                "workloadType"
+                "sparkVersion"
             ],
             "language": {
                 "nodejs": {
-                    "requiredInputs": []
+                    "requiredInputs": [
+                        "numWorkers",
+                        "sparkVersion"
+                    ]
                 }
             }
         },
@@ -12842,16 +11815,7 @@
                     "$ref": "#/types/databricks:index/getJobJobSettingsSettingsNewClusterClusterLogConfS3:getJobJobSettingsSettingsNewClusterClusterLogConfS3"
                 }
             },
-            "type": "object",
-            "required": [
-                "dbfs",
-                "s3"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getJobJobSettingsSettingsNewClusterClusterLogConfDbfs:getJobJobSettingsSettingsNewClusterClusterLogConfDbfs": {
             "properties": {
@@ -12862,12 +11826,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsNewClusterClusterLogConfS3:getJobJobSettingsSettingsNewClusterClusterLogConfS3": {
             "properties": {
@@ -12896,12 +11855,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsNewClusterClusterMountInfo:getJobJobSettingsSettingsNewClusterClusterMountInfo": {
             "properties": {
@@ -12919,12 +11873,7 @@
             "required": [
                 "localMountDirPath",
                 "networkFilesystemInfo"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsNewClusterClusterMountInfoNetworkFilesystemInfo:getJobJobSettingsSettingsNewClusterClusterMountInfoNetworkFilesystemInfo": {
             "properties": {
@@ -12938,12 +11887,7 @@
             "type": "object",
             "required": [
                 "serverAddress"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsNewClusterDockerImage:getJobJobSettingsSettingsNewClusterDockerImage": {
             "properties": {
@@ -12956,14 +11900,8 @@
             },
             "type": "object",
             "required": [
-                "basicAuth",
                 "url"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsNewClusterDockerImageBasicAuth:getJobJobSettingsSettingsNewClusterDockerImageBasicAuth": {
             "properties": {
@@ -12979,12 +11917,7 @@
             "required": [
                 "password",
                 "username"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsNewClusterGcpAttributes:getJobJobSettingsSettingsNewClusterGcpAttributes": {
             "properties": {
@@ -13033,21 +11966,7 @@
                     "$ref": "#/types/databricks:index/getJobJobSettingsSettingsNewClusterInitScriptWorkspace:getJobJobSettingsSettingsNewClusterInitScriptWorkspace"
                 }
             },
-            "type": "object",
-            "required": [
-                "abfss",
-                "dbfs",
-                "file",
-                "gcs",
-                "s3",
-                "volumes",
-                "workspace"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getJobJobSettingsSettingsNewClusterInitScriptAbfss:getJobJobSettingsSettingsNewClusterInitScriptAbfss": {
             "properties": {
@@ -13058,12 +11977,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsNewClusterInitScriptDbfs:getJobJobSettingsSettingsNewClusterInitScriptDbfs": {
             "properties": {
@@ -13074,12 +11988,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsNewClusterInitScriptFile:getJobJobSettingsSettingsNewClusterInitScriptFile": {
             "properties": {
@@ -13090,12 +11999,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsNewClusterInitScriptGcs:getJobJobSettingsSettingsNewClusterInitScriptGcs": {
             "properties": {
@@ -13106,12 +12010,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsNewClusterInitScriptS3:getJobJobSettingsSettingsNewClusterInitScriptS3": {
             "properties": {
@@ -13140,12 +12039,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsNewClusterInitScriptVolumes:getJobJobSettingsSettingsNewClusterInitScriptVolumes": {
             "properties": {
@@ -13156,12 +12050,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsNewClusterInitScriptWorkspace:getJobJobSettingsSettingsNewClusterInitScriptWorkspace": {
             "properties": {
@@ -13172,12 +12061,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsNewClusterWorkloadType:getJobJobSettingsSettingsNewClusterWorkloadType": {
             "properties": {
@@ -13188,12 +12072,7 @@
             "type": "object",
             "required": [
                 "clients"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsNewClusterWorkloadTypeClients:getJobJobSettingsSettingsNewClusterWorkloadTypeClients": {
             "properties": {
@@ -13227,12 +12106,7 @@
             "type": "object",
             "required": [
                 "notebookPath"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsNotificationSettings:getJobJobSettingsSettingsNotificationSettings": {
             "properties": {
@@ -13258,12 +12132,7 @@
             "required": [
                 "default",
                 "name"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsPipelineTask:getJobJobSettingsSettingsPipelineTask": {
             "properties": {
@@ -13277,12 +12146,7 @@
             "type": "object",
             "required": [
                 "pipelineId"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsPythonWheelTask:getJobJobSettingsSettingsPythonWheelTask": {
             "properties": {
@@ -13316,12 +12180,7 @@
             "type": "object",
             "required": [
                 "enabled"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsRunAs:getJobJobSettingsSettingsRunAs": {
             "properties": {
@@ -13349,12 +12208,7 @@
             "type": "object",
             "required": [
                 "jobId"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsSchedule:getJobJobSettingsSettingsSchedule": {
             "properties": {
@@ -13372,12 +12226,7 @@
             "required": [
                 "quartzCronExpression",
                 "timezoneId"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsSparkJarTask:getJobJobSettingsSettingsSparkJarTask": {
             "properties": {
@@ -13414,12 +12263,7 @@
             "type": "object",
             "required": [
                 "pythonFile"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsSparkSubmitTask:getJobJobSettingsSettingsSparkSubmitTask": {
             "properties": {
@@ -13527,30 +12371,14 @@
             },
             "type": "object",
             "required": [
-                "conditionTask",
-                "dbtTask",
-                "dependsOns",
-                "emailNotifications",
-                "forEachTask",
-                "health",
-                "libraries",
-                "newCluster",
-                "notebookTask",
-                "notificationSettings",
-                "pipelineTask",
-                "pythonWheelTask",
                 "retryOnTimeout",
-                "runJobTask",
-                "sparkJarTask",
-                "sparkPythonTask",
-                "sparkSubmitTask",
-                "sqlTask",
-                "taskKey",
-                "webhookNotifications"
+                "taskKey"
             ],
             "language": {
                 "nodejs": {
-                    "requiredInputs": []
+                    "requiredInputs": [
+                        "taskKey"
+                    ]
                 }
             }
         },
@@ -13571,12 +12399,7 @@
                 "left",
                 "op",
                 "right"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskDbtTask:getJobJobSettingsSettingsTaskDbtTask": {
             "properties": {
@@ -13608,12 +12431,7 @@
             "type": "object",
             "required": [
                 "commands"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskDependsOn:getJobJobSettingsSettingsTaskDependsOn": {
             "properties": {
@@ -13627,12 +12445,7 @@
             "type": "object",
             "required": [
                 "taskKey"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskEmailNotifications:getJobJobSettingsSettingsTaskEmailNotifications": {
             "properties": {
@@ -13688,12 +12501,7 @@
             "required": [
                 "inputs",
                 "task"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskForEachTaskTask:getJobJobSettingsSettingsTaskForEachTaskTask": {
             "properties": {
@@ -13787,29 +12595,14 @@
             },
             "type": "object",
             "required": [
-                "conditionTask",
-                "dbtTask",
-                "dependsOns",
-                "emailNotifications",
-                "health",
-                "libraries",
-                "newCluster",
-                "notebookTask",
-                "notificationSettings",
-                "pipelineTask",
-                "pythonWheelTask",
                 "retryOnTimeout",
-                "runJobTask",
-                "sparkJarTask",
-                "sparkPythonTask",
-                "sparkSubmitTask",
-                "sqlTask",
-                "taskKey",
-                "webhookNotifications"
+                "taskKey"
             ],
             "language": {
                 "nodejs": {
-                    "requiredInputs": []
+                    "requiredInputs": [
+                        "taskKey"
+                    ]
                 }
             }
         },
@@ -13830,12 +12623,7 @@
                 "left",
                 "op",
                 "right"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskForEachTaskTaskDbtTask:getJobJobSettingsSettingsTaskForEachTaskTaskDbtTask": {
             "properties": {
@@ -13867,12 +12655,7 @@
             "type": "object",
             "required": [
                 "commands"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskForEachTaskTaskDependsOn:getJobJobSettingsSettingsTaskForEachTaskTaskDependsOn": {
             "properties": {
@@ -13886,12 +12669,7 @@
             "type": "object",
             "required": [
                 "taskKey"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskForEachTaskTaskEmailNotifications:getJobJobSettingsSettingsTaskForEachTaskTaskEmailNotifications": {
             "properties": {
@@ -13943,12 +12721,7 @@
             "type": "object",
             "required": [
                 "rules"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskForEachTaskTaskHealthRule:getJobJobSettingsSettingsTaskForEachTaskTaskHealthRule": {
             "properties": {
@@ -13967,12 +12740,7 @@
                 "metric",
                 "op",
                 "value"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskForEachTaskTaskLibrary:getJobJobSettingsSettingsTaskForEachTaskTaskLibrary": {
             "properties": {
@@ -13998,17 +12766,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "cran",
-                "maven",
-                "pypi"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getJobJobSettingsSettingsTaskForEachTaskTaskLibraryCran:getJobJobSettingsSettingsTaskForEachTaskTaskLibraryCran": {
             "properties": {
@@ -14022,12 +12780,7 @@
             "type": "object",
             "required": [
                 "package"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskForEachTaskTaskLibraryMaven:getJobJobSettingsSettingsTaskForEachTaskTaskLibraryMaven": {
             "properties": {
@@ -14047,12 +12800,7 @@
             "type": "object",
             "required": [
                 "coordinates"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskForEachTaskTaskLibraryPypi:getJobJobSettingsSettingsTaskForEachTaskTaskLibraryPypi": {
             "properties": {
@@ -14066,12 +12814,7 @@
             "type": "object",
             "required": [
                 "package"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskForEachTaskTaskNewCluster:getJobJobSettingsSettingsTaskForEachTaskTaskNewCluster": {
             "properties": {
@@ -14186,26 +12929,20 @@
             },
             "type": "object",
             "required": [
-                "autoscale",
-                "awsAttributes",
-                "azureAttributes",
-                "clusterLogConf",
-                "clusterMountInfos",
-                "dockerImage",
                 "driverInstancePoolId",
                 "driverNodeTypeId",
                 "enableElasticDisk",
                 "enableLocalDiskEncryption",
-                "gcpAttributes",
-                "initScripts",
                 "nodeTypeId",
                 "numWorkers",
-                "sparkVersion",
-                "workloadType"
+                "sparkVersion"
             ],
             "language": {
                 "nodejs": {
-                    "requiredInputs": []
+                    "requiredInputs": [
+                        "numWorkers",
+                        "sparkVersion"
+                    ]
                 }
             }
         },
@@ -14272,16 +13009,7 @@
                     "$ref": "#/types/databricks:index/getJobJobSettingsSettingsTaskForEachTaskTaskNewClusterClusterLogConfS3:getJobJobSettingsSettingsTaskForEachTaskTaskNewClusterClusterLogConfS3"
                 }
             },
-            "type": "object",
-            "required": [
-                "dbfs",
-                "s3"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getJobJobSettingsSettingsTaskForEachTaskTaskNewClusterClusterLogConfDbfs:getJobJobSettingsSettingsTaskForEachTaskTaskNewClusterClusterLogConfDbfs": {
             "properties": {
@@ -14292,12 +13020,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskForEachTaskTaskNewClusterClusterLogConfS3:getJobJobSettingsSettingsTaskForEachTaskTaskNewClusterClusterLogConfS3": {
             "properties": {
@@ -14326,12 +13049,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskForEachTaskTaskNewClusterClusterMountInfo:getJobJobSettingsSettingsTaskForEachTaskTaskNewClusterClusterMountInfo": {
             "properties": {
@@ -14349,12 +13067,7 @@
             "required": [
                 "localMountDirPath",
                 "networkFilesystemInfo"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskForEachTaskTaskNewClusterClusterMountInfoNetworkFilesystemInfo:getJobJobSettingsSettingsTaskForEachTaskTaskNewClusterClusterMountInfoNetworkFilesystemInfo": {
             "properties": {
@@ -14368,12 +13081,7 @@
             "type": "object",
             "required": [
                 "serverAddress"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskForEachTaskTaskNewClusterDockerImage:getJobJobSettingsSettingsTaskForEachTaskTaskNewClusterDockerImage": {
             "properties": {
@@ -14386,14 +13094,8 @@
             },
             "type": "object",
             "required": [
-                "basicAuth",
                 "url"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskForEachTaskTaskNewClusterDockerImageBasicAuth:getJobJobSettingsSettingsTaskForEachTaskTaskNewClusterDockerImageBasicAuth": {
             "properties": {
@@ -14409,12 +13111,7 @@
             "required": [
                 "password",
                 "username"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskForEachTaskTaskNewClusterGcpAttributes:getJobJobSettingsSettingsTaskForEachTaskTaskNewClusterGcpAttributes": {
             "properties": {
@@ -14463,21 +13160,7 @@
                     "$ref": "#/types/databricks:index/getJobJobSettingsSettingsTaskForEachTaskTaskNewClusterInitScriptWorkspace:getJobJobSettingsSettingsTaskForEachTaskTaskNewClusterInitScriptWorkspace"
                 }
             },
-            "type": "object",
-            "required": [
-                "abfss",
-                "dbfs",
-                "file",
-                "gcs",
-                "s3",
-                "volumes",
-                "workspace"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getJobJobSettingsSettingsTaskForEachTaskTaskNewClusterInitScriptAbfss:getJobJobSettingsSettingsTaskForEachTaskTaskNewClusterInitScriptAbfss": {
             "properties": {
@@ -14488,12 +13171,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskForEachTaskTaskNewClusterInitScriptDbfs:getJobJobSettingsSettingsTaskForEachTaskTaskNewClusterInitScriptDbfs": {
             "properties": {
@@ -14504,12 +13182,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskForEachTaskTaskNewClusterInitScriptFile:getJobJobSettingsSettingsTaskForEachTaskTaskNewClusterInitScriptFile": {
             "properties": {
@@ -14520,12 +13193,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskForEachTaskTaskNewClusterInitScriptGcs:getJobJobSettingsSettingsTaskForEachTaskTaskNewClusterInitScriptGcs": {
             "properties": {
@@ -14536,12 +13204,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskForEachTaskTaskNewClusterInitScriptS3:getJobJobSettingsSettingsTaskForEachTaskTaskNewClusterInitScriptS3": {
             "properties": {
@@ -14570,12 +13233,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskForEachTaskTaskNewClusterInitScriptVolumes:getJobJobSettingsSettingsTaskForEachTaskTaskNewClusterInitScriptVolumes": {
             "properties": {
@@ -14586,12 +13244,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskForEachTaskTaskNewClusterInitScriptWorkspace:getJobJobSettingsSettingsTaskForEachTaskTaskNewClusterInitScriptWorkspace": {
             "properties": {
@@ -14602,12 +13255,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskForEachTaskTaskNewClusterWorkloadType:getJobJobSettingsSettingsTaskForEachTaskTaskNewClusterWorkloadType": {
             "properties": {
@@ -14618,12 +13266,7 @@
             "type": "object",
             "required": [
                 "clients"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskForEachTaskTaskNewClusterWorkloadTypeClients:getJobJobSettingsSettingsTaskForEachTaskTaskNewClusterWorkloadTypeClients": {
             "properties": {
@@ -14657,12 +13300,7 @@
             "type": "object",
             "required": [
                 "notebookPath"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskForEachTaskTaskNotificationSettings:getJobJobSettingsSettingsTaskForEachTaskTaskNotificationSettings": {
             "properties": {
@@ -14690,12 +13328,7 @@
             "type": "object",
             "required": [
                 "pipelineId"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskForEachTaskTaskPythonWheelTask:getJobJobSettingsSettingsTaskForEachTaskTaskPythonWheelTask": {
             "properties": {
@@ -14735,12 +13368,7 @@
             "type": "object",
             "required": [
                 "jobId"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskForEachTaskTaskSparkJarTask:getJobJobSettingsSettingsTaskForEachTaskTaskSparkJarTask": {
             "properties": {
@@ -14777,12 +13405,7 @@
             "type": "object",
             "required": [
                 "pythonFile"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskForEachTaskTaskSparkSubmitTask:getJobJobSettingsSettingsTaskForEachTaskTaskSparkSubmitTask": {
             "properties": {
@@ -14821,17 +13444,8 @@
             },
             "type": "object",
             "required": [
-                "alert",
-                "dashboard",
-                "file",
-                "query",
                 "warehouseId"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskForEachTaskTaskSqlTaskAlert:getJobJobSettingsSettingsTaskForEachTaskTaskSqlTaskAlert": {
             "properties": {
@@ -14852,12 +13466,7 @@
             "required": [
                 "alertId",
                 "subscriptions"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskForEachTaskTaskSqlTaskAlertSubscription:getJobJobSettingsSettingsTaskForEachTaskTaskSqlTaskAlertSubscription": {
             "properties": {
@@ -14890,14 +13499,8 @@
             },
             "type": "object",
             "required": [
-                "dashboardId",
-                "subscriptions"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+                "dashboardId"
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskForEachTaskTaskSqlTaskDashboardSubscription:getJobJobSettingsSettingsTaskForEachTaskTaskSqlTaskDashboardSubscription": {
             "properties": {
@@ -14922,12 +13525,7 @@
             "type": "object",
             "required": [
                 "path"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskForEachTaskTaskSqlTaskQuery:getJobJobSettingsSettingsTaskForEachTaskTaskSqlTaskQuery": {
             "properties": {
@@ -14938,12 +13536,7 @@
             "type": "object",
             "required": [
                 "queryId"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskForEachTaskTaskWebhookNotifications:getJobJobSettingsSettingsTaskForEachTaskTaskWebhookNotifications": {
             "properties": {
@@ -14978,19 +13571,7 @@
                     }
                 }
             },
-            "type": "object",
-            "required": [
-                "onDurationWarningThresholdExceededs",
-                "onFailures",
-                "onStarts",
-                "onStreamingBacklogExceededs",
-                "onSuccesses"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getJobJobSettingsSettingsTaskForEachTaskTaskWebhookNotificationsOnDurationWarningThresholdExceeded:getJobJobSettingsSettingsTaskForEachTaskTaskWebhookNotificationsOnDurationWarningThresholdExceeded": {
             "properties": {
@@ -15001,12 +13582,7 @@
             "type": "object",
             "required": [
                 "id"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskForEachTaskTaskWebhookNotificationsOnFailure:getJobJobSettingsSettingsTaskForEachTaskTaskWebhookNotificationsOnFailure": {
             "properties": {
@@ -15017,12 +13593,7 @@
             "type": "object",
             "required": [
                 "id"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskForEachTaskTaskWebhookNotificationsOnStart:getJobJobSettingsSettingsTaskForEachTaskTaskWebhookNotificationsOnStart": {
             "properties": {
@@ -15033,12 +13604,7 @@
             "type": "object",
             "required": [
                 "id"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskForEachTaskTaskWebhookNotificationsOnStreamingBacklogExceeded:getJobJobSettingsSettingsTaskForEachTaskTaskWebhookNotificationsOnStreamingBacklogExceeded": {
             "properties": {
@@ -15049,12 +13615,7 @@
             "type": "object",
             "required": [
                 "id"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskForEachTaskTaskWebhookNotificationsOnSuccess:getJobJobSettingsSettingsTaskForEachTaskTaskWebhookNotificationsOnSuccess": {
             "properties": {
@@ -15065,12 +13626,7 @@
             "type": "object",
             "required": [
                 "id"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskHealth:getJobJobSettingsSettingsTaskHealth": {
             "properties": {
@@ -15084,12 +13640,7 @@
             "type": "object",
             "required": [
                 "rules"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskHealthRule:getJobJobSettingsSettingsTaskHealthRule": {
             "properties": {
@@ -15108,12 +13659,7 @@
                 "metric",
                 "op",
                 "value"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskLibrary:getJobJobSettingsSettingsTaskLibrary": {
             "properties": {
@@ -15139,17 +13685,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "cran",
-                "maven",
-                "pypi"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getJobJobSettingsSettingsTaskLibraryCran:getJobJobSettingsSettingsTaskLibraryCran": {
             "properties": {
@@ -15163,12 +13699,7 @@
             "type": "object",
             "required": [
                 "package"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskLibraryMaven:getJobJobSettingsSettingsTaskLibraryMaven": {
             "properties": {
@@ -15188,12 +13719,7 @@
             "type": "object",
             "required": [
                 "coordinates"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskLibraryPypi:getJobJobSettingsSettingsTaskLibraryPypi": {
             "properties": {
@@ -15207,12 +13733,7 @@
             "type": "object",
             "required": [
                 "package"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskNewCluster:getJobJobSettingsSettingsTaskNewCluster": {
             "properties": {
@@ -15327,26 +13848,20 @@
             },
             "type": "object",
             "required": [
-                "autoscale",
-                "awsAttributes",
-                "azureAttributes",
-                "clusterLogConf",
-                "clusterMountInfos",
-                "dockerImage",
                 "driverInstancePoolId",
                 "driverNodeTypeId",
                 "enableElasticDisk",
                 "enableLocalDiskEncryption",
-                "gcpAttributes",
-                "initScripts",
                 "nodeTypeId",
                 "numWorkers",
-                "sparkVersion",
-                "workloadType"
+                "sparkVersion"
             ],
             "language": {
                 "nodejs": {
-                    "requiredInputs": []
+                    "requiredInputs": [
+                        "numWorkers",
+                        "sparkVersion"
+                    ]
                 }
             }
         },
@@ -15413,16 +13928,7 @@
                     "$ref": "#/types/databricks:index/getJobJobSettingsSettingsTaskNewClusterClusterLogConfS3:getJobJobSettingsSettingsTaskNewClusterClusterLogConfS3"
                 }
             },
-            "type": "object",
-            "required": [
-                "dbfs",
-                "s3"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getJobJobSettingsSettingsTaskNewClusterClusterLogConfDbfs:getJobJobSettingsSettingsTaskNewClusterClusterLogConfDbfs": {
             "properties": {
@@ -15433,12 +13939,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskNewClusterClusterLogConfS3:getJobJobSettingsSettingsTaskNewClusterClusterLogConfS3": {
             "properties": {
@@ -15467,12 +13968,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskNewClusterClusterMountInfo:getJobJobSettingsSettingsTaskNewClusterClusterMountInfo": {
             "properties": {
@@ -15490,12 +13986,7 @@
             "required": [
                 "localMountDirPath",
                 "networkFilesystemInfo"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskNewClusterClusterMountInfoNetworkFilesystemInfo:getJobJobSettingsSettingsTaskNewClusterClusterMountInfoNetworkFilesystemInfo": {
             "properties": {
@@ -15509,12 +14000,7 @@
             "type": "object",
             "required": [
                 "serverAddress"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskNewClusterDockerImage:getJobJobSettingsSettingsTaskNewClusterDockerImage": {
             "properties": {
@@ -15527,14 +14013,8 @@
             },
             "type": "object",
             "required": [
-                "basicAuth",
                 "url"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskNewClusterDockerImageBasicAuth:getJobJobSettingsSettingsTaskNewClusterDockerImageBasicAuth": {
             "properties": {
@@ -15550,12 +14030,7 @@
             "required": [
                 "password",
                 "username"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskNewClusterGcpAttributes:getJobJobSettingsSettingsTaskNewClusterGcpAttributes": {
             "properties": {
@@ -15604,21 +14079,7 @@
                     "$ref": "#/types/databricks:index/getJobJobSettingsSettingsTaskNewClusterInitScriptWorkspace:getJobJobSettingsSettingsTaskNewClusterInitScriptWorkspace"
                 }
             },
-            "type": "object",
-            "required": [
-                "abfss",
-                "dbfs",
-                "file",
-                "gcs",
-                "s3",
-                "volumes",
-                "workspace"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getJobJobSettingsSettingsTaskNewClusterInitScriptAbfss:getJobJobSettingsSettingsTaskNewClusterInitScriptAbfss": {
             "properties": {
@@ -15629,12 +14090,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskNewClusterInitScriptDbfs:getJobJobSettingsSettingsTaskNewClusterInitScriptDbfs": {
             "properties": {
@@ -15645,12 +14101,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskNewClusterInitScriptFile:getJobJobSettingsSettingsTaskNewClusterInitScriptFile": {
             "properties": {
@@ -15661,12 +14112,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskNewClusterInitScriptGcs:getJobJobSettingsSettingsTaskNewClusterInitScriptGcs": {
             "properties": {
@@ -15677,12 +14123,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskNewClusterInitScriptS3:getJobJobSettingsSettingsTaskNewClusterInitScriptS3": {
             "properties": {
@@ -15711,12 +14152,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskNewClusterInitScriptVolumes:getJobJobSettingsSettingsTaskNewClusterInitScriptVolumes": {
             "properties": {
@@ -15727,12 +14163,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskNewClusterInitScriptWorkspace:getJobJobSettingsSettingsTaskNewClusterInitScriptWorkspace": {
             "properties": {
@@ -15743,12 +14174,7 @@
             "type": "object",
             "required": [
                 "destination"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskNewClusterWorkloadType:getJobJobSettingsSettingsTaskNewClusterWorkloadType": {
             "properties": {
@@ -15759,12 +14185,7 @@
             "type": "object",
             "required": [
                 "clients"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskNewClusterWorkloadTypeClients:getJobJobSettingsSettingsTaskNewClusterWorkloadTypeClients": {
             "properties": {
@@ -15798,12 +14219,7 @@
             "type": "object",
             "required": [
                 "notebookPath"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskNotificationSettings:getJobJobSettingsSettingsTaskNotificationSettings": {
             "properties": {
@@ -15831,12 +14247,7 @@
             "type": "object",
             "required": [
                 "pipelineId"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskPythonWheelTask:getJobJobSettingsSettingsTaskPythonWheelTask": {
             "properties": {
@@ -15876,12 +14287,7 @@
             "type": "object",
             "required": [
                 "jobId"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskSparkJarTask:getJobJobSettingsSettingsTaskSparkJarTask": {
             "properties": {
@@ -15918,12 +14324,7 @@
             "type": "object",
             "required": [
                 "pythonFile"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskSparkSubmitTask:getJobJobSettingsSettingsTaskSparkSubmitTask": {
             "properties": {
@@ -15962,17 +14363,8 @@
             },
             "type": "object",
             "required": [
-                "alert",
-                "dashboard",
-                "file",
-                "query",
                 "warehouseId"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskSqlTaskAlert:getJobJobSettingsSettingsTaskSqlTaskAlert": {
             "properties": {
@@ -15993,12 +14385,7 @@
             "required": [
                 "alertId",
                 "subscriptions"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskSqlTaskAlertSubscription:getJobJobSettingsSettingsTaskSqlTaskAlertSubscription": {
             "properties": {
@@ -16031,14 +14418,8 @@
             },
             "type": "object",
             "required": [
-                "dashboardId",
-                "subscriptions"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+                "dashboardId"
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskSqlTaskDashboardSubscription:getJobJobSettingsSettingsTaskSqlTaskDashboardSubscription": {
             "properties": {
@@ -16063,12 +14444,7 @@
             "type": "object",
             "required": [
                 "path"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskSqlTaskQuery:getJobJobSettingsSettingsTaskSqlTaskQuery": {
             "properties": {
@@ -16079,12 +14455,7 @@
             "type": "object",
             "required": [
                 "queryId"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskWebhookNotifications:getJobJobSettingsSettingsTaskWebhookNotifications": {
             "properties": {
@@ -16119,19 +14490,7 @@
                     }
                 }
             },
-            "type": "object",
-            "required": [
-                "onDurationWarningThresholdExceededs",
-                "onFailures",
-                "onStarts",
-                "onStreamingBacklogExceededs",
-                "onSuccesses"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getJobJobSettingsSettingsTaskWebhookNotificationsOnDurationWarningThresholdExceeded:getJobJobSettingsSettingsTaskWebhookNotificationsOnDurationWarningThresholdExceeded": {
             "properties": {
@@ -16142,12 +14501,7 @@
             "type": "object",
             "required": [
                 "id"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskWebhookNotificationsOnFailure:getJobJobSettingsSettingsTaskWebhookNotificationsOnFailure": {
             "properties": {
@@ -16158,12 +14512,7 @@
             "type": "object",
             "required": [
                 "id"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskWebhookNotificationsOnStart:getJobJobSettingsSettingsTaskWebhookNotificationsOnStart": {
             "properties": {
@@ -16174,12 +14523,7 @@
             "type": "object",
             "required": [
                 "id"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskWebhookNotificationsOnStreamingBacklogExceeded:getJobJobSettingsSettingsTaskWebhookNotificationsOnStreamingBacklogExceeded": {
             "properties": {
@@ -16190,12 +14534,7 @@
             "type": "object",
             "required": [
                 "id"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTaskWebhookNotificationsOnSuccess:getJobJobSettingsSettingsTaskWebhookNotificationsOnSuccess": {
             "properties": {
@@ -16206,12 +14545,7 @@
             "type": "object",
             "required": [
                 "id"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTrigger:getJobJobSettingsSettingsTrigger": {
             "properties": {
@@ -16228,17 +14562,7 @@
                     "$ref": "#/types/databricks:index/getJobJobSettingsSettingsTriggerTableUpdate:getJobJobSettingsSettingsTriggerTableUpdate"
                 }
             },
-            "type": "object",
-            "required": [
-                "fileArrival",
-                "periodic",
-                "tableUpdate"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getJobJobSettingsSettingsTriggerFileArrival:getJobJobSettingsSettingsTriggerFileArrival": {
             "properties": {
@@ -16255,12 +14579,7 @@
             "type": "object",
             "required": [
                 "url"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTriggerPeriodic:getJobJobSettingsSettingsTriggerPeriodic": {
             "properties": {
@@ -16275,12 +14594,7 @@
             "required": [
                 "interval",
                 "unit"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsTriggerTableUpdate:getJobJobSettingsSettingsTriggerTableUpdate": {
             "properties": {
@@ -16303,12 +14617,7 @@
             "type": "object",
             "required": [
                 "tableNames"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsWebhookNotifications:getJobJobSettingsSettingsWebhookNotifications": {
             "properties": {
@@ -16343,19 +14652,7 @@
                     }
                 }
             },
-            "type": "object",
-            "required": [
-                "onDurationWarningThresholdExceededs",
-                "onFailures",
-                "onStarts",
-                "onStreamingBacklogExceededs",
-                "onSuccesses"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getJobJobSettingsSettingsWebhookNotificationsOnDurationWarningThresholdExceeded:getJobJobSettingsSettingsWebhookNotificationsOnDurationWarningThresholdExceeded": {
             "properties": {
@@ -16366,12 +14663,7 @@
             "type": "object",
             "required": [
                 "id"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsWebhookNotificationsOnFailure:getJobJobSettingsSettingsWebhookNotificationsOnFailure": {
             "properties": {
@@ -16382,12 +14674,7 @@
             "type": "object",
             "required": [
                 "id"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsWebhookNotificationsOnStart:getJobJobSettingsSettingsWebhookNotificationsOnStart": {
             "properties": {
@@ -16398,12 +14685,7 @@
             "type": "object",
             "required": [
                 "id"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsWebhookNotificationsOnStreamingBacklogExceeded:getJobJobSettingsSettingsWebhookNotificationsOnStreamingBacklogExceeded": {
             "properties": {
@@ -16414,12 +14696,7 @@
             "type": "object",
             "required": [
                 "id"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getJobJobSettingsSettingsWebhookNotificationsOnSuccess:getJobJobSettingsSettingsWebhookNotificationsOnSuccess": {
             "properties": {
@@ -16430,12 +14707,7 @@
             "type": "object",
             "required": [
                 "id"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getMetastoreMetastoreInfo:getMetastoreMetastoreInfo": {
             "properties": {
@@ -16552,15 +14824,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "tags"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getMlflowModelLatestVersionTag:getMlflowModelLatestVersionTag": {
             "properties": {
@@ -16664,15 +14928,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "effectivePredictiveOptimizationFlag"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getSchemaSchemaInfoEffectivePredictiveOptimizationFlag:getSchemaSchemaInfoEffectivePredictiveOptimizationFlag": {
             "properties": {
@@ -16689,12 +14945,7 @@
             "type": "object",
             "required": [
                 "value"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getShareObject:getShareObject": {
             "properties": {
@@ -16741,12 +14992,14 @@
                 "addedBy",
                 "dataObjectType",
                 "name",
-                "partitions",
                 "status"
             ],
             "language": {
                 "nodejs": {
-                    "requiredInputs": []
+                    "requiredInputs": [
+                        "dataObjectType",
+                        "name"
+                    ]
                 }
             }
         },
@@ -16762,12 +15015,7 @@
             "type": "object",
             "required": [
                 "values"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getShareObjectPartitionValue:getShareObjectPartitionValue": {
             "properties": {
@@ -16788,12 +15036,7 @@
             "required": [
                 "name",
                 "op"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getSqlWarehouseChannel:getSqlWarehouseChannel": {
             "properties": {
@@ -16824,15 +15067,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "failureReason"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getSqlWarehouseHealthFailureReason:getSqlWarehouseHealthFailureReason": {
             "properties": {
@@ -16877,15 +15112,7 @@
                     }
                 }
             },
-            "type": "object",
-            "required": [
-                "customTags"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getSqlWarehouseTagsCustomTag:getSqlWarehouseTagsCustomTag": {
             "properties": {
@@ -16952,19 +15179,7 @@
                     "type": "boolean"
                 }
             },
-            "type": "object",
-            "required": [
-                "awsIamRole",
-                "azureManagedIdentity",
-                "azureServicePrincipal",
-                "cloudflareApiToken",
-                "databricksGcpServiceAccount"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getStorageCredentialStorageCredentialInfoAwsIamRole:getStorageCredentialStorageCredentialInfoAwsIamRole": {
             "properties": {
@@ -16981,12 +15196,7 @@
             "type": "object",
             "required": [
                 "roleArn"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getStorageCredentialStorageCredentialInfoAzureManagedIdentity:getStorageCredentialStorageCredentialInfoAzureManagedIdentity": {
             "properties": {
@@ -17003,12 +15213,7 @@
             "type": "object",
             "required": [
                 "accessConnectorId"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getStorageCredentialStorageCredentialInfoAzureServicePrincipal:getStorageCredentialStorageCredentialInfoAzureServicePrincipal": {
             "properties": {
@@ -17027,12 +15232,7 @@
                 "applicationId",
                 "clientSecret",
                 "directoryId"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getStorageCredentialStorageCredentialInfoCloudflareApiToken:getStorageCredentialStorageCredentialInfoCloudflareApiToken": {
             "properties": {
@@ -17051,12 +15251,7 @@
                 "accessKeyId",
                 "accountId",
                 "secretAccessKey"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getStorageCredentialStorageCredentialInfoDatabricksGcpServiceAccount:getStorageCredentialStorageCredentialInfoDatabricksGcpServiceAccount": {
             "properties": {
@@ -17177,21 +15372,7 @@
                     "$ref": "#/types/databricks:index/getTableTableInfoViewDependencies:getTableTableInfoViewDependencies"
                 }
             },
-            "type": "object",
-            "required": [
-                "columns",
-                "deltaRuntimePropertiesKvpairs",
-                "effectivePredictiveOptimizationFlag",
-                "encryptionDetails",
-                "rowFilter",
-                "tableConstraints",
-                "viewDependencies"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getTableTableInfoColumn:getTableTableInfoColumn": {
             "properties": {
@@ -17232,15 +15413,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "mask"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getTableTableInfoColumnMask:getTableTableInfoColumnMask": {
             "properties": {
@@ -17268,12 +15441,7 @@
             "type": "object",
             "required": [
                 "deltaRuntimeProperties"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getTableTableInfoEffectivePredictiveOptimizationFlag:getTableTableInfoEffectivePredictiveOptimizationFlag": {
             "properties": {
@@ -17290,12 +15458,7 @@
             "type": "object",
             "required": [
                 "value"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getTableTableInfoEncryptionDetails:getTableTableInfoEncryptionDetails": {
             "properties": {
@@ -17303,15 +15466,7 @@
                     "$ref": "#/types/databricks:index/getTableTableInfoEncryptionDetailsSseEncryptionDetails:getTableTableInfoEncryptionDetailsSseEncryptionDetails"
                 }
             },
-            "type": "object",
-            "required": [
-                "sseEncryptionDetails"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getTableTableInfoEncryptionDetailsSseEncryptionDetails:getTableTableInfoEncryptionDetailsSseEncryptionDetails": {
             "properties": {
@@ -17340,12 +15495,7 @@
             "required": [
                 "functionName",
                 "inputColumnNames"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getTableTableInfoTableConstraint:getTableTableInfoTableConstraint": {
             "properties": {
@@ -17359,17 +15509,7 @@
                     "$ref": "#/types/databricks:index/getTableTableInfoTableConstraintPrimaryKeyConstraint:getTableTableInfoTableConstraintPrimaryKeyConstraint"
                 }
             },
-            "type": "object",
-            "required": [
-                "foreignKeyConstraint",
-                "namedTableConstraint",
-                "primaryKeyConstraint"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getTableTableInfoTableConstraintForeignKeyConstraint:getTableTableInfoTableConstraintForeignKeyConstraint": {
             "properties": {
@@ -17398,12 +15538,7 @@
                 "name",
                 "parentColumns",
                 "parentTable"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getTableTableInfoTableConstraintNamedTableConstraint:getTableTableInfoTableConstraintNamedTableConstraint": {
             "properties": {
@@ -17414,12 +15549,7 @@
             "type": "object",
             "required": [
                 "name"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getTableTableInfoTableConstraintPrimaryKeyConstraint:getTableTableInfoTableConstraintPrimaryKeyConstraint": {
             "properties": {
@@ -17437,12 +15567,7 @@
             "required": [
                 "childColumns",
                 "name"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getTableTableInfoViewDependencies:getTableTableInfoViewDependencies": {
             "properties": {
@@ -17453,15 +15578,7 @@
                     }
                 }
             },
-            "type": "object",
-            "required": [
-                "dependencies"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getTableTableInfoViewDependenciesDependency:getTableTableInfoViewDependenciesDependency": {
             "properties": {
@@ -17472,16 +15589,7 @@
                     "$ref": "#/types/databricks:index/getTableTableInfoViewDependenciesDependencyTable:getTableTableInfoViewDependenciesDependencyTable"
                 }
             },
-            "type": "object",
-            "required": [
-                "function",
-                "table"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getTableTableInfoViewDependenciesDependencyFunction:getTableTableInfoViewDependenciesDependencyFunction": {
             "properties": {
@@ -17492,12 +15600,7 @@
             "type": "object",
             "required": [
                 "functionFullName"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getTableTableInfoViewDependenciesDependencyTable:getTableTableInfoViewDependenciesDependencyTable": {
             "properties": {
@@ -17508,12 +15611,7 @@
             "type": "object",
             "required": [
                 "tableFullName"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            ]
         },
         "databricks:index/getVolumeVolumeInfo:getVolumeVolumeInfo": {
             "properties": {
@@ -17569,15 +15667,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "encryptionDetails"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getVolumeVolumeInfoEncryptionDetails:getVolumeVolumeInfoEncryptionDetails": {
             "properties": {
@@ -17585,15 +15675,7 @@
                     "$ref": "#/types/databricks:index/getVolumeVolumeInfoEncryptionDetailsSseEncryptionDetails:getVolumeVolumeInfoEncryptionDetailsSseEncryptionDetails"
                 }
             },
-            "type": "object",
-            "required": [
-                "sseEncryptionDetails"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getVolumeVolumeInfoEncryptionDetailsSseEncryptionDetails:getVolumeVolumeInfoEncryptionDetailsSseEncryptionDetails": {
             "properties": {
@@ -17836,10 +15918,15 @@
             },
             "required": [
                 "etag",
-                "grantRules",
                 "name"
             ],
             "inputProperties": {
+                "grantRules": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/types/databricks:index/AccessControlRuleSetGrantRule:AccessControlRuleSetGrantRule"
+                    }
+                },
                 "name": {
                     "type": "string"
                 }
@@ -17892,6 +15979,12 @@
                 "metastoreId"
             ],
             "inputProperties": {
+                "artifactMatchers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/types/databricks:index/ArtifactAllowlistArtifactMatcher:ArtifactAllowlistArtifactMatcher"
+                    }
+                },
                 "artifactType": {
                     "type": "string"
                 },
@@ -17906,6 +15999,7 @@
                 }
             },
             "requiredInputs": [
+                "artifactMatchers",
                 "artifactType"
             ],
             "stateInputs": {
@@ -17951,6 +16045,9 @@
                 "settingName"
             ],
             "inputProperties": {
+                "automaticClusterUpdateWorkspace": {
+                    "$ref": "#/types/databricks:index/AutomaticClusterUpdateWorkspaceSettingAutomaticClusterUpdateWorkspace:AutomaticClusterUpdateWorkspaceSettingAutomaticClusterUpdateWorkspace"
+                },
                 "etag": {
                     "type": "string"
                 },
@@ -17958,6 +16055,9 @@
                     "type": "string"
                 }
             },
+            "requiredInputs": [
+                "automaticClusterUpdateWorkspace"
+            ],
             "stateInputs": {
                 "description": "Input properties used for looking up and filtering AutomaticClusterUpdateWorkspaceSetting resources.\n",
                 "properties": {
@@ -18748,34 +16848,41 @@
                 }
             },
             "required": [
-                "autoscale",
-                "awsAttributes",
-                "azureAttributes",
                 "clusterId",
-                "clusterLogConf",
-                "clusterMountInfos",
                 "defaultTags",
-                "dockerImage",
                 "driverInstancePoolId",
                 "driverNodeTypeId",
                 "enableElasticDisk",
                 "enableLocalDiskEncryption",
-                "gcpAttributes",
-                "initScripts",
-                "libraries",
                 "nodeTypeId",
                 "sparkVersion",
                 "state",
-                "timeouts",
-                "url",
-                "workloadType"
+                "url"
             ],
             "inputProperties": {
                 "applyPolicyDefaultValues": {
                     "type": "boolean"
                 },
+                "autoscale": {
+                    "$ref": "#/types/databricks:index/ClusterAutoscale:ClusterAutoscale"
+                },
                 "autoterminationMinutes": {
                     "type": "number"
+                },
+                "awsAttributes": {
+                    "$ref": "#/types/databricks:index/ClusterAwsAttributes:ClusterAwsAttributes"
+                },
+                "azureAttributes": {
+                    "$ref": "#/types/databricks:index/ClusterAzureAttributes:ClusterAzureAttributes"
+                },
+                "clusterLogConf": {
+                    "$ref": "#/types/databricks:index/ClusterClusterLogConf:ClusterClusterLogConf"
+                },
+                "clusterMountInfos": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/types/databricks:index/ClusterClusterMountInfo:ClusterClusterMountInfo"
+                    }
                 },
                 "clusterName": {
                     "type": "string"
@@ -18789,6 +16896,9 @@
                 "dataSecurityMode": {
                     "type": "string"
                 },
+                "dockerImage": {
+                    "$ref": "#/types/databricks:index/ClusterDockerImage:ClusterDockerImage"
+                },
                 "driverInstancePoolId": {
                     "type": "string"
                 },
@@ -18801,14 +16911,29 @@
                 "enableLocalDiskEncryption": {
                     "type": "boolean"
                 },
+                "gcpAttributes": {
+                    "$ref": "#/types/databricks:index/ClusterGcpAttributes:ClusterGcpAttributes"
+                },
                 "idempotencyToken": {
                     "type": "string"
+                },
+                "initScripts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/types/databricks:index/ClusterInitScript:ClusterInitScript"
+                    }
                 },
                 "instancePoolId": {
                     "type": "string"
                 },
                 "isPinned": {
                     "type": "boolean"
+                },
+                "libraries": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/types/databricks:index/ClusterLibrary:ClusterLibrary"
+                    }
                 },
                 "nodeTypeId": {
                     "type": "string"
@@ -18845,6 +16970,12 @@
                     "items": {
                         "type": "string"
                     }
+                },
+                "timeouts": {
+                    "$ref": "#/types/databricks:index/ClusterTimeouts:ClusterTimeouts"
+                },
+                "workloadType": {
+                    "$ref": "#/types/databricks:index/ClusterWorkloadType:ClusterWorkloadType"
                 }
             },
             "requiredInputs": [
@@ -19021,7 +17152,6 @@
             },
             "required": [
                 "definition",
-                "libraries",
                 "name",
                 "policyId"
             ],
@@ -19031,6 +17161,12 @@
                 },
                 "description": {
                     "type": "string"
+                },
+                "libraries": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/types/databricks:index/ClusterPolicyLibrary:ClusterPolicyLibrary"
+                    }
                 },
                 "maxClustersPerUser": {
                     "type": "number"
@@ -19097,6 +17233,9 @@
                 "settingName"
             ],
             "inputProperties": {
+                "complianceSecurityProfileWorkspace": {
+                    "$ref": "#/types/databricks:index/ComplianceSecurityProfileWorkspaceSettingComplianceSecurityProfileWorkspace:ComplianceSecurityProfileWorkspaceSettingComplianceSecurityProfileWorkspace"
+                },
                 "etag": {
                     "type": "string"
                 },
@@ -19104,6 +17243,9 @@
                     "type": "string"
                 }
             },
+            "requiredInputs": [
+                "complianceSecurityProfileWorkspace"
+            ],
             "stateInputs": {
                 "description": "Input properties used for looking up and filtering ComplianceSecurityProfileWorkspaceSetting resources.\n",
                 "properties": {
@@ -19541,10 +17683,16 @@
                 "etag": {
                     "type": "string"
                 },
+                "namespace": {
+                    "$ref": "#/types/databricks:index/DefaultNamespaceSettingNamespace:DefaultNamespaceSettingNamespace"
+                },
                 "settingName": {
                     "type": "string"
                 }
             },
+            "requiredInputs": [
+                "namespace"
+            ],
             "stateInputs": {
                 "description": "Input properties used for looking up and filtering DefaultNamespaceSetting resources.\n",
                 "properties": {
@@ -19632,6 +17780,9 @@
                 "settingName"
             ],
             "inputProperties": {
+                "enhancedSecurityMonitoringWorkspace": {
+                    "$ref": "#/types/databricks:index/EnhancedSecurityMonitoringWorkspaceSettingEnhancedSecurityMonitoringWorkspace:EnhancedSecurityMonitoringWorkspaceSettingEnhancedSecurityMonitoringWorkspace"
+                },
                 "etag": {
                     "type": "string"
                 },
@@ -19639,6 +17790,9 @@
                     "type": "string"
                 }
             },
+            "requiredInputs": [
+                "enhancedSecurityMonitoringWorkspace"
+            ],
             "stateInputs": {
                 "description": "Input properties used for looking up and filtering EnhancedSecurityMonitoringWorkspaceSetting resources.\n",
                 "properties": {
@@ -19774,7 +17928,6 @@
             },
             "required": [
                 "credentialName",
-                "encryptionDetails",
                 "isolationMode",
                 "metastoreId",
                 "name",
@@ -19790,6 +17943,9 @@
                 },
                 "credentialName": {
                     "type": "string"
+                },
+                "encryptionDetails": {
+                    "$ref": "#/types/databricks:index/ExternalLocationEncryptionDetails:ExternalLocationEncryptionDetails"
                 },
                 "forceDestroy": {
                     "type": "boolean"
@@ -20026,8 +18182,7 @@
             },
             "required": [
                 "name",
-                "position",
-                "timeouts"
+                "position"
             ],
             "inputProperties": {
                 "contentBase64": {
@@ -20047,6 +18202,9 @@
                 },
                 "source": {
                     "type": "string"
+                },
+                "timeouts": {
+                    "$ref": "#/types/databricks:index/GlobalInitScriptTimeouts:GlobalInitScriptTimeouts"
                 }
             },
             "stateInputs": {
@@ -20305,6 +18463,12 @@
                 "function": {
                     "type": "string"
                 },
+                "grants": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/types/databricks:index/GrantsGrant:GrantsGrant"
+                    }
+                },
                 "metastore": {
                     "type": "string"
                 },
@@ -20333,6 +18497,9 @@
                     "type": "string"
                 }
             },
+            "requiredInputs": [
+                "grants"
+            ],
             "stateInputs": {
                 "description": "Input properties used for looking up and filtering Grants resources.\n",
                 "properties": {
@@ -20658,28 +18825,37 @@
                 }
             },
             "required": [
-                "awsAttributes",
-                "azureAttributes",
-                "diskSpec",
-                "gcpAttributes",
                 "idleInstanceAutoterminationMinutes",
-                "instancePoolFleetAttributes",
                 "instancePoolId",
-                "instancePoolName",
-                "preloadedDockerImages"
+                "instancePoolName"
             ],
             "inputProperties": {
+                "awsAttributes": {
+                    "$ref": "#/types/databricks:index/InstancePoolAwsAttributes:InstancePoolAwsAttributes"
+                },
+                "azureAttributes": {
+                    "$ref": "#/types/databricks:index/InstancePoolAzureAttributes:InstancePoolAzureAttributes"
+                },
                 "customTags": {
                     "type": "object",
                     "additionalProperties": {
                         "type": "string"
                     }
                 },
+                "diskSpec": {
+                    "$ref": "#/types/databricks:index/InstancePoolDiskSpec:InstancePoolDiskSpec"
+                },
                 "enableElasticDisk": {
                     "type": "boolean"
                 },
+                "gcpAttributes": {
+                    "$ref": "#/types/databricks:index/InstancePoolGcpAttributes:InstancePoolGcpAttributes"
+                },
                 "idleInstanceAutoterminationMinutes": {
                     "type": "number"
+                },
+                "instancePoolFleetAttributes": {
+                    "$ref": "#/types/databricks:index/InstancePoolInstancePoolFleetAttributes:InstancePoolInstancePoolFleetAttributes"
                 },
                 "instancePoolId": {
                     "type": "string"
@@ -20695,6 +18871,12 @@
                 },
                 "nodeTypeId": {
                     "type": "string"
+                },
+                "preloadedDockerImages": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/types/databricks:index/InstancePoolPreloadedDockerImage:InstancePoolPreloadedDockerImage"
+                    }
                 },
                 "preloadedSparkVersions": {
                     "type": "array",
@@ -21044,43 +19226,27 @@
                 }
             },
             "required": [
-                "continuous",
-                "dbtTask",
-                "deployment",
-                "emailNotifications",
-                "environments",
                 "format",
-                "gitSource",
-                "health",
-                "jobClusters",
-                "libraries",
                 "name",
-                "newCluster",
-                "notebookTask",
-                "notificationSettings",
-                "parameters",
-                "pipelineTask",
-                "pythonWheelTask",
-                "queue",
-                "runAs",
-                "runJobTask",
-                "schedule",
-                "sparkJarTask",
-                "sparkPythonTask",
-                "sparkSubmitTask",
-                "tasks",
-                "timeouts",
-                "trigger",
-                "url",
-                "webhookNotifications"
+                "url"
             ],
             "inputProperties": {
                 "alwaysRunning": {
                     "type": "boolean",
                     "deprecationMessage": "Deprecated"
                 },
+                "continuous": {
+                    "$ref": "#/types/databricks:index/JobContinuous:JobContinuous"
+                },
                 "controlRunState": {
                     "type": "boolean"
+                },
+                "dbtTask": {
+                    "$ref": "#/types/databricks:index/JobDbtTask:JobDbtTask",
+                    "deprecationMessage": "Deprecated"
+                },
+                "deployment": {
+                    "$ref": "#/types/databricks:index/JobDeployment:JobDeployment"
                 },
                 "description": {
                     "type": "string"
@@ -21088,11 +19254,38 @@
                 "editMode": {
                     "type": "string"
                 },
+                "emailNotifications": {
+                    "$ref": "#/types/databricks:index/JobEmailNotifications:JobEmailNotifications"
+                },
+                "environments": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/types/databricks:index/JobEnvironment:JobEnvironment"
+                    }
+                },
                 "existingClusterId": {
                     "type": "string"
                 },
                 "format": {
                     "type": "string"
+                },
+                "gitSource": {
+                    "$ref": "#/types/databricks:index/JobGitSource:JobGitSource"
+                },
+                "health": {
+                    "$ref": "#/types/databricks:index/JobHealth:JobHealth"
+                },
+                "jobClusters": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/types/databricks:index/JobJobCluster:JobJobCluster"
+                    }
+                },
+                "libraries": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/types/databricks:index/JobLibrary:JobLibrary"
+                    }
                 },
                 "maxConcurrentRuns": {
                     "type": "number"
@@ -21108,8 +19301,57 @@
                 "name": {
                     "type": "string"
                 },
+                "newCluster": {
+                    "$ref": "#/types/databricks:index/JobNewCluster:JobNewCluster"
+                },
+                "notebookTask": {
+                    "$ref": "#/types/databricks:index/JobNotebookTask:JobNotebookTask",
+                    "deprecationMessage": "Deprecated"
+                },
+                "notificationSettings": {
+                    "$ref": "#/types/databricks:index/JobNotificationSettings:JobNotificationSettings"
+                },
+                "parameters": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/types/databricks:index/JobParameter:JobParameter"
+                    }
+                },
+                "pipelineTask": {
+                    "$ref": "#/types/databricks:index/JobPipelineTask:JobPipelineTask",
+                    "deprecationMessage": "Deprecated"
+                },
+                "pythonWheelTask": {
+                    "$ref": "#/types/databricks:index/JobPythonWheelTask:JobPythonWheelTask",
+                    "deprecationMessage": "Deprecated"
+                },
+                "queue": {
+                    "$ref": "#/types/databricks:index/JobQueue:JobQueue"
+                },
                 "retryOnTimeout": {
                     "type": "boolean",
+                    "deprecationMessage": "Deprecated"
+                },
+                "runAs": {
+                    "$ref": "#/types/databricks:index/JobRunAs:JobRunAs"
+                },
+                "runJobTask": {
+                    "$ref": "#/types/databricks:index/JobRunJobTask:JobRunJobTask",
+                    "deprecationMessage": "Deprecated"
+                },
+                "schedule": {
+                    "$ref": "#/types/databricks:index/JobSchedule:JobSchedule"
+                },
+                "sparkJarTask": {
+                    "$ref": "#/types/databricks:index/JobSparkJarTask:JobSparkJarTask",
+                    "deprecationMessage": "Deprecated"
+                },
+                "sparkPythonTask": {
+                    "$ref": "#/types/databricks:index/JobSparkPythonTask:JobSparkPythonTask",
+                    "deprecationMessage": "Deprecated"
+                },
+                "sparkSubmitTask": {
+                    "$ref": "#/types/databricks:index/JobSparkSubmitTask:JobSparkSubmitTask",
                     "deprecationMessage": "Deprecated"
                 },
                 "tags": {
@@ -21118,8 +19360,23 @@
                         "type": "string"
                     }
                 },
+                "tasks": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/types/databricks:index/JobTask:JobTask"
+                    }
+                },
                 "timeoutSeconds": {
                     "type": "number"
+                },
+                "timeouts": {
+                    "$ref": "#/types/databricks:index/JobTimeouts:JobTimeouts"
+                },
+                "trigger": {
+                    "$ref": "#/types/databricks:index/JobTrigger:JobTrigger"
+                },
+                "webhookNotifications": {
+                    "$ref": "#/types/databricks:index/JobWebhookNotifications:JobWebhookNotifications"
                 }
             },
             "stateInputs": {
@@ -21353,21 +19610,13 @@
             },
             "required": [
                 "assetsDir",
-                "customMetrics",
                 "dashboardId",
-                "dataClassificationConfig",
                 "driftMetricsTableName",
-                "inferenceLog",
                 "monitorVersion",
-                "notifications",
                 "outputSchemaName",
                 "profileMetricsTableName",
-                "schedule",
-                "snapshot",
                 "status",
-                "tableName",
-                "timeSeries",
-                "timeouts"
+                "tableName"
             ],
             "inputProperties": {
                 "assetsDir": {
@@ -21376,11 +19625,29 @@
                 "baselineTableName": {
                     "type": "string"
                 },
+                "customMetrics": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/types/databricks:index/LakehouseMonitorCustomMetric:LakehouseMonitorCustomMetric"
+                    }
+                },
+                "dataClassificationConfig": {
+                    "$ref": "#/types/databricks:index/LakehouseMonitorDataClassificationConfig:LakehouseMonitorDataClassificationConfig"
+                },
+                "inferenceLog": {
+                    "$ref": "#/types/databricks:index/LakehouseMonitorInferenceLog:LakehouseMonitorInferenceLog"
+                },
                 "latestMonitorFailureMsg": {
                     "type": "string"
                 },
+                "notifications": {
+                    "$ref": "#/types/databricks:index/LakehouseMonitorNotifications:LakehouseMonitorNotifications"
+                },
                 "outputSchemaName": {
                     "type": "string"
+                },
+                "schedule": {
+                    "$ref": "#/types/databricks:index/LakehouseMonitorSchedule:LakehouseMonitorSchedule"
                 },
                 "skipBuiltinDashboard": {
                     "type": "boolean"
@@ -21391,8 +19658,17 @@
                         "type": "string"
                     }
                 },
+                "snapshot": {
+                    "$ref": "#/types/databricks:index/LakehouseMonitorSnapshot:LakehouseMonitorSnapshot"
+                },
                 "tableName": {
                     "type": "string"
+                },
+                "timeSeries": {
+                    "$ref": "#/types/databricks:index/LakehouseMonitorTimeSeries:LakehouseMonitorTimeSeries"
+                },
+                "timeouts": {
+                    "$ref": "#/types/databricks:index/LakehouseMonitorTimeouts:LakehouseMonitorTimeouts"
                 },
                 "warehouseId": {
                     "type": "string"
@@ -21507,20 +19783,26 @@
                 }
             },
             "required": [
-                "clusterId",
-                "cran",
-                "maven",
-                "pypi"
+                "clusterId"
             ],
             "inputProperties": {
                 "clusterId": {
                     "type": "string"
+                },
+                "cran": {
+                    "$ref": "#/types/databricks:index/LibraryCran:LibraryCran"
                 },
                 "egg": {
                     "type": "string"
                 },
                 "jar": {
                     "type": "string"
+                },
+                "maven": {
+                    "$ref": "#/types/databricks:index/LibraryMaven:LibraryMaven"
+                },
+                "pypi": {
+                    "$ref": "#/types/databricks:index/LibraryPypi:LibraryPypi"
                 },
                 "requirements": {
                     "type": "string"
@@ -21839,26 +20121,38 @@
                 }
             },
             "required": [
-                "awsIamRole",
-                "azureManagedIdentity",
-                "azureServicePrincipal",
-                "cloudflareApiToken",
-                "databricksGcpServiceAccount",
-                "gcpServiceAccountKey",
                 "isolationMode",
                 "metastoreId",
                 "name",
                 "owner"
             ],
             "inputProperties": {
+                "awsIamRole": {
+                    "$ref": "#/types/databricks:index/MetastoreDataAccessAwsIamRole:MetastoreDataAccessAwsIamRole"
+                },
+                "azureManagedIdentity": {
+                    "$ref": "#/types/databricks:index/MetastoreDataAccessAzureManagedIdentity:MetastoreDataAccessAzureManagedIdentity"
+                },
+                "azureServicePrincipal": {
+                    "$ref": "#/types/databricks:index/MetastoreDataAccessAzureServicePrincipal:MetastoreDataAccessAzureServicePrincipal"
+                },
+                "cloudflareApiToken": {
+                    "$ref": "#/types/databricks:index/MetastoreDataAccessCloudflareApiToken:MetastoreDataAccessCloudflareApiToken"
+                },
                 "comment": {
                     "type": "string"
+                },
+                "databricksGcpServiceAccount": {
+                    "$ref": "#/types/databricks:index/MetastoreDataAccessDatabricksGcpServiceAccount:MetastoreDataAccessDatabricksGcpServiceAccount"
                 },
                 "forceDestroy": {
                     "type": "boolean"
                 },
                 "forceUpdate": {
                     "type": "boolean"
+                },
+                "gcpServiceAccountKey": {
+                    "$ref": "#/types/databricks:index/MetastoreDataAccessGcpServiceAccountKey:MetastoreDataAccessGcpServiceAccountKey"
                 },
                 "isDefault": {
                     "type": "boolean"
@@ -21969,8 +20263,7 @@
                 "experimentId",
                 "lastUpdateTime",
                 "lifecycleStage",
-                "name",
-                "timeouts"
+                "name"
             ],
             "inputProperties": {
                 "artifactLocation": {
@@ -21993,6 +20286,9 @@
                 },
                 "name": {
                     "type": "string"
+                },
+                "timeouts": {
+                    "$ref": "#/types/databricks:index/MlflowExperimentTimeouts:MlflowExperimentTimeouts"
                 }
             },
             "stateInputs": {
@@ -22046,8 +20342,7 @@
             },
             "required": [
                 "name",
-                "registeredModelId",
-                "tags"
+                "registeredModelId"
             ],
             "inputProperties": {
                 "description": {
@@ -22055,6 +20350,12 @@
                 },
                 "name": {
                     "type": "string"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/types/databricks:index/MlflowModelTag:MlflowModelTag"
+                    }
                 }
             },
             "stateInputs": {
@@ -22104,9 +20405,7 @@
                 }
             },
             "required": [
-                "events",
-                "httpUrlSpec",
-                "jobSpec"
+                "events"
             ],
             "inputProperties": {
                 "description": {
@@ -22117,6 +20416,12 @@
                     "items": {
                         "type": "string"
                     }
+                },
+                "httpUrlSpec": {
+                    "$ref": "#/types/databricks:index/MlflowWebhookHttpUrlSpec:MlflowWebhookHttpUrlSpec"
+                },
+                "jobSpec": {
+                    "$ref": "#/types/databricks:index/MlflowWebhookJobSpec:MlflowWebhookJobSpec"
                 },
                 "modelName": {
                     "type": "string"
@@ -22189,19 +20494,37 @@
             "required": [
                 "config",
                 "name",
-                "rateLimits",
-                "servingEndpointId",
-                "tags",
-                "timeouts"
+                "servingEndpointId"
             ],
             "inputProperties": {
+                "config": {
+                    "$ref": "#/types/databricks:index/ModelServingConfig:ModelServingConfig"
+                },
                 "name": {
                     "type": "string"
                 },
+                "rateLimits": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/types/databricks:index/ModelServingRateLimit:ModelServingRateLimit"
+                    }
+                },
                 "routeOptimized": {
                     "type": "boolean"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/types/databricks:index/ModelServingTag:ModelServingTag"
+                    }
+                },
+                "timeouts": {
+                    "$ref": "#/types/databricks:index/ModelServingTimeouts:ModelServingTimeouts"
                 }
             },
+            "requiredInputs": [
+                "config"
+            ],
             "stateInputs": {
                 "description": "Input properties used for looking up and filtering ModelServing resources.\n",
                 "properties": {
@@ -22282,17 +20605,17 @@
                 }
             },
             "required": [
-                "abfs",
-                "adl",
                 "clusterId",
-                "gs",
                 "name",
-                "s3",
-                "source",
-                "timeouts",
-                "wasb"
+                "source"
             ],
             "inputProperties": {
+                "abfs": {
+                    "$ref": "#/types/databricks:index/MountAbfs:MountAbfs"
+                },
+                "adl": {
+                    "$ref": "#/types/databricks:index/MountAdl:MountAdl"
+                },
                 "clusterId": {
                     "type": "string"
                 },
@@ -22305,14 +20628,26 @@
                         "type": "string"
                     }
                 },
+                "gs": {
+                    "$ref": "#/types/databricks:index/MountGs:MountGs"
+                },
                 "name": {
                     "type": "string"
                 },
                 "resourceId": {
                     "type": "string"
                 },
+                "s3": {
+                    "$ref": "#/types/databricks:index/MountS3:MountS3"
+                },
+                "timeouts": {
+                    "$ref": "#/types/databricks:index/MountTimeouts:MountTimeouts"
+                },
                 "uri": {
                     "type": "string"
+                },
+                "wasb": {
+                    "$ref": "#/types/databricks:index/MountWasb:MountWasb"
                 }
             },
             "stateInputs": {
@@ -22470,21 +20805,25 @@
             },
             "required": [
                 "accountId",
-                "awsKeyInfo",
                 "creationTime",
                 "customerManagedKeyId",
-                "gcpKeyInfo",
                 "useCases"
             ],
             "inputProperties": {
                 "accountId": {
                     "type": "string"
                 },
+                "awsKeyInfo": {
+                    "$ref": "#/types/databricks:index/MwsCustomerManagedKeysAwsKeyInfo:MwsCustomerManagedKeysAwsKeyInfo"
+                },
                 "creationTime": {
                     "type": "number"
                 },
                 "customerManagedKeyId": {
                     "type": "string"
+                },
+                "gcpKeyInfo": {
+                    "$ref": "#/types/databricks:index/MwsCustomerManagedKeysGcpKeyInfo:MwsCustomerManagedKeysGcpKeyInfo"
                 },
                 "useCases": {
                     "type": "array",
@@ -22844,7 +21183,6 @@
             "required": [
                 "accountId",
                 "creationTime",
-                "egressConfig",
                 "name",
                 "networkConnectivityConfigId",
                 "region",
@@ -22856,6 +21194,9 @@
                 },
                 "creationTime": {
                     "type": "number"
+                },
+                "egressConfig": {
+                    "$ref": "#/types/databricks:index/MwsNetworkConnectivityConfigEgressConfig:MwsNetworkConnectivityConfigEgressConfig"
                 },
                 "name": {
                     "type": "string"
@@ -22953,11 +21294,8 @@
             "required": [
                 "accountId",
                 "creationTime",
-                "errorMessages",
-                "gcpNetworkInfo",
                 "networkId",
                 "networkName",
-                "vpcEndpoints",
                 "vpcStatus",
                 "workspaceId"
             ],
@@ -22968,6 +21306,15 @@
                 },
                 "creationTime": {
                     "type": "number"
+                },
+                "errorMessages": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/types/databricks:index/MwsNetworksErrorMessage:MwsNetworksErrorMessage"
+                    }
+                },
+                "gcpNetworkInfo": {
+                    "$ref": "#/types/databricks:index/MwsNetworksGcpNetworkInfo:MwsNetworksGcpNetworkInfo"
                 },
                 "networkId": {
                     "type": "string"
@@ -22986,6 +21333,9 @@
                     "items": {
                         "type": "string"
                     }
+                },
+                "vpcEndpoints": {
+                    "$ref": "#/types/databricks:index/MwsNetworksVpcEndpoints:MwsNetworksVpcEndpoints"
                 },
                 "vpcId": {
                     "type": "string"
@@ -23311,7 +21661,6 @@
             "required": [
                 "awsAccountId",
                 "awsEndpointServiceId",
-                "gcpVpcEndpointInfo",
                 "state",
                 "useCase",
                 "vpcEndpointId",
@@ -23329,6 +21678,9 @@
                 },
                 "awsVpcEndpointId": {
                     "type": "string"
+                },
+                "gcpVpcEndpointInfo": {
+                    "$ref": "#/types/databricks:index/MwsVpcEndpointGcpVpcEndpointInfo:MwsVpcEndpointGcpVpcEndpointInfo"
                 },
                 "region": {
                     "type": "string"
@@ -23481,15 +21833,9 @@
             "required": [
                 "accountId",
                 "cloud",
-                "cloudResourceContainer",
                 "creationTime",
-                "externalCustomerInfo",
-                "gcpManagedNetworkConfig",
                 "gcpWorkspaceSa",
-                "gkeConfig",
                 "pricingTier",
-                "timeouts",
-                "token",
                 "workspaceId",
                 "workspaceName",
                 "workspaceStatus",
@@ -23506,6 +21852,9 @@
                 },
                 "cloud": {
                     "type": "string"
+                },
+                "cloudResourceContainer": {
+                    "$ref": "#/types/databricks:index/MwsWorkspacesCloudResourceContainer:MwsWorkspacesCloudResourceContainer"
                 },
                 "creationTime": {
                     "type": "number"
@@ -23525,6 +21874,15 @@
                 },
                 "deploymentName": {
                     "type": "string"
+                },
+                "externalCustomerInfo": {
+                    "$ref": "#/types/databricks:index/MwsWorkspacesExternalCustomerInfo:MwsWorkspacesExternalCustomerInfo"
+                },
+                "gcpManagedNetworkConfig": {
+                    "$ref": "#/types/databricks:index/MwsWorkspacesGcpManagedNetworkConfig:MwsWorkspacesGcpManagedNetworkConfig"
+                },
+                "gkeConfig": {
+                    "$ref": "#/types/databricks:index/MwsWorkspacesGkeConfig:MwsWorkspacesGkeConfig"
                 },
                 "isNoPublicIpEnabled": {
                     "type": "boolean"
@@ -23549,6 +21907,12 @@
                 },
                 "storageCustomerManagedKeyId": {
                     "type": "string"
+                },
+                "timeouts": {
+                    "$ref": "#/types/databricks:index/MwsWorkspacesTimeouts:MwsWorkspacesTimeouts"
+                },
+                "token": {
+                    "$ref": "#/types/databricks:index/MwsWorkspacesToken:MwsWorkspacesToken"
                 },
                 "workspaceId": {
                     "type": "number"
@@ -23788,11 +22152,13 @@
                 }
             },
             "required": [
-                "config",
                 "destinationType",
                 "displayName"
             ],
             "inputProperties": {
+                "config": {
+                    "$ref": "#/types/databricks:index/NotificationDestinationConfig:NotificationDestinationConfig"
+                },
                 "destinationType": {
                     "type": "string"
                 },
@@ -23896,16 +22262,20 @@
             },
             "required": [
                 "name",
-                "spec",
-                "statuses",
-                "timeouts"
+                "statuses"
             ],
             "inputProperties": {
                 "name": {
                     "type": "string"
                 },
+                "spec": {
+                    "$ref": "#/types/databricks:index/OnlineTableSpec:OnlineTableSpec"
+                },
                 "tableServingUrl": {
                     "type": "string"
+                },
+                "timeouts": {
+                    "$ref": "#/types/databricks:index/OnlineTableTimeouts:OnlineTableTimeouts"
                 }
             },
             "stateInputs": {
@@ -24063,6 +22433,12 @@
                 "objectType"
             ],
             "inputProperties": {
+                "accessControls": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/types/databricks:index/PermissionsAccessControl:PermissionsAccessControl"
+                    }
+                },
                 "authorization": {
                     "type": "string"
                 },
@@ -24133,6 +22509,9 @@
                     "type": "string"
                 }
             },
+            "requiredInputs": [
+                "accessControls"
+            ],
             "stateInputs": {
                 "description": "Input properties used for looking up and filtering Permissions resources.\n",
                 "properties": {
@@ -24328,23 +22707,13 @@
             },
             "required": [
                 "cause",
-                "clusters",
                 "clusterId",
                 "creatorUserName",
-                "deployment",
-                "filters",
-                "gatewayDefinition",
                 "health",
-                "ingestionDefinition",
                 "lastModified",
-                "latestUpdates",
-                "libraries",
                 "name",
-                "notifications",
                 "runAsUserName",
                 "state",
-                "timeouts",
-                "trigger",
                 "url"
             ],
             "inputProperties": {
@@ -24363,6 +22732,12 @@
                 "clusterId": {
                     "type": "string"
                 },
+                "clusters": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/types/databricks:index/PipelineCluster:PipelineCluster"
+                    }
+                },
                 "configuration": {
                     "type": "object",
                     "additionalProperties": {
@@ -24375,6 +22750,9 @@
                 "creatorUserName": {
                     "type": "string"
                 },
+                "deployment": {
+                    "$ref": "#/types/databricks:index/PipelineDeployment:PipelineDeployment"
+                },
                 "development": {
                     "type": "boolean"
                 },
@@ -24384,14 +22762,41 @@
                 "expectedLastModified": {
                     "type": "number"
                 },
+                "filters": {
+                    "$ref": "#/types/databricks:index/PipelineFilters:PipelineFilters"
+                },
+                "gatewayDefinition": {
+                    "$ref": "#/types/databricks:index/PipelineGatewayDefinition:PipelineGatewayDefinition"
+                },
                 "health": {
                     "type": "string"
+                },
+                "ingestionDefinition": {
+                    "$ref": "#/types/databricks:index/PipelineIngestionDefinition:PipelineIngestionDefinition"
                 },
                 "lastModified": {
                     "type": "number"
                 },
+                "latestUpdates": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/types/databricks:index/PipelineLatestUpdate:PipelineLatestUpdate"
+                    }
+                },
+                "libraries": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/types/databricks:index/PipelineLibrary:PipelineLibrary"
+                    }
+                },
                 "name": {
                     "type": "string"
+                },
+                "notifications": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/types/databricks:index/PipelineNotification:PipelineNotification"
+                    }
                 },
                 "photon": {
                     "type": "boolean"
@@ -24410,6 +22815,12 @@
                 },
                 "target": {
                     "type": "string"
+                },
+                "timeouts": {
+                    "$ref": "#/types/databricks:index/PipelineTimeouts:PipelineTimeouts"
+                },
+                "trigger": {
+                    "$ref": "#/types/databricks:index/PipelineTrigger:PipelineTrigger"
                 },
                 "url": {
                     "type": "string"
@@ -24604,21 +23015,13 @@
             },
             "required": [
                 "assetsDir",
-                "customMetrics",
                 "dashboardId",
-                "dataClassificationConfig",
                 "driftMetricsTableName",
-                "inferenceLog",
                 "monitorVersion",
-                "notifications",
                 "outputSchemaName",
                 "profileMetricsTableName",
-                "schedule",
-                "snapshot",
                 "status",
-                "tableName",
-                "timeSeries",
-                "timeouts"
+                "tableName"
             ],
             "inputProperties": {
                 "assetsDir": {
@@ -24627,11 +23030,29 @@
                 "baselineTableName": {
                     "type": "string"
                 },
+                "customMetrics": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/types/databricks:index/QualityMonitorCustomMetric:QualityMonitorCustomMetric"
+                    }
+                },
+                "dataClassificationConfig": {
+                    "$ref": "#/types/databricks:index/QualityMonitorDataClassificationConfig:QualityMonitorDataClassificationConfig"
+                },
+                "inferenceLog": {
+                    "$ref": "#/types/databricks:index/QualityMonitorInferenceLog:QualityMonitorInferenceLog"
+                },
                 "latestMonitorFailureMsg": {
                     "type": "string"
                 },
+                "notifications": {
+                    "$ref": "#/types/databricks:index/QualityMonitorNotifications:QualityMonitorNotifications"
+                },
                 "outputSchemaName": {
                     "type": "string"
+                },
+                "schedule": {
+                    "$ref": "#/types/databricks:index/QualityMonitorSchedule:QualityMonitorSchedule"
                 },
                 "skipBuiltinDashboard": {
                     "type": "boolean"
@@ -24642,8 +23063,17 @@
                         "type": "string"
                     }
                 },
+                "snapshot": {
+                    "$ref": "#/types/databricks:index/QualityMonitorSnapshot:QualityMonitorSnapshot"
+                },
                 "tableName": {
                     "type": "string"
+                },
+                "timeSeries": {
+                    "$ref": "#/types/databricks:index/QualityMonitorTimeSeries:QualityMonitorTimeSeries"
+                },
+                "timeouts": {
+                    "$ref": "#/types/databricks:index/QualityMonitorTimeouts:QualityMonitorTimeouts"
                 },
                 "warehouseId": {
                     "type": "string"
@@ -24798,12 +23228,9 @@
                 "cloud",
                 "createdAt",
                 "createdBy",
-                "ipAccessList",
                 "metastoreId",
                 "name",
-                "propertiesKvpairs",
                 "region",
-                "tokens",
                 "updatedAt",
                 "updatedBy"
             ],
@@ -24817,15 +23244,27 @@
                 "dataRecipientGlobalMetastoreId": {
                     "type": "string"
                 },
+                "ipAccessList": {
+                    "$ref": "#/types/databricks:index/RecipientIpAccessList:RecipientIpAccessList"
+                },
                 "name": {
                     "type": "string"
                 },
                 "owner": {
                     "type": "string"
                 },
+                "propertiesKvpairs": {
+                    "$ref": "#/types/databricks:index/RecipientPropertiesKvpairs:RecipientPropertiesKvpairs"
+                },
                 "sharingCode": {
                     "type": "string",
                     "secret": true
+                },
+                "tokens": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/types/databricks:index/RecipientToken:RecipientToken"
+                    }
                 }
             },
             "requiredInputs": [
@@ -25005,7 +23444,6 @@
                 "commitHash",
                 "gitProvider",
                 "path",
-                "sparseCheckout",
                 "url",
                 "workspacePath"
             ],
@@ -25021,6 +23459,9 @@
                 },
                 "path": {
                     "type": "string"
+                },
+                "sparseCheckout": {
+                    "$ref": "#/types/databricks:index/RepoSparseCheckout:RepoSparseCheckout"
                 },
                 "tag": {
                     "type": "string"
@@ -25084,10 +23525,16 @@
                 "etag": {
                     "type": "string"
                 },
+                "restrictWorkspaceAdmins": {
+                    "$ref": "#/types/databricks:index/RestrictWorkspaceAdminsSettingRestrictWorkspaceAdmins:RestrictWorkspaceAdminsSettingRestrictWorkspaceAdmins"
+                },
                 "settingName": {
                     "type": "string"
                 }
             },
+            "requiredInputs": [
+                "restrictWorkspaceAdmins"
+            ],
             "stateInputs": {
                 "description": "Input properties used for looking up and filtering RestrictWorkspaceAdminsSetting resources.\n",
                 "properties": {
@@ -25348,7 +23795,6 @@
             },
             "required": [
                 "backendType",
-                "keyvaultMetadata",
                 "name"
             ],
             "inputProperties": {
@@ -25357,6 +23803,9 @@
                 },
                 "initialManagePrincipal": {
                     "type": "string"
+                },
+                "keyvaultMetadata": {
+                    "$ref": "#/types/databricks:index/SecretScopeKeyvaultMetadata:SecretScopeKeyvaultMetadata"
                 },
                 "name": {
                     "type": "string"
@@ -25647,8 +24096,7 @@
             "required": [
                 "createdAt",
                 "createdBy",
-                "name",
-                "objects"
+                "name"
             ],
             "inputProperties": {
                 "createdAt": {
@@ -25659,6 +24107,12 @@
                 },
                 "name": {
                     "type": "string"
+                },
+                "objects": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/types/databricks:index/ShareObject:ShareObject"
+                    }
                 },
                 "owner": {
                     "type": "string"
@@ -25727,6 +24181,9 @@
                 "name": {
                     "type": "string"
                 },
+                "options": {
+                    "$ref": "#/types/databricks:index/SqlAlertOptions:SqlAlertOptions"
+                },
                 "parent": {
                     "type": "string"
                 },
@@ -25741,6 +24198,7 @@
                 }
             },
             "requiredInputs": [
+                "options",
                 "queryId"
             ],
             "stateInputs": {
@@ -25933,7 +24391,6 @@
                 }
             },
             "required": [
-                "channel",
                 "clusterSize",
                 "creatorName",
                 "dataSourceId",
@@ -25944,13 +24401,14 @@
                 "numActiveSessions",
                 "numClusters",
                 "odbcParams",
-                "state",
-                "tags",
-                "timeouts"
+                "state"
             ],
             "inputProperties": {
                 "autoStopMins": {
                     "type": "number"
+                },
+                "channel": {
+                    "$ref": "#/types/databricks:index/SqlEndpointChannel:SqlEndpointChannel"
                 },
                 "clusterSize": {
                     "type": "string"
@@ -25978,6 +24436,12 @@
                 },
                 "spotInstancePolicy": {
                     "type": "string"
+                },
+                "tags": {
+                    "$ref": "#/types/databricks:index/SqlEndpointTags:SqlEndpointTags"
+                },
+                "timeouts": {
+                    "$ref": "#/types/databricks:index/SqlEndpointTimeouts:SqlEndpointTimeouts"
                 },
                 "warehouseType": {
                     "type": "string"
@@ -26183,8 +24647,7 @@
                 }
             },
             "required": [
-                "clusterId",
-                "privilegeAssignments"
+                "clusterId"
             ],
             "inputProperties": {
                 "anonymousFunction": {
@@ -26201,6 +24664,12 @@
                 },
                 "database": {
                     "type": "string"
+                },
+                "privilegeAssignments": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/types/databricks:index/SqlPermissionsPrivilegeAssignment:SqlPermissionsPrivilegeAssignment"
+                    }
                 },
                 "table": {
                     "type": "string"
@@ -26290,9 +24759,7 @@
                 "createdAt",
                 "dataSourceId",
                 "name",
-                "parameters",
                 "query",
-                "schedule",
                 "updatedAt"
             ],
             "inputProperties": {
@@ -26308,6 +24775,12 @@
                 "name": {
                     "type": "string"
                 },
+                "parameters": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/types/databricks:index/SqlQueryParameter:SqlQueryParameter"
+                    }
+                },
                 "parent": {
                     "type": "string"
                 },
@@ -26316,6 +24789,10 @@
                 },
                 "runAsRole": {
                     "type": "string"
+                },
+                "schedule": {
+                    "$ref": "#/types/databricks:index/SqlQuerySchedule:SqlQuerySchedule",
+                    "deprecationMessage": "Deprecated"
                 },
                 "tags": {
                     "type": "array",
@@ -26450,7 +24927,6 @@
             "required": [
                 "catalogName",
                 "clusterId",
-                "columns",
                 "name",
                 "owner",
                 "properties",
@@ -26468,6 +24944,12 @@
                     "type": "array",
                     "items": {
                         "type": "string"
+                    }
+                },
+                "columns": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/types/databricks:index/SqlTableColumn:SqlTableColumn"
                     }
                 },
                 "comment": {
@@ -26716,8 +25198,6 @@
             },
             "required": [
                 "dashboardId",
-                "parameters",
-                "position",
                 "widgetId"
             ],
             "inputProperties": {
@@ -26726,6 +25206,15 @@
                 },
                 "description": {
                     "type": "string"
+                },
+                "parameters": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/types/databricks:index/SqlWidgetParameter:SqlWidgetParameter"
+                    }
+                },
+                "position": {
+                    "$ref": "#/types/databricks:index/SqlWidgetPosition:SqlWidgetPosition"
                 },
                 "text": {
                     "type": "string"
@@ -26829,12 +25318,6 @@
                 }
             },
             "required": [
-                "awsIamRole",
-                "azureManagedIdentity",
-                "azureServicePrincipal",
-                "cloudflareApiToken",
-                "databricksGcpServiceAccount",
-                "gcpServiceAccountKey",
                 "isolationMode",
                 "metastoreId",
                 "name",
@@ -26842,14 +25325,32 @@
                 "storageCredentialId"
             ],
             "inputProperties": {
+                "awsIamRole": {
+                    "$ref": "#/types/databricks:index/StorageCredentialAwsIamRole:StorageCredentialAwsIamRole"
+                },
+                "azureManagedIdentity": {
+                    "$ref": "#/types/databricks:index/StorageCredentialAzureManagedIdentity:StorageCredentialAzureManagedIdentity"
+                },
+                "azureServicePrincipal": {
+                    "$ref": "#/types/databricks:index/StorageCredentialAzureServicePrincipal:StorageCredentialAzureServicePrincipal"
+                },
+                "cloudflareApiToken": {
+                    "$ref": "#/types/databricks:index/StorageCredentialCloudflareApiToken:StorageCredentialCloudflareApiToken"
+                },
                 "comment": {
                     "type": "string"
+                },
+                "databricksGcpServiceAccount": {
+                    "$ref": "#/types/databricks:index/StorageCredentialDatabricksGcpServiceAccount:StorageCredentialDatabricksGcpServiceAccount"
                 },
                 "forceDestroy": {
                     "type": "boolean"
                 },
                 "forceUpdate": {
                     "type": "boolean"
+                },
+                "gcpServiceAccountKey": {
+                    "$ref": "#/types/databricks:index/StorageCredentialGcpServiceAccountKey:StorageCredentialGcpServiceAccountKey"
                 },
                 "isolationMode": {
                     "type": "string"
@@ -27030,6 +25531,12 @@
                 "catalogName": {
                     "type": "string"
                 },
+                "columns": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/types/databricks:index/TableColumn:TableColumn"
+                    }
+                },
                 "comment": {
                     "type": "string"
                 },
@@ -27066,6 +25573,7 @@
             },
             "requiredInputs": [
                 "catalogName",
+                "columns",
                 "dataSourceFormat",
                 "schemaName",
                 "tableType"
@@ -27469,8 +25977,7 @@
                 "lastUpdatedTimestamp",
                 "lastUpdatedUser",
                 "name",
-                "numIndexes",
-                "timeouts"
+                "numIndexes"
             ],
             "inputProperties": {
                 "endpointType": {
@@ -27478,6 +25985,9 @@
                 },
                 "name": {
                     "type": "string"
+                },
+                "timeouts": {
+                    "$ref": "#/types/databricks:index/VectorSearchEndpointTimeouts:VectorSearchEndpointTimeouts"
                 }
             },
             "requiredInputs": [
@@ -27558,16 +26068,19 @@
             },
             "required": [
                 "creator",
-                "deltaSyncIndexSpec",
-                "directAccessIndexSpec",
                 "endpointName",
                 "indexType",
                 "name",
                 "primaryKey",
-                "statuses",
-                "timeouts"
+                "statuses"
             ],
             "inputProperties": {
+                "deltaSyncIndexSpec": {
+                    "$ref": "#/types/databricks:index/VectorSearchIndexDeltaSyncIndexSpec:VectorSearchIndexDeltaSyncIndexSpec"
+                },
+                "directAccessIndexSpec": {
+                    "$ref": "#/types/databricks:index/VectorSearchIndexDirectAccessIndexSpec:VectorSearchIndexDirectAccessIndexSpec"
+                },
                 "endpointName": {
                     "type": "string"
                 },
@@ -27579,6 +26092,9 @@
                 },
                 "primaryKey": {
                     "type": "string"
+                },
+                "timeouts": {
+                    "$ref": "#/types/databricks:index/VectorSearchIndexTimeouts:VectorSearchIndexTimeouts"
                 }
             },
             "requiredInputs": [
@@ -28183,6 +26699,9 @@
             "inputs": {
                 "description": "A collection of arguments for invoking getCatalog.\n",
                 "properties": {
+                    "catalogInfo": {
+                        "$ref": "#/types/databricks:index/getCatalogCatalogInfo:getCatalogCatalogInfo"
+                    },
                     "id": {
                         "type": "string"
                     },
@@ -28210,7 +26729,6 @@
                 },
                 "type": "object",
                 "required": [
-                    "catalogInfo",
                     "id",
                     "name"
                 ]
@@ -28259,6 +26777,9 @@
                     "clusterId": {
                         "type": "string"
                     },
+                    "clusterInfo": {
+                        "$ref": "#/types/databricks:index/getClusterClusterInfo:getClusterClusterInfo"
+                    },
                     "clusterName": {
                         "type": "string"
                     },
@@ -28287,7 +26808,6 @@
                 "type": "object",
                 "required": [
                     "clusterId",
-                    "clusterInfo",
                     "clusterName",
                     "id"
                 ]
@@ -28471,6 +26991,9 @@
                 "properties": {
                     "id": {
                         "type": "string"
+                    },
+                    "metastoreInfo": {
+                        "$ref": "#/types/databricks:index/getCurrentMetastoreMetastoreInfo:getCurrentMetastoreMetastoreInfo"
                     }
                 },
                 "type": "object"
@@ -28487,8 +27010,7 @@
                 },
                 "type": "object",
                 "required": [
-                    "id",
-                    "metastoreInfo"
+                    "id"
                 ]
             }
         },
@@ -28691,6 +27213,9 @@
             "inputs": {
                 "description": "A collection of arguments for invoking getExternalLocation.\n",
                 "properties": {
+                    "externalLocationInfo": {
+                        "$ref": "#/types/databricks:index/getExternalLocationExternalLocationInfo:getExternalLocationExternalLocationInfo"
+                    },
                     "id": {
                         "type": "string"
                     },
@@ -28718,7 +27243,6 @@
                 },
                 "type": "object",
                 "required": [
-                    "externalLocationInfo",
                     "id",
                     "name"
                 ]
@@ -28926,6 +27450,9 @@
                     },
                     "name": {
                         "type": "string"
+                    },
+                    "poolInfo": {
+                        "$ref": "#/types/databricks:index/getInstancePoolPoolInfo:getInstancePoolPoolInfo"
                     }
                 },
                 "type": "object",
@@ -28949,8 +27476,7 @@
                 "type": "object",
                 "required": [
                     "id",
-                    "name",
-                    "poolInfo"
+                    "name"
                 ]
             }
         },
@@ -28960,6 +27486,12 @@
                 "properties": {
                     "id": {
                         "type": "string"
+                    },
+                    "instanceProfiles": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/types/databricks:index/getInstanceProfilesInstanceProfile:getInstanceProfilesInstanceProfile"
+                        }
                     }
                 },
                 "type": "object"
@@ -28979,8 +27511,7 @@
                 },
                 "type": "object",
                 "required": [
-                    "id",
-                    "instanceProfiles"
+                    "id"
                 ]
             }
         },
@@ -28996,6 +27527,9 @@
                     },
                     "jobName": {
                         "type": "string"
+                    },
+                    "jobSettings": {
+                        "$ref": "#/types/databricks:index/getJobJobSettings:getJobJobSettings"
                     },
                     "name": {
                         "type": "string"
@@ -29027,7 +27561,6 @@
                     "id",
                     "jobId",
                     "jobName",
-                    "jobSettings",
                     "name"
                 ]
             }
@@ -29078,6 +27611,9 @@
                     "metastoreId": {
                         "type": "string"
                     },
+                    "metastoreInfo": {
+                        "$ref": "#/types/databricks:index/getMetastoreMetastoreInfo:getMetastoreMetastoreInfo"
+                    },
                     "name": {
                         "type": "string"
                     },
@@ -29110,7 +27646,6 @@
                 "required": [
                     "id",
                     "metastoreId",
-                    "metastoreInfo",
                     "name",
                     "region"
                 ]
@@ -29176,6 +27711,12 @@
                     },
                     "name": {
                         "type": "string"
+                    },
+                    "tags": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/types/databricks:index/getMlflowExperimentTag:getMlflowExperimentTag"
+                        }
                     }
                 },
                 "type": "object"
@@ -29219,8 +27760,7 @@
                     "id",
                     "lastUpdateTime",
                     "lifecycleStage",
-                    "name",
-                    "tags"
+                    "name"
                 ]
             }
         },
@@ -29231,11 +27771,23 @@
                     "description": {
                         "type": "string"
                     },
+                    "latestVersions": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/types/databricks:index/getMlflowModelLatestVersion:getMlflowModelLatestVersion"
+                        }
+                    },
                     "name": {
                         "type": "string"
                     },
                     "permissionLevel": {
                         "type": "string"
+                    },
+                    "tags": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/types/databricks:index/getMlflowModelTag:getMlflowModelTag"
+                        }
                     },
                     "userId": {
                         "type": "string"
@@ -29281,10 +27833,8 @@
                 "required": [
                     "description",
                     "id",
-                    "latestVersions",
                     "name",
                     "permissionLevel",
-                    "tags",
                     "userId"
                 ]
             }
@@ -29631,6 +28181,9 @@
                     },
                     "name": {
                         "type": "string"
+                    },
+                    "schemaInfo": {
+                        "$ref": "#/types/databricks:index/getSchemaSchemaInfo:getSchemaSchemaInfo"
                     }
                 },
                 "type": "object",
@@ -29654,8 +28207,7 @@
                 "type": "object",
                 "required": [
                     "id",
-                    "name",
-                    "schemaInfo"
+                    "name"
                 ]
             }
         },
@@ -29842,6 +28394,12 @@
                     },
                     "name": {
                         "type": "string"
+                    },
+                    "objects": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/types/databricks:index/getShareObject:getShareObject"
+                        }
                     }
                 },
                 "type": "object"
@@ -29873,8 +28431,7 @@
                     "createdAt",
                     "createdBy",
                     "id",
-                    "name",
-                    "objects"
+                    "name"
                 ]
             }
         },
@@ -30008,6 +28565,9 @@
                     "autoStopMins": {
                         "type": "number"
                     },
+                    "channel": {
+                        "$ref": "#/types/databricks:index/getSqlWarehouseChannel:getSqlWarehouseChannel"
+                    },
                     "clusterSize": {
                         "type": "string"
                     },
@@ -30022,6 +28582,9 @@
                     },
                     "enableServerlessCompute": {
                         "type": "boolean"
+                    },
+                    "health": {
+                        "$ref": "#/types/databricks:index/getSqlWarehouseHealth:getSqlWarehouseHealth"
                     },
                     "id": {
                         "type": "string"
@@ -30047,11 +28610,17 @@
                     "numClusters": {
                         "type": "number"
                     },
+                    "odbcParams": {
+                        "$ref": "#/types/databricks:index/getSqlWarehouseOdbcParams:getSqlWarehouseOdbcParams"
+                    },
                     "spotInstancePolicy": {
                         "type": "string"
                     },
                     "state": {
                         "type": "string"
+                    },
+                    "tags": {
+                        "$ref": "#/types/databricks:index/getSqlWarehouseTags:getSqlWarehouseTags"
                     },
                     "warehouseType": {
                         "type": "string"
@@ -30129,13 +28698,11 @@
                 "type": "object",
                 "required": [
                     "autoStopMins",
-                    "channel",
                     "clusterSize",
                     "creatorName",
                     "dataSourceId",
                     "enablePhoton",
                     "enableServerlessCompute",
-                    "health",
                     "id",
                     "instanceProfileArn",
                     "jdbcUrl",
@@ -30144,10 +28711,8 @@
                     "name",
                     "numActiveSessions",
                     "numClusters",
-                    "odbcParams",
                     "spotInstancePolicy",
                     "state",
-                    "tags",
                     "warehouseType"
                 ]
             }
@@ -30203,6 +28768,9 @@
                     },
                     "name": {
                         "type": "string"
+                    },
+                    "storageCredentialInfo": {
+                        "$ref": "#/types/databricks:index/getStorageCredentialStorageCredentialInfo:getStorageCredentialStorageCredentialInfo"
                     }
                 },
                 "type": "object",
@@ -30226,8 +28794,7 @@
                 "type": "object",
                 "required": [
                     "id",
-                    "name",
-                    "storageCredentialInfo"
+                    "name"
                 ]
             }
         },
@@ -30276,6 +28843,9 @@
                     },
                     "name": {
                         "type": "string"
+                    },
+                    "tableInfo": {
+                        "$ref": "#/types/databricks:index/getTableTableInfo:getTableTableInfo"
                     }
                 },
                 "type": "object",
@@ -30299,8 +28869,7 @@
                 "type": "object",
                 "required": [
                     "id",
-                    "name",
-                    "tableInfo"
+                    "name"
                 ]
             }
         },
@@ -30488,6 +29057,9 @@
                     },
                     "name": {
                         "type": "string"
+                    },
+                    "volumeInfo": {
+                        "$ref": "#/types/databricks:index/getVolumeVolumeInfo:getVolumeVolumeInfo"
                     }
                 },
                 "type": "object",
@@ -30511,8 +29083,7 @@
                 "type": "object",
                 "required": [
                     "id",
-                    "name",
-                    "volumeInfo"
+                    "name"
                 ]
             }
         },

--- a/pf/proto/block.go
+++ b/pf/proto/block.go
@@ -114,12 +114,12 @@ func (m blockSchema) Elem() interface{} {
 	}
 }
 
-func (s blockSchema) Optional() bool {
-	return !s.Required()
+func (m blockSchema) Optional() bool {
+	return !m.Required()
 }
 
-func (s blockSchema) Required() bool {
-	return s.MinItems() > 0
+func (m blockSchema) Required() bool {
+	return m.MinItems() > 0
 }
 
 func (m blockSchema) Default() interface{}                { return nil }

--- a/pf/proto/block.go
+++ b/pf/proto/block.go
@@ -114,8 +114,14 @@ func (m blockSchema) Elem() interface{} {
 	}
 }
 
-func (m blockSchema) Optional() bool                      { return false }
-func (m blockSchema) Required() bool                      { return false }
+func (s blockSchema) Optional() bool {
+	return !s.Required()
+}
+
+func (s blockSchema) Required() bool {
+	return s.MinItems() > 0
+}
+
 func (m blockSchema) Default() interface{}                { return nil }
 func (m blockSchema) DefaultFunc() shim.SchemaDefaultFunc { return nil }
 func (m blockSchema) DefaultValue() (interface{}, error)  { return nil, nil }

--- a/pf/proto/protov6_test.go
+++ b/pf/proto/protov6_test.go
@@ -25,14 +25,15 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hexops/autogold/v2"
-	"github.com/pulumi/pulumi-terraform-bridge/pf/proto"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen"
-	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-terraform-bridge/pf/proto"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
 func marshalProviderShim(t *testing.T, p shim.Provider) []byte {
@@ -109,6 +110,7 @@ func TestBlockSchemaGeneration(t *testing.T) {
 	spec, err := tfgen.GenerateSchema(providerInfo, nilSink)
 	require.NoError(t, err)
 	specBytes, err := json.MarshalIndent(spec.Resources, "", "  ")
+	require.NoError(t, err)
 	autogold.Expect(`{
   "testprov:index:MyRes": {
     "properties": {

--- a/pf/proto/protov6_test.go
+++ b/pf/proto/protov6_test.go
@@ -19,16 +19,20 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hexops/autogold/v2"
-	"github.com/stretchr/testify/require"
-
 	"github.com/pulumi/pulumi-terraform-bridge/pf/proto"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func marshalProviderShim(t *testing.T, p shim.Provider) []byte {
@@ -68,6 +72,77 @@ func TestDynamicType(t *testing.T) {
     }
 }
 `).Equal(t, string(b))
+}
+
+func TestBlockSchemaGeneration(t *testing.T) {
+	p := proto.New(context.Background(), providerServer{
+		SchemaResponse: &tfprotov6.GetProviderSchemaResponse{
+			ResourceSchemas: map[string]*tfprotov6.Schema{
+				"testprov_my_res": {Block: &tfprotov6.SchemaBlock{
+					BlockTypes: []*tfprotov6.SchemaNestedBlock{
+						{
+							TypeName: "blk",
+							Nesting:  tfprotov6.SchemaNestedBlockNestingModeList,
+							Block: &tfprotov6.SchemaBlock{
+								Attributes: []*tfprotov6.SchemaAttribute{{
+									Name:     "bah",
+									Type:     tftypes.Bool,
+									Optional: true,
+								}},
+							},
+						},
+					},
+				}},
+			},
+		},
+	})
+	providerInfo := info.Provider{
+		P:    p,
+		Name: "testprov",
+		Resources: map[string]*info.Resource{
+			"testprov_my_res": {
+				Tok: "testprov:index:MyRes",
+			},
+		},
+	}
+	nilSink := diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never})
+	spec, err := tfgen.GenerateSchema(providerInfo, nilSink)
+	require.NoError(t, err)
+	specBytes, err := json.MarshalIndent(spec.Resources, "", "  ")
+	autogold.Expect(`{
+  "testprov:index:MyRes": {
+    "properties": {
+      "blks": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/testprov:index/MyResBlk:MyResBlk"
+        }
+      }
+    },
+    "inputProperties": {
+      "blks": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/testprov:index/MyResBlk:MyResBlk"
+        }
+      }
+    },
+    "stateInputs": {
+      "description": "Input properties used for looking up and filtering MyRes resources.\n",
+      "properties": {
+        "blks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/testprov:index/MyResBlk:MyResBlk"
+          }
+        }
+      },
+      "type": "object"
+    }
+  }
+}`).Equal(t, string(specBytes))
+	assert.Containsf(t, spec.Resources["testprov:index:MyRes"].InputProperties, "blks",
+		"Blocks should map to input properties")
 }
 
 type providerServer struct {

--- a/pf/tests/schemashim_test.go
+++ b/pf/tests/schemashim_test.go
@@ -384,14 +384,14 @@ func TestSchemaShimRepresentations(t *testing.T) {
 
 			tc.expect.Equal(t, string(prettyBytes))
 
-			token := "testprov:index:R1"
+			rtok := "testprov:index:R1"
 
 			info := info.Provider{
 				Name: "testprov",
 				P:    shimmedProvider,
 				Resources: map[string]*info.Resource{
 					"testprov_r1": {
-						Tok: tokens.Type(token),
+						Tok: tokens.Type(rtok),
 					},
 				},
 			}
@@ -406,7 +406,7 @@ func TestSchemaShimRepresentations(t *testing.T) {
 			}
 
 			ms := miniSpec{
-				Resource: pSpec.Resources[token],
+				Resource: pSpec.Resources[rtok],
 				Types:    pSpec.Types,
 			}
 

--- a/pf/tests/schemashim_test.go
+++ b/pf/tests/schemashim_test.go
@@ -17,6 +17,7 @@ package tfbridgetests
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -27,23 +28,33 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/pf/internal/schemashim"
 	pb "github.com/pulumi/pulumi-terraform-bridge/pf/tests/internal/providerbuilder"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/stretchr/testify/require"
 )
 
-// Test how various PF-based schemata translate to the shim.Schema layer.
+// Test how various PF-based schemata translate to the shim.Schema layer. Excerpts of the resulting Pulumi Package
+// Schema are included for reasoning convenience.
 func TestSchemaShimRepresentations(t *testing.T) {
 
 	type testCase struct {
-		name     string
-		provider provider.Provider
-		expect   autogold.Value
+		name         string
+		provider     provider.Provider
+		expect       autogold.Value // expected prettified shim.Schema representation
+		expectSchema autogold.Value // expected corresponding Pulumi Package Schema extract
 	}
 
 	testCases := []testCase{
+		//------------------------------------------------------------------------------------------------------
 		{
 			"single-nested-block",
 			&pb.Provider{
+				TypeName: "testprov",
 				AllResources: []pb.Resource{{
+					Name: "r1",
 					ResourceSchema: schema.Schema{
 						Blocks: map[string]schema.Block{
 							"single_nested_block": schema.SingleNestedBlock{
@@ -59,7 +70,7 @@ func TestSchemaShimRepresentations(t *testing.T) {
 			},
 			autogold.Expect(`{
   "resources": {
-    "_": {
+    "testprov_r1": {
       "single_nested_block": {
         "element": {
           "resource": {
@@ -75,11 +86,47 @@ func TestSchemaShimRepresentations(t *testing.T) {
     }
   }
 }`),
+			autogold.Expect(`{
+  "resource": {
+    "properties": {
+      "singleNestedBlock": {
+        "$ref": "#/types/testprov:index/R1SingleNestedBlock:R1SingleNestedBlock"
+      }
+    },
+    "inputProperties": {
+      "singleNestedBlock": {
+        "$ref": "#/types/testprov:index/R1SingleNestedBlock:R1SingleNestedBlock"
+      }
+    },
+    "stateInputs": {
+      "description": "Input properties used for looking up and filtering R1 resources.\n",
+      "properties": {
+        "singleNestedBlock": {
+          "$ref": "#/types/testprov:index/R1SingleNestedBlock:R1SingleNestedBlock"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "types": {
+    "testprov:index/R1SingleNestedBlock:R1SingleNestedBlock": {
+      "properties": {
+        "a1": {
+          "type": "number"
+        }
+      },
+      "type": "object"
+    }
+  }
+}`),
 		},
+		//------------------------------------------------------------------------------------------------------
 		{
 			"list-nested-block",
 			&pb.Provider{
+				TypeName: "testprov",
 				AllResources: []pb.Resource{{
+					Name: "r1",
 					ResourceSchema: schema.Schema{
 						Blocks: map[string]schema.Block{
 							"list_nested_block": schema.ListNestedBlock{
@@ -97,7 +144,7 @@ func TestSchemaShimRepresentations(t *testing.T) {
 			},
 			autogold.Expect(`{
   "resources": {
-    "_": {
+    "testprov_r1": {
       "list_nested_block": {
         "element": {
           "resource": {
@@ -113,14 +160,60 @@ func TestSchemaShimRepresentations(t *testing.T) {
     }
   }
 }`),
+			autogold.Expect(`{
+  "resource": {
+    "properties": {
+      "listNestedBlocks": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/testprov:index/R1ListNestedBlock:R1ListNestedBlock"
+        }
+      }
+    },
+    "inputProperties": {
+      "listNestedBlocks": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/testprov:index/R1ListNestedBlock:R1ListNestedBlock"
+        }
+      }
+    },
+    "stateInputs": {
+      "description": "Input properties used for looking up and filtering R1 resources.\n",
+      "properties": {
+        "listNestedBlocks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/testprov:index/R1ListNestedBlock:R1ListNestedBlock"
+          }
+        }
+      },
+      "type": "object"
+    }
+  },
+  "types": {
+    "testprov:index/R1ListNestedBlock:R1ListNestedBlock": {
+      "properties": {
+        "a1": {
+          "type": "number"
+        }
+      },
+      "type": "object"
+    }
+  }
+}`),
 		},
+		//------------------------------------------------------------------------------------------------------
 		{
 			"map-nested-attribute",
 			&pb.Provider{
+				TypeName: "testprov",
 				AllResources: []pb.Resource{{
+					Name: "r1",
 					ResourceSchema: schema.Schema{
 						Attributes: map[string]schema.Attribute{
 							"map_nested_attribute": schema.MapNestedAttribute{
+								Optional: true,
 								NestedObject: schema.NestedAttributeObject{
 									Attributes: map[string]schema.Attribute{
 										"a1": schema.StringAttribute{
@@ -135,7 +228,7 @@ func TestSchemaShimRepresentations(t *testing.T) {
 			},
 			autogold.Expect(`{
   "resources": {
-    "_": {
+    "testprov_r1": {
       "map_nested_attribute": {
         "element": {
           "schema": {
@@ -150,19 +243,66 @@ func TestSchemaShimRepresentations(t *testing.T) {
             "type": 6
           }
         },
+        "optional": true,
         "type": 6
       }
     }
   }
 }`),
+			autogold.Expect(`{
+  "resource": {
+    "properties": {
+      "mapNestedAttribute": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/types/testprov:index/R1MapNestedAttribute:R1MapNestedAttribute"
+        }
+      }
+    },
+    "inputProperties": {
+      "mapNestedAttribute": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/types/testprov:index/R1MapNestedAttribute:R1MapNestedAttribute"
+        }
+      }
+    },
+    "stateInputs": {
+      "description": "Input properties used for looking up and filtering R1 resources.\n",
+      "properties": {
+        "mapNestedAttribute": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/types/testprov:index/R1MapNestedAttribute:R1MapNestedAttribute"
+          }
+        }
+      },
+      "type": "object"
+    }
+  },
+  "types": {
+    "testprov:index/R1MapNestedAttribute:R1MapNestedAttribute": {
+      "properties": {
+        "a1": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  }
+}`),
 		},
+		//------------------------------------------------------------------------------------------------------
 		{
 			"object-attribute",
 			&pb.Provider{
+				TypeName: "testprov",
 				AllResources: []pb.Resource{{
+					Name: "r1",
 					ResourceSchema: schema.Schema{
 						Attributes: map[string]schema.Attribute{
 							"object_attribute": schema.ObjectAttribute{
+								Optional: true,
 								AttributeTypes: map[string]attr.Type{
 									"a1": types.StringType,
 								},
@@ -173,7 +313,7 @@ func TestSchemaShimRepresentations(t *testing.T) {
 			},
 			autogold.Expect(`{
   "resources": {
-    "_": {
+    "testprov_r1": {
       "object_attribute": {
         "element": {
           "resource": {
@@ -182,8 +322,45 @@ func TestSchemaShimRepresentations(t *testing.T) {
             }
           }
         },
+        "optional": true,
         "type": 6
       }
+    }
+  }
+}`),
+			autogold.Expect(`{
+  "resource": {
+    "properties": {
+      "objectAttribute": {
+        "$ref": "#/types/testprov:index/R1ObjectAttribute:R1ObjectAttribute"
+      }
+    },
+    "inputProperties": {
+      "objectAttribute": {
+        "$ref": "#/types/testprov:index/R1ObjectAttribute:R1ObjectAttribute"
+      }
+    },
+    "stateInputs": {
+      "description": "Input properties used for looking up and filtering R1 resources.\n",
+      "properties": {
+        "objectAttribute": {
+          "$ref": "#/types/testprov:index/R1ObjectAttribute:R1ObjectAttribute"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "types": {
+    "testprov:index/R1ObjectAttribute:R1ObjectAttribute": {
+      "properties": {
+        "a1": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": [
+        "a1"
+      ]
     }
   }
 }`),
@@ -206,6 +383,37 @@ func TestSchemaShimRepresentations(t *testing.T) {
 			require.NoError(t, err)
 
 			tc.expect.Equal(t, string(prettyBytes))
+
+			token := "testprov:index:R1"
+
+			info := info.Provider{
+				Name: "testprov",
+				P:    shimmedProvider,
+				Resources: map[string]*info.Resource{
+					"testprov_r1": {
+						Tok: tokens.Type(token),
+					},
+				},
+			}
+
+			nilSink := diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never})
+			pSpec, err := tfgen.GenerateSchema(info, nilSink)
+			require.NoError(t, err)
+
+			type miniSpec struct {
+				Resource any `json:"resource"`
+				Types    any `json:"types"`
+			}
+
+			ms := miniSpec{
+				Resource: pSpec.Resources[token],
+				Types:    pSpec.Types,
+			}
+
+			prettySpec, err := json.MarshalIndent(ms, "", "  ")
+			require.NoError(t, err)
+
+			tc.expectSchema.Equal(t, string(prettySpec))
 		})
 	}
 }

--- a/pkg/tfshim/shim.go
+++ b/pkg/tfshim/shim.go
@@ -91,15 +91,36 @@ type SchemaDefaultFunc func() (interface{}, error)
 
 type SchemaStateFunc func(interface{}) string
 
+// Schema instances can represent static information about various elements of a TF schema, including attributes,
+// blocks, and types such as the element type of a list attribute.
 type Schema interface {
 	Type() ValueType
-	Optional() bool
-	Required() bool
 	Default() interface{}
 	DefaultFunc() SchemaDefaultFunc
 	DefaultValue() (interface{}, error)
 	Description() string
+
+	// Optional, Required and Computed are coupled attributes that influence schema generation.
+	//
+	// If the Schema instance represents an attribute, it must be one of Required, Optional, Computed, or Computed
+	// and Optional. Computed attributes will not generate inputs in Pulumi Package Schema and will be output-only,
+	// to reflect the fact that they can only be set by the provider, not the user.
+	//
+	// If the Schema instance represents a block, this distinction is no longer present in TF, but the bridge
+	// historically treats blocks as Optional or Required to enable Pulumi Package Schema generating inputs for
+	// these.
+	Optional() bool
+
+	// An element must be provided in the configuration. See [Optional] for details.
+	//
+	// See also: https://developer.hashicorp.com/terraform/plugin/sdkv2/schemas/schema-behaviors#required
+	Required() bool
+
+	// Indicates an element that the provider may modify. See [Optional] for details.
+	//
+	// See also: https://developer.hashicorp.com/terraform/plugin/sdkv2/schemas/schema-behaviors#computed
 	Computed() bool
+
 	ForceNew() bool
 	StateFunc() SchemaStateFunc
 


### PR DESCRIPTION
This fixes the dynamic bridged provider inability to pass input parameters to resources that use blocks in their schema.

As part of the fix, doc comments are added around shim.Schema encoding clarifying the uses of Optional and the
conventions for blocks specifically.

Fixes https://github.com/pulumi/pulumi-terraform-provider/issues/8
