### PR TITLE
Display dynamic provider stacktrace on upstream provider panic

### DIFF
--- a/dynamic/test/pfprovider/panic_resource.go
+++ b/dynamic/test/pfprovider/panic_resource.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+)
+
+// Ensure provider defined types fully satisfy framework interfaces.
+var _ resource.Resource = &panicResource{}
+var _ resource.ResourceWithImportState = &panicResource{}
+
+func NewPanicResource() resource.Resource { return &panicResource{} }
+
+// panicResource defines the resource implementation.
+type panicResource struct{}
+
+func (r *panicResource) Metadata(
+	ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse,
+) {
+	resp.TypeName = req.ProviderTypeName + "_panic"
+}
+
+func (r *panicResource) Schema(
+	ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse,
+) {
+	resp.Schema = schema.Schema{
+		// This description is used by the documentation generator and the language server.
+		MarkdownDescription: "Example resource",
+
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "Example identifier",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+func (r *panicResource) Configure(
+	ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse,
+) {
+}
+
+func (r *panicResource) Create(
+	ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse,
+) {
+	panic("PANIC MESSAGE HERE")
+}
+
+func (r *panicResource) Read(
+	ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse,
+) {
+	panic("PANIC MESSAGE HERE")
+}
+
+func (r *panicResource) Update(
+	ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse,
+) {
+	panic("PANIC MESSAGE HERE")
+}
+
+func (r *panicResource) Delete(
+	ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse,
+) {
+	panic("PANIC MESSAGE HERE")
+}
+
+func (r *panicResource) ImportState(
+	ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse,
+) {
+	panic("PANIC MESSAGE HERE")
+}

--- a/dynamic/test/pfprovider/provider.go
+++ b/dynamic/test/pfprovider/provider.go
@@ -90,6 +90,7 @@ func (p *PFProvider) Configure(
 func (p *PFProvider) Resources(ctx context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
 		NewExampleResource,
+		NewPanicResource,
 	}
 }
 

--- a/dynamic/testdata/TestStacktraceDisplayed/parameterize.golden
+++ b/dynamic/testdata/TestStacktraceDisplayed/parameterize.golden
@@ -1,0 +1,4 @@
+{
+  "name": "pfprovider",
+  "version": "0.0.0"
+}


### PR DESCRIPTION
We ensure that panic messages are added to the returned error so that they are displayed to the user.

Fixes https://github.com/pulumi/pulumi-terraform-provider/issues/22.