### PR TITLE
Add HasPulumiProviderName check for use in terraform converter.

### DIFF
--- a/pkg/tf2pulumi/il/plugin_info.go
+++ b/pkg/tf2pulumi/il/plugin_info.go
@@ -158,6 +158,12 @@ var pulumiNames = map[string]string{
 	"template": "terraform-template",
 }
 
+// HasPulumiProviderName returns true if the given Terraform provider has a corresponding Pulumi provider name.
+func HasPulumiProviderName(terraformProviderName string) bool {
+	_, hasPulumiName := pulumiNames[terraformProviderName]
+	return hasPulumiName
+}
+
 // GetPulumiProviderName returns the Pulumi name for the given Terraform provider. In most cases the two names will be
 // identical.
 func GetPulumiProviderName(terraformProviderName string) string {


### PR DESCRIPTION
This will be used in GetProviderInfo in converter-terraform.

In that case, the main.tf package info will be used to get the repo and package in the open tofu repositories (as opposed to just the raw name) to be passed to the GetMapper command.
