### PR TITLE
Do not attempt to find upstream repo in PF tests

### DIFF
--- a/pkg/pf/tests/pulcheck/pulcheck.go
+++ b/pkg/pf/tests/pulcheck/pulcheck.go
@@ -49,6 +49,7 @@ func genMetadata(t T, info tfbridge0.ProviderInfo) (tfbridge.ProviderMetadata, e
 	generated, err := tfgen.GenerateSchema(context.Background(), tfgen.GenerateSchemaOptions{
 		ProviderInfo:    info,
 		DiagnosticsSink: testSink(t),
+		XInMemoryDocs:   true,
 	})
 	if err != nil {
 		return tfbridge.ProviderMetadata{}, err

--- a/pkg/pf/tfgen/gen.go
+++ b/pkg/pf/tfgen/gen.go
@@ -32,6 +32,7 @@ import (
 type GenerateSchemaOptions struct {
 	ProviderInfo    sdkbridge.ProviderInfo
 	DiagnosticsSink diag.Sink
+	XInMemoryDocs   bool
 }
 
 type GenerateSchemaResult struct {
@@ -58,8 +59,8 @@ func GenerateSchema(_ context.Context, opts GenerateSchemaOptions) (*GenerateSch
 	generated, err := realtfgen.GenerateSchemaWithOptions(realtfgen.GenerateSchemaOptions{
 		ProviderInfo:    opts.ProviderInfo,
 		DiagnosticsSink: sink,
+		XInMemoryDocs:   opts.XInMemoryDocs,
 	})
-
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This change makes test providers use the in-memory-docs strategy which stops them from trying to access an upstream repo (which doesn't exist). This suppresses a redundant error message from test runs:

```
    schemas.go:58: warning: Unable to find the upstream provider's documentation:
        The upstream repository is expected to be at "github.com/terraform-providers/terraform-provider-random".
        
        If the expected path is not correct, you should check the values of these fields (current values shown):
        tfbridge.ProviderInfo{
        	GitHubHost:              "github.com",
        	GitHubOrg:               "terraform-providers",
        	Name:                    "random",
        	TFProviderModuleVersion: "",
        }
        The original error is: error running 'go mod download -json' in "/Users/runner/work/pulumi-terraform-bridge/pulumi-terraform-bridge/pkg/pf/tests/provider" dir for module: chdir /Users/runner/work/pulumi-terraform-bridge/pulumi-terraform-bridge/pkg/pf/tests/provider: no such file or directory
        
        Output: 
```

In a typical test run this log message appears hundreds of times, making the logs hard to use: https://github.com/pulumi/pulumi-terraform-bridge/actions/runs/11893917663/job/33139971665?pr=2628