### PR TITLE
provider index doc: Skip headers that mention Contributing

### DIFF
--- a/pkg/tfgen/installation_docs.go
+++ b/pkg/tfgen/installation_docs.go
@@ -400,7 +400,7 @@ func getDefaultHeadersToSkip() []*regexp.Regexp {
 		regexp.MustCompile("[Dd]evelopment"),
 		regexp.MustCompile("[Dd]ebugging"),
 		regexp.MustCompile("[Tt]erraform CLI"),
-		regexp.MustCompile("[Tt]erraform Cloud"),
+		regexp.MustCompile("[Tt]erraform [Cc]loud"),
 		regexp.MustCompile("Delete Protection"),
 		regexp.MustCompile("[Cc]ontributing"),
 	}

--- a/pkg/tfgen/installation_docs.go
+++ b/pkg/tfgen/installation_docs.go
@@ -402,6 +402,7 @@ func getDefaultHeadersToSkip() []*regexp.Regexp {
 		regexp.MustCompile("[Tt]erraform CLI"),
 		regexp.MustCompile("[Tt]erraform Cloud"),
 		regexp.MustCompile("Delete Protection"),
+		regexp.MustCompile("[Cc]ontributing"),
 	}
 	return defaultHeaderSkipRegexps
 }


### PR DESCRIPTION
This pull request globalizes skipping sections whose headers mention Contributing, in the `docs/_index.md` file.

It does so by adding Contributing/contributing to the denylist of words found in a header in an index.md file.

Example: https://github.com/pulumi/pulumi-vsphere/pull/607
