### PR TITLE
Refactor cross-tests to use (cty.Value, resource.PropertyMap) pairs

### DIFF
--- a/pkg/internal/tests/cross-tests/pu_driver.go
+++ b/pkg/internal/tests/cross-tests/pu_driver.go
@@ -15,25 +15,19 @@
 package crosstests
 
 import (
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
-
-	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
 type pulumiDriver struct {
 	name                string
 	pulumiResourceToken string
 	tfResourceName      string
-	objectType          *tftypes.Object
 }
 
-func (pd *pulumiDriver) generateYAML(t T, resMap shim.ResourceMap, tfConfig any) []byte {
-	res := resMap.Get(pd.tfResourceName)
-	schema := res.Schema()
-
-	data, err := generateYaml(schema, pd.pulumiResourceToken, pd.objectType, tfConfig)
+func (pd *pulumiDriver) generateYAML(t T, puConfig resource.PropertyMap) []byte {
+	data, err := generateYaml(pd.pulumiResourceToken, puConfig)
 	require.NoErrorf(t, err, "generateYaml")
 
 	b, err := yaml.Marshal(data)

--- a/pkg/internal/tests/cross-tests/puwrite_test.go
+++ b/pkg/internal/tests/cross-tests/puwrite_test.go
@@ -122,7 +122,8 @@ runtime: yaml
 				func(tfResourceType string) bool { return true },
 			))
 			schema := shimProvider.ResourcesMap().Get(rtype).Schema()
-			out, err := generateYaml(schema, rtoken, nil, tc.tfConfig)
+			out, err := generateYaml(rtoken,
+				convertConfigValueForYamlProperties(t, schema, nil, tc.tfConfig))
 			require.NoError(t, err)
 			b, err := yaml.Marshal(out)
 			require.NoError(t, err)


### PR DESCRIPTION
Stacked PRs:
 * #2502
 * #2503
 * #2501
 * __->__#2500


--- --- ---

### Refactor cross-tests to use (cty.Value, resource.PropertyMap) pairs


Passing `(cty.Value, resource.PropertyMap)` pairs (instead of just passing
`map[string]any` or `tftypes.Value`) is necessary for testing scenarios where the
Terraform value doesn't neatly line up with the Pulumi value, such as #2048.

This commit pushes pkg/tests/cross-tests to work directly with cty.Value and
resource.PropertyMap instead of converting at the last minute.

All tests pass after this refactor. It only effects test code. Existing tests do not need
to be rewritten.
