### PR TITLE
More info on compute ID mapping error

### DIFF
--- a/docs/resource-ids.md
+++ b/docs/resource-ids.md
@@ -60,7 +60,21 @@ If the type of the `"id"` attribute is not coercible to a string, you must set `
 error: Resource test_res has a problem: no "id" attribute. To map this resource consider specifying ResourceInfo.ComputeID
 ```
 
-If the resource simply doesn't have an `"id"` attribute, you will need to set `ResourceInfo.ComputeID`. If you want to delegate the ID field in Pulumi to another attribute, you should use `tfbridge.DelegateIDField` to produce a `ResourceInfo.ComputeID` compatible function. Otherwise you can pass in any function that complies with:
+If the resource simply doesn't have an `"id"` attribute, you will need to set `ResourceInfo.ComputeID`. 
+
+```go
+"test_res": {ComputeID: computeIDField("id")}
+```
+
+Note that the computeIDField needs to be a valid property, i.e. if the mapped resource does not have a field called "id",
+you may need to map this field to something else:
+
+```go
+"test_res": {ComputeID: computeIDField("valid_key")}
+```
+
+If you want to delegate the ID field in Pulumi to another attribute, you should use `tfbridge.DelegateIDField` to produce a `ResourceInfo.ComputeID` compatible function. 
+Otherwise you can pass in any function that complies with:
 
 ```go
 func(ctx context.Context, state resource.PropertyMap) (resource.ID, error)

--- a/docs/resource-ids.md
+++ b/docs/resource-ids.md
@@ -60,20 +60,21 @@ If the type of the `"id"` attribute is not coercible to a string, you must set `
 error: Resource test_res has a problem: no "id" attribute. To map this resource consider specifying ResourceInfo.ComputeID
 ```
 
-If the resource simply doesn't have an `"id"` attribute, you will need to set `ResourceInfo.ComputeID`. 
+If the resource simply doesn't have an `"id"` attribute, you will need to set `ResourceInfo.ComputeID`.
+If you want to delegate the ID field in Pulumi to another attribute, you should use `tfbridge.DelegateIDField` to produce a `ResourceInfo.ComputeID` compatible function.
 
 ```go
-"test_res": {ComputeID: computeIDField("id")}
+"test_res": {ComputeID: tfbridge.DelegateIDField("id", "testprovider", "https://github.com/pulumi/pulumi-testprovider")}
 ```
 
-Note that the computeIDField needs to be a valid property, i.e. if the mapped resource does not have a field called "id",
+Note that the delegated ID field needs to be a valid property, i.e. if the mapped resource does not have a field called "id",
 you may need to map this field to something else:
 
 ```go
-"test_res": {ComputeID: computeIDField("valid_key")}
+"test_res": {ComputeID: tfbridge.DelegateIDField("valid_key", "testprovider", "https://github.com/pulumi/pulumi-testprovider")}
 ```
 
-If you want to delegate the ID field in Pulumi to another attribute, you should use `tfbridge.DelegateIDField` to produce a `ResourceInfo.ComputeID` compatible function. 
+
 Otherwise you can pass in any function that complies with:
 
 ```go

--- a/pkg/pf/internal/check/check_test.go
+++ b/pkg/pf/internal/check/check_test.go
@@ -100,7 +100,7 @@ func TestMissingIDProperty(t *testing.T) {
 	})
 
 	assert.Equal(t, "error: Resource test_res has a problem: no \"id\" attribute. "+
-		"To map this resource consider specifying ResourceInfo.ComputeID\n", stderr)
+		"To map this resource consider specifying ResourceInfo.ComputeID to a valid field on the upstream resource\n", stderr)
 
 	assert.ErrorContains(t, err, "There were 1 unresolved ID mapping errors")
 }

--- a/pkg/pf/internal/check/checks.go
+++ b/pkg/pf/internal/check/checks.go
@@ -126,7 +126,7 @@ func (err errWrongIDType) Error() string {
 type errMissingIDAttribute struct{}
 
 func (errMissingIDAttribute) Error() string {
-	return `no "id" attribute. To map this resource consider specifying ResourceInfo.ComputeID`
+	return `no "id" attribute. To map this resource consider specifying ResourceInfo.ComputeID to a valid field on the upstream resource`
 }
 
 type errInvalidRequiredID struct{}


### PR DESCRIPTION
This is a papercut tweak to remind provider maintainers on what to do for ComputeID mapping errors.

I'm happy if we don't take this; but it confused me in a recent upgrade so I thought I'd address it.


