### PR TITLE
[PF] Property based Configure tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/hcl/v2 v2.19.1
 	github.com/hashicorp/hil v0.0.0-20190212132231-97b3a9cdfa93
-	github.com/hashicorp/terraform-plugin-framework v1.7.0
+	github.com/hashicorp/terraform-plugin-framework v1.12.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
 	github.com/hashicorp/terraform-plugin-mux v0.16.0
 	github.com/hashicorp/terraform-plugin-sdk v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -1666,8 +1666,8 @@ github.com/hashicorp/terraform-json v0.4.0/go.mod h1:eAbqb4w0pSlRmdvl8fOyHAi/+8j
 github.com/hashicorp/terraform-json v0.19.0/go.mod h1:qdeBs11ovMzo5puhrRibdD6d2Dq6TyE/28JiU4tIQxk=
 github.com/hashicorp/terraform-json v0.21.0 h1:9NQxbLNqPbEMze+S6+YluEdXgJmhQykRyRNd+zTI05U=
 github.com/hashicorp/terraform-json v0.21.0/go.mod h1:qdeBs11ovMzo5puhrRibdD6d2Dq6TyE/28JiU4tIQxk=
-github.com/hashicorp/terraform-plugin-framework v1.7.0 h1:wOULbVmfONnJo9iq7/q+iBOBJul5vRovaYJIu2cY/Pw=
-github.com/hashicorp/terraform-plugin-framework v1.7.0/go.mod h1:jY9Id+3KbZ17OMpulgnWLSfwxNVYSoYBQFTgsx044CI=
+github.com/hashicorp/terraform-plugin-framework v1.12.0 h1:7HKaueHPaikX5/7cbC1r9d1m12iYHY+FlNZEGxQ42CQ=
+github.com/hashicorp/terraform-plugin-framework v1.12.0/go.mod h1:N/IOQ2uYjW60Jp39Cp3mw7I/OpC/GfZ0385R0YibmkE=
 github.com/hashicorp/terraform-plugin-framework-validators v0.12.0 h1:HOjBuMbOEzl7snOdOoUfE2Jgeto6JOjLVQ39Ls2nksc=
 github.com/hashicorp/terraform-plugin-framework-validators v0.12.0/go.mod h1:jfHGE/gzjxYz6XoUwi/aYiiKrJDeutQNUtGQXkaHklg=
 github.com/hashicorp/terraform-plugin-go v0.22.0/go.mod h1:mPULV91VKss7sik6KFEcEu7HuTogMLLO/EvWCuFkRVE=

--- a/pf/go.mod
+++ b/pf/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/google/s2a-go v0.1.7 // indirect
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/hashicorp/terraform-plugin-framework v1.11.0 // indirect
+	github.com/hashicorp/terraform-plugin-framework v1.12.0 // indirect
 	github.com/hashicorp/terraform-plugin-go v0.24.0 // indirect
 	github.com/hashicorp/terraform-plugin-log v0.9.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect

--- a/pf/go.sum
+++ b/pf/go.sum
@@ -567,8 +567,8 @@ github.com/hashicorp/hil v0.0.0-20190212132231-97b3a9cdfa93 h1:T1Q6ag9tCwun16AW+
 github.com/hashicorp/hil v0.0.0-20190212132231-97b3a9cdfa93/go.mod h1:n2TSygSNwsLJ76m8qFXTSc7beTb+auJxYdqrnoqwZWE=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
-github.com/hashicorp/terraform-plugin-framework v1.11.0 h1:M7+9zBArexHFXDx/pKTxjE6n/2UCXY6b8FIq9ZYhwfE=
-github.com/hashicorp/terraform-plugin-framework v1.11.0/go.mod h1:qBXLDn69kM97NNVi/MQ9qgd1uWWsVftGSnygYG1tImM=
+github.com/hashicorp/terraform-plugin-framework v1.12.0 h1:7HKaueHPaikX5/7cbC1r9d1m12iYHY+FlNZEGxQ42CQ=
+github.com/hashicorp/terraform-plugin-framework v1.12.0/go.mod h1:N/IOQ2uYjW60Jp39Cp3mw7I/OpC/GfZ0385R0YibmkE=
 github.com/hashicorp/terraform-plugin-framework-validators v0.12.0 h1:HOjBuMbOEzl7snOdOoUfE2Jgeto6JOjLVQ39Ls2nksc=
 github.com/hashicorp/terraform-plugin-framework-validators v0.12.0/go.mod h1:jfHGE/gzjxYz6XoUwi/aYiiKrJDeutQNUtGQXkaHklg=
 github.com/hashicorp/terraform-plugin-go v0.24.0 h1:2WpHhginCdVhFIrWHxDEg6RBn3YaWzR2o6qUeIEat2U=

--- a/pkg/pf/tests/internal/cross-tests/util_test.go
+++ b/pkg/pf/tests/internal/cross-tests/util_test.go
@@ -1,0 +1,46 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crosstests
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConvertResourceValue(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input    resource.PropertyMap
+		expected map[string]any
+	}{
+		{
+			input: resource.PropertyMap{
+				"a": resource.NewProperty(resource.PropertyMap{}),
+			},
+			expected: map[string]any{
+				"a": map[string]any{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			actual := convertResourceValue(t, tt.input)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/pkg/pf/tests/util/property/pf/schema/provider/attr.go
+++ b/pkg/pf/tests/util/property/pf/schema/provider/attr.go
@@ -1,0 +1,93 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"pgregory.net/rapid"
+)
+
+func attrType(depth int) *rapid.Generator[attr.Type] {
+	if depth <= 1 {
+		return attrPrimitiveType()
+	}
+
+	types := []*rapid.Generator[attr.Type]{
+		attrPrimitiveType(),
+		rapid.Map(attrListType(depth-1), castToAttrType),
+		rapid.Map(attrMapType(depth-1), castToAttrType),
+		rapid.Map(attrSetType(depth-1), castToAttrType),
+		rapid.Map(attrObjectType(depth-1), castToAttrType),
+	}
+
+	if false { // TODO: Enable testing tuples
+		types = append(types, rapid.Map(attrTupleType(depth-1), castToAttrType))
+	}
+
+	return rapid.OneOf(types...)
+}
+
+func attrPrimitiveType() *rapid.Generator[attr.Type] {
+	return rapid.OneOf(
+		rapid.Map(rapid.Just(types.BoolType), castToAttrType),
+		rapid.Map(rapid.Just(types.NumberType), castToAttrType),
+		rapid.Map(rapid.Just(types.Float64Type), castToAttrType),
+		rapid.Map(rapid.Just(types.StringType), castToAttrType),
+		rapid.Map(rapid.Just(types.Int64Type), castToAttrType),
+	)
+}
+
+func attrListType(depth int) *rapid.Generator[types.ListType] {
+	return rapid.Map(attrType(depth-1), func(t attr.Type) types.ListType {
+		return types.ListType{ElemType: t}
+	})
+}
+
+func attrMapType(depth int) *rapid.Generator[types.MapType] {
+	return rapid.Map(attrType(depth-1), func(t attr.Type) types.MapType {
+		return types.MapType{ElemType: t}
+	})
+}
+
+func attrSetType(depth int) *rapid.Generator[types.SetType] {
+	return rapid.Map(attrType(depth-1), func(t attr.Type) types.SetType {
+		return types.SetType{ElemType: t}
+	})
+}
+
+func attrTupleType(depth int) *rapid.Generator[types.TupleType] {
+	return rapid.Custom(func(t *rapid.T) types.TupleType {
+		return types.TupleType{
+			// 1 is assumed to be a minimum.
+			// 4 is chosen as an arbitrary maximum.
+			ElemTypes: rapid.SliceOfN(attrType(depth-1), 1, 4).Draw(t, "ElemTypes"),
+		}
+	})
+}
+
+func attrObjectType(depth int) *rapid.Generator[types.ObjectType] {
+	return rapid.Custom(func(t *rapid.T) types.ObjectType {
+		return types.ObjectType{
+			AttrTypes: rapid.MapOfN(
+				rapid.StringMatching(tfIdentifierRegexp),
+				attrType(depth-1),
+				1, maxObjectSize,
+			).Draw(t, "AttrTypes"),
+		}
+	})
+}
+
+func castToAttrType[T attr.Type](v T) attr.Type { return v }

--- a/pkg/pf/tests/util/property/pf/schema/provider/schema.go
+++ b/pkg/pf/tests/util/property/pf/schema/provider/schema.go
@@ -1,0 +1,369 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package pf provides [rapid] based property testing to Hashicorp's Plugin Framework for
+// TF SDKs.
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"pgregory.net/rapid"
+)
+
+const (
+	tfIdentifierRegexp = "[a-z]|([a-z_][a-z_0-9]+)"
+	defaultDepth       = 3
+	maxObjectSize      = 4
+)
+
+func Schema(ctx context.Context) *rapid.Generator[schema.Schema] {
+	return rapid.Custom(func(t *rapid.T) schema.Schema {
+		// We need to generate a set of attributes and blocks, all with non-overlapping names.
+		names := attrAndBlockNames(allowEmpty).Draw(t, "names")
+		s := schema.Schema{
+			Attributes: attributes(names.attr, defaultDepth).Draw(t, "attributes"),
+			Blocks:     blocks(names.block, defaultDepth).Draw(t, "blocks"),
+		}
+
+		if diags := s.ValidateImplementation(ctx); diags.HasError() {
+			t.Fatalf("Invalid schema generated: %#v", diags)
+		}
+
+		return s
+	})
+}
+
+type canBeEmpty uint8
+
+const (
+	allowEmpty canBeEmpty = iota
+	notEmpty   canBeEmpty = iota
+)
+
+func attrAndBlockNames(canBeEmpty canBeEmpty) *rapid.Generator[struct{ attr, block []string }] {
+	minSize := 1
+	if canBeEmpty == allowEmpty {
+		minSize = 0
+	}
+	return rapid.Custom(func(t *rapid.T) struct{ attr, block []string } {
+		attrAndBlockNames := rapid.SliceOfNDistinct(
+			rapid.StringMatching(tfIdentifierRegexp),
+			minSize,
+			maxObjectSize,
+			rapid.ID,
+		).Draw(t, "names")
+		split := rapid.IntRange(0, len(attrAndBlockNames)).Draw(t, "attr block split")
+		attrNames, blockNames := attrAndBlockNames[:split], attrAndBlockNames[split:]
+		return struct{ attr, block []string }{attrNames, blockNames}
+	})
+}
+
+func attributes(names []string, depth int) *rapid.Generator[map[string]schema.Attribute] {
+	if len(names) == 0 {
+		return rapid.Just[map[string]schema.Attribute](nil)
+	}
+	return rapid.Custom(func(t *rapid.T) map[string]schema.Attribute {
+		m := make(map[string]schema.Attribute, len(names))
+		for _, v := range names {
+			m[v] = attribute(depth).Draw(t, v)
+		}
+		return m
+	})
+}
+
+func attribute(depth int) *rapid.Generator[schema.Attribute] {
+	return rapid.Custom(func(t *rapid.T) schema.Attribute {
+		if depth <= 1 {
+			return rapid.OneOf(primitiveAttributes()...).Draw(t, "attr")
+		}
+		return rapid.OneOf(
+			append(primitiveAttributes(), complexAttributes(depth)...)...,
+		).Draw(t, "attr")
+	})
+}
+
+func primitiveAttributes() []*rapid.Generator[schema.Attribute] {
+	return []*rapid.Generator[schema.Attribute]{
+		rapid.Map(stringAttr(), castToAttribute),
+		rapid.Map(boolAttr(), castToAttribute),
+		rapid.Map(float64Attr(), castToAttribute),
+		rapid.Map(int64Attr(), castToAttribute),
+		rapid.Map(numberAttr(), castToAttribute),
+	}
+}
+
+func castToAttribute[T schema.Attribute](v T) schema.Attribute { return v }
+
+func boolAttr() *rapid.Generator[schema.BoolAttribute] {
+	return rapid.Custom(func(t *rapid.T) schema.BoolAttribute {
+
+		required := rapid.Bool().Draw(t, "required")
+		optional := !required
+		return schema.BoolAttribute{
+			Required:  required,
+			Optional:  optional,
+			Sensitive: rapid.Bool().Draw(t, "sensitive"),
+		}
+	})
+}
+
+func float64Attr() *rapid.Generator[schema.Float64Attribute] {
+	return rapid.Custom(func(t *rapid.T) schema.Float64Attribute {
+
+		required := rapid.Bool().Draw(t, "required")
+		optional := !required
+		return schema.Float64Attribute{
+			Required:  required,
+			Optional:  optional,
+			Sensitive: rapid.Bool().Draw(t, "sensitive"),
+		}
+	})
+}
+
+func int64Attr() *rapid.Generator[schema.Int64Attribute] {
+	return rapid.Custom(func(t *rapid.T) schema.Int64Attribute {
+
+		required := rapid.Bool().Draw(t, "required")
+		optional := !required
+		return schema.Int64Attribute{
+			Required:  required,
+			Optional:  optional,
+			Sensitive: rapid.Bool().Draw(t, "sensitive"),
+		}
+	})
+}
+
+func numberAttr() *rapid.Generator[schema.NumberAttribute] {
+	return rapid.Custom(func(t *rapid.T) schema.NumberAttribute {
+
+		required := rapid.Bool().Draw(t, "required")
+		optional := !required
+		return schema.NumberAttribute{
+			Required:  required,
+			Optional:  optional,
+			Sensitive: rapid.Bool().Draw(t, "sensitive"),
+		}
+	})
+}
+
+func stringAttr() *rapid.Generator[schema.StringAttribute] {
+	return rapid.Custom(func(t *rapid.T) schema.StringAttribute {
+
+		required := rapid.Bool().Draw(t, "required")
+		optional := !required
+		return schema.StringAttribute{
+			Required:  required,
+			Optional:  optional,
+			Sensitive: rapid.Bool().Draw(t, "sensitive"),
+		}
+	})
+}
+
+func complexAttributes(depth int) []*rapid.Generator[schema.Attribute] {
+	return []*rapid.Generator[schema.Attribute]{
+		rapid.Map(listAttr(depth), castToAttribute),
+		rapid.Map(listNestedAttr(depth), castToAttribute),
+		rapid.Map(mapAttr(depth), castToAttribute),
+		rapid.Map(mapNestedAttr(depth), castToAttribute),
+		rapid.Map(setAttr(depth), castToAttribute),
+		rapid.Map(setNestedAttr(depth), castToAttribute),
+		rapid.Map(objectAttr(depth), castToAttribute),
+		rapid.Map(singleNestedAttr(depth), castToAttribute),
+	}
+}
+
+func listAttr(depth int) *rapid.Generator[schema.ListAttribute] {
+	return rapid.Custom(func(t *rapid.T) schema.ListAttribute {
+
+		required := rapid.Bool().Draw(t, "required")
+		optional := !required
+		return schema.ListAttribute{
+			ElementType: attrType(depth-1).Draw(t, "ElementType"),
+			Required:    required,
+			Optional:    optional,
+			Sensitive:   rapid.Bool().Draw(t, "sensitive"),
+		}
+	})
+}
+
+func listNestedAttr(depth int) *rapid.Generator[schema.ListNestedAttribute] {
+	return rapid.Custom(func(t *rapid.T) schema.ListNestedAttribute {
+
+		required := rapid.Bool().Draw(t, "required")
+		optional := !required
+		return schema.ListNestedAttribute{
+			NestedObject: nestedAttributeObject(depth-1).Draw(t, "NestedObject"),
+			Required:     required,
+			Optional:     optional,
+			Sensitive:    rapid.Bool().Draw(t, "sensitive"),
+		}
+	})
+}
+
+func mapAttr(depth int) *rapid.Generator[schema.MapAttribute] {
+	return rapid.Custom(func(t *rapid.T) schema.MapAttribute {
+
+		required := rapid.Bool().Draw(t, "required")
+		optional := !required
+		return schema.MapAttribute{
+			ElementType: attrType(depth-1).Draw(t, "ElementType"),
+			Required:    required,
+			Optional:    optional,
+			Sensitive:   rapid.Bool().Draw(t, "sensitive"),
+		}
+	})
+}
+
+func mapNestedAttr(depth int) *rapid.Generator[schema.MapNestedAttribute] {
+	return rapid.Custom(func(t *rapid.T) schema.MapNestedAttribute {
+
+		required := rapid.Bool().Draw(t, "required")
+		optional := !required
+		return schema.MapNestedAttribute{
+			NestedObject: nestedAttributeObject(depth-1).Draw(t, "NestedObject"),
+			Required:     required,
+			Optional:     optional,
+			Sensitive:    rapid.Bool().Draw(t, "sensitive"),
+		}
+	})
+}
+
+func setAttr(depth int) *rapid.Generator[schema.SetAttribute] {
+	return rapid.Custom(func(t *rapid.T) schema.SetAttribute {
+
+		required := rapid.Bool().Draw(t, "required")
+		optional := !required
+		return schema.SetAttribute{
+			ElementType: attrType(depth-1).Draw(t, "ElementType"),
+			Required:    required,
+			Optional:    optional,
+			Sensitive:   rapid.Bool().Draw(t, "sensitive"),
+		}
+	})
+}
+
+func setNestedAttr(depth int) *rapid.Generator[schema.SetNestedAttribute] {
+	return rapid.Custom(func(t *rapid.T) schema.SetNestedAttribute {
+
+		required := rapid.Bool().Draw(t, "required")
+		optional := !required
+		return schema.SetNestedAttribute{
+			NestedObject: nestedAttributeObject(depth-1).Draw(t, "NestedObject"),
+			Required:     required,
+			Optional:     optional,
+			Sensitive:    rapid.Bool().Draw(t, "sensitive"),
+		}
+	})
+}
+
+func objectAttr(depth int) *rapid.Generator[schema.ObjectAttribute] {
+	return rapid.Custom(func(t *rapid.T) schema.ObjectAttribute {
+
+		required := rapid.Bool().Draw(t, "required")
+		optional := !required
+		return schema.ObjectAttribute{
+			AttributeTypes: attrObjectType(depth-1).Draw(t, "AttributeTypes").AttrTypes,
+			Required:       required,
+			Optional:       optional,
+			Sensitive:      rapid.Bool().Draw(t, "sensitive"),
+		}
+	})
+}
+
+func singleNestedAttr(depth int) *rapid.Generator[schema.SingleNestedAttribute] {
+	return rapid.Custom(func(t *rapid.T) schema.SingleNestedAttribute {
+
+		required := rapid.Bool().Draw(t, "required")
+		optional := !required
+		return schema.SingleNestedAttribute{
+			Attributes: nestedAttributeObject(depth-1).Draw(t, "Attributes").Attributes,
+			Required:   required,
+			Optional:   optional,
+			Sensitive:  rapid.Bool().Draw(t, "sensitive"),
+		}
+	})
+}
+
+func nestedAttributeObject(depth int) *rapid.Generator[schema.NestedAttributeObject] {
+	return rapid.Custom(func(t *rapid.T) schema.NestedAttributeObject {
+		return schema.NestedAttributeObject{
+			Attributes: rapid.MapOfN(
+				rapid.StringMatching(tfIdentifierRegexp),
+				attribute(depth-1),
+				1, maxObjectSize,
+			).Draw(t, "Attributes"),
+		}
+	})
+}
+
+func blocks(names []string, depth int) *rapid.Generator[map[string]schema.Block] {
+	if len(names) == 0 || depth < 1 {
+		return rapid.Just[map[string]schema.Block](nil)
+	}
+	return rapid.Custom(func(t *rapid.T) map[string]schema.Block {
+		m := make(map[string]schema.Block, len(names))
+		for _, k := range names {
+			m[k] = block(depth).Draw(t, k)
+		}
+		return m
+	})
+}
+
+func castToBlock[T schema.Block](v T) schema.Block { return v }
+
+func block(depth int) *rapid.Generator[schema.Block] {
+	return rapid.OneOf(
+		rapid.Map(listNestedBlock(depth), castToBlock),
+		rapid.Map(setNestedBlock(depth), castToBlock),
+		rapid.Map(singleNestedBlock(depth), castToBlock),
+	)
+}
+
+func listNestedBlock(depth int) *rapid.Generator[schema.ListNestedBlock] {
+	return rapid.Custom(func(t *rapid.T) schema.ListNestedBlock {
+		return schema.ListNestedBlock{
+			NestedObject: nestedBlockObject(depth-1).Draw(t, "NestedObject"),
+		}
+	})
+}
+
+func setNestedBlock(depth int) *rapid.Generator[schema.SetNestedBlock] {
+	return rapid.Custom(func(t *rapid.T) schema.SetNestedBlock {
+		return schema.SetNestedBlock{
+			NestedObject: nestedBlockObject(depth-1).Draw(t, "NestedObject"),
+		}
+	})
+}
+
+func singleNestedBlock(depth int) *rapid.Generator[schema.SingleNestedBlock] {
+	return rapid.Custom(func(t *rapid.T) schema.SingleNestedBlock {
+		names := attrAndBlockNames(notEmpty).Draw(t, "names")
+		return schema.SingleNestedBlock{
+			Attributes: attributes(names.attr, depth-1).Draw(t, "Attributes"),
+			Blocks:     blocks(names.block, depth-1).Draw(t, "Blocks"),
+		}
+	})
+}
+
+func nestedBlockObject(depth int) *rapid.Generator[schema.NestedBlockObject] {
+	return rapid.Custom(func(t *rapid.T) schema.NestedBlockObject {
+		names := attrAndBlockNames(notEmpty).Draw(t, "names")
+		return schema.NestedBlockObject{
+			Attributes: attributes(names.attr, depth-1).Draw(t, "Attributes"),
+			Blocks:     blocks(names.block, depth-1).Draw(t, "Blocks"),
+		}
+	})
+}

--- a/pkg/pf/tests/util/property/pf/value/provider/primitive.go
+++ b/pkg/pf/tests/util/property/pf/value/provider/primitive.go
@@ -1,0 +1,75 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"github.com/zclconf/go-cty/cty"
+	"pgregory.net/rapid"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
+func boolVal(t *rapid.T) value {
+	f := rapid.Bool().Draw(t, "v")
+	return value{
+		hasValue: true,
+		tf:       cty.BoolVal(f),
+		pu:       resource.NewProperty(f),
+	}
+}
+
+func stringV() *rapid.Generator[string] { return rapid.StringMatching("[a-zA-Z0-9-]*") }
+
+func stringVal(t *rapid.T) value {
+	s := stringV().Draw(t, "v")
+	return value{
+		hasValue: true,
+		tf:       cty.StringVal(s),
+		pu:       resource.NewProperty(s),
+	}
+
+}
+
+func float64Val(t *rapid.T) value {
+	f := rapid.Float64().Draw(t, "v")
+	return value{
+		hasValue: true,
+		tf:       cty.NumberFloatVal(f),
+		pu:       resource.NewProperty(f),
+	}
+}
+
+func float32Val(t *rapid.T) value {
+	f := rapid.Float32().Draw(t, "v")
+	return value{
+		hasValue: true,
+		tf:       cty.NumberFloatVal(float64(f)),
+		pu:       resource.NewProperty(float64(f)),
+	}
+}
+
+func int32Val(t *rapid.T) value {
+	f := rapid.Int32().Draw(t, "v")
+	return value{
+		hasValue: true,
+		tf:       cty.NumberIntVal(int64(f)),
+		pu:       resource.NewProperty(float64(f)),
+	}
+}
+
+func int64Val(t *rapid.T) value {
+	// TODO: We know that we cannot round trip int64 values.
+	return int32Val(t)
+}

--- a/pkg/pf/tests/util/property/pf/value/provider/util.go
+++ b/pkg/pf/tests/util/property/pf/value/provider/util.go
@@ -1,0 +1,299 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"cmp"
+	"fmt"
+	"hash/maphash"
+	"slices"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/zclconf/go-cty/cty"
+
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+func (g generator) valueID(v value) uint64 {
+	v = coelesceNulls(v)
+	h := maphash.Hash{}
+	h.SetSeed(g.seed)
+	_, err := h.WriteString(v.tf.GoString())
+	contract.AssertNoErrorf(err, "maphash.Hash.WriteString does not error")
+	_, err = h.WriteString(v.pu.String())
+	contract.AssertNoErrorf(err, "maphash.Hash.WriteString does not error")
+	return h.Sum64()
+}
+
+func coelesceNulls(v value) value {
+	var coelescePu func(v resource.PropertyValue) resource.PropertyValue
+	coelescePu = func(v resource.PropertyValue) resource.PropertyValue {
+		switch {
+		case v.IsObject():
+			src := v.ObjectValue()
+			dst := make(resource.PropertyMap, len(src))
+			elementsAreNull := true
+			for i, e := range src {
+				e = coelescePu(e)
+				elementsAreNull = elementsAreNull && e.IsNull()
+				dst[i] = e
+			}
+			if elementsAreNull {
+				return resource.NewNullProperty()
+			}
+			return resource.NewProperty(dst)
+		case v.IsArray():
+			src := v.ArrayValue()
+			dst := make([]resource.PropertyValue, len(src))
+			elementsAreNull := true
+			for i, e := range src {
+				e = coelescePu(e)
+				elementsAreNull = elementsAreNull && e.IsNull()
+				dst[i] = e
+			}
+			if elementsAreNull {
+				return resource.NewNullProperty()
+			}
+			return resource.NewProperty(dst)
+		case v.IsSecret():
+			return resource.MakeSecret(coelescePu(v.SecretValue().Element))
+		default:
+			return v
+		}
+	}
+
+	var coelesceTf func(v cty.Value) cty.Value
+	coelesceTf = func(v cty.Value) cty.Value {
+		if v.IsNull() || !v.IsKnown() {
+			return v
+		}
+		typ := v.Type()
+
+		switch {
+		case typ.IsListType():
+			arr := v.AsValueSlice()
+			elementsAreNull := true
+			for i, e := range arr {
+				arr[i] = coelesceTf(e)
+				elementsAreNull = elementsAreNull && arr[i].IsNull()
+			}
+			if elementsAreNull {
+				return cty.NullVal(typ)
+			}
+			return cty.ListVal(arr)
+		case typ.IsSetType():
+			arr := v.AsValueSlice()
+			elementsAreNull := true
+			for i, e := range arr {
+				arr[i] = coelesceTf(e)
+				elementsAreNull = elementsAreNull && arr[i].IsNull()
+			}
+			if elementsAreNull {
+				return cty.NullVal(typ)
+			}
+			return cty.SetVal(arr)
+		case typ.IsMapType():
+			m := v.AsValueMap()
+			elementsAreNull := true
+			for k, e := range m {
+				m[k] = coelesceTf(e)
+				elementsAreNull = elementsAreNull && m[k].IsNull()
+			}
+			if elementsAreNull {
+				return cty.NullVal(typ)
+			}
+			return cty.MapVal(m)
+		case typ.IsObjectType():
+			m := v.AsValueMap()
+			elementsAreNull := true
+			for k, e := range m {
+				m[k] = coelesceTf(e)
+				elementsAreNull = elementsAreNull && m[k].IsNull()
+			}
+			if elementsAreNull {
+				return cty.NullVal(typ)
+			}
+			return cty.ObjectVal(m)
+		default:
+			return v
+		}
+	}
+
+	return value{
+		tf:       coelesceTf(v.tf),
+		pu:       coelescePu(v.pu),
+		hasValue: v.hasValue,
+	}
+}
+
+func shimType(t tftypes.Type) shim.ValueType {
+	switch {
+	case t.Is(tftypes.Set{}):
+		return shim.TypeSet
+	case t.Is(tftypes.Map{}):
+		return shim.TypeMap
+	case t.Is(tftypes.List{}):
+		return shim.TypeList
+	default:
+		// shimType is only used when interacting with
+		// [tfbridge.TerraformToPulumiNameV2], so other scalar types don't matter
+		// here.
+		return shim.TypeBool
+	}
+}
+
+func makeConvertMap(elem cty.Type) func(map[string]value) value {
+	return func(m map[string]value) value { return convertMap(m, elem) }
+}
+
+func convertMap(m map[string]value, elem cty.Type) value {
+	tfMap, puMap := make(map[string]cty.Value, len(m)), make(resource.PropertyMap, len(m))
+	for k, v := range m {
+		tfMap[k] = v.tf
+		if v.hasValue {
+			puMap[resource.PropertyKey(k)] = v.pu
+		}
+	}
+
+	ctyMap := cty.MapValEmpty(elem)
+	if len(tfMap) > 0 {
+		ctyMap = cty.MapVal(tfMap)
+	}
+
+	return value{
+		hasValue: true,
+		tf:       ctyMap,
+		pu:       resource.NewProperty(puMap),
+	}
+}
+
+func convertObject(m map[string]value, names map[string]resource.PropertyKey) value {
+	tfMap, puMap := make(map[string]cty.Value, len(m)), make(resource.PropertyMap, len(m))
+	for k, v := range m {
+		tfMap[k] = v.tf
+		if v.hasValue {
+			puMap[names[k]] = v.pu
+		}
+	}
+	return value{
+		hasValue: true,
+		tf:       cty.ObjectVal(tfMap),
+		pu:       resource.NewProperty(puMap),
+	}
+}
+
+func makeConvertSet(elem cty.Type) func([]value) value {
+	return func(a []value) value { return convertSet(a, elem) }
+}
+
+func convertSet(a []value, elem cty.Type) value {
+	tfArr, puArr := make([]cty.Value, len(a)), make([]resource.PropertyValue, len(a))
+	for i, v := range a {
+		tfArr[i] = v.tf
+		puArr[i] = v.pu
+	}
+
+	tfSet := cty.NullVal(cty.Set(elem))
+	if len(tfArr) > 0 {
+		tfSet = cty.SetVal(tfArr)
+		contract.Assertf(tfSet.LengthInt() == len(puArr),
+			"Set values have different lengths: (%d != %d), of %#v", tfSet.LengthInt(), len(puArr), a)
+	}
+	puSet := resource.NewNullProperty()
+	if len(puArr) > 0 {
+		puSet = resource.NewProperty(puArr)
+	}
+
+	return value{
+		hasValue: true,
+		tf:       tfSet,
+		pu:       puSet,
+	}
+}
+
+func makeConvertList(elem cty.Type) func([]value) value {
+	return func(a []value) value { return convertList(a, elem) }
+}
+
+func convertList(a []value, elem cty.Type) value {
+	tfArr, puArr := make([]cty.Value, len(a)), make([]resource.PropertyValue, len(a))
+	for i, v := range a {
+		tfArr[i] = v.tf
+		puArr[i] = v.pu
+	}
+
+	tfList := cty.NullVal(cty.List(elem))
+	if len(tfArr) > 0 {
+		tfList = cty.ListVal(tfArr)
+	}
+	puList := resource.NewNullProperty()
+	if len(puArr) > 0 {
+		puList = resource.NewProperty(puArr)
+	}
+
+	return value{
+		hasValue: true,
+		tf:       tfList,
+		pu:       puList,
+	}
+}
+
+func ctyType(typ tftypes.Type) cty.Type {
+	switch {
+	case typ.Is(tftypes.Bool):
+		return cty.Bool
+	case typ.Is(tftypes.Number):
+		return cty.Number
+	case typ.Is(tftypes.String):
+		return cty.String
+	case typ.Is(tftypes.Map{}):
+		return cty.Map(ctyType(typ.(tftypes.Map).ElementType))
+	case typ.Is(tftypes.List{}):
+		return cty.List(ctyType(typ.(tftypes.List).ElementType))
+	case typ.Is(tftypes.Set{}):
+		return cty.Set(ctyType(typ.(tftypes.Set).ElementType))
+	case typ.Is(tftypes.Object{}):
+		o := typ.(tftypes.Object)
+		attrs := make(map[string]cty.Type, len(o.AttributeTypes))
+		optionals := make([]string, 0, len(o.OptionalAttributes))
+
+		for k, v := range o.AttributeTypes {
+			attrs[k] = ctyType(v)
+		}
+		for k := range o.OptionalAttributes {
+			optionals = append(optionals, k)
+		}
+
+		slices.Sort(optionals)
+		return cty.ObjectWithOptionalAttrs(attrs, optionals)
+	default:
+		panic(fmt.Sprintf("Unknown tftypes.Type: %v", typ))
+	}
+
+}
+
+func stableIter[K cmp.Ordered, V any](m map[K]V, f func(k K, v V)) {
+	order := make([]K, 0, len(m))
+	for k := range m {
+		order = append(order, k)
+	}
+	slices.Sort(order)
+
+	for _, k := range order {
+		f(k, m[k])
+	}
+}

--- a/pkg/pf/tests/util/property/pf/value/provider/value.go
+++ b/pkg/pf/tests/util/property/pf/value/provider/value.go
@@ -1,0 +1,364 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"hash/maphash"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/zclconf/go-cty/cty"
+	"pgregory.net/rapid"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	shimschema "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+const maxIterableSize = 4
+
+// Value represents a single conceptual value, represented in both a [cty.Value] and in a
+// [resource.PropertyValue].
+type Value struct {
+	Tf cty.Value
+	Pu resource.PropertyMap
+}
+
+type value struct {
+	tf       cty.Value
+	pu       resource.PropertyValue
+	hasValue bool
+}
+
+type generator struct {
+	// isInput means that the generator is generating input values, not output values.
+	isInput bool
+
+	seed maphash.Seed
+}
+
+func WithValue(ctx context.Context, s schema.Schema) *rapid.Generator[Value] {
+	g := generator{
+		isInput: true,
+		seed:    maphash.MakeSeed(),
+	}
+
+	return rapid.Map(
+		g.nestedBlockObject(ctx, schema.NestedBlockObject{
+			Attributes: s.Attributes,
+			Blocks:     s.Blocks,
+		}),
+		func(v value) Value {
+			var pu resource.PropertyMap
+			if !v.pu.IsNull() {
+				pu = v.pu.ObjectValue()
+			}
+			return Value{Tf: v.tf, Pu: pu}
+		},
+	)
+}
+
+func (g generator) withAttr(ctx context.Context, attribute schema.Attribute) *rapid.Generator[value] {
+	contract.Assertf(g.isInput, "only input values are implemented")
+
+	// computed & !optional => the provider will set the value
+	if attribute.IsComputed() && !attribute.IsOptional() {
+		return rapid.Just(value{hasValue: false})
+	}
+
+	makeOptional := func(v *rapid.Generator[value]) *rapid.Generator[value] {
+		if attribute.IsRequired() {
+			return v
+		}
+
+		return rapid.Custom(func(t *rapid.T) value {
+			// optional => we may set the value
+			contract.Assertf(attribute.IsOptional(), "optional or required must be set")
+			if rapid.Bool().Draw(t, "drop optional") {
+				return value{hasValue: false, tf: cty.NullVal(ctyType(attribute.GetType().TerraformType(ctx)))}
+			}
+
+			return v.Draw(t, "v")
+		})
+	}
+
+	var minIterableSize int
+	if attribute.IsRequired() {
+		minIterableSize = 1
+	}
+
+	getValue := func() *rapid.Generator[value] {
+		switch attribute := attribute.(type) {
+
+		// Primitive attributes
+
+		case schema.StringAttribute:
+			return rapid.Custom(stringVal)
+		case schema.NumberAttribute:
+			return rapid.Custom(float64Val)
+		case schema.BoolAttribute:
+			return rapid.Custom(boolVal)
+		case schema.Int32Attribute:
+			return rapid.Custom(int32Val)
+		case schema.Int64Attribute:
+			return rapid.Custom(int64Val)
+		case schema.Float32Attribute:
+			return rapid.Custom(float32Val)
+		case schema.Float64Attribute:
+			return rapid.Custom(float64Val)
+
+		// Complex attributes
+
+		case schema.MapAttribute:
+			elemType := attribute.ElementType
+			return rapid.Map(
+				rapid.MapOfN(
+					stringV(), g.attrType(ctx, elemType),
+					minIterableSize, maxIterableSize,
+				),
+				makeConvertMap(ctyType(elemType.TerraformType(ctx))),
+			)
+
+		case schema.ListAttribute:
+			elemType := attribute.ElementType
+			return rapid.Map(
+				rapid.SliceOfN(g.attrType(ctx, elemType), minIterableSize, maxIterableSize),
+				makeConvertList(ctyType(elemType.TerraformType(ctx))),
+			)
+		case schema.SetAttribute:
+			elemType := attribute.ElementType
+			return rapid.Map(
+				rapid.SliceOfNDistinct(g.attrType(ctx, elemType), minIterableSize, maxIterableSize, g.valueID),
+				makeConvertSet(ctyType(elemType.TerraformType(ctx))),
+			)
+
+		case schema.ObjectAttribute:
+			if len(attribute.AttributeTypes) == 0 {
+				return rapid.Just(value{
+					tf: cty.EmptyObjectVal,
+					pu: resource.NewProperty(resource.PropertyMap{}),
+				})
+			}
+			names := translateAttrNames(ctx, attribute.AttributeTypes)
+			return rapid.Custom(func(t *rapid.T) value {
+				m := make(map[string]value, len(attribute.AttributeTypes))
+				stableIter(attribute.AttributeTypes, func(k string, a attr.Type) {
+					m[k] = g.attrType(ctx, a).Draw(t, k)
+				})
+				return convertObject(m, names)
+			})
+
+		// Nested attributes
+		case schema.SingleNestedAttribute:
+			return g.nestedAttributeObject(ctx, schema.NestedAttributeObject{
+				Attributes: attribute.Attributes,
+			})
+		case schema.MapNestedAttribute:
+			return rapid.Map(
+				rapid.MapOfN(stringV(), g.nestedAttributeObject(ctx, attribute.NestedObject), minIterableSize, maxIterableSize),
+				makeConvertMap(ctyType(attribute.NestedObject.Type().TerraformType(ctx))),
+			)
+		case schema.ListNestedAttribute:
+			return rapid.Map(
+				rapid.SliceOfN(g.nestedAttributeObject(ctx, attribute.NestedObject), minIterableSize, maxIterableSize),
+				makeConvertList(ctyType(attribute.NestedObject.Type().TerraformType(ctx))),
+			)
+		case schema.SetNestedAttribute:
+			return rapid.Map(
+				rapid.SliceOfNDistinct(g.nestedAttributeObject(ctx, attribute.NestedObject), minIterableSize, maxIterableSize, g.valueID),
+				makeConvertSet(ctyType(attribute.NestedObject.Type().TerraformType(ctx))),
+			)
+		default:
+			panic(fmt.Sprintf("Unknown schema.Attribute type %T", attribute))
+		}
+	}
+
+	return makeOptional(getValue())
+}
+
+func (g generator) attrType(ctx context.Context, typ attr.Type) *rapid.Generator[value] {
+	switch typ := typ.(type) {
+
+	// Primitive types
+
+	case basetypes.Int64Typable:
+		return rapid.Custom(int64Val)
+	case basetypes.Int32Typable:
+		return rapid.Custom(int32Val)
+	case basetypes.BoolTypable:
+		return rapid.Custom(boolVal)
+	case basetypes.StringTypable:
+		return rapid.Custom(stringVal)
+	case basetypes.NumberTypable:
+		return rapid.Custom(float64Val)
+	case basetypes.Float64Typable:
+		return rapid.Custom(float64Val)
+	case basetypes.Float32Typable:
+		return rapid.Custom(float32Val)
+
+	// Collection types
+
+	case basetypes.MapType:
+		return rapid.Map(
+			rapid.MapOfN(stringV(), g.attrType(ctx, typ.ElemType), -1, maxIterableSize),
+			makeConvertMap(ctyType(typ.ElemType.TerraformType(ctx))),
+		)
+	case basetypes.SetType:
+		return rapid.Map(
+			rapid.SliceOfNDistinct(g.attrType(ctx, typ.ElemType), -1, maxIterableSize, g.valueID),
+			makeConvertSet(ctyType(typ.ElemType.TerraformType(ctx))),
+		)
+	case basetypes.ListType:
+		return rapid.Map(
+			rapid.SliceOfN(g.attrType(ctx, typ.ElemType), -1, maxIterableSize),
+			makeConvertList(ctyType(typ.ElemType.TerraformType(ctx))),
+		)
+
+	// Product types
+
+	case basetypes.ObjectType:
+		if len(typ.AttrTypes) == 0 {
+			m := make(map[string]value, len(typ.AttrTypes))
+			return rapid.Just(convertObject(m, nil))
+		}
+
+		names := translateAttrNames(ctx, typ.AttrTypes)
+		return rapid.Custom(func(t *rapid.T) value {
+			m := make(map[string]value, len(typ.AttrTypes))
+			stableIter(typ.AttrTypes, func(k string, v attr.Type) {
+				m[k] = g.attrType(ctx, v).Draw(t, k)
+			})
+
+			return convertObject(m, names)
+		})
+	default:
+		panic(fmt.Sprintf("Unknown attr.Type type %T", typ))
+	}
+}
+
+func (g generator) nestedAttributeObject(ctx context.Context, obj schema.NestedAttributeObject) *rapid.Generator[value] {
+	if len(obj.Attributes) == 0 {
+		return rapid.Just(convertObject(map[string]value{}, nil))
+	}
+
+	names := translateNames(ctx, obj.Attributes, nil)
+	return rapid.Custom(func(t *rapid.T) value {
+		m := make(map[string]value, len(obj.Attributes))
+		stableIter(obj.Attributes, func(k string, a schema.Attribute) {
+			m[k] = g.withAttr(ctx, a).Draw(t, k)
+		})
+		return convertObject(m, names)
+	})
+}
+
+func (g generator) withBlock(ctx context.Context, block schema.Block) *rapid.Generator[value] {
+	contract.Assertf(g.isInput, "only input values are implemented")
+
+	switch block := block.(type) {
+	case schema.ListNestedBlock:
+		return rapid.Map(
+			rapid.SliceOfN(g.nestedBlockObject(ctx, block.NestedObject), -1, maxIterableSize),
+			makeConvertList(ctyType(block.NestedObject.Type().TerraformType(ctx))),
+		)
+	case schema.SetNestedBlock:
+		return rapid.Map(
+			rapid.SliceOfNDistinct(g.nestedBlockObject(ctx, block.NestedObject), -1, maxIterableSize, g.valueID),
+			makeConvertSet(ctyType(block.NestedObject.Type().TerraformType(ctx))),
+		)
+	case schema.SingleNestedBlock:
+		return g.nestedBlockObject(ctx, schema.NestedBlockObject{
+			Attributes: block.Attributes,
+			Blocks:     block.Blocks,
+		})
+	default:
+		panic(fmt.Sprintf("Unknown schema.Block type: %T", block))
+	}
+}
+
+func (g generator) nestedBlockObject(ctx context.Context, obj schema.NestedBlockObject) *rapid.Generator[value] {
+
+	// All rapid.Custom generators *must* consume entropy, so we special case empty
+	// schemas.
+	if len(obj.Attributes)+len(obj.Blocks) == 0 {
+		return rapid.Just(value{
+			tf: cty.EmptyObjectVal,
+			pu: resource.NewNullProperty(),
+		})
+	}
+
+	names := translateNames(ctx, obj.Attributes, obj.Blocks)
+
+	return rapid.Custom(func(t *rapid.T) value {
+		m := make(map[string]value, len(names))
+		stableIter(obj.Attributes, func(k string, a schema.Attribute) {
+			m[k] = g.withAttr(ctx, a).Draw(t, k)
+		})
+
+		stableIter(obj.Blocks, func(k string, b schema.Block) {
+			m[k] = g.withBlock(ctx, b).Draw(t, k)
+		})
+
+		return convertObject(m, names)
+	})
+}
+
+func translareTftypeNames(attrs map[string]tftypes.Type) map[string]resource.PropertyKey {
+	sch := make(shimschema.SchemaMap, len(attrs))
+	for k, v := range attrs {
+		sch[k] = (&shimschema.Schema{
+			Type: shimType(v),
+		}).Shim()
+	}
+
+	names := make(map[string]resource.PropertyKey, len(sch))
+	for k := range sch {
+		names[k] = resource.PropertyKey(tfbridge.TerraformToPulumiNameV2(k, sch, nil))
+	}
+	return names
+}
+
+func translateAttrNames(ctx context.Context, attrs map[string]attr.Type) map[string]resource.PropertyKey {
+	m := make(map[string]tftypes.Type, len(attrs))
+	for k, v := range attrs {
+		m[k] = v.TerraformType(ctx)
+	}
+	return translareTftypeNames(m)
+}
+
+func translateNames(ctx context.Context, attrs map[string]schema.Attribute, blocks map[string]schema.Block) map[string]resource.PropertyKey {
+	sch := make(shimschema.SchemaMap, len(attrs)+len(blocks))
+	for k, v := range attrs {
+		sch[k] = (&shimschema.Schema{
+			Type: shimType(v.GetType().TerraformType(ctx)),
+		}).Shim()
+	}
+	for k, v := range blocks {
+		sch[k] = (&shimschema.Schema{
+			Type: shimType(v.Type().TerraformType(ctx)),
+		}).Shim()
+	}
+
+	names := make(map[string]resource.PropertyKey, len(sch))
+	for k := range sch {
+		names[k] = resource.PropertyKey(tfbridge.TerraformToPulumiNameV2(k, sch, nil))
+	}
+	return names
+}

--- a/pkg/tests/assume/assume.go
+++ b/pkg/tests/assume/assume.go
@@ -1,0 +1,31 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// package assume defines a set of assumptions tests can make.
+//
+// If tests fail assumptions in CI, then they are skipped. Any assume.* should be run at
+// least once in CI.
+package assume
+
+import (
+	"os"
+	"runtime"
+	"strings"
+)
+
+func TerraformCLI(t interface{ Skip(args ...any) }) {
+	if ci, ok := os.LookupEnv("CI"); ok && ci == "true" && !strings.Contains(strings.ToLower(runtime.GOOS), "linux") {
+		t.Skip("Skipping on non-Linux platforms as our CI does not yet install Terraform CLI required for these tests")
+	}
+}

--- a/pkg/tests/cross-tests/tfwrite.go
+++ b/pkg/tests/cross-tests/tfwrite.go
@@ -82,6 +82,9 @@ func writePfProvider(body *hclwrite.Body, schemas pfproviderschema.Schema, value
 // This is why writePfBlock is called with parentBody, instead of with the block body
 // already created (as with [writeBlock]).
 func writePfBlock(key string, parentBody *hclwrite.Body, schemas pfproviderschema.Block, value cty.Value) {
+	if value.IsNull() {
+		return
+	}
 	switch schemas := schemas.(type) {
 	case pfproviderschema.ListNestedBlock:
 		for _, v := range value.AsValueSlice() {


### PR DESCRIPTION
Property based testing (using `"pgregory.net/rapid"`) for PF's Configure call.

This includes:
- Provider schema generation in `pkg/pf/tests/util/property/pf/schema/provider`
- Provider value generation in `pkg/pf/tests/util/property/pf/value/provider`
- Actual usage of the test in `pkg/pf/tests/provider_configure_test.go`

`crosstests.Configure` is strict by default, which we do not pass in the arbitrary case. The implementation in `provider_configure_test.go` includes an equality function that relaxes the assertion so it is passible. Each clause in the relax function is a potential bug that we can address.