### PR TITLE
Custom timeouts cross test

### DIFF
--- a/pf/tests/internal/pftfcheck/pftf_test.go
+++ b/pf/tests/internal/pftfcheck/pftf_test.go
@@ -35,8 +35,10 @@ output "s_val" {
 }
 `)
 
-	plan := driver.Plan(t)
-	driver.Apply(t, plan)
+	plan, err := driver.Plan(t)
+	require.NoError(t, err)
+	err = driver.Apply(t, plan)
+	require.NoError(t, err)
 
 	require.Equal(t, "hello", driver.GetOutput(t, "s_val"))
 }
@@ -68,8 +70,10 @@ output "s_val" {
 }
 `)
 
-	plan := driver.Plan(t)
-	driver.Apply(t, plan)
+	plan, err := driver.Plan(t)
+	require.NoError(t, err)
+	err = driver.Apply(t, plan)
+	require.NoError(t, err)
 
 	require.Equal(t, "Default val", driver.GetOutput(t, "s_val"))
 }

--- a/pkg/tests/cross-tests/tf_driver.go
+++ b/pkg/tests/cross-tests/tf_driver.go
@@ -78,7 +78,8 @@ func (d *TfResDriver) writePlanApply(
 		t.Logf("empty config file")
 		d.driver.Write(t, "")
 	}
-	plan := d.driver.Plan(t)
+	plan, err := d.driver.Plan(t)
+	require.NoError(t, err)
 	d.driver.Apply(t, plan)
 	return plan
 }

--- a/pkg/tests/cross-tests/tf_driver.go
+++ b/pkg/tests/cross-tests/tf_driver.go
@@ -80,7 +80,8 @@ func (d *TfResDriver) writePlanApply(
 	}
 	plan, err := d.driver.Plan(t)
 	require.NoError(t, err)
-	d.driver.Apply(t, plan)
+	err = d.driver.Apply(t, plan)
+	require.NoError(t, err)
 	return plan
 }
 

--- a/pkg/tests/schema_pulumi_test.go
+++ b/pkg/tests/schema_pulumi_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"q"
 	"testing"
 	"time"
 
@@ -3016,8 +3015,6 @@ resources:
 			customTimeouts:
 				create: %s
 `, pulumiTimeout)
-
-		q.Q(program)
 
 		pt := pulcheck.PulCheck(t, bridgedProvider, program)
 		pt.Up()

--- a/pkg/tests/schema_pulumi_test.go
+++ b/pkg/tests/schema_pulumi_test.go
@@ -3040,7 +3040,8 @@ resource "prov_test" "mainRes" {
 			return
 		}
 		require.NoError(t, err)
-		tfdriver.Apply(t, plan)
+		err = tfdriver.Apply(t, plan)
+		require.NoError(t, err)
 		require.NotNil(t, tfCapturedTimeout)
 
 		assert.Equal(t, *pulumiCapturedTimeout, *tfCapturedTimeout)

--- a/pkg/tests/tfcheck/exec.go
+++ b/pkg/tests/tfcheck/exec.go
@@ -21,10 +21,9 @@ import (
 	"strings"
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/pulcheck"
-	"github.com/stretchr/testify/require"
 )
 
-func execCmd(t pulcheck.T, wdir string, environ []string, program string, args ...string) *exec.Cmd {
+func execCmd(t pulcheck.T, wdir string, environ []string, program string, args ...string) (*exec.Cmd, error) {
 	t.Logf("%s %s", program, strings.Join(args, " "))
 	cmd := exec.Command(program, args...)
 	var stdout, stderr bytes.Buffer
@@ -34,7 +33,7 @@ func execCmd(t pulcheck.T, wdir string, environ []string, program string, args .
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	err := cmd.Run()
-	require.NoError(t, err, "error from `%s %s`\n\nStdout:\n%s\n\nStderr:\n%s\n\n",
+	t.Logf("error from `%s %s`\n\nStdout:\n%s\n\nStderr:\n%s\n\n",
 		program, strings.Join(args, " "), stdout.String(), stderr.String())
-	return cmd
+	return cmd, err
 }

--- a/pkg/tests/tfcheck/tf_test.go
+++ b/pkg/tests/tfcheck/tf_test.go
@@ -43,7 +43,8 @@ resource "test_resource" "test" {
 	plan, err := driver.Plan(t)
 	require.NoError(t, err)
 	t.Log(driver.Show(t, plan.PlanFile))
-	driver.Apply(t, plan)
+	err = driver.Apply(t, plan)
+	require.NoError(t, err)
 
 	t.Log(driver.GetState(t))
 
@@ -52,7 +53,8 @@ resource "test_resource" "test" {
 
 	t.Log(driver.Show(t, plan.PlanFile))
 
-	driver.Apply(t, newPlan)
+	err = driver.Apply(t, newPlan)
+	require.NoError(t, err)
 
 	t.Log(driver.GetState(t))
 }
@@ -107,7 +109,8 @@ resource "test_resource" "test" {
 	require.NoError(t, err)
 
 	t.Log(driver.Show(t, plan.PlanFile))
-	driver.Apply(t, plan)
+	err = driver.Apply(t, plan)
+	require.NoError(t, err)
 
 	t.Log(driver.GetState(t))
 
@@ -116,7 +119,8 @@ resource "test_resource" "test" {
 
 	t.Log(driver.Show(t, plan.PlanFile))
 
-	driver.Apply(t, newPlan)
+	err = driver.Apply(t, newPlan)
+	require.NoError(t, err)
 
 	t.Log(driver.GetState(t))
 }
@@ -196,7 +200,8 @@ resource "test_resource" "test" {
 
 	t.Log(driver.Show(t, plan.PlanFile))
 
-	driver.Apply(t, plan)
+	err = driver.Apply(t, plan)
+	require.NoError(t, err)
 	t.Log(driver.GetState(t))
 
 	driver.Write(t, unknownProgram)
@@ -205,6 +210,7 @@ resource "test_resource" "test" {
 
 	t.Log(driver.Show(t, plan.PlanFile))
 
-	driver.Apply(t, plan)
+	err = driver.Apply(t, plan)
+	require.NoError(t, err)
 	t.Log(driver.GetState(t))
 }

--- a/pkg/tests/tfcheck/tf_test.go
+++ b/pkg/tests/tfcheck/tf_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTfComputed(t *testing.T) {
@@ -39,13 +40,15 @@ resource "test_resource" "test" {
 `,
 	)
 
-	plan := driver.Plan(t)
+	plan, err := driver.Plan(t)
+	require.NoError(t, err)
 	t.Log(driver.Show(t, plan.PlanFile))
 	driver.Apply(t, plan)
 
 	t.Log(driver.GetState(t))
 
-	newPlan := driver.Plan(t)
+	newPlan, err := driver.Plan(t)
+	require.NoError(t, err)
 
 	t.Log(driver.Show(t, plan.PlanFile))
 
@@ -100,13 +103,16 @@ resource "test_resource" "test" {
 `,
 	)
 
-	plan := driver.Plan(t)
+	plan, err := driver.Plan(t)
+	require.NoError(t, err)
+
 	t.Log(driver.Show(t, plan.PlanFile))
 	driver.Apply(t, plan)
 
 	t.Log(driver.GetState(t))
 
-	newPlan := driver.Plan(t)
+	newPlan, err := driver.Plan(t)
+	require.NoError(t, err)
 
 	t.Log(driver.Show(t, plan.PlanFile))
 
@@ -185,14 +191,18 @@ resource "test_resource" "test" {
     }
 }`
 	driver.Write(t, knownProgram)
-	plan := driver.Plan(t)
+	plan, err := driver.Plan(t)
+	require.NoError(t, err)
+
 	t.Log(driver.Show(t, plan.PlanFile))
 
 	driver.Apply(t, plan)
 	t.Log(driver.GetState(t))
 
 	driver.Write(t, unknownProgram)
-	plan = driver.Plan(t)
+	plan, err = driver.Plan(t)
+	require.NoError(t, err)
+
 	t.Log(driver.Show(t, plan.PlanFile))
 
 	driver.Apply(t, plan)


### PR DESCRIPTION
This adds cross tests for custom timeouts, comparing our handling of custom timeouts with terraform's. To do that we've exposed the `plan` error in tfcheck.

Looks like the TF rules are the following:
- If the schema specifies a timeout for the operation, then the user is allowed to override that.
- If the schema does not specify a timeout, then the resource is said not to support timeouts. That makes it a runtime error if the user then tries to customise the timeout on the resource.

That makes sense conceptually, as not all resources would be implemented in a way which supports timeouts.

Related to https://github.com/pulumi/pulumi-terraform-bridge/issues/2386