### PR TITLE
Make pf data source map mutable

### DIFF
--- a/pkg/pf/internal/schemashim/provider.go
+++ b/pkg/pf/internal/schemashim/provider.go
@@ -35,6 +35,7 @@ type SchemaOnlyProvider struct {
 	ctx         context.Context
 	tf          pfprovider.Provider
 	resourceMap shim.ResourceMap
+	dataSourceMap shim.ResourceMap
 }
 
 func (p *SchemaOnlyProvider) Server(ctx context.Context) (tfprotov6.ProviderServer, error) {
@@ -87,11 +88,7 @@ func (p *SchemaOnlyProvider) ResourcesMap() shim.ResourceMap {
 }
 
 func (p *SchemaOnlyProvider) DataSourcesMap() shim.ResourceMap {
-	dataSources, err := pfutils.GatherDatasources(context.TODO(), p.tf, NewSchemaMap)
-	if err != nil {
-		panic(err)
-	}
-	return &schemaOnlyDataSourceMap{dataSources}
+	return p.dataSourceMap
 }
 
 func (p *SchemaOnlyProvider) InternalValidate() error {

--- a/pkg/pf/internal/schemashim/schemashim.go
+++ b/pkg/pf/internal/schemashim/schemashim.go
@@ -28,10 +28,16 @@ func ShimSchemaOnlyProvider(ctx context.Context, provider pfprovider.Provider) s
 	if err != nil {
 		panic(err)
 	}
+	dataSources, err := pfutils.GatherDatasources(ctx, provider, NewSchemaMap)
+	if err != nil {
+		panic(err)
+	}
 	resourceMap := newSchemaOnlyResourceMap(resources)
+	dataSourceMap := newSchemaOnlyDataSourceMap(dataSources)
 	return &SchemaOnlyProvider{
-		ctx:         ctx,
-		tf:          provider,
-		resourceMap: resourceMap,
+		ctx:           ctx,
+		tf:            provider,
+		resourceMap:   resourceMap,
+		dataSourceMap: dataSourceMap,
 	}
 }

--- a/pkg/pf/tests/internal/providerbuilder/build_datasource.go
+++ b/pkg/pf/tests/internal/providerbuilder/build_datasource.go
@@ -1,0 +1,46 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package providerbuilder
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+)
+
+type DataSource struct {
+	Name             string
+	DataSourceSchema schema.Schema
+
+	ReadFunc func(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse)
+}
+
+func (r *DataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, re *datasource.MetadataResponse) {
+	re.TypeName = req.ProviderTypeName + "_" + r.Name
+}
+
+func (r *DataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, re *datasource.SchemaResponse) {
+	re.Schema = r.DataSourceSchema
+}
+
+func (r *DataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	if r.ReadFunc == nil {
+		return
+	}
+	r.ReadFunc(ctx, req, resp)
+}
+
+var _ datasource.DataSource = &DataSource{}

--- a/pkg/pf/tests/internal/providerbuilder/build_datasource.go
+++ b/pkg/pf/tests/internal/providerbuilder/build_datasource.go
@@ -37,9 +37,6 @@ func (r *DataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, re 
 }
 
 func (r *DataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	if r.ReadFunc == nil {
-		return
-	}
 	r.ReadFunc(ctx, req, resp)
 }
 


### PR DESCRIPTION
This change makes the PF datasources map mutable in order to support aliases like we do for resources.

The changes here mimic what we did for resources in https://github.com/pulumi/pulumi-terraform-bridge/pull/1938

Related to https://github.com/pulumi/pulumi-terraform-bridge/issues/2585