### PR TITLE
Detailed diff block tests

### DIFF
--- a/pkg/tfbridge/diff.go
+++ b/pkg/tfbridge/diff.go
@@ -386,3 +386,27 @@ func makeDetailedDiffExtra(
 		collectionDiffs: collectionDiffs,
 	}
 }
+
+// func makePulumiDetailedDiffV2(
+// 	ctx context.Context,
+// 	tfs shim.SchemaMap,
+// 	ps map[string]*SchemaInfo,
+// 	oldState, plannedState resource.PropertyMap,
+// ) (map[string]*pulumirpc.PropertyDiff) {
+// 	keys := make(map[resource.PropertyKey]struct{})
+// 	for k := range oldState {
+// 		keys[k] = struct{}{}
+// 	}
+// 	for k := range plannedState {
+// 		keys[k] = struct{}{}
+// 	}
+
+// 	diff := make(map[string]*pulumirpc.PropertyDiff)
+// 	for k := range keys {
+// 		old, _ := oldState[k]
+// 		new, _ := plannedState[k]
+// 		en, etf, eps := getInfoFromPulumiName(k, tfs, ps)
+
+
+// 	}
+// }


### PR DESCRIPTION
This adds tests for the detailed diff output of
- List blocks
- Set blocks
- MaxItemsOne list blocks

for adding, removing, removing, changing the property and adding/removing/changing nested properties in the block.

A few issues here:
- https://github.com/pulumi/pulumi-terraform-bridge/issues/2234 affects quite a few of the cases
- 