### PR TITLE
Remove specific PF testing step in CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -47,8 +47,6 @@ jobs:
         run: cd pkg/pf && make build
       - name: Test
         run: make test
-      - name: Test PF
-        run: cd pkg/pf && make test
       - name: Test Dynamic
         run: cd dynamic && make test
       - name: Upload coverage reports to Codecov


### PR DESCRIPTION
Right now, our PF tests run twice in CI: once in the `make test` step and once in the `make -C pkg/pf test` step. This adds a needless 2 minutes to our CI time.

The test duplication was caused when we moved `pf` into `pkg`.