### PR TITLE
Harden token mapping

### DIFF
--- a/pkg/tfbridge/tokens/tokens.go
+++ b/pkg/tfbridge/tokens/tokens.go
@@ -17,6 +17,7 @@ package tokens
 import (
 	"fmt"
 	"reflect"
+	"regexp"
 	"sort"
 	"unicode"
 
@@ -51,10 +52,42 @@ func MakeStandard(pkgName string) Make {
 		if name == "" {
 			return "", fmt.Errorf("missing name for module %q", module)
 		}
+
+		name = makeSafeTokenPart(name)
+
 		lowerName := string(unicode.ToLower(rune(name[0]))) + name[1:]
 		return fmt.Sprintf("%s:%s/%s:%s", pkgName, module, lowerName, name), nil
 	}
 }
+
+// makeSafeTokenPart makes part safe to use as a token segment.
+//
+// makeSafeTokenPart fixes:
+// - parts that start with numbers, since these are not valid in Pulumi schema.
+func makeSafeTokenPart(part string) string {
+	return startsWithNumeric.ReplaceAllStringFunc(part, func(s string) string {
+		w, ok := digitToWord[s[0:1]]
+		if !ok {
+			return s
+		}
+		return w + upperCamelCase(s[1:])
+	})
+}
+
+var digitToWord = map[string]string{
+	"0": "Zero",
+	"1": "One",
+	"2": "Two",
+	"3": "Three",
+	"4": "Four",
+	"5": "Five",
+	"6": "Six",
+	"7": "Seven",
+	"8": "Eight",
+	"9": "Nine",
+}
+
+var startsWithNumeric = regexp.MustCompile("^[0-9].?")
 
 // upperCamelCase converts a TF token to a valid Pulumi token segment in CamelCase format.
 func upperCamelCase(s string) string { return cgstrings.UppercaseFirst(camelCase(s)) }


### PR DESCRIPTION
This PR hardens the token auto-mapping functionality to handle 2 new corner cases:

- Tokens that *are* their prefix, such as `jfrog/project`'s `project` resource.
- Tokens who's natural split begin with a forbidden character, such as `[0-9]`, such as `CloudBoltSoftware/cloudbolt`'s `cloudbolt_1f_ansible_tower_deployment`.

Fixes https://github.com/pulumi/pulumi-terraform-provider/issues/27
Fixes https://github.com/pulumi/pulumi-terraform-provider/issues/28