### PR TITLE
Bump the minimum supported go version to 1.22

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,7 +18,7 @@ jobs:
         #
         # When we decide to bump our minimum go version, we need to remember to bump the
         # go version in our go.mod files.
-        go-version: [1.21.x, 1.22.x]
+        go-version: [1.22.x, 1.23.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -61,7 +61,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
           cache-dependency-path: |
             **/go.sum
       - name: Install golangci-lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
           cache-dependency-path: |
             **/go.sum
       - run: make -C pf build.testproviders

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.21.x
+        - 1.23.x
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
@@ -32,7 +32,7 @@ jobs:
           skip-cache: true
           skip-pkg-cache: true
           skip-build-cache: true
-          version: v1.57
+          version: v1.60
     - name: Update Pulumi/Pulumi
       id: gomod
       run: >-

--- a/dynamic/go.mod
+++ b/dynamic/go.mod
@@ -145,7 +145,7 @@ require (
 	github.com/hashicorp/hcl/v2 v2.20.1 // indirect
 	github.com/hashicorp/hil v0.0.0-20190212132231-97b3a9cdfa93 // indirect
 	github.com/hashicorp/terraform-plugin-framework v1.6.0 // indirect
-	github.com/hashicorp/terraform-plugin-go v0.23.0 // indirect
+	github.com/hashicorp/terraform-plugin-go v0.23.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0 // indirect
 	github.com/hashicorp/terraform-plugin-mux v0.16.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi-terraform-bridge/v3
 
-go 1.21.12
+go 1.22
 
 replace github.com/pulumi/pulumi-terraform-bridge/x/muxer => ./x/muxer
 

--- a/pf/go.mod
+++ b/pf/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi-terraform-bridge/pf
 
-go 1.21.12
+go 1.22
 
 replace (
 	github.com/pulumi/pulumi-terraform-bridge/v3 => ./..

--- a/pf/tests/go.mod
+++ b/pf/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi-terraform-bridge/pf/tests
 
-go 1.21.12
+go 1.22
 
 replace github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests => ../../pkg/tests
 

--- a/pkg/tests/go.mod
+++ b/pkg/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests
 
-go 1.21.12
+go 1.22
 
 replace (
 	github.com/pulumi/pulumi-terraform-bridge/v3 => ../..


### PR DESCRIPTION
go1.21 has reached EOL with the release of go1.23. By policy, we only support the 2 supported go versions. This PR ends testing of go1.21 and starts testing go1.23.