### PR TITLE
Add AppendPath when parameterizing dynamic terraform provider.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -217,8 +217,8 @@ require (
 	github.com/pkg/term v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/posener/complete v1.2.3 // indirect
-	github.com/pulumi/pulumi/pkg/v3 v3.137.0
-	github.com/pulumi/pulumi/sdk/v3 v3.137.0
+	github.com/pulumi/pulumi/pkg/v3 v3.140.0
+	github.com/pulumi/pulumi/sdk/v3 v3.140.0
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect


### PR DESCRIPTION
When a provider is parameterized for go specifically it needs to specify
an appended path so the package modules are formed correctly.

This saves the tf provider name and configures the append operation.

Depends on pulumi/pulumi#17795
