### PR TITLE
Support data source aliasing using clone

### DIFF
--- a/pkg/pf/internal/schemashim/provider.go
+++ b/pkg/pf/internal/schemashim/provider.go
@@ -35,6 +35,7 @@ type SchemaOnlyProvider struct {
 	ctx         context.Context
 	tf          pfprovider.Provider
 	resourceMap shim.ResourceMap
+	dataSourceMap shim.ResourceMap
 }
 
 func (p *SchemaOnlyProvider) Server(ctx context.Context) (tfprotov6.ProviderServer, error) {
@@ -87,11 +88,7 @@ func (p *SchemaOnlyProvider) ResourcesMap() shim.ResourceMap {
 }
 
 func (p *SchemaOnlyProvider) DataSourcesMap() shim.ResourceMap {
-	dataSources, err := pfutils.GatherDatasources(context.TODO(), p.tf, NewSchemaMap)
-	if err != nil {
-		panic(err)
-	}
-	return &schemaOnlyDataSourceMap{dataSources}
+	return p.dataSourceMap
 }
 
 func (p *SchemaOnlyProvider) InternalValidate() error {

--- a/pkg/pf/internal/schemashim/schemashim.go
+++ b/pkg/pf/internal/schemashim/schemashim.go
@@ -28,10 +28,16 @@ func ShimSchemaOnlyProvider(ctx context.Context, provider pfprovider.Provider) s
 	if err != nil {
 		panic(err)
 	}
+	dataSources, err := pfutils.GatherDatasources(ctx, provider, NewSchemaMap)
+	if err != nil {
+		panic(err)
+	}
 	resourceMap := newSchemaOnlyResourceMap(resources)
+	dataSourceMap := newSchemaOnlyDataSourceMap(dataSources)
 	return &SchemaOnlyProvider{
-		ctx:         ctx,
-		tf:          provider,
-		resourceMap: resourceMap,
+		ctx:           ctx,
+		tf:            provider,
+		resourceMap:   resourceMap,
+		dataSourceMap: dataSourceMap,
 	}
 }

--- a/pkg/pf/tests/internal/providerbuilder/build_datasource.go
+++ b/pkg/pf/tests/internal/providerbuilder/build_datasource.go
@@ -1,0 +1,46 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package providerbuilder
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+)
+
+type DataSource struct {
+	Name             string
+	DataSourceSchema schema.Schema
+
+	ReadFunc func(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse)
+}
+
+func (r *DataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, re *datasource.MetadataResponse) {
+	re.TypeName = req.ProviderTypeName + "_" + r.Name
+}
+
+func (r *DataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, re *datasource.SchemaResponse) {
+	re.Schema = r.DataSourceSchema
+}
+
+func (r *DataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	if r.ReadFunc == nil {
+		return
+	}
+	r.ReadFunc(ctx, req, resp)
+}
+
+var _ datasource.DataSource = &DataSource{}

--- a/pkg/pf/tests/internal/providerbuilder/build_datasource.go
+++ b/pkg/pf/tests/internal/providerbuilder/build_datasource.go
@@ -37,9 +37,6 @@ func (r *DataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, re 
 }
 
 func (r *DataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	if r.ReadFunc == nil {
-		return
-	}
 	r.ReadFunc(ctx, req, resp)
 }
 

--- a/pkg/pf/tests/tfgen_test.go
+++ b/pkg/pf/tests/tfgen_test.go
@@ -64,7 +64,7 @@ func TestRenameResourceWithAliasInAugmentedProvider(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestRenameDataSourceWithAliasInAugmentedProvider(t *testing.T) {
+func TestRenameMuxedDataSourceWithAliasInAugmentedProvider(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	discardSink := diag.DefaultSink(os.Stdout, os.Stdout, diag.FormatOptions{Color: colors.Never})
@@ -93,6 +93,9 @@ func TestRenameDataSourceWithAliasInAugmentedProvider(t *testing.T) {
 	i.RenameDataSource(fullDataSourceID, legacyToken, aliasToken, resModule, resModule, nil)
 	_, err := tfgen.GenerateSchema(i, discardSink)
 	require.NoError(t, err)
-	_, err = i.P.(*muxer.ProviderShim).ResolveDispatch(&i)
+	table, err := i.P.(*muxer.ProviderShim).ResolveDispatch(&i)
 	require.NoError(t, err)
+
+	require.Contains(t, table.Functions, string(aliasToken))
+	require.Contains(t, table.Functions, string(legacyToken))
 }

--- a/pkg/pf/tests/tfgen_test.go
+++ b/pkg/pf/tests/tfgen_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 func TestRenameResourceWithAliasInAugmentedProvider(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	ctx := context.Background()
 	discardSink := diag.DefaultSink(os.Stdout, os.Stdout, diag.FormatOptions{Color: colors.Never})
 	providerID := "my"
@@ -58,6 +58,39 @@ func TestRenameResourceWithAliasInAugmentedProvider(t *testing.T) {
 		},
 	}
 	i.RenameResourceWithAlias(fullResourceID, legacyToken, aliasToken, resModule, resModule, nil)
+	_, err := tfgen.GenerateSchema(i, discardSink)
+	require.NoError(t, err)
+	_, err = i.P.(*muxer.ProviderShim).ResolveDispatch(&i)
+	require.NoError(t, err)
+}
+
+func TestRenameDataSourceWithAliasInAugmentedProvider(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	discardSink := diag.DefaultSink(os.Stdout, os.Stdout, diag.FormatOptions{Color: colors.Never})
+	providerID := "my"
+	dataSourceID := "ds"
+	fullDataSourceID := fmt.Sprintf("%s_%s", providerID, dataSourceID)
+	resModule := "mod"
+	baselineProvider := (&helper.Provider{}).Shim()
+	pfProvider := pb.NewProvider(pb.NewProviderArgs{
+		TypeName: providerID,
+		AllDataSources: []providerbuilder.DataSource{
+			{Name: dataSourceID},
+		},
+	})
+
+	legacyToken := tokens.ModuleMember(fmt.Sprintf("my:%s:DataSource", resModule))
+	aliasToken := tokens.ModuleMember(fmt.Sprintf("my:%s:LegacyDataSource", resModule))
+	di := &info.DataSource{Tok: legacyToken}
+	i := info.Provider{
+		Name: providerID,
+		P:    muxer.AugmentShimWithPF(ctx, baselineProvider, pfProvider),
+		DataSources: map[string]*info.DataSource{
+			fullDataSourceID: di,
+		},
+	}
+	i.RenameDataSource(fullDataSourceID, legacyToken, aliasToken, resModule, resModule, nil)
 	_, err := tfgen.GenerateSchema(i, discardSink)
 	require.NoError(t, err)
 	_, err = i.P.(*muxer.ProviderShim).ResolveDispatch(&i)

--- a/pkg/tfbridge/info/rename.go
+++ b/pkg/tfbridge/info/rename.go
@@ -60,10 +60,10 @@ func (p *Provider) RenameResourceWithAlias(resourceName string, legacyTok tokens
 }
 
 // RenameDataSource adds an alias to a data source and marks the original as deprecated.
-func (p *Provider) RenameDataSource(resourceName string, legacyTok tokens.ModuleMember, newTok tokens.ModuleMember,
+func (p *Provider) RenameDataSource(dataSourceName string, legacyTok tokens.ModuleMember, newTok tokens.ModuleMember,
 	legacyModule string, newModule string, info *DataSource,
 ) {
-	legacyResourceName := resourceName + RenamedEntitySuffix
+	legacyResourceName := dataSourceName + RenamedEntitySuffix
 	if info == nil {
 		info = &DataSource{}
 	}
@@ -83,9 +83,9 @@ func (p *Provider) RenameDataSource(resourceName string, legacyTok tokens.Module
 			legacyInfo.Tok.Name().String()),
 		generateResourceName(currentInfo.Tok.Module().Package(), strings.ToLower(newModule),
 			currentInfo.Tok.Name().String()))
-	p.DataSources[resourceName] = &currentInfo
+	p.DataSources[dataSourceName] = &currentInfo
 	p.DataSources[legacyResourceName] = &legacyInfo
-	err := shim.CloneResource(p.P.DataSourcesMap(), resourceName, legacyResourceName)
+	err := shim.CloneResource(p.P.DataSourcesMap(), dataSourceName, legacyResourceName)
 	contract.AssertNoErrorf(err, "Failed to rename the data source")
 }
 

--- a/pkg/tfbridge/info/rename.go
+++ b/pkg/tfbridge/info/rename.go
@@ -59,6 +59,7 @@ func (p *Provider) RenameResourceWithAlias(resourceName string, legacyTok tokens
 	contract.AssertNoErrorf(err, "Failed to rename the resource")
 }
 
+// RenameDataSource adds an alias to a data source and marks the original as deprecated.
 func (p *Provider) RenameDataSource(resourceName string, legacyTok tokens.ModuleMember, newTok tokens.ModuleMember,
 	legacyModule string, newModule string, info *DataSource,
 ) {

--- a/pkg/tfbridge/info/rename.go
+++ b/pkg/tfbridge/info/rename.go
@@ -84,7 +84,8 @@ func (p *Provider) RenameDataSource(resourceName string, legacyTok tokens.Module
 			currentInfo.Tok.Name().String()))
 	p.DataSources[resourceName] = &currentInfo
 	p.DataSources[legacyResourceName] = &legacyInfo
-	p.P.DataSourcesMap().Set(legacyResourceName, p.P.DataSourcesMap().Get(resourceName))
+	err := shim.CloneResource(p.P.DataSourcesMap(), resourceName, legacyResourceName)
+	contract.AssertNoErrorf(err, "Failed to rename the data source")
 }
 
 func generateResourceName(packageName tokens.Package, moduleName string, moduleMemberName string) string {


### PR DESCRIPTION
This changes allows us to support automatic aliasing of legacy data sources. This now means that data sources mimic what we do for resources.

fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/2585
related to https://github.com/pulumi/pulumi-terraform-bridge/pull/1938