### PR TITLE
Add more regex filters to installation docsgen

### DIFF
--- a/pkg/tfgen/installation_docs.go
+++ b/pkg/tfgen/installation_docs.go
@@ -401,6 +401,7 @@ func getDefaultHeadersToSkip() []*regexp.Regexp {
 		regexp.MustCompile("[Dd]ebugging"),
 		regexp.MustCompile("[Tt]erraform CLI"),
 		regexp.MustCompile("[Tt]erraform Cloud"),
+		regexp.MustCompile("Delete Protection"),
 	}
 	return defaultHeaderSkipRegexps
 }

--- a/pkg/tfgen/installation_docs.go
+++ b/pkg/tfgen/installation_docs.go
@@ -407,8 +407,9 @@ func getDefaultHeadersToSkip() []*regexp.Regexp {
 
 func getTfVersionsToRemove() []*regexp.Regexp {
 	tfVersionsToRemove := []*regexp.Regexp{
-		regexp.MustCompile(`It requires [tT]erraform [v0-9]+\.?[0-9]?\.?[0-9]? or later.`),
+		regexp.MustCompile(`(It|This provider) requires(.*|at least) [tT]erraform [v0-9]+\.?[0-9]?\.?[0-9]?(.*|or later).`),
 		regexp.MustCompile(`(?s)(For )?[tT]erraform [v0-9]+\.?[0-9]?\.?[0-9]? and (later|earlier):`),
+		regexp.MustCompile(`A minimum of [tT]erraform [v0-9]+\.?[0-9]?\.?[0-9]? is recommended.`),
 	}
 	return tfVersionsToRemove
 }

--- a/pkg/tfgen/installation_docs_test.go
+++ b/pkg/tfgen/installation_docs_test.go
@@ -278,6 +278,27 @@ func TestApplyEditRules(t *testing.T) {
 			},
 			expected: []byte("This is a provider with an example.\nUse this code."),
 		},
+		{
+			name: "Strips mentions of Terraform version pattern 6",
+			docFile: DocFile{
+				Content: []byte("This provider requires at least Terraform 1.0."),
+			},
+			expected: []byte(""),
+		},
+		{
+			name: "Strips mentions of Terraform version pattern 7",
+			docFile: DocFile{
+				Content: []byte("This provider requires Terraform 1.0."),
+			},
+			expected: []byte(""),
+		},
+		{
+			name: "Strips mentions of Terraform version pattern 8",
+			docFile: DocFile{
+				Content: []byte("A minimum of Terraform 1.4.0 is recommended."),
+			},
+			expected: []byte(""),
+		},
 	}
 	for _, tt := range tests {
 		tt := tt


### PR DESCRIPTION
Rather than handling these in individual providers, they're best served here.

Adds a few test cases to guard against any regression.

- **Match TF mentions found in gitlab provider and add test cases**
- **Add a header to skip as seen in hcloud**
