### PR TITLE
Silence lint warnings

### DIFF
--- a/pf/tests/.golangci.yml
+++ b/pf/tests/.golangci.yml
@@ -9,7 +9,9 @@ linters:
     - gosec
     - govet
     - ineffassign
-    - megacheck
+    - gosimple
+    - staticcheck
+    - unused
     - misspell
     - nakedret
     - nolintlint

--- a/pkg/tests/.golangci.yml
+++ b/pkg/tests/.golangci.yml
@@ -9,7 +9,9 @@ linters:
     - gosec
     - govet
     - ineffassign
-    - megacheck
+    - gosimple
+    - staticcheck
+    - unused
     - misspell
     - nakedret
     - nolintlint


### PR DESCRIPTION
This silences the following warning which was polluting the linter output. Should have no other effect.

```
level=warning msg="[lintersdb] The linter named \"megacheck\" is deprecated. It has been split into: gosimple, staticcheck, unused."
```