### PR TITLE
Tighten configure cross-tests

### DIFF
--- a/pkg/internal/tests/cross-tests/configure.go
+++ b/pkg/internal/tests/cross-tests/configure.go
@@ -82,6 +82,9 @@ func Configure(
 		return &schema.Provider{
 			Schema: provider,
 			ConfigureContextFunc: func(_ context.Context, rd *schema.ResourceData) (any, diag.Diagnostics) {
+				if rd == nil {
+					return nil, diag.Errorf("Attempted to configure the provider with nil %T", rd)
+				}
 				*writeTo = result{rd, true, false}
 
 				return configureResult, nil
@@ -114,7 +117,7 @@ func Configure(
 	require.NoError(t, tfd.Apply(t, plan))
 
 	require.True(t, tfResult.wasSet, "terraform configure result was not set")
-	require.True(t, tfResult.wasSet, "terraform resource result was not set")
+	require.True(t, tfResult.resourceCreated, "terraform resource result was not set")
 
 	bridgedProvider := pulcheck.BridgedProvider(
 		t, defProviderShortName, makeProvider(&puResult),
@@ -141,8 +144,11 @@ func Configure(
 
 	pt.Up(t)
 
-	require.True(t, tfResult.wasSet, "pulumi configure result was not set")
-	require.True(t, tfResult.wasSet, "pulumi resource result was not set")
+	require.True(t, puResult.wasSet, "pulumi configure result was not set")
+	// We don't create a resource for Pulumi since `pulumi up` will always provision a provider, even when
+	// it won't be used in any resource creation.
+	//
+	//	require.True(t, puResult.resourceCreated, "pulumi resource result was not set")
 
 	assertResourceDataEqual(t, provider, tfResult.data, puResult.data)
 }


### PR DESCRIPTION
As part of diagnosing https://github.com/pulumi/pulumi-terraform-bridge/issues/2530, this commit tightens `crosstests.Configure`. My assumption is that we will occasionally see failures in the bridged provider here.