### PR TITLE
Add replacement rules for installation docs

### DIFF
--- a/pkg/tfgen/edit_rules.go
+++ b/pkg/tfgen/edit_rules.go
@@ -69,8 +69,6 @@ func defaultEditRules() editRules {
 		reReplace("`provider` block", "provider configuration", info.PostCodeTranslation),
 		reReplace("Data Source", "Function", info.PostCodeTranslation),
 		reReplace("data source", "function", info.PostCodeTranslation),
-		//reReplace("Data Source", "Function", info.PostCodeTranslation),
-		//reReplace("data source", "function", info.PostCodeTranslation),
 	}
 }
 

--- a/pkg/tfgen/edit_rules.go
+++ b/pkg/tfgen/edit_rules.go
@@ -58,8 +58,12 @@ func defaultEditRules() editRules {
 		// Reformat certain headers
 		reReplace(`The following arguments are supported`,
 			`The following configuration inputs are supported`, info.PostCodeTranslation),
+		reReplace(`The provider supports the following arguments`,
+			`The following configuration inputs are supported`, info.PostCodeTranslation),
 		reReplace(`Argument Reference`,
 			`Configuration Reference`, info.PostCodeTranslation),
+		reReplace(`# Arguments`,
+			`# Configuration Reference`, info.PostCodeTranslation),
 		reReplace(`Schema`,
 			`Configuration Reference`, info.PostCodeTranslation),
 		reReplace("### Optional\n", "", info.PostCodeTranslation),

--- a/pkg/tfgen/edit_rules.go
+++ b/pkg/tfgen/edit_rules.go
@@ -66,6 +66,11 @@ func defaultEditRules() editRules {
 		reReplace(`block contains the following arguments`,
 			`input has the following nested fields`, info.PostCodeTranslation),
 		reReplace(`provider block`, `provider configuration`, info.PostCodeTranslation),
+		reReplace("`provider` block", "provider configuration", info.PostCodeTranslation),
+		reReplace("Data Source", "Function", info.PostCodeTranslation),
+		reReplace("data source", "function", info.PostCodeTranslation),
+		//reReplace("Data Source", "Function", info.PostCodeTranslation),
+		//reReplace("data source", "function", info.PostCodeTranslation),
 	}
 }
 

--- a/pkg/tfgen/edit_rules_test.go
+++ b/pkg/tfgen/edit_rules_test.go
@@ -61,7 +61,7 @@ func TestApplyEditRules(t *testing.T) {
 			phase:    info.PostCodeTranslation,
 		},
 		{
-			name: "Replaces argument headers with input headers",
+			name: "Replaces argument headers with input headers pattern 1",
 			docFile: DocFile{
 				Content: []byte("# Argument Reference\n" +
 					"The following arguments are supported:\n* `some_argument`\n\n" +
@@ -70,6 +70,16 @@ func TestApplyEditRules(t *testing.T) {
 			expected: []byte("# Configuration Reference\n" +
 				"The following configuration inputs are supported:\n* `some_argument`\n\n" +
 				"input has the following nested fields"),
+			phase: info.PostCodeTranslation,
+		},
+		{
+			name: "Replaces argument headers with input headers pattern 2",
+			docFile: DocFile{
+				Content: []byte("## Arguments\n" +
+					"The provider supports the following arguments:"),
+			},
+			expected: []byte("## Configuration Reference\n" +
+				"The following configuration inputs are supported:"),
 			phase: info.PostCodeTranslation,
 		},
 		{

--- a/pkg/tfgen/edit_rules_test.go
+++ b/pkg/tfgen/edit_rules_test.go
@@ -179,6 +179,24 @@ func TestApplyEditRules(t *testing.T) {
 			expected: []byte(readfile(t, "test_data/replace-provider-block/expected.md")),
 			phase:    info.PostCodeTranslation,
 		},
+		{
+			// Found in scm
+			name: "Replaces `provider` block with provider configuration",
+			docFile: DocFile{
+				Content: []byte(readfile(t, "test_data/replace-provider-block/input-backtick.md")),
+			},
+			expected: []byte(readfile(t, "test_data/replace-provider-block/expected-backtick.md")),
+			phase:    info.PostCodeTranslation,
+		},
+		{
+			// Found in scm
+			name: "Replaces 'D/data source(s)' with 'F/function(s)",
+			docFile: DocFile{
+				Content: []byte(readfile(t, "test_data/replace-data-source/input.md")),
+			},
+			expected: []byte(readfile(t, "test_data/replace-data-source/expected.md")),
+			phase:    info.PostCodeTranslation,
+		},
 	}
 	edits := defaultEditRules()
 

--- a/pkg/tfgen/test_data/replace-data-source/expected.md
+++ b/pkg/tfgen/test_data/replace-data-source/expected.md
@@ -1,0 +1,9 @@
+The `scm` provider provides resources and functions to manage and query Strata Cloud Manager.
+
+This provider covers the following aspects of Strata Cloud Manager:
+* Unified Networking Security
+
+It also translates a singular function.
+
+## Functions
+

--- a/pkg/tfgen/test_data/replace-data-source/input.md
+++ b/pkg/tfgen/test_data/replace-data-source/input.md
@@ -1,0 +1,9 @@
+The `scm` provider provides resources and data sources to manage and query Strata Cloud Manager.
+
+This provider covers the following aspects of Strata Cloud Manager:
+* Unified Networking Security
+
+It also translates a singular data source.
+
+## Data Sources
+

--- a/pkg/tfgen/test_data/replace-provider-block/expected-backtick.md
+++ b/pkg/tfgen/test_data/replace-provider-block/expected-backtick.md
@@ -1,0 +1,7 @@
+## Provider Parameter Priority
+
+There are multiple ways to specify the provider's parameters.  If overlapping values are configured for the provider, then this is the resolution order:
+
+1. Statically configured in the provider configuration
+2. Environment variable (where applicable)
+3. Taken from the JSON config file

--- a/pkg/tfgen/test_data/replace-provider-block/input-backtick.md
+++ b/pkg/tfgen/test_data/replace-provider-block/input-backtick.md
@@ -1,0 +1,7 @@
+## Provider Parameter Priority
+
+There are multiple ways to specify the provider's parameters.  If overlapping values are configured for the provider, then this is the resolution order:
+
+1. Statically configured in the `provider` block
+2. Environment variable (where applicable)
+3. Taken from the JSON config file

--- a/pkg/tfgen/test_data/replace-terraform-version/expected.md
+++ b/pkg/tfgen/test_data/replace-terraform-version/expected.md
@@ -5,7 +5,7 @@ the proper credentials before you can use it.
 The provider uses the [`xanzy/go-gitlab`](https://github.com/xanzy/go-gitlab) library
 to interact with the [GitLab REST API](https://docs.gitlab.com/ee/api/api_resources.html).
 
-Each data source and resource references the appropriate upstream GitLab REST API documentation,
+Each function and resource references the appropriate upstream GitLab REST API documentation,
 which may be consumed to better understand the behavior of the API.
 
-Use the navigation to the left to read about the valid data sources and resources.
+Use the navigation to the left to read about the valid functions and resources.


### PR DESCRIPTION
This pull request adds two new default edit rules to the postCodeTranslation edit rules:

- Replace D/data source with F/function
- Account for back ticks when `provider` block appears as such.

Test cases were added and a previous test case had to be adjusted.
These changes are seen in the wild at https://github.com/pulumi/pulumi-scm/pull/101.
