### PR TITLE
Only check mapped resources

### DIFF
--- a/pf/internal/check/check_test.go
+++ b/pf/internal/check/check_test.go
@@ -32,6 +32,7 @@ import (
 
 	pfbridge "github.com/pulumi/pulumi-terraform-bridge/pf/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/tokens"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	sdkv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
 )
@@ -112,6 +113,16 @@ func TestMissingIDWithOverride(t *testing.T) {
 				panic("ComputeID")
 			}},
 		},
+	})
+
+	assert.Empty(t, stderr)
+	assert.NoError(t, err)
+}
+
+func TestMissingIDUnmapped(t *testing.T) {
+	stderr, err := test(t, tfbridge.ProviderInfo{
+		P:              pfbridge.ShimProvider(testProvider{missingID: true}),
+		IgnoreMappings: []string{"test_res"},
 	})
 
 	assert.Empty(t, stderr)
@@ -269,6 +280,9 @@ func test(t *testing.T, info tfbridge.ProviderInfo) (string, error) {
 	sink := diag.DefaultSink(&stdout, &stderr, diag.FormatOptions{
 		Color: colors.Never,
 	})
+
+	info.MustComputeTokens(tokens.SingleModule(info.GetResourcePrefix(),
+		"index", tokens.MakeStandard(info.GetResourcePrefix())))
 
 	err := Provider(sink, info)
 

--- a/pf/internal/check/checks.go
+++ b/pf/internal/check/checks.go
@@ -49,6 +49,11 @@ func checkIDProperties(sink diag.Sink, info tfbridge.ProviderInfo, isPFResource 
 	errors := 0
 
 	info.P.ResourcesMap().Range(func(rname string, resource shim.Resource) bool {
+		// Unmapped resources are not available, so they don't need to be correct.
+		if v, ok := info.Resources[rname]; !ok || v.Tok == "" {
+			return true
+		}
+
 		// If a resource is sdk based, it always has an ID, regardless of the
 		// schema it describes.
 		if !isPFResource(rname) {


### PR DESCRIPTION
We should only validate resources we will use. Discovered as part of https://github.com/pulumi/pulumi-databricks/issues/595.