### PR TITLE
fix: remove frontmatter whitespace when trimming

### DIFF
--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -373,7 +373,9 @@ var (
 )
 
 func trimFrontMatter(text []byte) []byte {
-	body, ok := bytes.CutPrefix(text, []byte("---"))
+	// trim any leading or trailing whitespace
+	body := bytes.TrimSpace(text)
+	body, ok := bytes.CutPrefix(body, []byte("---"))
 	if !ok {
 		return text
 	}

--- a/pkg/tfgen/installation_docs_test.go
+++ b/pkg/tfgen/installation_docs_test.go
@@ -75,6 +75,11 @@ func TestTrimFrontmatter(t *testing.T) {
 			input:    readfile(t, "test_data/strip-front-matter/artifactory-input.md"),
 			expected: readfile(t, "test_data/strip-front-matter/artifactory-expected.md"),
 		},
+		{
+			name:     "Strips Upstream Frontmatter Wit Leading Whitespace",
+			input:    readfile(t, "test_data/strip-front-matter/ise-input.md"),
+			expected: readfile(t, "test_data/strip-front-matter/ise-expected.md"),
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/tfgen/test_data/strip-front-matter/ise-expected.md
+++ b/pkg/tfgen/test_data/strip-front-matter/ise-expected.md
@@ -1,0 +1,6 @@
+
+# ISE Provider
+
+The ISE provider provides resources to interact with a Cisco ISE (Identity Service Engine) instance. It communicates with ISE via the REST API.
+
+This provider uses both, the ERS and Open API. 

--- a/pkg/tfgen/test_data/strip-front-matter/ise-input.md
+++ b/pkg/tfgen/test_data/strip-front-matter/ise-input.md
@@ -1,0 +1,13 @@
+
+---
+layout: ""
+page_title: "Provider: ISE"
+description: |-
+The ISE provider provides resources to interact with a Cisco ISE (Identity Service Engine) instance.
+---
+
+# ISE Provider
+
+The ISE provider provides resources to interact with a Cisco ISE (Identity Service Engine) instance. It communicates with ISE via the REST API.
+
+This provider uses both, the ERS and Open API. 


### PR DESCRIPTION
[Some providers](https://github.com/CiscoDevNet/terraform-provider-ise/blob/main/docs/index.md?plain=1#L1C1-L14C1) have poorly formatted files. We can fix this by removing the whitespace before trimming off the remaining frontmatter.

