### PR TITLE
Add another TF version pattern to removal regexes

### DIFF
--- a/pkg/tfgen/edit_rules_test.go
+++ b/pkg/tfgen/edit_rules_test.go
@@ -164,6 +164,15 @@ func TestApplyEditRules(t *testing.T) {
 			phase:    info.PostCodeTranslation,
 		},
 		{
+			// Found in confluentcloud
+			name: "Strips mentions of Terraform version With Backticks",
+			docFile: DocFile{
+				Content: []byte("Terraform `v0.13` and later:"),
+			},
+			expected: []byte(""),
+			phase:    info.PostCodeTranslation,
+		},
+		{
 			// Found in linode
 			name: "Rewrites providers.tf to Pulumi.yaml",
 			docFile: DocFile{

--- a/pkg/tfgen/installation_docs.go
+++ b/pkg/tfgen/installation_docs.go
@@ -413,6 +413,7 @@ func getTfVersionsToRemove() []*regexp.Regexp {
 		regexp.MustCompile(`(It|This provider) requires( at least)? [tT]erraform [v0-9]+\.?[0-9]?\.?[0-9]?( or later)?.`),
 		regexp.MustCompile(`(?s)(For )?[tT]erraform [v0-9]+\.?[0-9]?\.?[0-9]? and (later|earlier):`),
 		regexp.MustCompile(`A minimum of [tT]erraform [v0-9]+\.?[0-9]?\.?[0-9]? is recommended.`),
+		regexp.MustCompile("[tT]erraform `[v0-9.]+` (and|or) later:"),
 	}
 	return tfVersionsToRemove
 }


### PR DESCRIPTION
This pull request adds another pattern to the `getTfVersionsToRemove` regex collection. Ths one has back ticks around the version number.

Addresses a pattern found in confluentcloud provider.



