### PR TITLE
Automatically propagate bridge updates on providers when a new bridge version is tagged

### DIFF
--- a/.github/workflows/update-providers-auto.yml
+++ b/.github/workflows/update-providers-auto.yml
@@ -2,9 +2,9 @@ name: Update Providers with new bridge version upon release
 on:
   push:
     tags:
-      # Typically pf* module is tagged after the main module, so this is a good time to fire off
-      # automatic downstream upgrades.
-      - 'pf/**'
+      # Automatically trigger on valid patch releases of the bridge.
+      - v*.*.*
+      - '!v*.*.*-**' # Do not propagate prereleases
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request changes the automatic upgrade of providers to run on tagging of the main bridge version, since we are deprecating the `pf` module.
