### PR TITLE
Fix table renderer

### DIFF
--- a/pkg/tfgen/installation_docs.go
+++ b/pkg/tfgen/installation_docs.go
@@ -44,6 +44,7 @@ func plainDocsParser(docFile *DocFile, g *Generator) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	// Strip the tfplugindocs generation HTML comment
 	content = stripSchemaGeneratedByTFPluginDocs(content)
 

--- a/pkg/tfgen/installation_docs.go
+++ b/pkg/tfgen/installation_docs.go
@@ -44,7 +44,6 @@ func plainDocsParser(docFile *DocFile, g *Generator) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	// Strip the tfplugindocs generation HTML comment
 	content = stripSchemaGeneratedByTFPluginDocs(content)
 

--- a/pkg/tfgen/installation_docs_test.go
+++ b/pkg/tfgen/installation_docs_test.go
@@ -78,6 +78,16 @@ func TestPlainDocsParser(t *testing.T) {
 				},
 			),
 		},
+		{
+			// Discovered while generating docs for SD-WAN.
+			// Tests whether the custom table renderer is used correctly in docsgen overall.
+			name: "Transforms table correctly",
+			docFile: DocFile{
+				Content: []byte(readfile(t, "test_data/convert-index-file-with-table/input.md")),
+			},
+			expected: []byte(readfile(t, "test_data/convert-index-file-with-table/expected.md")),
+			edits:    defaultEditRules(),
+		},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/pkg/tfgen/parse/extension.go
+++ b/pkg/tfgen/parse/extension.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 
 	"github.com/olekukonko/tablewriter"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen/parse/section"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	markdown "github.com/teekennedy/goldmark-markdown"
 	"github.com/yuin/goldmark"
@@ -30,6 +29,8 @@ import (
 	"github.com/yuin/goldmark/renderer"
 	"github.com/yuin/goldmark/text"
 	"github.com/yuin/goldmark/util"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen/parse/section"
 )
 
 // TFRegistryExtension is the catch-all extension to prepare TF registry markdown to be
@@ -162,7 +163,6 @@ func (tableRenderer *tableRenderer) renderTable(
 		tableRenderer.headerRow = make([]string, 0, tableRenderer.tableWidth)
 		tableRenderer.rows = [][]string{}
 		tableRenderer.tableWriter = tablewriter.NewWriter(writer)
-
 	} else {
 		_, err := writer.WriteRune('\n')
 		contract.AssertNoErrorf(err, "impossible")
@@ -196,7 +196,7 @@ func (tableRenderer *tableRenderer) renderRow(
 	entering bool,
 ) (ast.WalkStatus, error) {
 	if entering {
-		tableRenderer.rows = append(tableRenderer.rows, make([]string, 0, tableRenderer.tableWidth)) //TODO: call this table width
+		tableRenderer.rows = append(tableRenderer.rows, make([]string, 0, tableRenderer.tableWidth))
 	}
 
 	return ast.WalkContinue, nil
@@ -208,7 +208,6 @@ func (tableRenderer *tableRenderer) renderCell(
 	n ast.Node,
 	entering bool,
 ) (ast.WalkStatus, error) {
-
 	if entering {
 		var cell bytes.Buffer
 		textBlock := ast.NewTextBlock()

--- a/pkg/tfgen/parse/extension_test.go
+++ b/pkg/tfgen/parse/extension_test.go
@@ -16,7 +16,6 @@ package parse
 
 import (
 	"bytes"
-	"fmt"
 	"os"
 	"runtime"
 	"testing"
@@ -24,7 +23,6 @@ import (
 	"github.com/hexops/autogold/v2"
 	"github.com/stretchr/testify/require"
 	"github.com/yuin/goldmark"
-	"github.com/yuin/goldmark/text"
 )
 
 func TestRenderTable(t *testing.T) {
@@ -96,24 +94,9 @@ func TestRenderTable(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			var out bytes.Buffer
-			//
-			//reader := text.NewReader(source)
-			//doc := m.parser.Parse(reader, opts...)
-			//return m.renderer.Render(writer, source, doc)
-
-			m := goldmark.New(goldmark.WithExtensions(TFRegistryExtension))
-			reader := text.NewReader([]byte(tt.input))
-
-			doc := m.Parser().Parse(reader)
-			//doc.Dump([]byte(tt.input), 0)
-
-			err := m.Renderer().Render(&out, []byte(tt.input), doc)
-
-			fmt.Println(out.String())
-
-			//err = goldmark.New(
-			//	goldmark.WithExtensions(TFRegistryExtension),
-			//).Convert([]byte(tt.input), &out)
+			err := goldmark.New(
+				goldmark.WithExtensions(TFRegistryExtension),
+			).Convert([]byte(tt.input), &out)
 			require.NoError(t, err)
 			tt.expected.Equal(t, out.String())
 		})

--- a/pkg/tfgen/parse/extension_test.go
+++ b/pkg/tfgen/parse/extension_test.go
@@ -16,6 +16,7 @@ package parse
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"runtime"
 	"testing"
@@ -23,6 +24,7 @@ import (
 	"github.com/hexops/autogold/v2"
 	"github.com/stretchr/testify/require"
 	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/text"
 )
 
 func TestRenderTable(t *testing.T) {
@@ -83,15 +85,35 @@ func TestRenderTable(t *testing.T) {
 			input:    readfile(t, "../test_data/table-rendering/input.md"),
 			expected: autogold.Expect(readfile(t, "../test_data/table-rendering/expected.md")),
 		},
+		{
+			name:     "in-middle-of-document",
+			input:    readfile(t, "../test_data/table-rendering/in-middle-of-doc-input.md"),
+			expected: autogold.Expect(readfile(t, "../test_data/table-rendering/in-middle-of-doc-expected.md")),
+		},
 	}
 
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			var out bytes.Buffer
-			err := goldmark.New(
-				goldmark.WithExtensions(TFRegistryExtension),
-			).Convert([]byte(tt.input), &out)
+			//
+			//reader := text.NewReader(source)
+			//doc := m.parser.Parse(reader, opts...)
+			//return m.renderer.Render(writer, source, doc)
+
+			m := goldmark.New(goldmark.WithExtensions(TFRegistryExtension))
+			reader := text.NewReader([]byte(tt.input))
+
+			doc := m.Parser().Parse(reader)
+			//doc.Dump([]byte(tt.input), 0)
+
+			err := m.Renderer().Render(&out, []byte(tt.input), doc)
+
+			fmt.Println(out.String())
+
+			//err = goldmark.New(
+			//	goldmark.WithExtensions(TFRegistryExtension),
+			//).Convert([]byte(tt.input), &out)
 			require.NoError(t, err)
 			tt.expected.Equal(t, out.String())
 		})

--- a/pkg/tfgen/test_data/convert-index-file-with-table/expected.md
+++ b/pkg/tfgen/test_data/convert-index-file-with-table/expected.md
@@ -1,0 +1,267 @@
+---
+# *** WARNING: This file was auto-generated. Do not edit by hand unless you're certain you know what you are doing! ***
+title: Libvirt Provider
+meta_desc: Provides an overview on how to configure the Pulumi Libvirt provider.
+layout: package
+---
+## Installation
+
+The Libvirt provider is available as a package in all Pulumi languages:
+
+* JavaScript/TypeScript: [`@pulumi/libvirt`](https://www.npmjs.com/package/@pulumi/libvirt)
+* Python: [`pulumi-libvirt`](https://pypi.org/project/pulumi-libvirt/)
+* Go: [`github.com/pulumi/pulumi-libvirt/sdk/go/libvirt`](https://github.com/pulumi/pulumi-libvirt)
+* .NET: [`Pulumi.Libvirt`](https://www.nuget.org/packages/Pulumi.Libvirt)
+* Java: [`com.pulumi/libvirt`](https://central.sonatype.com/artifact/com.pulumi/libvirt)
+## Overview
+
+The Libvirt provider is used to interact with Linux
+[libvirt](https://libvirt.org) hypervisors.
+
+The provider needs to be configured with the proper connection information
+before it can be used.
+
+|    t1    | *t2* |
+|----------|------|
+| **r1c1** | r1c2 |
+
+> **Note:** while libvirt can be used with several types of hypervisors, this
+provider focuses on [KVM](http://libvirt.org/drvqemu.html). Other drivers may not be
+working and haven't been tested.
+## The connection URI
+
+The provider understands [connection URIs](https://libvirt.org/uri.html). The supported transports are:
+
+* `tcp` (non-encrypted connection)
+* `unix` (UNIX domain socket)
+* `tls` (See [here](https://libvirt.org/kbase/tlscerts.html) for information how to setup certificates)
+* `ssh` (Secure shell)
+
+Unlike the original libvirt, the `ssh` transport is not implemented using the ssh command and therefore does not require `nc` (netcat) on the server side.
+
+Additionally, the `ssh` URI supports passwords using the `driver+ssh://[username:PASSWORD@][hostname][:port]/[path]?sshauth=ssh-password` syntax.
+
+As the provider does not use libvirt on the client side, not all connection URI options are supported or apply.
+## Example Usage
+
+{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
+{{% choosable language typescript %}}
+```yaml
+# Pulumi.yaml provider configuration file
+name: configuration-example
+runtime: nodejs
+config:
+    simple-provider:authUrl:
+        value: http://myauthurl:5000/v3
+    simple-provider:password:
+        value: pwd
+    simple-provider:region:
+        value: RegionOne
+    simple-provider:tenantName:
+        value: admin
+    simple-provider:userName:
+        value: admin
+
+```
+```typescript
+import * as pulumi from "@pulumi/pulumi";
+import * as simple from "@pulumi/simple";
+
+//# Define a resource
+const aResource = new simple.index.Resource("a_resource", {
+    inputOne: "hello",
+    inputTwo: true,
+});
+```
+{{% /choosable %}}
+{{% choosable language python %}}
+```yaml
+# Pulumi.yaml provider configuration file
+name: configuration-example
+runtime: python
+config:
+    simple-provider:authUrl:
+        value: http://myauthurl:5000/v3
+    simple-provider:password:
+        value: pwd
+    simple-provider:region:
+        value: RegionOne
+    simple-provider:tenantName:
+        value: admin
+    simple-provider:userName:
+        value: admin
+
+```
+```python
+import pulumi
+import pulumi_simple as simple
+
+## Define a resource
+a_resource = simple.index.Resource("a_resource",
+    input_one=hello,
+    input_two=True)
+```
+{{% /choosable %}}
+{{% choosable language csharp %}}
+```yaml
+# Pulumi.yaml provider configuration file
+name: configuration-example
+runtime: dotnet
+config:
+    simple-provider:authUrl:
+        value: http://myauthurl:5000/v3
+    simple-provider:password:
+        value: pwd
+    simple-provider:region:
+        value: RegionOne
+    simple-provider:tenantName:
+        value: admin
+    simple-provider:userName:
+        value: admin
+
+```
+```csharp
+using System.Collections.Generic;
+using System.Linq;
+using Pulumi;
+using Simple = Pulumi.Simple;
+
+return await Deployment.RunAsync(() =>
+{
+    //# Define a resource
+    var aResource = new Simple.Index.Resource("a_resource", new()
+    {
+        InputOne = "hello",
+        InputTwo = true,
+    });
+
+});
+
+```
+{{% /choosable %}}
+{{% choosable language go %}}
+```yaml
+# Pulumi.yaml provider configuration file
+name: configuration-example
+runtime: go
+config:
+    simple-provider:authUrl:
+        value: http://myauthurl:5000/v3
+    simple-provider:password:
+        value: pwd
+    simple-provider:region:
+        value: RegionOne
+    simple-provider:tenantName:
+        value: admin
+    simple-provider:userName:
+        value: admin
+
+```
+```go
+package main
+
+import (
+	"github.com/pulumi/pulumi-simple/sdk/go/simple"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		// # Define a resource
+		_, err := simple.NewResource(ctx, "a_resource", &simple.ResourceArgs{
+			InputOne: "hello",
+			InputTwo: true,
+		})
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}
+```
+{{% /choosable %}}
+{{% choosable language yaml %}}
+```yaml
+# Pulumi.yaml provider configuration file
+name: configuration-example
+runtime: yaml
+config:
+    simple-provider:authUrl:
+        value: http://myauthurl:5000/v3
+    simple-provider:password:
+        value: pwd
+    simple-provider:region:
+        value: RegionOne
+    simple-provider:tenantName:
+        value: admin
+    simple-provider:userName:
+        value: admin
+
+```
+```yaml
+resources:
+  ## Define a resource
+  aResource:
+    type: simple:resource
+    name: a_resource
+    properties:
+      inputOne: hello
+      inputTwo: true
+```
+{{% /choosable %}}
+{{% choosable language java %}}
+```yaml
+# Pulumi.yaml provider configuration file
+name: configuration-example
+runtime: java
+config:
+    simple-provider:authUrl:
+        value: http://myauthurl:5000/v3
+    simple-provider:password:
+        value: pwd
+    simple-provider:region:
+        value: RegionOne
+    simple-provider:tenantName:
+        value: admin
+    simple-provider:userName:
+        value: admin
+
+```
+```java
+package generated_program;
+
+import com.pulumi.Context;
+import com.pulumi.Pulumi;
+import com.pulumi.core.Output;
+import com.pulumi.simple.resource;
+import com.pulumi.simple.ResourceArgs;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Map;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+public class App {
+    public static void main(String[] args) {
+        Pulumi.run(App::stack);
+    }
+
+    public static void stack(Context ctx) {
+        //# Define a resource
+        var aResource = new Resource("aResource", ResourceArgs.builder()
+            .inputOne("hello")
+            .inputTwo(true)
+            .build());
+
+    }
+}
+```
+{{% /choosable %}}
+{{< /chooser >}}
+## Configuration Reference
+
+The following keys can be used to configure the provider.
+
+* `uri` - (Required) The [connection URI](https://libvirt.org/uri.html) used
+  to connect to the libvirt host.

--- a/pkg/tfgen/test_data/convert-index-file-with-table/input.md
+++ b/pkg/tfgen/test_data/convert-index-file-with-table/input.md
@@ -1,0 +1,64 @@
+---
+layout: "libvirt"
+page_title: "Provider: libvirt"
+sidebar_current: "docs-libvirt-index"
+description: |-
+  The Libvirt provider is used to interact with Linux KVM/libvirt hypervisors. The provider needs to be configured with the proper connection information before it can be used.
+---
+
+# Libvirt Provider
+
+The Libvirt provider is used to interact with Linux
+[libvirt](https://libvirt.org) hypervisors.
+
+The provider needs to be configured with the proper connection information
+before it can be used.
+
+|t1    | *t2* |
+|------|------|
+| **r1c1** | r1c2 |
+
+~> **Note:** while libvirt can be used with several types of hypervisors, this
+provider focuses on [KVM](http://libvirt.org/drvqemu.html). Other drivers may not be
+working and haven't been tested.
+
+## The connection URI
+
+The provider understands [connection URIs](https://libvirt.org/uri.html). The supported transports are:
+
+* `tcp` (non-encrypted connection)
+* `unix` (UNIX domain socket)
+* `tls` (See [here](https://libvirt.org/kbase/tlscerts.html) for information how to setup certificates)
+* `ssh` (Secure shell)
+
+Unlike the original libvirt, the `ssh` transport is not implemented using the ssh command and therefore does not require `nc` (netcat) on the server side.
+
+Additionally, the `ssh` URI supports passwords using the `driver+ssh://[username:PASSWORD@][hostname][:port]/[path]?sshauth=ssh-password` syntax.
+
+As the provider does not use libvirt on the client side, not all connection URI options are supported or apply.
+
+## Example Usage
+
+```hcl
+# Configure the OpenStack Provider
+provider "simple-provider" {
+  user_name   = "admin"
+  tenant_name = "admin"
+  password    = "pwd"
+  auth_url    = "http://myauthurl:5000/v3"
+  region      = "RegionOne"
+}
+## Define a resource
+resource "simple_resource" "a_resource" {
+  input_one = "hello"
+  input_two = true
+}
+```
+
+## Configuration Reference
+
+The following keys can be used to configure the provider.
+
+* `uri` - (Required) The [connection URI](https://libvirt.org/uri.html) used
+  to connect to the libvirt host.
+

--- a/pkg/tfgen/test_data/remove-title/sdwan-expected.md
+++ b/pkg/tfgen/test_data/remove-title/sdwan-expected.md
@@ -1,0 +1,26 @@
+The SDWAN provider provides resources to interact with a Cisco Catalyst SD-WAN environment. It communicates with the SD-WAN Manager via the REST API.
+
+All resources and data sources have been tested with the following releases.
+
+| Platform        | Version |
+| --------------- | ------- |
+| Catalyst SD-WAN | 20.9    |
+| Catalyst SD-WAN | 20.12   |
+
+## Getting Started
+
+The following guides with examples exist to demonstrate the use of the provider:
+
+- [Getting Started](https://registry.terraform.io/providers/CiscoDevNet/sdwan/latest/docs/guides/getting_started)
+- [Updating Templates](https://registry.terraform.io/providers/CiscoDevNet/sdwan/latest/docs/guides/updating_templates)
+- [Configuration Groups](https://registry.terraform.io/providers/CiscoDevNet/sdwan/latest/docs/guides/configuration_groups)
+
+## Example Usage
+
+Here is some example
+
+## Schema
+
+### Optional
+
+Getting some stuff

--- a/pkg/tfgen/test_data/remove-title/sdwan-input.md
+++ b/pkg/tfgen/test_data/remove-title/sdwan-input.md
@@ -1,0 +1,28 @@
+# SDWAN Provider
+
+The SDWAN provider provides resources to interact with a Cisco Catalyst SD-WAN environment. It communicates with the SD-WAN Manager via the REST API.
+
+All resources and data sources have been tested with the following releases.
+
+| Platform        | Version |
+| --------------- | ------- |
+| Catalyst SD-WAN | 20.9    |
+| Catalyst SD-WAN | 20.12   |
+
+## Getting Started
+
+The following guides with examples exist to demonstrate the use of the provider:
+
+- [Getting Started](https://registry.terraform.io/providers/CiscoDevNet/sdwan/latest/docs/guides/getting_started)
+- [Updating Templates](https://registry.terraform.io/providers/CiscoDevNet/sdwan/latest/docs/guides/updating_templates)
+- [Configuration Groups](https://registry.terraform.io/providers/CiscoDevNet/sdwan/latest/docs/guides/configuration_groups)
+
+## Example Usage
+
+Here is some example 
+
+## Schema
+
+### Optional
+
+Getting some stuff

--- a/pkg/tfgen/test_data/table-rendering/in-middle-of-doc-expected.md
+++ b/pkg/tfgen/test_data/table-rendering/in-middle-of-doc-expected.md
@@ -5,7 +5,6 @@
 | **r1c1** | r1c2 |
 
 this is also dropped
-
 ## Another Header
 
 With More Stuff!

--- a/pkg/tfgen/test_data/table-rendering/in-middle-of-doc-expected.md
+++ b/pkg/tfgen/test_data/table-rendering/in-middle-of-doc-expected.md
@@ -1,0 +1,11 @@
+## Here is a section
+
+|    t1    | *t2* |
+|----------|------|
+| **r1c1** | r1c2 |
+
+this is also dropped
+
+## Another Header
+
+With More Stuff!

--- a/pkg/tfgen/test_data/table-rendering/in-middle-of-doc-input.md
+++ b/pkg/tfgen/test_data/table-rendering/in-middle-of-doc-input.md
@@ -1,0 +1,11 @@
+## Here is a section
+
+|t1    | *t2* |
+|----------|------|
+| **r1c1** | r1c2 |
+
+this is also dropped
+
+## Another Header
+
+With More Stuff!


### PR DESCRIPTION
This pull request does a couple of things:

- Implement a render function for each subset of Table
- Expand the `tableRenderer` struct to hold state
- initialize a separate Renderer for the table renderer, since the logic for cell rendering calls back into the outer renderer and trying to use the same renderer lost track of content.
- add tests to reflect a table in the middle of a document to ensure text after the table continues to get rendered
- ad an overall doc test that contains a table.

PR using this change: https://github.com/pulumi/pulumi-sdwan/pull/114
Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/2466