### PR TITLE
Post-code-translation edit rules: Configuration Schema and datasource

### DIFF
--- a/pkg/tfgen/edit_rules.go
+++ b/pkg/tfgen/edit_rules.go
@@ -74,6 +74,8 @@ func defaultEditRules() editRules {
 		reReplace("`provider` block", "provider configuration", info.PostCodeTranslation),
 		reReplace("Data Source", "Function", info.PostCodeTranslation),
 		reReplace("data source", "function", info.PostCodeTranslation),
+		reReplace("Datasource", "Function", info.PostCodeTranslation),
+		reReplace("datasource", "function", info.PostCodeTranslation),
 	}
 }
 

--- a/pkg/tfgen/edit_rules.go
+++ b/pkg/tfgen/edit_rules.go
@@ -65,6 +65,8 @@ func defaultEditRules() editRules {
 			`Configuration Reference`, info.PostCodeTranslation),
 		reReplace(`# Arguments`,
 			`# Configuration Reference`, info.PostCodeTranslation),
+		reReplace(`# Configuration Schema`,
+			`# Configuration Reference`, info.PostCodeTranslation),
 		reReplace(`# Schema`,
 			`# Configuration Reference`, info.PostCodeTranslation),
 		reReplace("### Optional\n", "", info.PostCodeTranslation),

--- a/pkg/tfgen/edit_rules_test.go
+++ b/pkg/tfgen/edit_rules_test.go
@@ -217,6 +217,23 @@ func TestApplyEditRules(t *testing.T) {
 			phase:    info.PostCodeTranslation,
 		},
 		{
+			// Found in snowflake
+			name: "Replaces 'datasource' with 'function'",
+			docFile: DocFile{
+				Content: []byte("Currently deprecated datasources"),
+			},
+			expected: []byte("Currently deprecated functions"),
+			phase:    info.PostCodeTranslation,
+		},
+		{
+			name: "Replaces 'Datasource' with 'Function'",
+			docFile: DocFile{
+				Content: []byte("How About This Datasource"),
+			},
+			expected: []byte("How About This Function"),
+			phase:    info.PostCodeTranslation,
+		},
+		{
 			name: "Replaces 'Terraform W/workspace' with 'Pulumi Stack'",
 			docFile: DocFile{
 				Content: []byte("Manage a single Schema Registry cluster in the same Terraform workspace"),

--- a/pkg/tfgen/edit_rules_test.go
+++ b/pkg/tfgen/edit_rules_test.go
@@ -256,6 +256,15 @@ func TestApplyEditRules(t *testing.T) {
 			expected: []byte("Manage a single Schema Registry cluster"),
 			phase:    info.PostCodeTranslation,
 		},
+		{
+			// Found in snowflake
+			name: "Replaces '# Configuration Schema' with '# Configuration Reference  ",
+			docFile: DocFile{
+				Content: []byte("# Configuration Schema"),
+			},
+			expected: []byte("# Configuration Reference"),
+			phase:    info.PostCodeTranslation,
+		},
 	}
 	edits := defaultEditRules()
 


### PR DESCRIPTION
Papercuts discovered when generating Snowflake's registry `_index.md` file.

The string "D/datasource" should be translated to "function", and "Configuration Schema" would translate to "Configuration Configuration Reference" without tis change.

They're worth having as global rules in my opinion.


- **Add datasource -> function replace edit rule**
- **Add replace rule for '# Configuration Schema' because some providers are extra special**
