### PR TITLE
Add SDKv2 PlanStateEdit

### DIFF
--- a/pkg/tests/schema_pulumi_test.go
+++ b/pkg/tests/schema_pulumi_test.go
@@ -4169,7 +4169,7 @@ func TestPlanStateEdit(t *testing.T) {
 	}
 
 	tfp := &schema.Provider{
-		Schema: map[string]*schema.Schema{"config_value": &schema.Schema{
+		Schema: map[string]*schema.Schema{"config_value": {
 			Type:     schema.TypeString,
 			Optional: true,
 		}},

--- a/pkg/tests/schema_pulumi_test.go
+++ b/pkg/tests/schema_pulumi_test.go
@@ -17,8 +17,10 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/pulcheck"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/tfcheck"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optpreview"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optrefresh"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
@@ -4084,4 +4086,102 @@ outputs:
 	res := pt.Up()
 	require.Equal(t, "hello world", res.Outputs["testOut"].Value)
 	pt.Preview(optpreview.ExpectNoChanges())
+}
+
+// TestPlanStateEdit tests that [shimv2.WithPlanStateEdit] can be used to effectively edit
+// planed state.
+//
+// The test is set up to reproduce https://github.com/pulumi/pulumi-gcp/issues/2372.
+func TestPlanStateEdit(t *testing.T) {
+	setLabelsDiff := func(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
+		raw := d.Get("labels")
+		if raw == nil {
+			return nil
+		}
+
+		if d.Get("terraform_labels") == nil {
+			return fmt.Errorf("`terraform_labels` field is not present in the resource schema")
+		}
+
+		// If "labels" field is computed, set "terraform_labels" and "effective_labels" to computed.
+		// https://github.com/hashicorp/terraform-provider-google/issues/16217
+		if !d.GetRawPlan().GetAttr("labels").IsWhollyKnown() {
+			if err := d.SetNewComputed("terraform_labels"); err != nil {
+				return fmt.Errorf("error setting terraform_labels to computed: %w", err)
+			}
+
+			return nil
+		}
+
+		// Merge provider default labels with the user defined labels in the resource to get terraform managed labels
+		terraformLabels := make(map[string]string)
+
+		labels := raw.(map[string]interface{})
+		for k, v := range labels {
+			terraformLabels[k] = v.(string)
+		}
+
+		if err := d.SetNew("terraform_labels", terraformLabels); err != nil {
+			return fmt.Errorf("error setting new terraform_labels diff: %w", err)
+		}
+
+		return nil
+	}
+
+	const tfLabelsKey = "terraform_labels"
+
+	fixEmptyLabels := func(ctx context.Context, req shimv2.PlanStateEditRequest) (cty.Value, error) {
+		tfbridge.GetLogger(ctx).Debug("Invoked") // ctx is correctly passed and the logger is available
+
+		assert.Equal(t, "prov_test", req.TfToken)
+		assert.Equal(t, resource.PropertyMap{
+			"__defaults": resource.NewProperty([]resource.PropertyValue{}),
+			"labels": resource.NewProperty(resource.PropertyMap{
+				"empty": resource.NewProperty(""),
+				"key":   resource.NewProperty("val"),
+			}),
+		}, req.NewInputs)
+
+		m := req.PlanState.AsValueMap()
+		effectiveLabels := m[tfLabelsKey].AsValueMap()
+		effectiveLabels["empty"] = cty.StringVal("")
+		m[tfLabelsKey] = cty.MapVal(effectiveLabels)
+		return cty.ObjectVal(m), nil
+	}
+
+	res := &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"labels": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			tfLabelsKey: {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+		CustomizeDiff: setLabelsDiff,
+	}
+
+	tfp := &schema.Provider{ResourcesMap: map[string]*schema.Resource{"prov_test": res}}
+	bridgedProvider := pulcheck.BridgedProvider(t, "prov", tfp, pulcheck.WithStateEdit(fixEmptyLabels))
+	program := `
+	name: test
+	runtime: yaml
+	resources:
+	  mainRes:
+		type: prov:index:Test
+		properties:
+		  labels: { "key": "val", "empty": "" }
+	outputs:
+	  keyValue: ${mainRes.terraformLabels["key"]}
+	  emptyValue: ${mainRes.terraformLabels["empty"]}
+	`
+	pt := pulcheck.PulCheck(t, bridgedProvider, program)
+	out := pt.Up()
+
+	assert.Equal(t, "val", out.Outputs["keyValue"].Value)
+	assert.Equal(t, "", out.Outputs["emptyValue"].Value)
 }

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -1136,8 +1136,9 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 
 	diff, err := callWithRecover(urn, p.recoverOnTypeError, func() (shim.InstanceDiff, error) {
 		return p.tf.Diff(ctx, res.TFName, state, config, shim.DiffOptions{
-			IgnoreChanges: ic,
-			NewInputs:     news,
+			IgnoreChanges:  ic,
+			NewInputs:      news,
+			ProviderConfig: p.configValues,
 		})
 	})
 	if err != nil {
@@ -1290,7 +1291,8 @@ func (p *Provider) Create(ctx context.Context, req *pulumirpc.CreateRequest) (*p
 
 	diff, err := callWithRecover(urn, p.recoverOnTypeError, func() (shim.InstanceDiff, error) {
 		return p.tf.Diff(ctx, res.TFName, nil, config, shim.DiffOptions{
-			NewInputs: props,
+			NewInputs:      props,
+			ProviderConfig: p.configValues,
 			TimeoutOptions: shim.TimeoutOptions{
 				ResourceTimeout:  timeouts,
 				TimeoutOverrides: newTimeoutOverrides(shim.TimeoutCreate, req.Timeout),
@@ -1619,8 +1621,9 @@ func (p *Provider) Update(ctx context.Context, req *pulumirpc.UpdateRequest) (*p
 
 	diff, err := callWithRecover(urn, p.recoverOnTypeError, func() (shim.InstanceDiff, error) {
 		return p.tf.Diff(ctx, res.TFName, state, config, shim.DiffOptions{
-			IgnoreChanges: ic,
-			NewInputs:     news,
+			IgnoreChanges:  ic,
+			NewInputs:      news,
+			ProviderConfig: p.configValues,
 			TimeoutOptions: shim.TimeoutOptions{
 				TimeoutOverrides: newTimeoutOverrides(shim.TimeoutUpdate, req.Timeout),
 				ResourceTimeout:  timeouts,

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -1137,6 +1137,7 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 	diff, err := callWithRecover(urn, p.recoverOnTypeError, func() (shim.InstanceDiff, error) {
 		return p.tf.Diff(ctx, res.TFName, state, config, shim.DiffOptions{
 			IgnoreChanges: ic,
+			NewInputs:     news,
 		})
 	})
 	if err != nil {
@@ -1289,6 +1290,7 @@ func (p *Provider) Create(ctx context.Context, req *pulumirpc.CreateRequest) (*p
 
 	diff, err := callWithRecover(urn, p.recoverOnTypeError, func() (shim.InstanceDiff, error) {
 		return p.tf.Diff(ctx, res.TFName, nil, config, shim.DiffOptions{
+			NewInputs: props,
 			TimeoutOptions: shim.TimeoutOptions{
 				ResourceTimeout:  timeouts,
 				TimeoutOverrides: newTimeoutOverrides(shim.TimeoutCreate, req.Timeout),
@@ -1618,6 +1620,7 @@ func (p *Provider) Update(ctx context.Context, req *pulumirpc.UpdateRequest) (*p
 	diff, err := callWithRecover(urn, p.recoverOnTypeError, func() (shim.InstanceDiff, error) {
 		return p.tf.Diff(ctx, res.TFName, state, config, shim.DiffOptions{
 			IgnoreChanges: ic,
+			NewInputs:     news,
 			TimeoutOptions: shim.TimeoutOptions{
 				TimeoutOverrides: newTimeoutOverrides(shim.TimeoutUpdate, req.Timeout),
 				ResourceTimeout:  timeouts,

--- a/pkg/tfshim/sdk-v2/provider2.go
+++ b/pkg/tfshim/sdk-v2/provider2.go
@@ -264,9 +264,10 @@ func (p *planResourceChangeImpl) Diff(
 	}
 
 	plannedState, err := p.planEdit(ctx, PlanStateEditRequest{
-		NewInputs: opts.NewInputs,
-		TfToken:   t,
-		PlanState: plan.PlannedState,
+		NewInputs:      opts.NewInputs,
+		ProviderConfig: opts.ProviderConfig,
+		TfToken:        t,
+		PlanState:      plan.PlannedState,
 	})
 	return &v2InstanceDiff2{
 		v2InstanceDiff: v2InstanceDiff{

--- a/pkg/tfshim/sdk-v2/provider_options.go
+++ b/pkg/tfshim/sdk-v2/provider_options.go
@@ -32,9 +32,10 @@ type providerOption func(providerOptions) (providerOptions, error)
 //
 // For use, see [WithPlanStateEdit].
 type PlanStateEditRequest struct {
-	TfToken   string               // The TF token
-	PlanState cty.Value            // The plan state calculated by TF.
-	NewInputs resource.PropertyMap // The post-check inputs given by Pulumi.
+	TfToken        string               // The TF token
+	PlanState      cty.Value            // The plan state calculated by TF.
+	NewInputs      resource.PropertyMap // The post-check inputs given by Pulumi.
+	ProviderConfig resource.PropertyMap // The config of the provider
 }
 
 // PlanStateEditFunc describes a user supplied function to edit TF's plan state.

--- a/pkg/tfshim/sdk-v2/provider_options.go
+++ b/pkg/tfshim/sdk-v2/provider_options.go
@@ -14,11 +14,49 @@
 
 package sdkv2
 
+import (
+	"context"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
 type providerOptions struct {
 	planResourceChangeFilter func(string) bool
+	planStateEdit            PlanStateEditFunc
 }
 
 type providerOption func(providerOptions) (providerOptions, error)
+
+// PlanStateEditRequest
+//
+// For use, see [WithPlanStateEdit].
+type PlanStateEditRequest struct {
+	TfToken   string               // The TF token
+	PlanState cty.Value            // The plan state calculated by TF.
+	NewInputs resource.PropertyMap // The post-check inputs given by Pulumi.
+}
+
+// PlanStateEditFunc describes a user supplied function to edit TF's plan state.
+//
+// For use, see [WithPlanStateEdit].
+type PlanStateEditFunc = func(context.Context, PlanStateEditRequest) (cty.Value, error)
+
+// WithPlanStateEdit adds the PlanStateEditFunc hook to be called on the planned state
+// after each resource is updated.
+//
+// WithPlanStateEdit only applies to resources where Plan Resource Change[^1] is enabled.
+//
+// WithPlanStateEdit is experimental. The API may be removed or experience backwards
+// incompatible changes at any time.
+//
+// [^1]: See [WithPlanResourceChange] for more details.
+func WithPlanStateEdit(f PlanStateEditFunc) providerOption { //nolint:revive
+	return func(opts providerOptions) (providerOptions, error) {
+		opts.planStateEdit = f
+		return opts, nil
+	}
+}
 
 // Deprecated.
 // TODO[pulumi/pulumi-terraform-bridge#2062] clean up deprecation.

--- a/pkg/tfshim/shim.go
+++ b/pkg/tfshim/shim.go
@@ -295,6 +295,11 @@ type DiffOptions struct {
 	//
 	// NewInputs is always populated.
 	NewInputs resource.PropertyMap
+
+	// The config values used to configure the provider.
+	//
+	// DO NOT EDIT ProviderConfig.
+	ProviderConfig resource.PropertyMap
 }
 
 // Supports the ignoreChanges Pulumi option.

--- a/pkg/tfshim/shim.go
+++ b/pkg/tfshim/shim.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"time"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
 type ResourceConfig interface {
@@ -288,6 +290,11 @@ type TimeoutOptions struct {
 type DiffOptions struct {
 	IgnoreChanges  IgnoreChanges
 	TimeoutOptions TimeoutOptions
+
+	// The original new (post-check) inputs given to the request.
+	//
+	// NewInputs is always populated.
+	NewInputs resource.PropertyMap
 }
 
 // Supports the ignoreChanges Pulumi option.


### PR DESCRIPTION
PlanStateEdit allows a bridged provider author to correct the diff generated by the TF
provider with additional information: the original Pulumi encoded inputs. This allows
Pulumi to recover from information lost in the Terraform encoding.

The ability to recover information from Pulumi's representation is only available outside the normal TF information flow. This is why diff customizers can't fill the role of PlanStateEdit.

One example of this information loss is pulumi/pulumi-gcp#2372, where SDKv2's
representation of an unknown value `""` is not distinguished from an actual empty
string. A sister PR uses this capability to resolve (not this one GH) pulumi/pulumi-gcp#2372.