### PR TITLE
Exclude vendored and deprecated folders from codecov metrics

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,3 +6,7 @@ coverage:
     patch:
       default:
         informational: true
+ignore:
+  - "pkg/vendored"
+  # deprecated
+  - "pkg/tfshim/tfplugin5"


### PR DESCRIPTION
The two biggest sources of missed line coverage in the repo are the vendored folder and tfplugin5 which was never in use. The account for a third of all missed lines in the repo. We should exclude these from metrics in order to make them more representative.