### PR TITLE
Add more shim representation tests

### DIFF
--- a/pkg/tfshim/sdk-v2/cty.go
+++ b/pkg/tfshim/sdk-v2/cty.go
@@ -160,7 +160,7 @@ func recoverScalarCtyValue(dT cty.Type, value interface{}) (cty.Value, error) {
 		if value > math.MaxInt64 {
 			return cty.NilVal, fmt.Errorf("cannot convert %d (uint) to a int64: overflow", value)
 		}
-		
+
 		return cty.NumberIntVal(int64(value)), nil
 	case int64:
 		return cty.NumberIntVal(value), nil

--- a/pkg/tfshim/sdk-v2/cty.go
+++ b/pkg/tfshim/sdk-v2/cty.go
@@ -160,7 +160,7 @@ func recoverScalarCtyValue(dT cty.Type, value interface{}) (cty.Value, error) {
 		if value > math.MaxInt64 {
 			return cty.NilVal, fmt.Errorf("cannot convert %d (uint) to a int64: overflow", value)
 		}
-
+		//nolint:gosec
 		return cty.NumberIntVal(int64(value)), nil
 	case int64:
 		return cty.NumberIntVal(value), nil

--- a/pkg/tfshim/sdk-v2/cty.go
+++ b/pkg/tfshim/sdk-v2/cty.go
@@ -160,7 +160,7 @@ func recoverScalarCtyValue(dT cty.Type, value interface{}) (cty.Value, error) {
 		if value > math.MaxInt64 {
 			return cty.NilVal, fmt.Errorf("cannot convert %d (uint) to a int64: overflow", value)
 		}
-		//nolint:gosec
+		
 		return cty.NumberIntVal(int64(value)), nil
 	case int64:
 		return cty.NumberIntVal(value), nil

--- a/pkg/tfshim/sdk-v2/shim_test.go
+++ b/pkg/tfshim/sdk-v2/shim_test.go
@@ -16,6 +16,7 @@ package sdkv2
 
 import (
 	"encoding/json"
+	"io"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -23,6 +24,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 )
 
 // Test how various SDKv2-based schemata translate to the shim.Schema layer.
@@ -30,7 +36,8 @@ func TestSchemaShimRepresentations(t *testing.T) {
 	type testCase struct {
 		name           string
 		resourceSchema map[string]*schema.Schema
-		expect         autogold.Value
+		expect         autogold.Value // expected prettified shim.Schema representation
+		expectSchema   autogold.Value // expected corresponding Pulumi Package Schema extract
 	}
 
 	testCases := []testCase{
@@ -51,6 +58,30 @@ func TestSchemaShimRepresentations(t *testing.T) {
       }
     }
   }
+}`),
+			autogold.Expect(`{
+  "resource": {
+    "properties": {
+      "fieldAttr": {
+        "type": "string"
+      }
+    },
+    "inputProperties": {
+      "fieldAttr": {
+        "type": "string"
+      }
+    },
+    "stateInputs": {
+      "description": "Input properties used for looking up and filtering Res resources.\n",
+      "properties": {
+        "fieldAttr": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "types": {}
 }`),
 		},
 		{
@@ -78,6 +109,39 @@ func TestSchemaShimRepresentations(t *testing.T) {
       }
     }
   }
+}`),
+			autogold.Expect(`{
+  "resource": {
+    "properties": {
+      "fieldAttrs": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "inputProperties": {
+      "fieldAttrs": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "stateInputs": {
+      "description": "Input properties used for looking up and filtering Res resources.\n",
+      "properties": {
+        "fieldAttrs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "type": "object"
+    }
+  },
+  "types": {}
 }`),
 		},
 		{
@@ -114,9 +178,51 @@ func TestSchemaShimRepresentations(t *testing.T) {
     }
   }
 }`),
+			autogold.Expect(`{
+  "resource": {
+    "properties": {
+      "blockFields": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/testprov:index/ResBlockField:ResBlockField"
+        }
+      }
+    },
+    "inputProperties": {
+      "blockFields": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/testprov:index/ResBlockField:ResBlockField"
+        }
+      }
+    },
+    "stateInputs": {
+      "description": "Input properties used for looking up and filtering Res resources.\n",
+      "properties": {
+        "blockFields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/testprov:index/ResBlockField:ResBlockField"
+          }
+        }
+      },
+      "type": "object"
+    }
+  },
+  "types": {
+    "testprov:index/ResBlockField:ResBlockField": {
+      "properties": {
+        "fieldAttr": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  }
+}`),
 		},
 		{
-			"list nested block",
+			"list block nested",
 			map[string]*schema.Schema{
 				"block_field": {
 					Type:     schema.TypeList,
@@ -165,9 +271,62 @@ func TestSchemaShimRepresentations(t *testing.T) {
     }
   }
 }`),
+			autogold.Expect(`{
+  "resource": {
+    "properties": {
+      "blockFields": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/testprov:index/ResBlockField:ResBlockField"
+        }
+      }
+    },
+    "inputProperties": {
+      "blockFields": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/testprov:index/ResBlockField:ResBlockField"
+        }
+      }
+    },
+    "stateInputs": {
+      "description": "Input properties used for looking up and filtering Res resources.\n",
+      "properties": {
+        "blockFields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/testprov:index/ResBlockField:ResBlockField"
+          }
+        }
+      },
+      "type": "object"
+    }
+  },
+  "types": {
+    "testprov:index/ResBlockField:ResBlockField": {
+      "properties": {
+        "nestedFields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/testprov:index/ResBlockFieldNestedField:ResBlockFieldNestedField"
+          }
+        }
+      },
+      "type": "object"
+    },
+    "testprov:index/ResBlockFieldNestedField:ResBlockFieldNestedField": {
+      "properties": {
+        "fieldAttr": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  }
+}`),
 		},
 		{
-			"list attribute max items one",
+			"list attribute flattened",
 			map[string]*schema.Schema{
 				"field_attr": {
 					Type:     schema.TypeList,
@@ -194,9 +353,33 @@ func TestSchemaShimRepresentations(t *testing.T) {
     }
   }
 }`),
+			autogold.Expect(`{
+  "resource": {
+    "properties": {
+      "fieldAttr": {
+        "type": "string"
+      }
+    },
+    "inputProperties": {
+      "fieldAttr": {
+        "type": "string"
+      }
+    },
+    "stateInputs": {
+      "description": "Input properties used for looking up and filtering Res resources.\n",
+      "properties": {
+        "fieldAttr": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "types": {}
+}`),
 		},
 		{
-			"list block",
+			"list block flattened",
 			map[string]*schema.Schema{
 				"block_field": {
 					Type:     schema.TypeList,
@@ -231,6 +414,39 @@ func TestSchemaShimRepresentations(t *testing.T) {
     }
   }
 }`),
+			autogold.Expect(`{
+  "resource": {
+    "properties": {
+      "blockField": {
+        "$ref": "#/types/testprov:index/ResBlockField:ResBlockField"
+      }
+    },
+    "inputProperties": {
+      "blockField": {
+        "$ref": "#/types/testprov:index/ResBlockField:ResBlockField"
+      }
+    },
+    "stateInputs": {
+      "description": "Input properties used for looking up and filtering Res resources.\n",
+      "properties": {
+        "blockField": {
+          "$ref": "#/types/testprov:index/ResBlockField:ResBlockField"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "types": {
+    "testprov:index/ResBlockField:ResBlockField": {
+      "properties": {
+        "fieldAttr": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  }
+}`),
 		},
 	}
 
@@ -258,6 +474,37 @@ func TestSchemaShimRepresentations(t *testing.T) {
 			require.NoError(t, err)
 
 			tc.expect.Equal(t, string(prettyBytes))
+
+			rtok := "testprov:index:Res"
+
+			info := info.Provider{
+				Name: "testprov",
+				P:    shimmedProvider,
+				Resources: map[string]*info.Resource{
+					"res": {
+						Tok: tokens.Type(rtok),
+					},
+				},
+			}
+
+			nilSink := diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never})
+			pSpec, err := tfgen.GenerateSchema(info, nilSink)
+			require.NoError(t, err)
+
+			type miniSpec struct {
+				Resource any `json:"resource"`
+				Types    any `json:"types"`
+			}
+
+			ms := miniSpec{
+				Resource: pSpec.Resources[rtok],
+				Types:    pSpec.Types,
+			}
+
+			prettySpec, err := json.MarshalIndent(ms, "", "  ")
+			require.NoError(t, err)
+
+			tc.expectSchema.Equal(t, string(prettySpec))
 		})
 	}
 }

--- a/pkg/tfshim/sdk-v2/shim_test.go
+++ b/pkg/tfshim/sdk-v2/shim_test.go
@@ -21,14 +21,14 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hexops/autogold/v2"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 )
 
 // Test how various SDKv2-based schemata translate to the shim.Schema layer.


### PR DESCRIPTION
This PR simply adds test cases around tfgen and shim representations of various schemata found in SDKv2 and PF. For PF I went through the docs to cover each major advertised case. What's of special interest is pinning down when Pulumi generates object types. 

It seems to be happening in two cases:

1. when TF specifies object types directly in PF: 
       - Single Nested Attribute
       - Object Attribute
       - Single Nested Block

2. when TF specifies a block with MaxItems=1 that is a list or set in TF but is flattened to an object in Pulumi:
       - In SDKv2 this is typically a list-nested block with MaxItems=1, very common
       - In PF this may be a block with List Validators indicating that at most 1 item is supported; seems rare


It seems helpful to pin down what shim.Schema captures in each of these cases.