### PR TITLE
Revert autoupdate trigger

### DIFF
--- a/.github/workflows/update-providers-auto.yml
+++ b/.github/workflows/update-providers-auto.yml
@@ -2,9 +2,9 @@ name: Update Providers with new bridge version upon release
 on:
   push:
     tags:
-      # Automatically trigger on valid patch releases of the bridge.
-      - v*.*.*
-      - '!v*.*.*-**' # Do not propagate prereleases
+      # Typically pf* module is tagged after the main module, so this is a good time to fire off
+      # automatic downstream upgrades.
+      - 'pf/**'
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
It turns out we need to do one final tag of the pf/ module, so this automation needs to be reverted.

Reverts https://github.com/pulumi/pulumi-terraform-bridge/pull/2492.
