### PR TITLE
SDKv2 cross-tests for Configure

### DIFF
--- a/pkg/internal/tests/cross-tests/assert.go
+++ b/pkg/internal/tests/cross-tests/assert.go
@@ -2,6 +2,7 @@ package crosstests
 
 import (
 	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,5 +27,30 @@ func assertValEqual(t T, name string, tfVal, pulVal any) {
 		}
 	} else {
 		require.Equal(t, tfVal, pulVal, "Values for key %s do not match", name)
+	}
+}
+
+func assertResourceDataEqual(t T, schema map[string]*schema.Schema, tfResult, puResult *schema.ResourceData) {
+	// We are unable to assert that both providers were configured with the exact same
+	// data. Type information doesn't line up in the simple case. This just doesn't work:
+	//
+	//	assert.Equal(t, tfResult, puResult)
+	//
+	// We make do by comparing raw data.
+	assertCtyValEqual(t, "RawConfig", tfResult.GetRawConfig(), puResult.GetRawConfig())
+	assertCtyValEqual(t, "RawPlan", tfResult.GetRawPlan(), puResult.GetRawPlan())
+	assertCtyValEqual(t, "RawState", tfResult.GetRawState(), puResult.GetRawState())
+
+	for k := range schema {
+		// TODO: make this recursive
+		tfVal := tfResult.Get(k)
+		pulVal := puResult.Get(k)
+
+		tfChangeValOld, tfChangeValNew := tfResult.GetChange(k)
+		pulChangeValOld, pulChangeValNew := puResult.GetChange(k)
+
+		assertValEqual(t, k, tfVal, pulVal)
+		assertValEqual(t, k+" Change Old", tfChangeValOld, pulChangeValOld)
+		assertValEqual(t, k+" Change New", tfChangeValNew, pulChangeValNew)
 	}
 }

--- a/pkg/internal/tests/cross-tests/configure.go
+++ b/pkg/internal/tests/cross-tests/configure.go
@@ -1,0 +1,155 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+
+package crosstests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+	"gopkg.in/yaml.v3"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/pulcheck"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/tfcheck"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
+	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
+)
+
+func MakeConfigure(
+	provider map[string]*schema.Schema, tfConfig cty.Value, puConfig resource.PropertyMap,
+	options ...ConfigureOption,
+) func(*testing.T) {
+	return func(t *testing.T) { Configure(t, provider, tfConfig, puConfig, options...) }
+}
+
+// Configure validates that a Terraform provider witnesses the same input when:
+// - invoked directly with HCL on tfConfig
+// - bridged and invoked via Pulumi YAML on puConfig
+//
+// Create only applies to resources defined with github.com/hashicorp/terraform-plugin-sdk/v2. For cross-tests
+// on Plugin Framework based resources, see
+// github.com/pulumi/pulumi-terraform-bridge/pkg/pf/tests/internal/cross-tests.
+func Configure(
+	t T, provider map[string]*schema.Schema, tfConfig cty.Value, puConfig resource.PropertyMap,
+	options ...ConfigureOption,
+) {
+
+	var opts configureOpts
+	for _, f := range options {
+		f(&opts)
+	}
+
+	if isInferPulumiMarker(puConfig) {
+		puConfig = inferPulumiValue(t,
+			shimv2.NewSchemaMap(provider),
+			opts.resourceInfo.GetFields(),
+			tfConfig,
+		)
+	}
+
+	tfwd := t.TempDir()
+	const configureResult = "some-value"
+	type result struct {
+		data   *schema.ResourceData
+		wasSet bool
+
+		resourceCreated bool
+	}
+	var tfResult, puResult result
+	makeProvider := func(writeTo *result) *schema.Provider {
+		return &schema.Provider{
+			Schema: provider,
+			ConfigureContextFunc: func(_ context.Context, rd *schema.ResourceData) (any, diag.Diagnostics) {
+				*writeTo = result{rd, true, false}
+
+				return configureResult, nil
+			},
+			ResourcesMap: map[string]*schema.Resource{
+				defRtype: {
+					Schema: map[string]*schema.Schema{},
+					CreateContext: func(_ context.Context, data *schema.ResourceData, meta any) diag.Diagnostics {
+						data.SetId("id")
+						writeTo.resourceCreated = true
+						s, ok := meta.(string)
+						if !ok {
+							return diag.Errorf("meta of unexpected type %T", meta)
+						}
+						if s != configureResult {
+							return diag.Errorf("unexpected configuration value: %s (!= %s)",
+								s, configureResult)
+						}
+						return nil
+					},
+				},
+			},
+		}
+	}
+	tfProvider := makeProvider(&tfResult)
+	tfd := tfcheck.NewTfDriver(t, tfwd, defProviderShortName, tfProvider)
+	tfd.Write(t, providerHCLProgram(t, defProviderShortName, tfProvider, tfConfig))
+	plan, err := tfd.Plan(t)
+	require.NoError(t, err)
+	require.NoError(t, tfd.Apply(t, plan))
+
+	require.True(t, tfResult.wasSet, "terraform configure result was not set")
+	require.True(t, tfResult.wasSet, "terraform resource result was not set")
+
+	bridgedProvider := pulcheck.BridgedProvider(
+		t, defProviderShortName, makeProvider(&puResult),
+		pulcheck.WithResourceInfo(map[string]*info.Resource{defRtype: opts.resourceInfo}),
+	)
+	pd := &pulumiDriver{
+		name:                defProviderShortName,
+		pulumiResourceToken: "pulumi:providers:" + defProviderShortName,
+	}
+
+	data, err := generateYaml(t, pd.pulumiResourceToken, puConfig)
+	require.NoErrorf(t, err, "generateYaml")
+	data["resources"].(map[string]any)["res"] = map[string]any{
+		"type":       "crosstests:Res",
+		"properties": map[string]any{},
+	}
+	b, err := yaml.Marshal(data)
+	require.NoErrorf(t, err, "marshaling Pulumi.yaml")
+	t.Logf("\n\n%s", b)
+
+	yamlProgram := pd.generateYAML(t, puConfig)
+
+	pt := pulcheck.PulCheck(t, bridgedProvider, string(yamlProgram))
+
+	pt.Up(t)
+
+	require.True(t, tfResult.wasSet, "pulumi configure result was not set")
+	require.True(t, tfResult.wasSet, "pulumi resource result was not set")
+
+	assertResourceDataEqual(t, provider, tfResult.data, puResult.data)
+}
+
+type configureOpts struct {
+	resourceInfo *info.Resource
+}
+
+// An option that can be used to customize [Create].
+type ConfigureOption func(*configureOpts)
+
+// CreateResourceInfo specifies an [info.Resource] to apply to the resource under test.
+func ConfigureProviderInfo(info info.Resource) ConfigureOption {
+	contract.Assertf(info.Tok == "", "cannot set info.Tok, it will not be respected")
+	return func(o *configureOpts) { o.resourceInfo = &info }
+}

--- a/pkg/internal/tests/cross-tests/create.go
+++ b/pkg/internal/tests/cross-tests/create.go
@@ -107,28 +107,7 @@ func Create(
 	assert.Equal(t, tfResult.meta, puResult.meta,
 		"assert that both providers were configured with the same provider metadata")
 
-	// We are unable to assert that both providers were configured with the exact same
-	// data. Type information doesn't line up in the simple case. This just doesn't work:
-	//
-	//	assert.Equal(t, tfResult.data, puResult.data)
-	//
-	// We make due by comparing raw data.
-	assertCtyValEqual(t, "RawConfig", tfResult.data.GetRawConfig(), puResult.data.GetRawConfig())
-	assertCtyValEqual(t, "RawPlan", tfResult.data.GetRawPlan(), puResult.data.GetRawPlan())
-	assertCtyValEqual(t, "RawState", tfResult.data.GetRawState(), puResult.data.GetRawState())
-
-	for k := range resource {
-		// TODO: make this recursive
-		tfVal := tfResult.data.Get(k)
-		pulVal := puResult.data.Get(k)
-
-		tfChangeValOld, tfChangeValNew := tfResult.data.GetChange(k)
-		pulChangeValOld, pulChangeValNew := puResult.data.GetChange(k)
-
-		assertValEqual(t, k, tfVal, pulVal)
-		assertValEqual(t, k+" Change Old", tfChangeValOld, pulChangeValOld)
-		assertValEqual(t, k+" Change New", tfChangeValNew, pulChangeValNew)
-	}
+	assertResourceDataEqual(t, resource, tfResult.data, puResult.data)
 }
 
 type createOpts struct {

--- a/pkg/internal/tests/cross-tests/pu_driver.go
+++ b/pkg/internal/tests/cross-tests/pu_driver.go
@@ -27,7 +27,7 @@ type pulumiDriver struct {
 }
 
 func (pd *pulumiDriver) generateYAML(t T, puConfig resource.PropertyMap) []byte {
-	data, err := generateYaml(pd.pulumiResourceToken, puConfig)
+	data, err := generateYaml(t, pd.pulumiResourceToken, puConfig)
 	require.NoErrorf(t, err, "generateYaml")
 
 	b, err := yaml.Marshal(data)

--- a/pkg/internal/tests/cross-tests/puwrite_test.go
+++ b/pkg/internal/tests/cross-tests/puwrite_test.go
@@ -122,7 +122,7 @@ runtime: yaml
 				func(tfResourceType string) bool { return true },
 			))
 			schema := shimProvider.ResourcesMap().Get(rtype).Schema()
-			out, err := generateYaml(rtoken,
+			out, err := generateYaml(t, rtoken,
 				inferPulumiValue(t, schema, nil, coalesceInputs(t, tc.schema, tc.tfConfig)))
 			require.NoError(t, err)
 			b, err := yaml.Marshal(out)

--- a/pkg/internal/tests/cross-tests/tfwrite_test.go
+++ b/pkg/internal/tests/cross-tests/tfwrite_test.go
@@ -266,7 +266,7 @@ resource "res" "ex" {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			var out bytes.Buffer
-			err := WriteHCL(&out, tc.schema, "res", "ex", tc.value)
+			err := WriteSDKv2(&out).Resource(tc.schema, "res", "ex", tc.value)
 			require.NoError(t, err)
 			tc.expect.Equal(t, "\n"+out.String())
 		})

--- a/pkg/pf/tests/internal/cross-tests/configure.go
+++ b/pkg/pf/tests/internal/cross-tests/configure.go
@@ -138,7 +138,7 @@ resource "` + providerName + `_res" "res" {}
 			"resources": map[string]any{
 				"p": map[string]any{
 					"type":       "pulumi:providers:" + providerName,
-					"properties": convertResourceValue(t, puConfig),
+					"properties": crosstests.ConvertResourceValue(t, puConfig),
 				},
 			},
 		}

--- a/pkg/tfbridge/tests/provider_configure_test.go
+++ b/pkg/tfbridge/tests/provider_configure_test.go
@@ -1,0 +1,65 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+
+package tfbridgetests
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/tests/cross-tests"
+)
+
+func TestConfigureSimpleValues(t *testing.T) {
+	t.Run("string", crosstests.MakeConfigure(map[string]*schema.Schema{
+		"f0": {Type: schema.TypeString, Required: true},
+	}, cty.ObjectVal(map[string]cty.Value{
+		"f0": cty.StringVal("v0"),
+	}), crosstests.InferPulumiValue()))
+
+	t.Run("bool", crosstests.MakeConfigure(map[string]*schema.Schema{
+		"f0": {Type: schema.TypeBool, Required: true},
+		"f1": {Type: schema.TypeBool, Required: true},
+	}, cty.ObjectVal(map[string]cty.Value{
+		"f0": cty.BoolVal(false),
+		"f1": cty.BoolVal(true),
+	}), crosstests.InferPulumiValue()))
+
+	t.Run("int", crosstests.MakeConfigure(map[string]*schema.Schema{
+		"f0": {Type: schema.TypeInt, Required: true},
+	}, cty.ObjectVal(map[string]cty.Value{
+		"f0": cty.NumberIntVal(123456),
+	}), crosstests.InferPulumiValue()))
+
+	t.Run("float64", func(t *testing.T) {
+		t.Skip("TODO: Float64 does not pass cross-tests")
+		crosstests.Configure(t, map[string]*schema.Schema{
+			"f0": {Type: schema.TypeFloat, Required: true},
+		}, cty.ObjectVal(map[string]cty.Value{
+			"f0": cty.NumberFloatVal(123.456),
+		}), crosstests.InferPulumiValue())
+	})
+}
+
+func TestConfigureSimpleSecretValues(t *testing.T) {
+	t.Run("string", crosstests.MakeConfigure(map[string]*schema.Schema{
+		"f0": {Type: schema.TypeString, Required: true},
+	}, cty.ObjectVal(map[string]cty.Value{
+		"f0": cty.StringVal("v0"),
+	}), resource.PropertyMap{
+		"f0": resource.MakeSecret(resource.NewProperty("v0")),
+	}))
+}

--- a/pkg/tfbridge/tests/provider_test.go
+++ b/pkg/tfbridge/tests/provider_test.go
@@ -1,3 +1,16 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+
 package tfbridgetests
 
 import (


### PR DESCRIPTION
As part of https://github.com/pulumi/pulumi-terraform-bridge/issues/2440, I wanted to be able to write cross-tests with that passed secrets to `Configure`. This PR implements `crosstests.Configure`.

The PR stacks on top of https://github.com/pulumi/pulumi-terraform-bridge/pull/2505.

Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/2274