### PR TITLE
Refactor the type checker to it's own package

### DIFF
--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -46,6 +46,7 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/typechecker"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/walk"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/logging"
@@ -596,7 +597,7 @@ func (p *Provider) typeCheckConfig(
 		return nil
 	}
 
-	iv := NewInputValidator(urn, *p.pulumiSchemaSpec, true)
+	iv := typechecker.NewInputValidator(urn, *p.pulumiSchemaSpec, true)
 	typeFailures := iv.ValidateConfig(news)
 	if validateShouldError {
 		return p.convertTypeFailures(urn, typeFailures)
@@ -638,7 +639,9 @@ func (p *Provider) typeCheckConfig(
 	return nil
 }
 
-func (p *Provider) convertTypeFailures(urn resource.URN, typeFailures []TypeFailure) *pulumirpc.CheckResponse {
+func (p *Provider) convertTypeFailures(
+	urn resource.URN, typeFailures []typechecker.TypeFailure,
+) *pulumirpc.CheckResponse {
 	if len(typeFailures) == 0 {
 		return nil
 	}
@@ -967,7 +970,7 @@ func (p *Provider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (*pul
 	if p.pulumiSchema != nil {
 		schema := p.pulumiSchemaSpec
 		if schema != nil {
-			iv := NewInputValidator(urn, *schema, false)
+			iv := typechecker.NewInputValidator(urn, *schema, false)
 			typeFailures := iv.ValidateInputs(t, news)
 			if len(typeFailures) > 0 {
 				p.hasTypeErrors[urn] = struct{}{}

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -597,7 +597,7 @@ func (p *Provider) typeCheckConfig(
 		return nil
 	}
 
-	iv := typechecker.NewInputValidator(urn, *p.pulumiSchemaSpec, true)
+	iv := typechecker.New(urn, *p.pulumiSchemaSpec, true)
 	typeFailures := iv.ValidateConfig(news)
 	if validateShouldError {
 		return p.convertTypeFailures(urn, typeFailures)
@@ -640,7 +640,7 @@ func (p *Provider) typeCheckConfig(
 }
 
 func (p *Provider) convertTypeFailures(
-	urn resource.URN, typeFailures []typechecker.TypeFailure,
+	urn resource.URN, typeFailures []typechecker.Failure,
 ) *pulumirpc.CheckResponse {
 	if len(typeFailures) == 0 {
 		return nil
@@ -970,7 +970,7 @@ func (p *Provider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (*pul
 	if p.pulumiSchema != nil {
 		schema := p.pulumiSchemaSpec
 		if schema != nil {
-			iv := typechecker.NewInputValidator(urn, *schema, false)
+			iv := typechecker.New(urn, *schema, false)
 			typeFailures := iv.ValidateInputs(t, news)
 			if len(typeFailures) > 0 {
 				p.hasTypeErrors[urn] = struct{}{}

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -597,8 +597,7 @@ func (p *Provider) typeCheckConfig(
 		return nil
 	}
 
-	iv := typechecker.New(*p.pulumiSchemaSpec, true)
-	typeFailures := iv.ValidateConfig(news)
+	typeFailures := typechecker.New(*p.pulumiSchemaSpec, true).ValidateConfig(news)
 	if validateShouldError {
 		return p.convertTypeFailures(urn, typeFailures)
 	}
@@ -970,8 +969,7 @@ func (p *Provider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (*pul
 	if p.pulumiSchema != nil {
 		schema := p.pulumiSchemaSpec
 		if schema != nil {
-			iv := typechecker.New(*schema, false)
-			typeFailures := iv.ValidateInputs(t, news)
+			typeFailures := typechecker.New(*schema, false).ValidateInputs(t, news)
 			if len(typeFailures) > 0 {
 				p.hasTypeErrors[urn] = struct{}{}
 				logger.Warn("Type checking failed: ")

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -597,7 +597,7 @@ func (p *Provider) typeCheckConfig(
 		return nil
 	}
 
-	iv := typechecker.New(urn, *p.pulumiSchemaSpec, true)
+	iv := typechecker.New(*p.pulumiSchemaSpec, true)
 	typeFailures := iv.ValidateConfig(news)
 	if validateShouldError {
 		return p.convertTypeFailures(urn, typeFailures)
@@ -970,7 +970,7 @@ func (p *Provider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (*pul
 	if p.pulumiSchema != nil {
 		schema := p.pulumiSchemaSpec
 		if schema != nil {
-			iv := typechecker.New(urn, *schema, false)
+			iv := typechecker.New(*schema, false)
 			typeFailures := iv.ValidateInputs(t, news)
 			if len(typeFailures) > 0 {
 				p.hasTypeErrors[urn] = struct{}{}

--- a/pkg/tfbridge/typechecker/typechecker.go
+++ b/pkg/tfbridge/typechecker/typechecker.go
@@ -24,9 +24,6 @@ import (
 )
 
 type TypeChecker struct {
-	// The resource URN that we are validating
-	urn resource.URN
-
 	// The pulumi schema of the package
 	schema pschema.PackageSpec
 
@@ -44,9 +41,8 @@ type Failure struct {
 }
 
 // New creates a new type checker for a given resource and package schema
-func New(urn resource.URN, schema pschema.PackageSpec, validateUnknownTypes bool) *TypeChecker {
+func New(schema pschema.PackageSpec, validateUnknownTypes bool) *TypeChecker {
 	return &TypeChecker{
-		urn:                  urn,
 		schema:               schema,
 		validateUnknownTypes: validateUnknownTypes,
 	}

--- a/pkg/tfbridge/typechecker/typechecker.go
+++ b/pkg/tfbridge/typechecker/typechecker.go
@@ -1,4 +1,18 @@
-package tfbridge
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package typechecker
 
 import (
 	"fmt"

--- a/pkg/tfbridge/typechecker/typechecker_test.go
+++ b/pkg/tfbridge/typechecker/typechecker_test.go
@@ -279,7 +279,7 @@ func TestValidateInputType_objects(t *testing.T) {
 					"prop": []string{"foo"},
 				})),
 			}),
-			failures: autogold.Expect([]TypeFailure{{
+			failures: autogold.Expect([]Failure{{
 				Reason:       "expected object type, got {[{map[prop:{[{foo}]}]}]} of type []",
 				ResourcePath: "top_level_type_failure",
 			}}),
@@ -334,7 +334,7 @@ func TestValidateInputType_objects(t *testing.T) {
 			input: resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
 				"objectStringProp": map[string]string{"foo": "bar"},
 			})),
-			failures: autogold.Expect([]TypeFailure{{
+			failures: autogold.Expect([]Failure{{
 				Reason:       "expected string type, got {map[foo:{bar}]} of type object",
 				ResourcePath: "object_string_type_failure.objectStringProp",
 			}}),
@@ -390,7 +390,7 @@ func TestValidateInputType_objects(t *testing.T) {
 					{"foo": "bar"},
 				},
 			})),
-			failures: autogold.Expect([]TypeFailure{{
+			failures: autogold.Expect([]Failure{{
 				Reason:       "expected object type, got {[{map[foo:{bar}]}]} of type []",
 				ResourcePath: "object_nested_object_type_failure.prop",
 			}}),
@@ -468,7 +468,7 @@ func TestValidateInputType_objects(t *testing.T) {
 					"objectStringProp": "foo",
 				},
 			})),
-			failures: autogold.Expect([]TypeFailure{{
+			failures: autogold.Expect([]Failure{{
 				Reason:       `expected object type, got "foo" of type string`,
 				ResourcePath: "object_double_nested_object_type_failure.prop.objectStringProp",
 			}}),
@@ -541,7 +541,7 @@ func TestValidateInputType_objects(t *testing.T) {
 			input: resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
 				"prop": map[string]string{"foo": "bar"},
 			})),
-			failures: autogold.Expect([]TypeFailure{{
+			failures: autogold.Expect([]Failure{{
 				Reason:       "expected array type, got {map[foo:{bar}]} of type object",
 				ResourcePath: "object_nested_array_type_failure.prop",
 			}}),
@@ -615,7 +615,7 @@ func TestValidateInputType_objects(t *testing.T) {
 					{"objectStringProp": []string{"foo"}},
 				},
 			})),
-			failures: autogold.Expect([]TypeFailure{{
+			failures: autogold.Expect([]Failure{{
 				Reason:       "expected string type, got {[{foo}]} of type []",
 				ResourcePath: "object_nested_array_object_type_failure.prop[0].objectStringProp",
 			}}),
@@ -803,7 +803,7 @@ func TestValidateInputType_objects(t *testing.T) {
 				"project",
 			)
 
-			v := &PulumiInputValidator{
+			v := &TypeChecker{
 				urn:    urn,
 				schema: pspec,
 			}
@@ -965,7 +965,7 @@ func TestValidateInputType_arrays(t *testing.T) {
 				})),
 				resource.NewStringProperty("foo"),
 			}),
-			failures: autogold.Expect([]TypeFailure{
+			failures: autogold.Expect([]Failure{
 				{
 					Reason:       "expected string type, got {[{1}]} of type []",
 					ResourcePath: "object_string_type_failure[1].objectStringProp",
@@ -1036,7 +1036,7 @@ func TestValidateInputType_arrays(t *testing.T) {
 					},
 				})),
 			}),
-			failures: autogold.Expect([]TypeFailure{{
+			failures: autogold.Expect([]Failure{{
 				Reason:       "expected string type, got {[{1}]} of type []",
 				ResourcePath: "object_nested_object_type_failure[1].prop.foo",
 			}}),
@@ -1134,7 +1134,7 @@ func TestValidateInputType_arrays(t *testing.T) {
 					},
 				})),
 			}),
-			failures: autogold.Expect([]TypeFailure{
+			failures: autogold.Expect([]Failure{
 				{
 					Reason:       "expected string type, got {map[foo:{bar}]} of type object",
 					ResourcePath: "object_nested_array_type_failure[0].prop[1]",
@@ -1226,7 +1226,7 @@ func TestValidateInputType_arrays(t *testing.T) {
 					},
 				})),
 			}),
-			failures: autogold.Expect([]TypeFailure{{
+			failures: autogold.Expect([]Failure{{
 				Reason:       "expected string type, got {[{foo}]} of type []",
 				ResourcePath: "object_nested_array_object_type_failure[0].prop[1].objectStringProp",
 			}}),
@@ -1294,7 +1294,7 @@ func TestValidateInputType_arrays(t *testing.T) {
 				"project",
 			)
 
-			v := &PulumiInputValidator{
+			v := &TypeChecker{
 				urn:    urn,
 				schema: pspec,
 			}
@@ -1376,7 +1376,7 @@ func TestValidateInputType_toplevel(t *testing.T) {
 		{
 			name:  "string_type_failure",
 			input: resource.NewArrayProperty([]resource.PropertyValue{resource.NewNumberProperty(1)}),
-			failures: autogold.Expect([]TypeFailure{{
+			failures: autogold.Expect([]Failure{{
 				Reason:       "expected string type, got {[{1}]} of type []",
 				ResourcePath: "string_type_failure",
 			}}),
@@ -1462,7 +1462,7 @@ func TestValidateInputType_toplevel(t *testing.T) {
 			input: resource.NewObjectProperty(
 				resource.NewPropertyMapFromMap(map[string]interface{}{"foo": []string{"bar"}}),
 			),
-			failures: autogold.Expect([]TypeFailure{{
+			failures: autogold.Expect([]Failure{{
 				Reason:       "expected boolean type, got {[{bar}]} of type []",
 				ResourcePath: "object_type_failure.foo",
 			}}),
@@ -1616,7 +1616,7 @@ func TestValidateInputType_toplevel(t *testing.T) {
 				"project",
 			)
 
-			v := &PulumiInputValidator{
+			v := &TypeChecker{
 				urn:    urn,
 				schema: pspec,
 			}
@@ -1642,7 +1642,7 @@ func TestValidateConfigType(t *testing.T) {
 		{
 			name:      "unexpected_argument",
 			inputName: "endpoints",
-			failures: autogold.Expect([]TypeFailure{{
+			failures: autogold.Expect([]Failure{{
 				Reason:       "an unexpected argument \"wxyz\" was provided",
 				ResourcePath: "endpoints[0]",
 			}}),
@@ -1702,7 +1702,7 @@ func TestValidateConfigType(t *testing.T) {
 				"project",
 			)
 
-			v := &PulumiInputValidator{
+			v := &TypeChecker{
 				urn:                  urn,
 				schema:               pspec,
 				validateUnknownTypes: true,

--- a/pkg/tfbridge/typechecker/typechecker_test.go
+++ b/pkg/tfbridge/typechecker/typechecker_test.go
@@ -795,18 +795,8 @@ func TestValidateInputType_objects(t *testing.T) {
 					},
 				},
 			}
-			urn := resource.CreateURN(
-				"testResource",
-				"pkg:mod:ResA",
-				"",
-				"stack",
-				"project",
-			)
 
-			v := &TypeChecker{
-				urn:    urn,
-				schema: pspec,
-			}
+			v := &TypeChecker{schema: pspec}
 			failures := v.ValidateInputs(tokens.Type("pkg:mod:ResA"), resource.PropertyMap{
 				resource.PropertyKey(tc.name): tc.input,
 			})
@@ -1286,18 +1276,8 @@ func TestValidateInputType_arrays(t *testing.T) {
 					},
 				},
 			}
-			urn := resource.CreateURN(
-				"testResource",
-				"pkg:mod:ResA",
-				"",
-				"stack",
-				"project",
-			)
 
-			v := &TypeChecker{
-				urn:    urn,
-				schema: pspec,
-			}
+			v := &TypeChecker{schema: pspec}
 			failures := v.ValidateInputs(tokens.Type("pkg:mod:ResA"), resource.PropertyMap{
 				resource.PropertyKey(tc.name): tc.input,
 			})
@@ -1608,18 +1588,8 @@ func TestValidateInputType_toplevel(t *testing.T) {
 					},
 				},
 			}
-			urn := resource.CreateURN(
-				"testResource",
-				"pkg:mod:ResA",
-				"",
-				"stack",
-				"project",
-			)
 
-			v := &TypeChecker{
-				urn:    urn,
-				schema: pspec,
-			}
+			v := &TypeChecker{schema: pspec}
 			failures := v.ValidateInputs(tokens.Type("pkg:mod:ResA"), resource.PropertyMap{
 				resource.PropertyKey(tc.name): tc.input,
 			})
@@ -1694,16 +1664,8 @@ func TestValidateConfigType(t *testing.T) {
 					},
 				},
 			}
-			urn := resource.CreateURN(
-				"testResource",
-				"pkg:mod:ResA",
-				"",
-				"stack",
-				"project",
-			)
 
 			v := &TypeChecker{
-				urn:                  urn,
 				schema:               pspec,
 				validateUnknownTypes: true,
 			}

--- a/pkg/tfbridge/typechecker/typechecker_test.go
+++ b/pkg/tfbridge/typechecker/typechecker_test.go
@@ -1,4 +1,18 @@
-package tfbridge
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package typechecker
 
 import (
 	"fmt"


### PR DESCRIPTION
This PR is best reviewed commit by commit. This is a pure refactor, there is no change in functionality.

- 0c6245cf46532780eb26f0543a5137f709258004 moves the `validate_input_types*` to a `typechecker` package located under `pkg/tfbridge`. The type checker is fully independent from other bridge code, and this makes the interface much easer to distinguish (because public vs private is enforced).
- 3d7918f16243bc1b41cb5b2d2b5a271c8adde208 does some type renames because type checker types will be prefixed by `typechecker`.
- 19038ebeb9c03113a17ef898a7cbd6e3ace8336b removes the `urn` argument to `typechecker.New` (previously `tfbridge.NewTypeValidator`). The argument is only stored and never used.
- b60f64f569a2049a1305574c4bc644d72e42676f removes the intermediate variable when a new type checker is created.