### PR TITLE
Fix provider name discrepancy in index doc

### DIFF
--- a/pkg/tfgen/installation_docs.go
+++ b/pkg/tfgen/installation_docs.go
@@ -35,7 +35,7 @@ func plainDocsParser(docFile *DocFile, g *Generator) ([]byte, error) {
 
 	// Add pulumi-specific front matter
 	// Generate pulumi-specific front matter
-	frontMatter := writeFrontMatter(g.info.Name)
+	frontMatter := writeFrontMatter(g.pkg.Name().String())
 
 	// Remove the title. A title gets populated from Hugo frontmatter; we do not want two.
 	content, err = removeTitle(content)
@@ -47,7 +47,7 @@ func plainDocsParser(docFile *DocFile, g *Generator) ([]byte, error) {
 	content = stripSchemaGeneratedByTFPluginDocs(content)
 
 	// Generate pulumi-specific installation instructions
-	installationInstructions := writeInstallationInstructions(g.info.Golang.ImportBasePath, g.info.Name)
+	installationInstructions := writeInstallationInstructions(g.info.Golang.ImportBasePath, g.pkg.Name().String())
 
 	// Determine if we should write an overview header.
 	overviewHeader := getOverviewHeader(content)

--- a/pkg/tfgen/installation_docs_test.go
+++ b/pkg/tfgen/installation_docs_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	sdkv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 )
 
 func TestPlainDocsParser(t *testing.T) {
@@ -91,7 +92,6 @@ func TestPlainDocsParser(t *testing.T) {
 					Golang: &tfbridge.GolangInfo{
 						ImportBasePath: "github.com/pulumi/pulumi-libvirt/sdk/go/libvirt",
 					},
-					Name: "libvirt",
 				},
 				cliConverterState: &cliConverter{
 					info: p,
@@ -99,6 +99,7 @@ func TestPlainDocsParser(t *testing.T) {
 				},
 				editRules: tt.edits,
 				language:  RegistryDocs,
+				pkg:       tokens.NewPackageToken("libvirt"),
 			}
 			actual, err := plainDocsParser(&tt.docFile, g)
 			require.NoError(t, err)


### PR DESCRIPTION
This pull request swaps out use of `g.info.Name` for `g.pkg.Name().String()` when determining the name of the provider for title and download link purposes.
`g.info.Name` refers to the upstream Terraform provider name. We need to use the Pulumi package name instead. 
Fortunately the bridge already knows how to do this, so this pull request swaps out the package name getter and adjusts the parser test provider to have a pkg name.

Fixes https://github.com/pulumi/pulumi-f5bigip/issues/598.
PR in that provider with these changes: https://github.com/pulumi/pulumi-f5bigip/pull/601
