### PR TITLE
Move capitalization logic into getPackageDisplayName

### DIFF
--- a/pkg/tfgen/installation_docs_test.go
+++ b/pkg/tfgen/installation_docs_test.go
@@ -351,7 +351,7 @@ func TestWriteFrontMatter(t *testing.T) {
 
 	tc := testCase{
 		name:         "Generates Front Matter for installation-configuration.md",
-		providerName: "test",
+		providerName: "Test",
 		expected: delimiter +
 			"# *** WARNING: This file was auto-generated. " +
 			"Do not edit by hand unless you're certain you know what you are doing! ***\n" +

--- a/pkg/tfgen/installation_docs_test.go
+++ b/pkg/tfgen/installation_docs_test.go
@@ -131,6 +131,17 @@ func TestDisplayNameFallback(t *testing.T) {
 			pkgName:  "Horse",
 			expected: "Horse",
 		},
+		{
+			name:     "Capitalizes pkgName if lower case",
+			pkgName:  "shetlandpony",
+			expected: "Shetlandpony",
+		},
+		{
+			name:        "Does not alter Display Name",
+			displayName: "Palo Alto Networks Cloud NGFW For AWS Provider",
+			pkgName:     "cloudngfwaws",
+			expected:    "Palo Alto Networks Cloud NGFW For AWS Provider",
+		},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -145,7 +156,7 @@ func TestDisplayNameFallback(t *testing.T) {
 				},
 				pkg: tokens.NewPackageToken(tokens.PackageName(tt.pkgName)),
 			}
-			actual := getProviderName(g)
+			actual := getProviderDisplayName(g)
 
 			assert.Equal(t, tt.expected, actual)
 		})

--- a/pkg/tfgen/test_data/convert-index-file-edit-rules/expected.md
+++ b/pkg/tfgen/test_data/convert-index-file-edit-rules/expected.md
@@ -6,7 +6,7 @@ layout: package
 ---
 ## Installation
 
-The libvirt provider is available as a package in all Pulumi languages:
+The Libvirt provider is available as a package in all Pulumi languages:
 
 * JavaScript/TypeScript: [`@pulumi/libvirt`](https://www.npmjs.com/package/@pulumi/libvirt)
 * Python: [`pulumi-libvirt`](https://pypi.org/project/pulumi-libvirt/)

--- a/pkg/tfgen/test_data/convert-index-file/expected.md
+++ b/pkg/tfgen/test_data/convert-index-file/expected.md
@@ -6,7 +6,7 @@ layout: package
 ---
 ## Installation
 
-The libvirt provider is available as a package in all Pulumi languages:
+The Libvirt provider is available as a package in all Pulumi languages:
 
 * JavaScript/TypeScript: [`@pulumi/libvirt`](https://www.npmjs.com/package/@pulumi/libvirt)
 * Python: [`pulumi-libvirt`](https://pypi.org/project/pulumi-libvirt/)


### PR DESCRIPTION
This pull request clarifies the purpose and use of a package name for display reasons.

Prior to this change, when generating front matter, a provider's display name would be put through a capitalization logic that would capitalize each word in the name, even if the word was in all caps already. E.g.:

`Palo Alto Networks Cloud NGFW For AWS Provider` -> `Palo Alto Networks Cloud Ngfw For Aws Provider`

This change ensures that whatever is passed into `info.DisplayName` in the provider remains unaltered. It also unblocks the setting up of automatic index docs for https://github.com/pulumi/pulumi-cloudngfwaws.

I've also updated the function name to clarify it is specifically about finding or generating a display name.