### PR TITLE
PF Diff cross tests

### DIFF
--- a/pkg/internal/tests/cross-tests/diff_check.go
+++ b/pkg/internal/tests/cross-tests/diff_check.go
@@ -15,7 +15,6 @@
 package crosstests
 
 import (
-	"encoding/json"
 	"os"
 	"path/filepath"
 
@@ -85,13 +84,7 @@ func runDiffCheck(t T, tc diffTestCase) crosstestsimpl.DiffResult {
 
 	changes := tfd.driver.ParseChangesFromTFPlan(tfDiffPlan)
 
-	diffResponse := crosstestsimpl.PulumiDiffResp{}
-	for _, entry := range pt.GrpcLog(t).Entries {
-		if entry.Method == "/pulumirpc.ResourceProvider/Diff" {
-			err := json.Unmarshal(entry.Response, &diffResponse)
-			require.NoError(t, err)
-		}
-	}
+	diffResponse := crosstestsimpl.GetPulumiDiffResponse(t, pt)
 	crosstestsimpl.VerifyBasicDiffAgreement(t, changes.Actions, x.Summary, diffResponse)
 
 	return crosstestsimpl.DiffResult{

--- a/pkg/internal/tests/cross-tests/diff_check.go
+++ b/pkg/internal/tests/cross-tests/diff_check.go
@@ -80,7 +80,7 @@ func runDiffCheck(t T, tc diffTestCase) crosstestsimpl.DiffResult {
 	require.NoErrorf(t, err, "writing Pulumi.yaml")
 
 	previewRes := pt.Preview(t)
-	diffResponse := crosstestsimpl.GetPulumiDiffResponse(t, pt)
+	diffResponse := crosstestsimpl.GetPulumiDiffResponse(t, pt.GrpcLog(t).Entries)
 	x := pt.Up(t)
 
 	changes := tfd.driver.ParseChangesFromTFPlan(tfDiffPlan)

--- a/pkg/internal/tests/cross-tests/diff_check.go
+++ b/pkg/internal/tests/cross-tests/diff_check.go
@@ -80,11 +80,11 @@ func runDiffCheck(t T, tc diffTestCase) crosstestsimpl.DiffResult {
 	require.NoErrorf(t, err, "writing Pulumi.yaml")
 
 	previewRes := pt.Preview(t)
+	diffResponse := crosstestsimpl.GetPulumiDiffResponse(t, pt)
 	x := pt.Up(t)
 
 	changes := tfd.driver.ParseChangesFromTFPlan(tfDiffPlan)
 
-	diffResponse := crosstestsimpl.GetPulumiDiffResponse(t, pt)
 	crosstestsimpl.VerifyBasicDiffAgreement(t, changes.Actions, x.Summary, diffResponse)
 
 	return crosstestsimpl.DiffResult{

--- a/pkg/internal/tests/cross-tests/diff_check.go
+++ b/pkg/internal/tests/cross-tests/diff_check.go
@@ -79,6 +79,8 @@ func runDiffCheck(t T, tc diffTestCase) crosstestsimpl.DiffResult {
 		bridgedProvider.P.ResourcesMap().Get(defRtype).Schema(), nil, tfConfig2))
 	err := os.WriteFile(filepath.Join(pt.CurrentStack().Workspace().WorkDir(), "Pulumi.yaml"), yamlProgram, 0o600)
 	require.NoErrorf(t, err, "writing Pulumi.yaml")
+
+	previewRes := pt.Preview(t)
 	x := pt.Up(t)
 
 	changes := tfd.driver.ParseChangesFromTFPlan(tfDiffPlan)
@@ -95,5 +97,7 @@ func runDiffCheck(t T, tc diffTestCase) crosstestsimpl.DiffResult {
 	return crosstestsimpl.DiffResult{
 		TFDiff:     changes,
 		PulumiDiff: diffResponse,
+		TFOut:      tfDiffPlan.StdOut,
+		PulumiOut:  previewRes.StdOut,
 	}
 }

--- a/pkg/internal/tests/cross-tests/impl/diff.go
+++ b/pkg/internal/tests/cross-tests/impl/diff.go
@@ -92,10 +92,10 @@ func GetPulumiDiffResponse(t T, pt *pulumitest.PulumiTest) PulumiDiffResp {
 			require.False(t, found)
 			err := json.Unmarshal(entry.Response, &diffResponse)
 			require.NoError(t, err)
+			found = true
 		}
 	}
 
 	require.True(t, found, "expected to find a diff entry in the gRPC log")
-
 	return diffResponse
 }

--- a/pkg/internal/tests/cross-tests/impl/diff.go
+++ b/pkg/internal/tests/cross-tests/impl/diff.go
@@ -19,6 +19,8 @@ type PulumiDiffResp struct {
 type DiffResult struct {
 	TFDiff     tfcheck.TFChange
 	PulumiDiff PulumiDiffResp
+	TFOut      string
+	PulumiOut  string
 }
 
 func VerifyBasicDiffAgreement(t T, tfActions []string, us auto.UpdateSummary, diffResponse PulumiDiffResp) {

--- a/pkg/internal/tests/cross-tests/impl/diff.go
+++ b/pkg/internal/tests/cross-tests/impl/diff.go
@@ -1,8 +1,10 @@
 package crosstestsimpl
 
 import (
+	"encoding/json"
 	"fmt"
 
+	"github.com/pulumi/providertest/pulumitest"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/stretchr/testify/assert"
@@ -19,8 +21,10 @@ type PulumiDiffResp struct {
 type DiffResult struct {
 	TFDiff     tfcheck.TFChange
 	PulumiDiff PulumiDiffResp
-	TFOut      string
-	PulumiOut  string
+	// TFOut is the stdout of the terraform plan command
+	TFOut string
+	// PulumiOut is the stdout of the pulumi preview command
+	PulumiOut string
 }
 
 func VerifyBasicDiffAgreement(t T, tfActions []string, us auto.UpdateSummary, diffResponse PulumiDiffResp) {
@@ -78,4 +82,20 @@ func VerifyBasicDiffAgreement(t T, tfActions []string, us auto.UpdateSummary, di
 	} else {
 		panic("TODO: do not understand this TF action yet: " + fmt.Sprint(tfActions))
 	}
+}
+
+func GetPulumiDiffResponse(t T, pt *pulumitest.PulumiTest) PulumiDiffResp {
+	diffResponse := PulumiDiffResp{}
+	found := false
+	for _, entry := range pt.GrpcLog(t).Entries {
+		if entry.Method == "/pulumirpc.ResourceProvider/Diff" {
+			require.False(t, found)
+			err := json.Unmarshal(entry.Response, &diffResponse)
+			require.NoError(t, err)
+		}
+	}
+
+	require.True(t, found, "expected to find a diff entry in the gRPC log")
+
+	return diffResponse
 }

--- a/pkg/internal/tests/cross-tests/impl/diff.go
+++ b/pkg/internal/tests/cross-tests/impl/diff.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/pulumi/providertest/pulumitest"
+	"github.com/pulumi/providertest/grpclog"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/stretchr/testify/assert"
@@ -84,18 +84,18 @@ func VerifyBasicDiffAgreement(t T, tfActions []string, us auto.UpdateSummary, di
 	}
 }
 
-func GetPulumiDiffResponse(t T, pt *pulumitest.PulumiTest) PulumiDiffResp {
+func GetPulumiDiffResponse(t T, entries []grpclog.GrpcLogEntry) PulumiDiffResp {
 	diffResponse := PulumiDiffResp{}
 	found := false
-	for _, entry := range pt.GrpcLog(t).Entries {
+	for _, entry := range entries {
+		t.Logf("entry.Method: %s", entry.Method)
 		if entry.Method == "/pulumirpc.ResourceProvider/Diff" {
-			require.False(t, found)
+			require.False(t, found, "expected to find only one Diff entry in the gRPC log")
 			err := json.Unmarshal(entry.Response, &diffResponse)
 			require.NoError(t, err)
 			found = true
 		}
 	}
 
-	require.True(t, found, "expected to find a diff entry in the gRPC log")
 	return diffResponse
 }

--- a/pkg/pf/tests/diff_test.go
+++ b/pkg/pf/tests/diff_test.go
@@ -2,9 +2,48 @@ package tfbridgetests
 
 import (
 	"testing"
+
+	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hexops/autogold/v2"
+	crosstests "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/cross-tests"
+	"github.com/zclconf/go-cty/cty"
 )
 
-
-func TestDiff(t *testing.T) {
+func TestSimpleNoDiff(t *testing.T) {
 	t.Parallel()
+
+	sch := rschema.Schema{
+		Attributes: map[string]rschema.Attribute{
+			"key": rschema.StringAttribute{Optional: true},
+		},
+	}
+
+	res := crosstests.Diff(t, sch,
+		map[string]cty.Value{"key": cty.StringVal("value")}, map[string]cty.Value{"key": cty.StringVal("value1")})
+
+	autogold.Expect(`
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id  = "test-id"
+      ~ key = "value" -> "value1"
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`).Equal(t, res.TFOut)
+	autogold.Expect(`Previewing update (test):
+
+ ~  testprovider:index:Test p update [diff: ~key]
+    pulumi:pulumi:Stack project-test
+Resources:
+    ~ 1 to update
+    1 unchanged
+
+`).Equal(t, res.PulumiOut)
 }

--- a/pkg/pf/tests/diff_test.go
+++ b/pkg/pf/tests/diff_test.go
@@ -1,0 +1,10 @@
+package tfbridgetests
+
+import (
+	"testing"
+)
+
+
+func TestDiff(t *testing.T) {
+	t.Parallel()
+}

--- a/pkg/pf/tests/internal/cross-tests/diff.go
+++ b/pkg/pf/tests/internal/cross-tests/diff.go
@@ -136,7 +136,7 @@ func Diff(t *testing.T, schema rschema.Schema, tfConfig1, tfConfig2 map[string]c
 
 		pulumiRes = pt.Up(t)
 
-		diffResponse = crosstestsimpl.GetPulumiDiffResponse(t, pt)
+		diffResponse = crosstestsimpl.GetPulumiDiffResponse(t, pt.GrpcLog(t).Entries)
 	})
 
 	skipCompare := t.Failed() || t.Skipped()

--- a/pkg/pf/tests/internal/cross-tests/diff.go
+++ b/pkg/pf/tests/internal/cross-tests/diff.go
@@ -1,0 +1,186 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crosstests
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	crosstests "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/tests/cross-tests"
+	crosstestsimpl "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/tests/cross-tests/impl"
+	pb "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/providerbuilder"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/pulcheck"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/tfcheck"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
+	"github.com/pulumi/pulumi/sdk/v3/go/auto"
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+	"gopkg.in/yaml.v3"
+)
+
+// MakeDiff returns a [testing] subtest of [Diff].
+//
+//	func TestMyProperty(t *testing.T) {
+//		t.Run("my-subtest", crosstests.MakeDiff(schema, tfConfig, puConfig))
+//	}
+//
+// For details on the test itself, see [Diff].
+func MakeDiff(schema rschema.Schema, tfConfig1, tfConfig2 map[string]cty.Value, options ...DiffOption) func(t *testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+		Diff(t, schema, tfConfig1, tfConfig2, options...)
+	}
+}
+
+// Diff will assert that given two resource configurations, the diffs are the same
+// when computed by Terraform and Pulumi.
+//
+// Diff should be safe to run in parallel.
+func Diff(t *testing.T, schema rschema.Schema, tfConfig1, tfConfig2 map[string]cty.Value, options ...DiffOption) crosstestsimpl.DiffResult {
+	skipUnlessLinux(t)
+
+	var opts diffOpts
+	for _, f := range options {
+		f(&opts)
+	}
+
+	// By default, logs only show when they are on a failed test. By logging to
+	// topLevelT, we can log items to be shown if downstream tests fail.
+	topLevelT := t
+
+	prov := pb.NewProvider(pb.NewProviderArgs{
+		AllResources: []pb.Resource{{
+			Name:           "res",
+			ResourceSchema: schema,
+		}},
+	})
+
+	shimProvider := tfbridge.ShimProvider(prov)
+
+	var tfChanges tfcheck.TFChange
+	var pulumiRes auto.UpResult
+	var diffResponse crosstestsimpl.PulumiDiffResp
+	t.Run("tf", func(t *testing.T) {
+		defer propagateSkip(topLevelT, t)
+		var hcl1 bytes.Buffer
+
+		err := WritePF(&hcl1).Resource(schema, "res", "res", tfConfig1)
+		require.NoError(t, err)
+
+		driver := tfcheck.NewTfDriver(t, t.TempDir(), prov.TypeName, prov)
+
+		driver.Write(t, hcl1.String())
+		plan, err := driver.Plan(t)
+		require.NoError(t, err)
+		err = driver.Apply(t, plan)
+		require.NoError(t, err)
+
+		var hcl2 bytes.Buffer
+		err = WritePF(&hcl2).Resource(schema, "res", "res", tfConfig2)
+		require.NoError(t, err)
+		driver.Write(t, hcl2.String())
+		plan, err = driver.Plan(t)
+		require.NoError(t, err)
+		tfChanges = driver.ParseChangesFromTFPlan(plan)
+	})
+
+	t.Run("bridged", func(t *testing.T) {
+		defer propagateSkip(topLevelT, t)
+
+		puConfig1 := crosstestsimpl.InferPulumiValue(t,
+			shimProvider.ResourcesMap().Get("res").Schema(),
+			opts.resourceInfo,
+			cty.ObjectVal(tfConfig1),
+		)
+
+		puConfig2 := crosstestsimpl.InferPulumiValue(t,
+			shimProvider.ResourcesMap().Get("res").Schema(),
+			opts.resourceInfo,
+			cty.ObjectVal(tfConfig2),
+		)
+
+		pulumiYaml1 := map[string]any{
+			"name":    "project",
+			"runtime": "yaml",
+			"resources": map[string]any{
+				"p": map[string]any{
+					"type":       "testprovider:res",
+					"properties": crosstests.ConvertResourceValue(t, puConfig1),
+				},
+			},
+		}
+
+		pulumiYaml2 := map[string]any{
+			"name":    "project",
+			"runtime": "yaml",
+			"resources": map[string]any{
+				"p": map[string]any{
+					"type":       "testprovider:res",
+					"properties": crosstests.ConvertResourceValue(t, puConfig2),
+				},
+			},
+		}
+
+		bytes, err := yaml.Marshal(pulumiYaml1)
+		require.NoError(t, err)
+		topLevelT.Logf("Pulumi.yaml:\n%s", string(bytes))
+
+		pt, err := pulcheck.PulCheck(t, bridgedProvider(prov), string(bytes))
+		require.NoError(t, err)
+		pt.Up(t)
+
+		bytes, err = yaml.Marshal(pulumiYaml2)
+		require.NoError(t, err)
+		topLevelT.Logf("Pulumi.yaml:\n%s", string(bytes))
+		pt.WritePulumiYaml(t, string(bytes))
+		pulumiRes = pt.Up(t)
+
+		diffResponse = crosstestsimpl.PulumiDiffResp{}
+		for _, entry := range pt.GrpcLog(t).Entries {
+			if entry.Method == "/pulumirpc.ResourceProvider/Diff" {
+				err := json.Unmarshal(entry.Response, &diffResponse)
+				require.NoError(t, err)
+			}
+		}
+	})
+
+	skipCompare := t.Failed() || t.Skipped()
+	t.Run("compare", func(t *testing.T) {
+		if skipCompare {
+			t.Skipf("skipping since earlier steps did not complete")
+		}
+
+		crosstestsimpl.VerifyBasicDiffAgreement(t, tfChanges.Actions, pulumiRes.Summary, diffResponse)
+	})
+
+	return crosstestsimpl.DiffResult{
+		TFDiff:     tfChanges,
+		PulumiDiff: diffResponse,
+	}
+}
+
+type diffOpts struct {
+	resourceInfo map[string]*info.Schema
+}
+
+type DiffOption func(*diffOpts)
+
+// DiffProviderInfo specifies a map of [info.Schema] to apply to the provider under test.
+func DiffProviderInfo(info map[string]*info.Schema) DiffOption {
+	return func(o *diffOpts) { o.resourceInfo = info }
+}

--- a/pkg/pf/tests/internal/cross-tests/diff.go
+++ b/pkg/pf/tests/internal/cross-tests/diff.go
@@ -80,7 +80,7 @@ func Diff(t *testing.T, schema rschema.Schema, tfConfig1, tfConfig2 map[string]c
 		defer propagateSkip(topLevelT, t)
 		var hcl1 bytes.Buffer
 
-		err := WritePF(&hcl1).Resource(schema, "testprovider_test", "res", tfConfig1)
+		err := writeResource(&hcl1, schema, "testprovider_test", "res", tfConfig1)
 		require.NoError(t, err)
 
 		driver := tfcheck.NewTfDriver(t, t.TempDir(), prov.TypeName, prov)
@@ -92,7 +92,7 @@ func Diff(t *testing.T, schema rschema.Schema, tfConfig1, tfConfig2 map[string]c
 		require.NoError(t, err)
 
 		var hcl2 bytes.Buffer
-		err = WritePF(&hcl2).Resource(schema, "testprovider_test", "res", tfConfig2)
+		err = writeResource(&hcl2, schema, "testprovider_test", "res", tfConfig2)
 		require.NoError(t, err)
 		driver.Write(t, hcl2.String())
 		plan, err = driver.Plan(t)

--- a/pkg/pf/tests/internal/cross-tests/diff.go
+++ b/pkg/pf/tests/internal/cross-tests/diff.go
@@ -16,7 +16,6 @@ package crosstests
 
 import (
 	"bytes"
-	"encoding/json"
 	"testing"
 
 	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -137,13 +136,7 @@ func Diff(t *testing.T, schema rschema.Schema, tfConfig1, tfConfig2 map[string]c
 
 		pulumiRes = pt.Up(t)
 
-		diffResponse = crosstestsimpl.PulumiDiffResp{}
-		for _, entry := range pt.GrpcLog(t).Entries {
-			if entry.Method == "/pulumirpc.ResourceProvider/Diff" {
-				err := json.Unmarshal(entry.Response, &diffResponse)
-				require.NoError(t, err)
-			}
-		}
+		diffResponse = crosstestsimpl.GetPulumiDiffResponse(t, pt)
 	})
 
 	skipCompare := t.Failed() || t.Skipped()


### PR DESCRIPTION
This change adds the framework code for running Diff cross-tests in PF. It also adds a simple cross-test to show the framework works. I'll add additional coverage in a follow-up PR.

I've also exposed the Stdout output of both TF Plan and Pulumi Preview, so that they can be recorded in the cross-test. This will allow us to use the cross-tests for testing accurate bridge previews.

related to https://github.com/pulumi/pulumi-terraform-bridge/issues/2297