### PR TITLE
Add autogen warning to index file

### DIFF
--- a/pkg/tfgen/installation_docs.go
+++ b/pkg/tfgen/installation_docs.go
@@ -53,8 +53,12 @@ func plainDocsParser(docFile *DocFile, g *Generator) ([]byte, error) {
 	// Determine if we should write an overview header.
 	overviewHeader := getOverviewHeader(content)
 
+	autoGenMessage := fmt.Sprint(
+		"<!-- *** WARNING: This file was auto-generated. " +
+			"Do not edit by hand unless you're certain you know what you are doing! *** -->\n")
+
 	// Add instructions to top of file
-	contentStr := frontMatter + installationInstructions + overviewHeader + string(content)
+	contentStr := frontMatter + autoGenMessage + installationInstructions + overviewHeader + string(content)
 
 	//Translate code blocks to Pulumi
 	contentStr, err = translateCodeBlocks(contentStr, g)

--- a/pkg/tfgen/installation_docs.go
+++ b/pkg/tfgen/installation_docs.go
@@ -53,12 +53,8 @@ func plainDocsParser(docFile *DocFile, g *Generator) ([]byte, error) {
 	// Determine if we should write an overview header.
 	overviewHeader := getOverviewHeader(content)
 
-	autoGenMessage := fmt.Sprint(
-		"<!-- *** WARNING: This file was auto-generated. " +
-			"Do not edit by hand unless you're certain you know what you are doing! *** -->\n")
-
 	// Add instructions to top of file
-	contentStr := frontMatter + autoGenMessage + installationInstructions + overviewHeader + string(content)
+	contentStr := frontMatter + installationInstructions + overviewHeader + string(content)
 
 	//Translate code blocks to Pulumi
 	contentStr, err = translateCodeBlocks(contentStr, g)
@@ -86,8 +82,9 @@ func writeFrontMatter(providerName string) string {
 	// Capitalize the package name
 	capitalize := cases.Title(language.English)
 	title := capitalize.String(providerName)
-
 	return fmt.Sprintf(delimiter+
+		"# *** WARNING: This file was auto-generated. "+
+		"Do not edit by hand unless you're certain you know what you are doing! ***\n"+
 		"title: %[1]s Provider\n"+
 		"meta_desc: Provides an overview on how to configure the Pulumi %[1]s provider.\n"+
 		"layout: package\n"+

--- a/pkg/tfgen/installation_docs_test.go
+++ b/pkg/tfgen/installation_docs_test.go
@@ -272,6 +272,8 @@ func TestWriteFrontMatter(t *testing.T) {
 		name:         "Generates Front Matter for installation-configuration.md",
 		providerName: "test",
 		expected: delimiter +
+			"# *** WARNING: This file was auto-generated. " +
+			"Do not edit by hand unless you're certain you know what you are doing! ***\n" +
 			"title: Test Provider\n" +
 			"meta_desc: Provides an overview on how to configure the Pulumi Test provider.\n" +
 			"layout: package\n" +

--- a/pkg/tfgen/test_data/convert-index-file-edit-rules/expected.md
+++ b/pkg/tfgen/test_data/convert-index-file-edit-rules/expected.md
@@ -1,4 +1,5 @@
 ---
+# *** WARNING: This file was auto-generated. Do not edit by hand unless you're certain you know what you are doing! ***
 title: Libvirt Provider
 meta_desc: Provides an overview on how to configure the Pulumi Libvirt provider.
 layout: package

--- a/pkg/tfgen/test_data/convert-index-file/expected.md
+++ b/pkg/tfgen/test_data/convert-index-file/expected.md
@@ -1,4 +1,5 @@
 ---
+# *** WARNING: This file was auto-generated. Do not edit by hand unless you're certain you know what you are doing! ***
 title: Libvirt Provider
 meta_desc: Provides an overview on how to configure the Pulumi Libvirt provider.
 layout: package


### PR DESCRIPTION
This pull request adds a Markdown comment containing an autogen warning to the _index.md file.

It does so immediately inside the Hugo frontmatter. h/t to @iwahbe for pointing out Markdown will work fine here.

Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/2485.

