### PR TITLE
Improve automatic token mapping docs

### DIFF
--- a/docs/automatic-token-mapping.md
+++ b/docs/automatic-token-mapping.md
@@ -6,6 +6,29 @@ Automatic token mappings provide a programmatic way to map Terraform tokens to P
 
 `tfbridge.ProviderInfo.ComputeTokens` (or `tfbridge.ProviderInfo.MustComputeTokens` to panic on errors) is the entry point for automatic token mapping. `ComputeTokens` takes a strategy, which dictates how each Terraform token maps to Pulumi tokens. There are 4 built-in strategies, which cover most use cases. The interface is open, so you may write a custom strategy.
 
+```go
+import (
+	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
+	"github.com/pulumi/pulumi-terraform-bridge/pkg/tfbridge/info"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/tokens"
+)
+
+func Provider() info.Provider {
+	prov := info.Provider{
+    	Name: "myprovider",
+        P: shimv2.NewProvider(upstream.Provider()),
+
+        Resources: map[string]*info.Resource{
+        	# Automatic token maping will ignore resources that are manually mapped.
+        },
+        # ...
+    }
+
+    // myprovider_some_resource => myprovider:index/someResource:SomeResource
+    prov.MustComputeTokens(tokens.SingleModule("oci_", "index", tokens.MakeStandard("myprovider")))
+}
+```
+
 ## Mapping Strategies
 
 [Mapping strategies](https://github.com/pulumi/pulumi-terraform-bridge/blob/5e17c6c7e2d877db7e1d9c0b953a06d3ecabbaea/pkg/tfbridge/tokens.go#L32-L38) dictate the mapping from Terraform to Pulumi tokens. There are 4 Pulumi maintained strategies in the bridge. They live in "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/tokens".
@@ -36,7 +59,7 @@ Consider the following example:
 
 ```go
 m := map[string]string{"mod1": "foo", "mod2": "bar"}
-strategy := tokens.KnownModules("pkg_", "index", m, tokens.MakeStandard("pkg"))
+strategy := tokens.MappedModules("pkg_", "index", m, tokens.MakeStandard("pkg"))
 ```
 
 `strategy` will map `pkg_mod1_resource` to `pkg:foo/resource:Resource` and `pkg_mod2_datasource` to `pkg:bar/datasource:getDatasource`. `tokens.MappedModules` has the same behavior as `tokens.KnownModules` for Terraform tokens that don't have a matching prefix.


### PR DESCRIPTION
Fix a copy+pasta typo and add a full example for our automatic token mapping doc.