### PR TITLE
 cross-test.Configure create a dependent resource

### DIFF
--- a/pkg/internal/tests/cross-tests/configure.go
+++ b/pkg/internal/tests/cross-tests/configure.go
@@ -20,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"
 	"gopkg.in/yaml.v3"
@@ -64,7 +63,7 @@ func Configure(
 	} else {
 		puConfig = crosstestsimpl.InferPulumiValue(t,
 			shimv2.NewSchemaMap(provider),
-			opts.resourceInfo.GetFields(),
+			opts.providerInfo,
 			tfConfig,
 		)
 	}
@@ -121,40 +120,34 @@ func Configure(
 
 	bridgedProvider := pulcheck.BridgedProvider(
 		t, defProviderShortName, makeProvider(&puResult),
-		pulcheck.WithResourceInfo(map[string]*info.Resource{defRtype: opts.resourceInfo}),
+		pulcheck.WithConfigInfo(opts.providerInfo),
+		pulcheck.WithResourceInfo(map[string]*info.Resource{defRtype: {Tok: defRtoken}}),
 	)
-	pd := &pulumiDriver{
-		name:                defProviderShortName,
-		pulumiResourceToken: "pulumi:providers:" + defProviderShortName,
-	}
 
-	data, err := generateYaml(t, pd.pulumiResourceToken, puConfig)
+	data, err := generateYaml(t, "pulumi:providers:"+defProviderShortName, puConfig)
 	require.NoErrorf(t, err, "generateYaml")
 	data["resources"].(map[string]any)["res"] = map[string]any{
-		"type":       "crosstests:Res",
+		"type":       defRtoken,
 		"properties": map[string]any{},
+		"options": map[string]any{
+			"provider": "${example}",
+		},
 	}
-	b, err := yaml.Marshal(data)
+	yamlProgram, err := yaml.Marshal(data)
 	require.NoErrorf(t, err, "marshaling Pulumi.yaml")
-	t.Logf("\n\n%s", b)
+	t.Logf("\n\n%s", yamlProgram)
 
-	yamlProgram := pd.generateYAML(t, puConfig)
+	pulcheck.PulCheck(t, bridgedProvider, string(yamlProgram)).Up(t)
 
-	pt := pulcheck.PulCheck(t, bridgedProvider, string(yamlProgram))
-
-	pt.Up(t)
-
-	require.True(t, puResult.wasSet, "pulumi configure result was not set")
-	// We don't create a resource for Pulumi since `pulumi up` will always provision a provider, even when
-	// it won't be used in any resource creation.
-	//
-	//	require.True(t, puResult.resourceCreated, "pulumi resource result was not set")
+	require.True(t, puResult.wasSet, "pulumi configure result was not set (.resourceCreated = %t)",
+		puResult.resourceCreated)
+	require.True(t, puResult.resourceCreated, "pulumi resource result was not set")
 
 	assertResourceDataEqual(t, provider, tfResult.data, puResult.data)
 }
 
 type configureOpts struct {
-	resourceInfo *info.Resource
+	providerInfo map[string]*info.Schema
 	puConfig     *resource.PropertyMap
 }
 
@@ -162,9 +155,8 @@ type configureOpts struct {
 type ConfigureOption func(*configureOpts)
 
 // CreateResourceInfo specifies an [info.Resource] to apply to the resource under test.
-func ConfigureProviderInfo(info info.Resource) ConfigureOption {
-	contract.Assertf(info.Tok == "", "cannot set info.Tok, it will not be respected")
-	return func(o *configureOpts) { o.resourceInfo = &info }
+func ConfigureProviderInfo(info map[string]*info.Schema) ConfigureOption {
+	return func(o *configureOpts) { o.providerInfo = info }
 }
 
 // ConfigurePulumiConfig specifies an explicit pulumi value for the configure call.

--- a/pkg/tests/pulcheck/pulcheck.go
+++ b/pkg/tests/pulcheck/pulcheck.go
@@ -130,6 +130,7 @@ type bridgedProviderOpts struct {
 	DisablePlanResourceChange bool
 	StateEdit                 shimv2.PlanStateEditFunc
 	resourceInfo              map[string]*info.Resource
+	configInfo                map[string]*info.Schema
 }
 
 // BridgedProviderOpts
@@ -156,6 +157,14 @@ func WithResourceInfo(info map[string]*info.Resource) BridgedProviderOpt {
 	return func(o *bridgedProviderOpts) { o.resourceInfo = info }
 }
 
+// WithResourceInfo allows the user to set the info.Provider.Config field within a
+// [BridgedProvider].
+//
+// This is an experimental API.
+func WithConfigInfo(info map[string]*info.Schema) BridgedProviderOpt {
+	return func(o *bridgedProviderOpts) { o.configInfo = info }
+}
+
 // This is an experimental API.
 func BridgedProvider(t T, providerName string, tfp *schema.Provider, opts ...BridgedProviderOpt) info.Provider {
 	var options bridgedProviderOpts
@@ -179,6 +188,7 @@ func BridgedProvider(t T, providerName string, tfp *schema.Provider, opts ...Bri
 		MetadataInfo:                   &tfbridge.MetadataInfo{},
 		EnableZeroDefaultSchemaVersion: true,
 		Resources:                      options.resourceInfo,
+		Config:                         options.configInfo,
 	}
 	makeToken := func(module, name string) (string, error) {
 		return tokens.MakeStandard(providerName)(module, name)


### PR DESCRIPTION
Another attempt to address #2530.

- a58b69838f211a2fc6e190a214fae42185401c7d creates a resource that depends on the provider under test. This makes the requirement to call Configure more explicit to the engine. This fix considers if there is an engine/automation API bug when an explicit provider is created but not depended on.
- da20c5908120a4c48da6264727b648a268a1a5ff adds the full gRPC log to our output in case the failure trips again. This will tell us definitively if the error is in the engine or in the bridge.