### PR TITLE
Fix custom timeout handling under PlanResourceChange

### DIFF
--- a/pf/tests/internal/pftfcheck/pftf_test.go
+++ b/pf/tests/internal/pftfcheck/pftf_test.go
@@ -35,8 +35,10 @@ output "s_val" {
 }
 `)
 
-	plan := driver.Plan(t)
-	driver.Apply(t, plan)
+	plan, err := driver.Plan(t)
+	require.NoError(t, err)
+	err = driver.Apply(t, plan)
+	require.NoError(t, err)
 
 	require.Equal(t, "hello", driver.GetOutput(t, "s_val"))
 }
@@ -68,8 +70,10 @@ output "s_val" {
 }
 `)
 
-	plan := driver.Plan(t)
-	driver.Apply(t, plan)
+	plan, err := driver.Plan(t)
+	require.NoError(t, err)
+	err = driver.Apply(t, plan)
+	require.NoError(t, err)
 
 	require.Equal(t, "Default val", driver.GetOutput(t, "s_val"))
 }

--- a/pkg/tests/cross-tests/tf_driver.go
+++ b/pkg/tests/cross-tests/tf_driver.go
@@ -78,8 +78,10 @@ func (d *TfResDriver) writePlanApply(
 		t.Logf("empty config file")
 		d.driver.Write(t, "")
 	}
-	plan := d.driver.Plan(t)
-	d.driver.Apply(t, plan)
+	plan, err := d.driver.Plan(t)
+	require.NoError(t, err)
+	err = d.driver.Apply(t, plan)
+	require.NoError(t, err)
 	return plan
 }
 

--- a/pkg/tests/schema_pulumi_test.go
+++ b/pkg/tests/schema_pulumi_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -1618,7 +1619,8 @@ func TestConfigureCrossTest(t *testing.T) {
 
 		tfdriver := tfcheck.NewTfDriver(t, t.TempDir(), "prov", tfp)
 		tfdriver.Write(t, tfProgram)
-		tfdriver.Plan(t)
+		_, err := tfdriver.Plan(t)
+		require.NoError(t, err)
 		require.NotNil(t, tfRd)
 		require.Nil(t, puRd)
 
@@ -2941,7 +2943,7 @@ runtime: yaml
 			} else {
 				assert.NotContains(t, imp.Stdout, "One or more imported inputs failed to validate")
 
-				f, err := os.OpenFile(filepath.Join(pt.CurrentStack().Workspace().WorkDir(), "Pulumi.yaml"), os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
+				f, err := os.OpenFile(filepath.Join(pt.CurrentStack().Workspace().WorkDir(), "Pulumi.yaml"), os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0o600)
 				assert.NoError(t, err)
 				defer f.Close()
 				_, err = f.WriteString(string(contents))
@@ -2950,6 +2952,141 @@ runtime: yaml
 				// run preview using the generated file
 				pt.Preview(optpreview.Diff(), optpreview.ExpectNoChanges())
 			}
+		})
+	}
+}
+
+func TestCreateCustomTimeoutsCrossTest(t *testing.T) {
+	test := func(
+		t *testing.T,
+		schemaCreateTimeout *time.Duration,
+		programTimeout *string,
+		expected time.Duration,
+		ExpectFail bool,
+	) {
+		var pulumiCapturedTimeout *time.Duration
+		var tfCapturedTimeout *time.Duration
+		prov := &schema.Provider{
+			ResourcesMap: map[string]*schema.Resource{
+				"prov_test": {
+					Schema: map[string]*schema.Schema{
+						"prop": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+					CreateContext: func(ctx context.Context, rd *schema.ResourceData, i interface{}) diag.Diagnostics {
+						t := rd.Timeout(schema.TimeoutCreate)
+						if pulumiCapturedTimeout == nil {
+							pulumiCapturedTimeout = &t
+						} else {
+							tfCapturedTimeout = &t
+						}
+						rd.SetId("id")
+						return diag.Diagnostics{}
+					},
+					Timeouts: &schema.ResourceTimeout{
+						Create: schemaCreateTimeout,
+					},
+				},
+			},
+		}
+
+		bridgedProvider := pulcheck.BridgedProvider(t, "prov", prov)
+		pulumiTimeout := `""`
+		if programTimeout != nil {
+			pulumiTimeout = fmt.Sprintf(`"%s"`, *programTimeout)
+		}
+
+		tfTimeout := "null"
+		if programTimeout != nil {
+			tfTimeout = fmt.Sprintf(`"%s"`, *programTimeout)
+		}
+
+		program := fmt.Sprintf(`
+name: test
+runtime: yaml
+resources:
+	mainRes:
+		type: prov:Test
+		properties:
+			prop: "val"
+		options:
+			customTimeouts:
+				create: %s
+`, pulumiTimeout)
+
+		pt := pulcheck.PulCheck(t, bridgedProvider, program)
+		pt.Up()
+		// We pass custom timeouts in the program if the resource does not support them.
+
+		require.NotNil(t, pulumiCapturedTimeout)
+		require.Nil(t, tfCapturedTimeout)
+
+		tfProgram := fmt.Sprintf(`
+resource "prov_test" "mainRes" {
+	prop = "val"
+	timeouts {
+		create = %s
+	}
+}`, tfTimeout)
+
+		tfdriver := tfcheck.NewTfDriver(t, t.TempDir(), "prov", prov)
+		tfdriver.Write(t, tfProgram)
+
+		plan, err := tfdriver.Plan(t)
+		if ExpectFail {
+			require.Error(t, err)
+			return
+		}
+		require.NoError(t, err)
+		err = tfdriver.Apply(t, plan)
+		require.NoError(t, err)
+		require.NotNil(t, tfCapturedTimeout)
+
+		assert.Equal(t, *pulumiCapturedTimeout, *tfCapturedTimeout)
+		assert.Equal(t, *pulumiCapturedTimeout, expected)
+	}
+
+	oneSecString := "1s"
+	oneSec := 1 * time.Second
+	// twoSecString := "2s"
+	twoSec := 2 * time.Second
+
+	tests := []struct {
+		name                string
+		schemaCreateTimeout *time.Duration
+		programTimeout      *string
+		expected            time.Duration
+		expectFail          bool
+	}{
+		{
+			"schema specified timeout",
+			&oneSec,
+			nil,
+			oneSec,
+			false,
+		},
+		{
+			"program specified timeout",
+			&twoSec,
+			&oneSecString,
+			oneSec,
+			false,
+		},
+		{
+			"program specified without schema timeout",
+			nil,
+			&oneSecString,
+			oneSec,
+			true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			test(t, tc.schemaCreateTimeout, tc.programTimeout, tc.expected, tc.expectFail)
 		})
 	}
 }

--- a/pkg/tests/tfcheck/exec.go
+++ b/pkg/tests/tfcheck/exec.go
@@ -21,10 +21,9 @@ import (
 	"strings"
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/pulcheck"
-	"github.com/stretchr/testify/require"
 )
 
-func execCmd(t pulcheck.T, wdir string, environ []string, program string, args ...string) *exec.Cmd {
+func execCmd(t pulcheck.T, wdir string, environ []string, program string, args ...string) (*exec.Cmd, error) {
 	t.Logf("%s %s", program, strings.Join(args, " "))
 	cmd := exec.Command(program, args...)
 	var stdout, stderr bytes.Buffer
@@ -34,7 +33,7 @@ func execCmd(t pulcheck.T, wdir string, environ []string, program string, args .
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	err := cmd.Run()
-	require.NoError(t, err, "error from `%s %s`\n\nStdout:\n%s\n\nStderr:\n%s\n\n",
+	t.Logf("error from `%s %s`\n\nStdout:\n%s\n\nStderr:\n%s\n\n",
 		program, strings.Join(args, " "), stdout.String(), stderr.String())
-	return cmd
+	return cmd, err
 }

--- a/pkg/tests/tfcheck/tf_test.go
+++ b/pkg/tests/tfcheck/tf_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTfComputed(t *testing.T) {
@@ -39,17 +40,21 @@ resource "test_resource" "test" {
 `,
 	)
 
-	plan := driver.Plan(t)
+	plan, err := driver.Plan(t)
+	require.NoError(t, err)
 	t.Log(driver.Show(t, plan.PlanFile))
-	driver.Apply(t, plan)
+	err = driver.Apply(t, plan)
+	require.NoError(t, err)
 
 	t.Log(driver.GetState(t))
 
-	newPlan := driver.Plan(t)
+	newPlan, err := driver.Plan(t)
+	require.NoError(t, err)
 
 	t.Log(driver.Show(t, plan.PlanFile))
 
-	driver.Apply(t, newPlan)
+	err = driver.Apply(t, newPlan)
+	require.NoError(t, err)
 
 	t.Log(driver.GetState(t))
 }
@@ -100,17 +105,22 @@ resource "test_resource" "test" {
 `,
 	)
 
-	plan := driver.Plan(t)
+	plan, err := driver.Plan(t)
+	require.NoError(t, err)
+
 	t.Log(driver.Show(t, plan.PlanFile))
-	driver.Apply(t, plan)
+	err = driver.Apply(t, plan)
+	require.NoError(t, err)
 
 	t.Log(driver.GetState(t))
 
-	newPlan := driver.Plan(t)
+	newPlan, err := driver.Plan(t)
+	require.NoError(t, err)
 
 	t.Log(driver.Show(t, plan.PlanFile))
 
-	driver.Apply(t, newPlan)
+	err = driver.Apply(t, newPlan)
+	require.NoError(t, err)
 
 	t.Log(driver.GetState(t))
 }
@@ -185,16 +195,22 @@ resource "test_resource" "test" {
     }
 }`
 	driver.Write(t, knownProgram)
-	plan := driver.Plan(t)
+	plan, err := driver.Plan(t)
+	require.NoError(t, err)
+
 	t.Log(driver.Show(t, plan.PlanFile))
 
-	driver.Apply(t, plan)
+	err = driver.Apply(t, plan)
+	require.NoError(t, err)
 	t.Log(driver.GetState(t))
 
 	driver.Write(t, unknownProgram)
-	plan = driver.Plan(t)
+	plan, err = driver.Plan(t)
+	require.NoError(t, err)
+
 	t.Log(driver.Show(t, plan.PlanFile))
 
-	driver.Apply(t, plan)
+	err = driver.Apply(t, plan)
+	require.NoError(t, err)
 	t.Log(driver.GetState(t))
 }

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -27,8 +27,8 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/log"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/logging"
 )
 
 type urnCtxKeyType struct{}
@@ -65,29 +65,12 @@ const (
 // but can also contain specific name translations.
 type ProviderInfo = info.Provider
 
-// Send logs or status logs to the user.
-//
-// Logged messages are pre-associated with the resource they are called from.
-type Logger interface {
-	Log
-
-	// Convert to sending ephemeral status logs to the user.
-	Status() Log
-}
-
-// The set of logs available to show to the user
-type Log interface {
-	Debug(msg string)
-	Info(msg string)
-	Warn(msg string)
-	Error(msg string)
-}
+type Logger = log.Logger
+type Log = log.Log
 
 // Get access to the [Logger] associated with this context.
 func GetLogger(ctx context.Context) Logger {
-	logger := ctx.Value(logging.CtxKey)
-	contract.Assertf(logger != nil, "Cannot call GetLogger on a context that is not equipped with a Logger")
-	return newLoggerAdapter(logger)
+	return log.GetLogger(ctx)
 }
 
 // The function used to produce the set of edit rules for a provider.

--- a/pkg/tfbridge/log.go
+++ b/pkg/tfbridge/log.go
@@ -171,29 +171,3 @@ func (lr *LogRedirector) Write(p []byte) (n int, err error) {
 
 	return written, nil
 }
-
-type loggerAdapter struct {
-	Log
-	untyped untypedLogger
-}
-
-func (a *loggerAdapter) Status() Log {
-	return a.untyped.StatusUntyped().(Log)
-}
-
-var _ Logger = (*loggerAdapter)(nil)
-
-type untypedLogger interface {
-	Log
-	StatusUntyped() any
-}
-
-func newLoggerAdapter(logger any) Logger {
-	uLogger, ok := logger.(untypedLogger)
-	contract.Assertf(ok, "Context carries a logger that does not implement UntypedLogger")
-
-	return &loggerAdapter{
-		Log:     uLogger,
-		untyped: uLogger,
-	}
-}

--- a/pkg/tfbridge/log/log.go
+++ b/pkg/tfbridge/log/log.go
@@ -1,0 +1,74 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"context"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/logging"
+)
+
+// Send logs or status logs to the user.
+//
+// Logged messages are pre-associated with the resource they are called from.
+type Logger interface {
+	Log
+
+	// Convert to sending ephemeral status logs to the user.
+	Status() Log
+}
+
+// The set of logs available to show to the user
+type Log interface {
+	Debug(msg string)
+	Info(msg string)
+	Warn(msg string)
+	Error(msg string)
+}
+
+// Get access to the [Logger] associated with this context.
+func GetLogger(ctx context.Context) Logger {
+	logger := ctx.Value(logging.CtxKey)
+	contract.Assertf(logger != nil, "Cannot call GetLogger on a context that is not equipped with a Logger")
+	return newLoggerAdapter(logger)
+}
+
+func newLoggerAdapter(logger any) Logger {
+	uLogger, ok := logger.(untypedLogger)
+	contract.Assertf(ok, "Context carries a logger that does not implement UntypedLogger")
+
+	return &loggerAdapter{
+		Log:     uLogger,
+		untyped: uLogger,
+	}
+}
+
+type loggerAdapter struct {
+	Log
+	untyped untypedLogger
+}
+
+func (a *loggerAdapter) Status() Log {
+	return a.untyped.StatusUntyped().(Log)
+}
+
+var _ Logger = (*loggerAdapter)(nil)
+
+type untypedLogger interface {
+	Log
+	StatusUntyped() any
+}

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -3904,6 +3904,11 @@ func TestCustomTimeouts(t *testing.T) {
 
 	for _, schemaTimeout := range timeouts {
 		for _, userSpecifiedTimeout := range timeouts {
+			// It seems that schema timeout must be non-nil to permit customizing user timeout; omit these
+			// for now as the current behavior is falling back to 20m default.
+			if userSpecifiedTimeout != nil && schemaTimeout == nil {
+				continue
+			}
 			for _, cud := range cuds {
 				n := fmt.Sprintf("%s-schema-%v-user-%v", cud, schemaTimeout, userSpecifiedTimeout)
 				testCases = append(testCases, testCase{
@@ -3935,11 +3940,8 @@ func TestCustomTimeouts(t *testing.T) {
 				"testprov_testres": {
 					Schema: map[string]*schema.Schema{
 						"x": {
-							Type: schema.TypeMap,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{},
-							},
-							MaxItems: 1,
+							Type:     schema.TypeString,
+							Optional: true,
 						},
 					},
 					Timeouts: &schema.ResourceTimeout{
@@ -3983,7 +3985,10 @@ func TestCustomTimeouts(t *testing.T) {
 			},
 		}
 
-		shimmedProvider := shimv2.NewProvider(upstreamProvider)
+		shimmedProvider := shimv2.NewProvider(upstreamProvider,
+			shimv2.WithPlanResourceChange(func(tfResourceType string) bool {
+				return true
+			}))
 
 		bridgedProvider := &Provider{
 			tf:   shimmedProvider,
@@ -4001,11 +4006,22 @@ func TestCustomTimeouts(t *testing.T) {
 			})
 			require.NoError(t, err)
 		case "Update":
-			_, err := bridgedProvider.Update(context.Background(), &pulumirpc.UpdateRequest{
+			// When testing the Update case it is required that olds != news because otherwise the
+			// implementation assigns prior state to proposed state to produce a no-op diff and ignores
+			// custom timeouts.
+			olds, err := structpb.NewStruct(map[string]interface{}{
+				"x": "x1",
+			})
+			require.NoError(t, err)
+			news, err := structpb.NewStruct(map[string]interface{}{
+				"x": "x2",
+			})
+			require.NoError(t, err)
+			_, err = bridgedProvider.Update(context.Background(), &pulumirpc.UpdateRequest{
 				Id:      id,
 				Urn:     urn,
-				Olds:    &structpb.Struct{},
-				News:    &structpb.Struct{},
+				Olds:    olds,
+				News:    news,
 				Timeout: seconds(tc.userSpecifiedTimeout),
 			})
 			require.NoError(t, err)

--- a/pkg/tfshim/sdk-v2/cty.go
+++ b/pkg/tfshim/sdk-v2/cty.go
@@ -160,7 +160,6 @@ func recoverScalarCtyValue(dT cty.Type, value interface{}) (cty.Value, error) {
 		if value > math.MaxInt64 {
 			return cty.NilVal, fmt.Errorf("cannot convert %d (uint) to a int64: overflow", value)
 		}
-		//nolint:gosec
 		return cty.NumberIntVal(int64(value)), nil
 	case int64:
 		return cty.NumberIntVal(value), nil

--- a/pkg/tfshim/sdk-v2/cty.go
+++ b/pkg/tfshim/sdk-v2/cty.go
@@ -160,6 +160,7 @@ func recoverScalarCtyValue(dT cty.Type, value interface{}) (cty.Value, error) {
 		if value > math.MaxInt64 {
 			return cty.NilVal, fmt.Errorf("cannot convert %d (uint) to a int64: overflow", value)
 		}
+		//nolint:gosec
 		return cty.NumberIntVal(int64(value)), nil
 	case int64:
 		return cty.NumberIntVal(value), nil

--- a/pkg/tfshim/sdk-v2/instance_diff.go
+++ b/pkg/tfshim/sdk-v2/instance_diff.go
@@ -34,6 +34,7 @@ type v2InstanceDiff struct {
 }
 
 func (d v2InstanceDiff) applyTimeoutOptions(opts shim.TimeoutOptions) {
+	// This method is no longer used with PlanResourceChange; we handle timeouts more directly.
 	if opts.ResourceTimeout != nil {
 		err := d.encodeTimeouts(opts.ResourceTimeout)
 		contract.AssertNoErrorf(err, "encodeTimeouts should never fail")

--- a/pkg/tfshim/sdk-v2/provider2.go
+++ b/pkg/tfshim/sdk-v2/provider2.go
@@ -158,10 +158,11 @@ var _ planResourceChangeProvider = (*planResourceChangeImpl)(nil)
 // the corresponding slot. Warn the user if the custom timeout is a no-op.
 func (p *planResourceChangeImpl) configWithTimeouts(
 	ctx context.Context,
-	configWithoutTimeouts map[string]any,
+	c shim.ResourceConfig,
 	topts shim.TimeoutOptions,
 	impliedType cty.Type,
 ) map[string]any {
+	configWithoutTimeouts := configFromShim(c).Config
 	config := map[string]any{}
 	for k, v := range configWithoutTimeouts {
 		if k == schema.TimeoutsConfigKey {
@@ -225,7 +226,6 @@ func (p *planResourceChangeImpl) Diff(
 	c shim.ResourceConfig,
 	opts shim.DiffOptions,
 ) (shim.InstanceDiff, error) {
-	config := configFromShim(c)
 	s, err := p.upgradeState(ctx, t, s)
 	if err != nil {
 		return nil, err
@@ -241,7 +241,7 @@ func (p *planResourceChangeImpl) Diff(
 	}
 
 	cfg, err := recoverAndCoerceCtyValueWithSchema(res.CoreConfigSchema(),
-		p.configWithTimeouts(ctx, config.Config, opts.TimeoutOptions, ty))
+		p.configWithTimeouts(ctx, c, opts.TimeoutOptions, ty))
 	if err != nil {
 		return nil, fmt.Errorf("Resource %q: %w", t, err)
 	}

--- a/pkg/tfshim/sdk-v2/provider2.go
+++ b/pkg/tfshim/sdk-v2/provider2.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
+	"time"
 
 	"github.com/golang/glog"
 	"github.com/hashicorp/go-cty/cty"
@@ -17,11 +19,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 
-	"strings"
-
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/log"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
-	"time"
 )
 
 type v2Resource2 struct {
@@ -168,9 +167,8 @@ func (p *planResourceChangeImpl) configWithTimeouts(
 		if k == schema.TimeoutsConfigKey {
 			p.warnIgnoredCustomTimeouts(ctx, topts.TimeoutOverrides)
 			return configWithoutTimeouts
-		} else {
-			config[k] = v
 		}
+		config[k] = v
 	}
 	impliedAttrs := impliedType.AttributeTypes()
 	timeoutsObj, supportCustomTimeouts := impliedAttrs[schema.TimeoutsConfigKey]
@@ -217,7 +215,7 @@ func (*planResourceChangeImpl) warnIgnoredCustomTimeouts(
 	sort.Strings(parts)
 	keys := strings.Join(parts, ", ")
 	msg := fmt.Sprintf("Resource does not support customTimeouts, ignoring: %s", keys)
-	tfbridge.GetLogger(ctx).Warn(msg)
+	log.GetLogger(ctx).Warn(msg)
 }
 
 func (p *planResourceChangeImpl) Diff(

--- a/pkg/tfshim/sdk-v2/provider2_test.go
+++ b/pkg/tfshim/sdk-v2/provider2_test.go
@@ -2,19 +2,19 @@ package sdkv2
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"testing"
 	"time"
 
-	"fmt"
-
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hexops/autogold/v2"
-	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/logging"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/logging"
 )
 
 func TestProvider2UpgradeResourceState(t *testing.T) {
@@ -560,7 +560,8 @@ func TestConfigWithTimeouts(t *testing.T) {
 				shim.TimeoutDelete: 2 * time.Second,
 			}},
 			configWithoutTimeouts: map[string]any{"x": 1},
-			expectedWarnings:      autogold.Expect([]string{"WARN: Resource does not support customTimeouts, ignoring: create=1s, delete=2s"}),
+			//nolint:lll
+			expectedWarnings: autogold.Expect([]string{"WARN: Resource does not support customTimeouts, ignoring: create=1s, delete=2s"}),
 		},
 		{
 			name: "warn when customizing create timeouts against a custom timeout schema",
@@ -582,7 +583,8 @@ func TestConfigWithTimeouts(t *testing.T) {
 				shim.TimeoutCreate: 1 * time.Second,
 			}},
 			configWithoutTimeouts: map[string]any{"x": 1},
-			expectedWarnings:      autogold.Expect([]string{"WARN: Resource does not support customTimeouts, ignoring: create=1s"}),
+
+			expectedWarnings: autogold.Expect([]string{"WARN: Resource does not support customTimeouts, ignoring: create=1s"}),
 		},
 	}
 

--- a/pkg/tfshim/sdk-v2/provider2_test.go
+++ b/pkg/tfshim/sdk-v2/provider2_test.go
@@ -4,9 +4,15 @@ import (
 	"context"
 	"strconv"
 	"testing"
+	"time"
+
+	"fmt"
 
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hexops/autogold/v2"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/logging"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -476,4 +482,146 @@ func TestNormalizeBlockCollections(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConfigWithTimeouts(t *testing.T) {
+	type testCase struct {
+		name                  string
+		topts                 shim.TimeoutOptions
+		configWithoutTimeouts map[string]any
+		expected              map[string]any
+		expectedWarnings      autogold.Value
+		rschema               schema.Resource
+	}
+
+	sec20 := 20 * time.Second
+
+	testCases := []testCase{
+		{
+			name: "customize create timeout",
+			rschema: schema.Resource{
+				Timeouts: &schema.ResourceTimeout{Create: &sec20},
+				Schema: map[string]*schema.Schema{
+					"x": {Type: schema.TypeInt, Optional: true},
+				},
+			},
+			topts: shim.TimeoutOptions{TimeoutOverrides: map[shim.TimeoutKey]time.Duration{
+				shim.TimeoutCreate: 1 * time.Second,
+			}},
+			configWithoutTimeouts: map[string]any{"x": 1},
+			expected:              map[string]any{"x": 1, "timeouts": map[string]any{"create": "1s"}},
+		}, {
+			name: "customize update timeout",
+			rschema: schema.Resource{
+				Timeouts: &schema.ResourceTimeout{Update: &sec20},
+				Schema: map[string]*schema.Schema{
+					"x": {Type: schema.TypeInt, Optional: true},
+				},
+			},
+			topts: shim.TimeoutOptions{TimeoutOverrides: map[shim.TimeoutKey]time.Duration{
+				shim.TimeoutUpdate: 1 * time.Second,
+			}},
+			configWithoutTimeouts: map[string]any{"x": 1},
+			expected:              map[string]any{"x": 1, "timeouts": map[string]any{"update": "1s"}},
+		}, {
+			name: "customize delete timeout",
+			rschema: schema.Resource{
+				Timeouts: &schema.ResourceTimeout{Delete: &sec20},
+				Schema: map[string]*schema.Schema{
+					"x": {Type: schema.TypeInt, Optional: true},
+				},
+			},
+			topts: shim.TimeoutOptions{TimeoutOverrides: map[shim.TimeoutKey]time.Duration{
+				shim.TimeoutDelete: 1 * time.Second,
+			}},
+			configWithoutTimeouts: map[string]any{"x": 1},
+			expected:              map[string]any{"x": 1, "timeouts": map[string]any{"delete": "1s"}},
+		},
+		{
+			name: "pass through when no overrides specified",
+			rschema: schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"x": {Type: schema.TypeInt, Optional: true},
+				},
+			},
+			topts:                 shim.TimeoutOptions{},
+			configWithoutTimeouts: map[string]any{"x": 1},
+			expected:              map[string]any{"x": 1},
+		},
+		{
+			name: "warn when customizing create timeouts is not supported",
+			rschema: schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"x": {Type: schema.TypeInt, Optional: true},
+				},
+			},
+			topts: shim.TimeoutOptions{TimeoutOverrides: map[shim.TimeoutKey]time.Duration{
+				shim.TimeoutCreate: 1 * time.Second,
+				shim.TimeoutDelete: 2 * time.Second,
+			}},
+			configWithoutTimeouts: map[string]any{"x": 1},
+			expectedWarnings:      autogold.Expect([]string{"WARN: Resource does not support customTimeouts, ignoring: create=1s, delete=2s"}),
+		},
+		{
+			name: "warn when customizing create timeouts against a custom timeout schema",
+			rschema: schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"x": {Type: schema.TypeInt, Optional: true},
+					"timeouts": {
+						Type: schema.TypeList,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"appTimeout": {Type: schema.TypeInt, Optional: true},
+							},
+						},
+						MaxItems: 1,
+					},
+				},
+			},
+			topts: shim.TimeoutOptions{TimeoutOverrides: map[shim.TimeoutKey]time.Duration{
+				shim.TimeoutCreate: 1 * time.Second,
+			}},
+			configWithoutTimeouts: map[string]any{"x": 1},
+			expectedWarnings:      autogold.Expect([]string{"WARN: Resource does not support customTimeouts, ignoring: create=1s"}),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			logger := &testLogger{}
+			ctx := context.WithValue(context.Background(), logging.CtxKey, logger)
+			i := &planResourceChangeImpl{}
+			ty := tc.rschema.CoreConfigSchema().ImpliedType()
+			actual := i.configWithTimeouts(ctx, tc.configWithoutTimeouts, tc.topts, ty)
+			if tc.expected != nil {
+				assert.Equal(t, tc.expected, actual)
+			} else {
+				tc.expectedWarnings.Equal(t, logger.messages)
+			}
+		})
+	}
+}
+
+type testLogger struct {
+	messages []string
+}
+
+func (l *testLogger) Debug(msg string) {
+	l.messages = append(l.messages, fmt.Sprintf("DEBUG: %s", msg))
+}
+
+func (l *testLogger) Info(msg string) {
+	l.messages = append(l.messages, fmt.Sprintf("INFO: %s", msg))
+}
+
+func (l *testLogger) Warn(msg string) {
+	l.messages = append(l.messages, fmt.Sprintf("WARN: %s", msg))
+}
+
+func (l *testLogger) Error(msg string) {
+	l.messages = append(l.messages, fmt.Sprintf("ERROR: %s", msg))
+}
+
+func (*testLogger) StatusUntyped() any {
+	return "?"
 }

--- a/pkg/tfshim/sdk-v2/provider2_test.go
+++ b/pkg/tfshim/sdk-v2/provider2_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hexops/autogold/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -594,7 +595,15 @@ func TestConfigWithTimeouts(t *testing.T) {
 			ctx := context.WithValue(context.Background(), logging.CtxKey, logger)
 			i := &planResourceChangeImpl{}
 			ty := tc.rschema.CoreConfigSchema().ImpliedType()
-			actual := i.configWithTimeouts(ctx, tc.configWithoutTimeouts, tc.topts, ty)
+			// Quick short-cut here, taking advantage of the fact that configWithTimeouts only reads
+			// cfg.tf.Config, set only that. If this needs to be revised, can construct ResourceConfig in
+			// the usual way instead.
+			cfg := v2ResourceConfig{
+				tf: &terraform.ResourceConfig{
+					Config: tc.configWithoutTimeouts,
+				},
+			}
+			actual := i.configWithTimeouts(ctx, cfg, tc.topts, ty)
 			if tc.expected != nil {
 				assert.Equal(t, tc.expected, actual)
 			} else {


### PR DESCRIPTION
Under PlanResourceChange the way custom timeout option is handled is not properly communicating the value to the underlying TF provider. This is now fixed and the existing test made to pass.

See also: https://www.pulumi.com/docs/concepts/options/customtimeouts/

Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/2386

New warnings are introduced for the case when a user tries to set a customTimeouts option on a resource that does not support it. The customTiemeouts in this case are a no-op. I believe this should be a warning to guide the user but we might also consider downgrading severity to an INFO or debug level message. 
