### PR TITLE
Additional replacements for installation docs

### DIFF
--- a/pkg/tfgen/installation_docs.go
+++ b/pkg/tfgen/installation_docs.go
@@ -114,6 +114,9 @@ func applyEditRules(contentBytes []byte, docFile string, g *Generator) ([]byte, 
 	edits = append(edits,
 		skipSectionHeadersEdit(docFile),
 		removeTfVersionMentions(docFile),
+		//Replace "providers.tf" with "Pulumi.yaml"
+		reReplace(`providers.tf`, `Pulumi.yaml`),
+		reReplace(`terraform init`, `pulumi up`),
 		// Replace all "T/terraform" with "P/pulumi"
 		reReplace(`Terraform`, `Pulumi`),
 		reReplace(`terraform`, `pulumi`),
@@ -130,6 +133,7 @@ func applyEditRules(contentBytes []byte, docFile string, g *Generator) ([]byte, 
 		reReplace("### Optional\n", ""),
 		reReplace(`block contains the following arguments`,
 			`input has the following nested fields`),
+		reReplace(`provider block`, `provider configuration`),
 	)
 	contentBytes, err := edits.apply(docFile, contentBytes)
 	if err != nil {

--- a/pkg/tfgen/installation_docs_test.go
+++ b/pkg/tfgen/installation_docs_test.go
@@ -306,11 +306,37 @@ func TestApplyEditRules(t *testing.T) {
 			},
 			expected: []byte(readfile(t, "test_data/replace-terraform-version/expected.md")),
 		},
+		{
+			// Found in linode
+			name: "Rewrites providers.tf to Pulumi.yaml",
+			docFile: DocFile{
+				Content: []byte(readfile(t, "test_data/rewrite-providers-tf-to-pulumi-yaml/input.md")),
+			},
+			expected: []byte(readfile(t, "test_data/rewrite-providers-tf-to-pulumi-yaml/expected.md")),
+		},
+		{
+			name: "Rewrites terraform init to pulumi up",
+			docFile: DocFile{
+				Content: []byte(readfile(t, "test_data/rewrite-tf-init-to-pulumi-up/input.md")),
+			},
+			expected: []byte(readfile(t, "test_data/rewrite-tf-init-to-pulumi-up/expected.md")),
+		},
+		{
+			// Found in linode
+			name: "Replaces provider block with provider configuration",
+			docFile: DocFile{
+				Content: []byte(readfile(t, "test_data/replace-provider-block/input.md")),
+			},
+			expected: []byte(readfile(t, "test_data/replace-provider-block/expected.md")),
+		},
 	}
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			if runtime.GOOS == "windows" {
+				t.Skipf("Skipping on Windows due to a newline handling issue")
+			}
 			g := &Generator{
 				sink:      mockSink{t},
 				editRules: defaultEditRules(),

--- a/pkg/tfgen/test_data/replace-provider-block/expected.md
+++ b/pkg/tfgen/test_data/replace-provider-block/expected.md
@@ -1,0 +1,3 @@
+### Configuring the Target API Version
+
+The `api_version` can be set on the provider configuration like so:

--- a/pkg/tfgen/test_data/replace-provider-block/input.md
+++ b/pkg/tfgen/test_data/replace-provider-block/input.md
@@ -1,0 +1,3 @@
+### Configuring the Target API Version
+
+The `api_version` can be set on the provider block like so:

--- a/pkg/tfgen/test_data/rewrite-providers-tf-to-pulumi-yaml/expected.md
+++ b/pkg/tfgen/test_data/rewrite-providers-tf-to-pulumi-yaml/expected.md
@@ -1,0 +1,14 @@
+## Using Configuration Files
+
+Configuration files can be used to specify Linode client configuration options across various Linode integrations.
+
+For example:
+
+`~/.config/linode`
+
+```ini
+[default]
+token = mylinodetoken
+```
+
+`Pulumi.yaml`

--- a/pkg/tfgen/test_data/rewrite-providers-tf-to-pulumi-yaml/input.md
+++ b/pkg/tfgen/test_data/rewrite-providers-tf-to-pulumi-yaml/input.md
@@ -1,0 +1,14 @@
+## Using Configuration Files
+
+Configuration files can be used to specify Linode client configuration options across various Linode integrations.
+
+For example:
+
+`~/.config/linode`
+
+```ini
+[default]
+token = mylinodetoken
+```
+
+`providers.tf`

--- a/pkg/tfgen/test_data/rewrite-tf-init-to-pulumi-up/expected.md
+++ b/pkg/tfgen/test_data/rewrite-tf-init-to-pulumi-up/expected.md
@@ -1,0 +1,5 @@
+Note: Fully qualified `secret_name` ARN as input is REQUIRED for cross-AWS account secrets.
+
+Note: `sts_endpoint` parameter is REQUIRED for cross-AWS region or cross-AWS account secrets.
+
+In terminal, `pulumi up` 

--- a/pkg/tfgen/test_data/rewrite-tf-init-to-pulumi-up/input.md
+++ b/pkg/tfgen/test_data/rewrite-tf-init-to-pulumi-up/input.md
@@ -1,0 +1,5 @@
+Note: Fully qualified `secret_name` ARN as input is REQUIRED for cross-AWS account secrets.
+
+Note: `sts_endpoint` parameter is REQUIRED for cross-AWS region or cross-AWS account secrets.
+
+In terminal, `terraform init` 


### PR DESCRIPTION
A few additional useful replaces encountered in the installation docs:

- terraform init --> pulumi up
- providers.tf --> Pulumi.yaml
- provider block --> provider configuration
