### PR TITLE
Enable typechecker to allow stringified boolean property values on Type: "boolean"

### DIFF
--- a/pkg/tfbridge/typechecker/typechecker.go
+++ b/pkg/tfbridge/typechecker/typechecker.go
@@ -162,7 +162,8 @@ func (v *TypeChecker) validatePropertyValue(
 	switch typeSpec.Type {
 	case "boolean":
 		// Check for strings that are values "true" or "false".
-		// These are handled as booleans in the bridge, so they should be skipped by the type checker.
+		//TODO: Remove the boolString condition when https://github.com/pulumi/pulumi-terraform-bridge/issues/2520
+		// is resolved. This is a workaround for the config encoding not honoring type overrides.
 		var boolString bool
 		if propertyValue.IsString() {
 			if propertyValue.StringValue() == "true" || propertyValue.StringValue() == "false" {

--- a/pkg/tfbridge/typechecker/typechecker.go
+++ b/pkg/tfbridge/typechecker/typechecker.go
@@ -161,8 +161,15 @@ func (v *TypeChecker) validatePropertyValue(
 
 	switch typeSpec.Type {
 	case "boolean":
-		// The bridge permits the strings "true" and "false" to read as boolean, so allow strings.
-		if !propertyValue.IsBool() && !propertyValue.IsString() {
+		// Check for strings that are values "true" or "false".
+		// These are handled as booleans in the bridge, so they should be skipped by the type checker.
+		var boolString bool
+		if propertyValue.IsString() {
+			if propertyValue.StringValue() == "true" || propertyValue.StringValue() == "false" {
+				boolString = true
+			}
+		}
+		if !propertyValue.IsBool() && !boolString {
 			return []Failure{newTypeFailure(propertyPath, typeSpec.Type, propertyValue)}
 		}
 		return nil

--- a/pkg/tfbridge/typechecker/typechecker.go
+++ b/pkg/tfbridge/typechecker/typechecker.go
@@ -161,7 +161,8 @@ func (v *TypeChecker) validatePropertyValue(
 
 	switch typeSpec.Type {
 	case "boolean":
-		if !propertyValue.IsBool() {
+		// The bridge permits the strings "true" and "false" to read as boolean, so allow strings.
+		if !propertyValue.IsBool() && !propertyValue.IsString() {
 			return []Failure{newTypeFailure(propertyPath, typeSpec.Type, propertyValue)}
 		}
 		return nil

--- a/pkg/tfbridge/typechecker/typechecker_test.go
+++ b/pkg/tfbridge/typechecker/typechecker_test.go
@@ -1632,6 +1632,9 @@ func TestValidateConfigType(t *testing.T) {
 			}),
 		},
 		{
+			//TODO: Remove this test when https://github.com/pulumi/pulumi-terraform-bridge/issues/2520 is resolved.
+			// This tests a workaround path to keep the type checker from tripping on missing functionality in the
+			// config encoding and will fail once that is fixed.
 			name:      "allows_bool_strings",
 			inputName: "skipMetadataApiCheck",
 			input:     resource.PropertyValue{V: "true"},

--- a/pkg/tfbridge/typechecker/typechecker_test.go
+++ b/pkg/tfbridge/typechecker/typechecker_test.go
@@ -1631,6 +1631,11 @@ func TestValidateConfigType(t *testing.T) {
 				})),
 			}),
 		},
+		{
+			name:      "allows_bool_strings",
+			inputName: "skipMetadataApiCheck",
+			input:     resource.PropertyValue{V: "true"},
+		},
 	}
 	for _, tc := range testCases {
 		tc := tc
@@ -1659,6 +1664,11 @@ func TestValidateConfigType(t *testing.T) {
 								Items: &pschema.TypeSpec{
 									Ref: "#/types/aws:config/endpoints:endpoints",
 								},
+							},
+						},
+						"skipMetadataApiCheck": {
+							TypeSpec: pschema.TypeSpec{
+								Type: "boolean",
 							},
 						},
 					},


### PR DESCRIPTION
This pull request allows for strings called "true" or "false" that are set on the "boolean" type to pass the type checker.

This change is necessary because the JSON-style config encoding, which powers the TypeScript, Python, .NET, and Java SDKS,
returns a string for config values with a type override to "boolean". The engine can handle this regarding functionality,
but the type checker sends an unnecessary warning to affected SDKs.

Fixes #2339

For additional context, see changes made in https://github.com/pulumi/pulumi-terraform-bridge/pull/2310.
