### PR TITLE
Enable TestConfigureSimpleValues

### DIFF
--- a/pkg/internal/tests/cross-tests/assert.go
+++ b/pkg/internal/tests/cross-tests/assert.go
@@ -39,6 +39,8 @@ func assertResourceDataEqual(t T, resourceSchema map[string]*schema.Schema, tfRe
 	//	assert.Equal(t, tfResult, puResult)
 	//
 	// We make do by comparing slices tfResult and puResult.
+	require.NotNil(t, tfResult)
+	require.NotNil(t, puResult)
 	assertCtyValEqual(t, "RawConfig", tfResult.GetRawConfig(), puResult.GetRawConfig())
 	assertCtyValEqual(t, "RawPlan", tfResult.GetRawPlan(), puResult.GetRawPlan())
 	assertCtyValEqual(t, "RawState", tfResult.GetRawState(), puResult.GetRawState())

--- a/pkg/tfbridge/tests/provider_configure_test.go
+++ b/pkg/tfbridge/tests/provider_configure_test.go
@@ -24,7 +24,13 @@ import (
 )
 
 func TestConfigureSimpleValues(t *testing.T) {
-	t.Skip("TODO[pulumi/pulumi-terraform-bridge#2530]: flaky")
+	// TestConfigureSimpleValues was previously flaky:
+	//
+	// https://github.com/pulumi/pulumi-terraform-bridge/issues/2530
+	//
+	// The investigation was inconclusive, so we are adding back into circulation to
+	// see if the failures continue with tighter asserts.
+
 	t.Run("string", crosstests.MakeConfigure(map[string]*schema.Schema{
 		"f0": {Type: schema.TypeString, Required: true},
 	}, cty.ObjectVal(map[string]cty.Value{


### PR DESCRIPTION
I'm unable to get the flake on my computer, even with `--count 1000`. The test wasn't previously running in parallel, so it shouldn't be an interaction with other tests.

I've added better asserts so we can see which result is unexpectedly nil. I think our best chance at fixing the test is to turn the test back on and then re-engage if/when it flakes again.

Part of investigating https://github.com/pulumi/pulumi-terraform-bridge/issues/2530