### PR TITLE
OmitType and TypeName to support sharing types

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -323,6 +323,11 @@ func BoolRef(b bool) *bool {
 	return &b
 }
 
+// String returns a reference to the string argument.
+func StringRef(s string) *string {
+	return &s
+}
+
 // StringValue gets a string value from a property map if present, else ""
 func StringValue(vars resource.PropertyMap, prop resource.PropertyKey) string {
 	val, ok := vars[prop]

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -318,14 +318,16 @@ func MakeResource(pkg string, mod string, res string) tokens.Type {
 	return tokens.NewTypeToken(modT, tokens.TypeName(res))
 }
 
-// BoolRef returns a reference to the bool argument.
+// BoolRef returns a reference to the bool argument. Retained for backwards compatibility. Prefer [Ref] for new usage
+// and other types like strings.
 func BoolRef(b bool) *bool {
 	return &b
 }
 
-// String returns a reference to the string argument.
-func StringRef(s string) *string {
-	return &s
+// Fluently construct a reference to the argument. This utility function is needed to ease configuring the bridge where
+// references are expected instead of plain boolean or string literals.
+func Ref[T any](x T) *T {
+	return &x
 }
 
 // StringValue gets a string value from a property map if present, else ""

--- a/pkg/tfbridge/info/info.go
+++ b/pkg/tfbridge/info/info.go
@@ -448,6 +448,8 @@ type Schema struct {
 
 	// Used together with [Type] to omit generating any Pulumi types whatsoever for the current property, and
 	// instead use the object type identified by the token setup in [Type].
+	//
+	// It is an error to set [OmitType] to true without specifying [Type].
 	OmitType bool
 
 	// alternative types that can be used instead of the override.

--- a/pkg/tfbridge/info/info.go
+++ b/pkg/tfbridge/info/info.go
@@ -450,6 +450,8 @@ type Schema struct {
 	// instead use the object type identified by the token setup in [Type].
 	//
 	// It is an error to set [OmitType] to true without specifying [Type].
+	//
+	// Experimental.
 	OmitType bool
 
 	// alternative types that can be used instead of the override.
@@ -517,6 +519,8 @@ type Schema struct {
 	// prefix and the name of the property. Use [TypeName] to override this decision when the default names for
 	// nested properties are too long or otherwise undesirable. The choice will further affect the automatically
 	// generated names for any properties nested under the current one.
+	//
+	// Experimental.
 	TypeName *string
 }
 

--- a/pkg/tfbridge/info/info.go
+++ b/pkg/tfbridge/info/info.go
@@ -520,6 +520,14 @@ type Schema struct {
 	// nested properties are too long or otherwise undesirable. The choice will further affect the automatically
 	// generated names for any properties nested under the current one.
 	//
+	// Example use:
+	//
+	//     TypeName: tfbridge.Ref("Visual")
+	//
+	// Note that the type name, and not the full token like "aws:quicksight/Visual:Visual" is specified. The token
+	// will be picked based on the current module ("quicksight" in the above example) where the parent resource or
+	// data source is found.
+	//
 	// Experimental.
 	TypeName *string
 }

--- a/pkg/tfbridge/info/info.go
+++ b/pkg/tfbridge/info/info.go
@@ -509,11 +509,13 @@ type Schema struct {
 	// whether or not to treat this property as secret
 	Secret *bool
 
-	// If specified, resets the type name prefix for any types that Pulumi needs to generate to represent the schema
-	// of the current property. Normally the names for helper object types are built from concatenating fragments
-	// representing the path to the type in the schema. The default strategy can lead to unacceptably long type
-	// names, reducing the SDK usability. Using TypePrefixOverride allows the maintainer to get shorter type names.
-	TypePrefixOverride *string
+	// Specifies the exact name to use for the generated type.
+	//
+	// When generating types for properties, by default Pulumi picks reasonable names based on the property path
+	// prefix and the name of the property. Use [TypeName] to override this decision when the default names for
+	// nested properties are too long or otherwise undesirable. The choice will further affect the automatically
+	// generated names for any properties nested under the current one.
+	TypeName *string
 }
 
 // Config represents a synthetic configuration variable that is Pulumi-only, and not passed to Terraform.

--- a/pkg/tfbridge/info/info.go
+++ b/pkg/tfbridge/info/info.go
@@ -441,8 +441,14 @@ type Schema struct {
 	// a name to override the default when targeting C#; "" uses the default.
 	CSharpName string
 
-	// a type to override the default; "" uses the default.
+	// An optional Pulumi type token to use for the Pulumi type projection of the current property. When unset, the
+	// default behavior is to generate fresh named Pulumi types as needed to represent the schema. To force the use
+	// of a known type and avoid generating unnecessary types, use both [Type] and [OmitType].
 	Type tokens.Type
+
+	// Used together with [Type] to omit generating any Pulumi types whatsoever for the current property, and
+	// instead use the object type identified by the token setup in [Type].
+	OmitType bool
 
 	// alternative types that can be used instead of the override.
 	AltTypes []tokens.Type
@@ -502,6 +508,12 @@ type Schema struct {
 
 	// whether or not to treat this property as secret
 	Secret *bool
+
+	// If specified, resets the type name prefix for any types that Pulumi needs to generate to represent the schema
+	// of the current property. Normally the names for helper object types are built from concatenating fragments
+	// representing the path to the type in the schema. The default strategy can lead to unacceptably long type
+	// names, reducing the SDK usability. Using TypePrefixOverride allows the maintainer to get shorter type names.
+	TypePrefixOverride *string
 }
 
 // Config represents a synthetic configuration variable that is Pulumi-only, and not passed to Terraform.

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -569,7 +569,8 @@ func (t *propertyType) equals(other *propertyType) bool {
 		return false
 	case t.typePrefixOverride == nil && other.typePrefixOverride != nil:
 		return false
-	case t.typePrefixOverride != nil && other.typePrefixOverride != nil && *t.typePrefixOverride != *other.typePrefixOverride:
+	case t.typePrefixOverride != nil && other.typePrefixOverride != nil &&
+		*t.typePrefixOverride != *other.typePrefixOverride:
 		return false
 	}
 	for i, p := range t.properties {

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -464,7 +464,7 @@ func (g *Generator) makeObjectPropertyType(typePath paths.TypePath,
 
 	// If the user supplied an explicit Type token override, omit generating types and short-circuit.
 	if info != nil && info.OmitType {
-		if info.Type != "" {
+		if info.Type == "" {
 			return nil, fmt.Errorf("Cannot set info.OmitType without also setting info.Type")
 		}
 		return &propertyType{typ: info.Type}, nil

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -463,7 +463,10 @@ func (g *Generator) makeObjectPropertyType(typePath paths.TypePath,
 	out bool, entityDocs entityDocs) (*propertyType, error) {
 
 	// If the user supplied an explicit Type token override, omit generating types and short-circuit.
-	if info != nil && info.OmitType && info.Type != "" {
+	if info != nil && info.OmitType {
+		if info.Type != "" {
+			return nil, fmt.Errorf("Cannot set info.OmitType without also setting info.Type")
+		}
 		return &propertyType{typ: info.Type}, nil
 	}
 

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -343,7 +343,7 @@ type propertyType struct {
 	altTypes   []tokens.Type
 	asset      *tfbridge.AssetTranslation
 
-	typePrefixOverride *string
+	typeName *string
 }
 
 func (g *Generator) Sink() diag.Sink {
@@ -356,7 +356,7 @@ func (g *Generator) makePropertyType(typePath paths.TypePath,
 
 	t := &propertyType{}
 	if info != nil {
-		t.typePrefixOverride = info.TypePrefixOverride
+		t.typeName = info.TypeName
 	}
 
 	var elemInfo *tfbridge.SchemaInfo
@@ -472,7 +472,7 @@ func (g *Generator) makeObjectPropertyType(typePath paths.TypePath,
 	}
 
 	if info != nil {
-		t.typePrefixOverride = info.TypePrefixOverride
+		t.typeName = info.TypeName
 	}
 
 	if info != nil {
@@ -565,12 +565,12 @@ func (t *propertyType) equals(other *propertyType) bool {
 		return false
 	}
 	switch {
-	case t.typePrefixOverride != nil && other.typePrefixOverride == nil:
+	case t.typeName != nil && other.typeName == nil:
 		return false
-	case t.typePrefixOverride == nil && other.typePrefixOverride != nil:
+	case t.typeName == nil && other.typeName != nil:
 		return false
-	case t.typePrefixOverride != nil && other.typePrefixOverride != nil &&
-		*t.typePrefixOverride != *other.typePrefixOverride:
+	case t.typeName != nil && other.typeName != nil &&
+		*t.typeName != *other.typeName:
 		return false
 	}
 	for i, p := range t.properties {

--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -119,12 +119,16 @@ type declarer interface {
 func (nt *schemaNestedTypes) declareType(typePath paths.TypePath, declarer declarer, namePrefix, name string,
 	typ *propertyType, isInput bool) string {
 
-	if typ.typePrefixOverride != nil {
-		namePrefix = *typ.typePrefixOverride
-	}
-
 	// Generate a name for this nested type.
-	typeName := namePrefix + cases.Title(language.Und, cases.NoLower).String(name)
+	var typeName string
+
+	if typ.typeName != nil {
+		// Use an explicit name if provided.
+		typeName = *typ.typeName
+	} else {
+		// Otherwise build one based on the current property name and prefix.
+		typeName = namePrefix + cases.Title(language.Und, cases.NoLower).String(name)
+	}
 
 	// Override the nested type name, if necessary.
 	if typ.nestedType.Name().String() != "" {

--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -119,6 +119,10 @@ type declarer interface {
 func (nt *schemaNestedTypes) declareType(typePath paths.TypePath, declarer declarer, namePrefix, name string,
 	typ *propertyType, isInput bool) string {
 
+	if typ.typePrefixOverride != nil {
+		namePrefix = *typ.typePrefixOverride
+	}
+
 	// Generate a name for this nested type.
 	typeName := namePrefix + cases.Title(language.Und, cases.NoLower).String(name)
 

--- a/pkg/tfgen/generate_schema_test.go
+++ b/pkg/tfgen/generate_schema_test.go
@@ -24,6 +24,7 @@ import (
 	"text/template"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hexops/autogold/v2"
 	csgen "github.com/pulumi/pulumi/pkg/v3/codegen/dotnet"
 	gogen "github.com/pulumi/pulumi/pkg/v3/codegen/go"
@@ -34,7 +35,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	bridgetesting "github.com/pulumi/pulumi-terraform-bridge/v3/internal/testing"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
@@ -257,7 +257,7 @@ func TestTypeSharing(t *testing.T) {
 
 	keys := []string{}
 	for k := range schema.Types {
-		keys = append(keys, string(k))
+		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 

--- a/pkg/tfgen/generate_schema_test.go
+++ b/pkg/tfgen/generate_schema_test.go
@@ -121,8 +121,8 @@ func TestCSharpMiniRandom(t *testing.T) {
 	bridgetesting.AssertEqualsJSONFile(t, "test_data/minirandom-schema-csharp.json", schema)
 }
 
-// Test the ability to force type sharing. Some of the upstream providers generate very large concrete schemata by in
-// Go, with TF not being materially affected. The example is inspired by QuickSight types in AWS. In Pulumi the default
+// Test the ability to force type sharing. Some of the upstream providers generate very large concrete schemata in Go,
+// with TF not being materially affected. The example is inspired by QuickSight types in AWS. In Pulumi the default
 // projection is going to generate named types for every instance of the shared schema. This may lead to SDK bloat. Test
 // the ability of the provider author to curb the bloat and force an explicit sharing.
 func TestTypeSharing(t *testing.T) {

--- a/pkg/tfgen/generate_schema_test.go
+++ b/pkg/tfgen/generate_schema_test.go
@@ -124,7 +124,7 @@ func TestCSharpMiniRandom(t *testing.T) {
 // Test the ability to force type sharing. Some of the upstream providers generate very large concrete schemata by in
 // Go, with TF not being materially affected. The example is inspired by QuickSight types in AWS. In Pulumi the default
 // projection is going to generate named types for every instance of the shared schema. This may lead to SDK bloat. Test
-// the ability of the provider author to curb the bloat and force an explit sharing.
+// the ability of the provider author to curb the bloat and force an explicit sharing.
 func TestTypeSharing(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skipf("Skipping on Windows due to a test setup issue")
@@ -224,7 +224,7 @@ func TestTypeSharing(t *testing.T) {
 							Fields: map[string]*info.Schema{
 								"visuals": {
 									Elem: &info.Schema{
-										TypePrefixOverride: tfbridge.StringRef(""),
+										TypeName: tfbridge.StringRef("Visual"),
 									},
 								},
 							},

--- a/pkg/tfgen/generate_schema_test.go
+++ b/pkg/tfgen/generate_schema_test.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 	"sort"
 	"testing"
 	"text/template"
@@ -247,10 +246,14 @@ func TestTypeSharing(t *testing.T) {
 			},
 		},
 	}
-	schema, err := GenerateSchema(provider, diag.DefaultSink(os.Stdout, os.Stdout, diag.FormatOptions{
+
+	var buf bytes.Buffer
+	schema, err := GenerateSchema(provider, diag.DefaultSink(&buf, &buf, diag.FormatOptions{
 		Color: colors.Never,
 	}))
 	require.NoError(t, err)
+
+	t.Logf("%s", buf.String())
 
 	keys := []string{}
 	for k := range schema.Types {

--- a/pkg/tfgen/generate_schema_test.go
+++ b/pkg/tfgen/generate_schema_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"runtime"
 	"sort"
 	"testing"
 	"text/template"
@@ -125,6 +126,10 @@ func TestCSharpMiniRandom(t *testing.T) {
 // projection is going to generate named types for every instance of the shared schema. This may lead to SDK bloat. Test
 // the ability of the provider author to curb the bloat and force an explit sharing.
 func TestTypeSharing(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skipf("Skipping on Windows due to a test setup issue")
+	}
+
 	tmpdir := t.TempDir()
 	barCharVisualSchema := func() *schema.Schema {
 		return &schema.Schema{

--- a/pkg/tfgen/generate_schema_test.go
+++ b/pkg/tfgen/generate_schema_test.go
@@ -224,7 +224,7 @@ func TestTypeSharing(t *testing.T) {
 							Fields: map[string]*info.Schema{
 								"visuals": {
 									Elem: &info.Schema{
-										TypeName: tfbridge.StringRef("Visual"),
+										TypeName: tfbridge.Ref("Visual"),
 									},
 								},
 							},

--- a/pkg/tfgen/testdata/TestTypeSharing.golden
+++ b/pkg/tfgen/testdata/TestTypeSharing.golden
@@ -1,0 +1,164 @@
+{
+  "name": "testprov",
+  "attribution": "This Pulumi package is based on the [`testprov` Terraform Provider](https://github.com/terraform-providers/terraform-provider-testprov).",
+  "meta": {
+    "moduleFormat": "(.*)(?:/[^/]*)"
+  },
+  "language": {
+    "nodejs": {
+      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-testprov)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-testprov` repo](/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-testprov` repo](https://github.com/terraform-providers/terraform-provider-testprov/issues).",
+      "compatibility": "tfbridge20",
+      "disableUnionOutputTypes": true
+    },
+    "python": {
+      "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-testprov)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-testprov` repo](/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-testprov` repo](https://github.com/terraform-providers/terraform-provider-testprov/issues).",
+      "compatibility": "tfbridge20",
+      "pyproject": {}
+    }
+  },
+  "config": {},
+  "types": {
+    "testprov:index/R1Sheet:R1Sheet": {
+      "properties": {
+        "visuals": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/testprov:index/Visual:Visual"
+          }
+        }
+      },
+      "type": "object"
+    },
+    "testprov:index/R2Sheet:R2Sheet": {
+      "properties": {
+        "visuals": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/testprov:index/Visual:Visual"
+          }
+        },
+        "y": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "testprov:index/Visual:Visual": {
+      "properties": {
+        "barChartVisual": {
+          "$ref": "#/types/testprov:index/VisualBarChartVisual:VisualBarChartVisual"
+        },
+        "boxPlotVisual": {
+          "$ref": "#/types/testprov:index/VisualBoxPlotVisual:VisualBoxPlotVisual"
+        }
+      },
+      "type": "object"
+    },
+    "testprov:index/VisualBarChartVisual:VisualBarChartVisual": {
+      "properties": {
+        "nest": {
+          "$ref": "#/types/testprov:index/VisualBarChartVisualNest:VisualBarChartVisualNest"
+        }
+      },
+      "type": "object"
+    },
+    "testprov:index/VisualBarChartVisualNest:VisualBarChartVisualNest": {
+      "properties": {
+        "nestedProp": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "testprov:index/VisualBoxPlotVisual:VisualBoxPlotVisual": {
+      "properties": {
+        "nest": {
+          "$ref": "#/types/testprov:index/VisualBoxPlotVisualNest:VisualBoxPlotVisualNest"
+        }
+      },
+      "type": "object"
+    },
+    "testprov:index/VisualBoxPlotVisualNest:VisualBoxPlotVisualNest": {
+      "properties": {
+        "nestedProp": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "provider": {
+    "description": "The provider type for the testprov package. By default, resources use package-wide configuration\nsettings, however an explicit `Provider` instance may be created and passed during resource\nconstruction to achieve fine-grained programmatic control over provider settings. See the\n[documentation](https://www.pulumi.com/docs/reference/programming-model/#providers) for more information.\n"
+  },
+  "resources": {
+    "testprov:index:R1": {
+      "properties": {
+        "sheets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/testprov:index/R1Sheet:R1Sheet"
+          }
+        }
+      },
+      "inputProperties": {
+        "sheets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/testprov:index/R1Sheet:R1Sheet"
+          }
+        }
+      },
+      "stateInputs": {
+        "description": "Input properties used for looking up and filtering R1 resources.\n",
+        "properties": {
+          "sheets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/types/testprov:index/R1Sheet:R1Sheet"
+            }
+          }
+        },
+        "type": "object"
+      }
+    },
+    "testprov:index:R2": {
+      "properties": {
+        "sheets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/testprov:index/R2Sheet:R2Sheet"
+          }
+        },
+        "x": {
+          "type": "integer"
+        }
+      },
+      "inputProperties": {
+        "sheets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/testprov:index/R2Sheet:R2Sheet"
+          }
+        },
+        "x": {
+          "type": "integer"
+        }
+      },
+      "stateInputs": {
+        "description": "Input properties used for looking up and filtering R2 resources.\n",
+        "properties": {
+          "sheets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/types/testprov:index/R2Sheet:R2Sheet"
+            }
+          },
+          "x": {
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Introduce OmitType and TypeName flags to enforce type sharing.

Some of the upstream providers generate very large concrete schemata. TF is not being materially affected, just high RAM demands for in-memory processing. The example is inspired by QuickSight types in AWS. Pulumi is affected significantly. In Pulumi the default projection is going to generate named types for every instance of the shared schema. This leads to SDK bloat and issues with "filename too long." 

With this change it is possible for the provider maintainer opt into explicit sharing of types, and ensure that the type names for the shared types have shorter meaningful prefixes.

At definition type the user can specify the type name to generate, which can be very short, and replace the automatically implied ReallyLongPrefixedTypeName like this:

```go
"visuals": {
	Elem: &info.Schema{
		TypeName: tfbridge.Ref("Visual"),
	},
},
```

At reference time in another resource, the user can reuse an already generated type by token. This already worked before this change but had the downside of still generating unused helper types and causing SDK bloat.

```go
"visuals": {
	Elem: &info.Schema{
		Type:     "testprov:index/Visual:Visual",
	},
},
```

With this change it is possible to instruct the bridge to stop generating the unused helper types:

```go
"visuals": {
	Elem: &info.Schema{
		Type:     "testprov:index/Visual:Visual",
		OmitType: true
	},
},
```
