### PR TITLE
Fix docs panic with scaleway bucket

### DIFF
--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -1075,7 +1075,10 @@ func parseArgReferenceSection(subsection []string, ret *entityDocs) {
 				return
 			}
 			line = "\n" + strings.TrimSpace(line)
-			ret.Arguments[docsPath(lastMatch)].description += line
+			arg := ret.Arguments[docsPath(lastMatch)]
+			if arg != nil {
+				arg.description += line
+			}
 		}
 	}
 

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -624,6 +624,38 @@ func TestArgumentRegex(t *testing.T) {
 	}
 }
 
+func TestArgumentRegexAuto(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected autogold.Value
+	}{
+		{
+			name: "scaleway bucket_panic",
+			input: []string{
+				"",
+				"The following arguments are supported:", "",
+				"* `versioning` - (Optional) A state of [versioning](https://www.scaleway.com/en/docs/storage/object/how-to/use-bucket-versioning/). The `versioning` object supports the following:", "",
+				"    * `enabled` - (Optional) Enable versioning. Once you version-enable a bucket, it can never return to an unversioned state. You can, however, suspend versioning on that bucket.", "",
+			},
+			expected: autogold.Expect(map[docsPath]*argumentDocs{docsPath("versioning.enabled"): {
+				description: "Enable versioning. Once you version-enable a bucket, it can never return to an unversioned state. You can, however, suspend versioning on that bucket.",
+			}}),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			ret := entityDocs{
+				Arguments: make(map[docsPath]*argumentDocs),
+			}
+			parseArgReferenceSection(tt.input, &ret)
+			tt.expected.Equal(t, ret.Arguments)
+		})
+	}
+}
+
 func TestGetFooterLinks(t *testing.T) {
 	input := `## Attributes Reference
 

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -631,7 +631,7 @@ func TestArgumentRegexAuto(t *testing.T) {
 		expected autogold.Value
 	}{
 		{
-			name: "scaleway bucket_panic",
+			name: "newline after bullet",
 			input: []string{
 				"",
 				"The following arguments are supported:", "",

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -634,9 +634,12 @@ func TestArgumentRegexAuto(t *testing.T) {
 			name: "newline after bullet",
 			input: []string{
 				"",
-				"The following arguments are supported:", "",
-				"* `versioning` - (Optional) A state of [versioning](https://www.scaleway.com/en/docs/storage/object/how-to/use-bucket-versioning/). The `versioning` object supports the following:", "",
-				"    * `enabled` - (Optional) Enable versioning. Once you version-enable a bucket, it can never return to an unversioned state. You can, however, suspend versioning on that bucket.", "",
+				"The following arguments are supported:",
+				"",
+				"* `versioning` - (Optional) A state of [versioning](https://www.scaleway.com/en/docs/storage/object/how-to/use-bucket-versioning/). The `versioning` object supports the following:",
+				"",
+				"    * `enabled` - (Optional) Enable versioning. Once you version-enable a bucket, it can never return to an unversioned state. You can, however, suspend versioning on that bucket.",
+				"",
 			},
 			expected: autogold.Expect(map[docsPath]*argumentDocs{docsPath("versioning.enabled"): {
 				description: "Enable versioning. Once you version-enable a bucket, it can never return to an unversioned state. You can, however, suspend versioning on that bucket.",


### PR DESCRIPTION
The scaleway bucket docs have extra newlines so our nested argument parsing fails but our code does not handle that and panics.
This fixes the panic, ~the parsing is left as a follow-up.~ The docs are already fine: https://www.pulumi.com/registry/packages/scaleway/api-docs/objectbucket/#objectbucketversioning

fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/2453