### PR TITLE
Enable linters for more directories

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,6 +28,20 @@ linters:
     - wastedassign
     - whitespace
 issues:
+  exclude-rules:
+    # Exclude some linters from running on tests files.
+    - path: pkg/pf/tests
+      linters:
+        - lll
+        - paralleltest
+    - path: pkg/tests
+      linters:
+        - lll
+        - paralleltest
+    - path: pkg/pf/tests
+      linters:
+        - lll
+        - paralleltest
   exclude:
     - "unused-parameter: parameter"
     - "redefines-builtin-id:"
@@ -38,13 +52,6 @@ issues:
     - pkg/tf2pulumi/internal/configs
     - pkg/vendored
     # TODO(https://github.com/pulumi/pulumi-terraform-bridge/issues/2474)
-    - pkg/pf/tests
-    - pkg/tests
-    - pkg/x/testing
-    - pkg/x/muxer/tests
-    - pf
-    - x/muxer
-    - testing
 linters-settings:
   gci:
     sections:

--- a/pkg/pf/internal/check/check_test.go
+++ b/pkg/pf/internal/check/check_test.go
@@ -60,7 +60,7 @@ func (m *mockSchema) Computed() bool {
 }
 
 func TestIsInputProperty(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	tests := []struct {
 		name    string
 		schema  shim.Schema
@@ -96,7 +96,7 @@ func TestIsInputProperty(t *testing.T) {
 }
 
 func TestMissingIDProperty(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	stderr, err := test(t, tfbridge.ProviderInfo{
 		P: pfbridge.ShimProvider(testProvider{missingID: true}),
 	})
@@ -108,7 +108,7 @@ func TestMissingIDProperty(t *testing.T) {
 }
 
 func TestMissingIDWithOverride(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	stderr, err := test(t, tfbridge.ProviderInfo{
 		P: pfbridge.ShimProvider(testProvider{missingID: true}),
 		Resources: map[string]*tfbridge.ResourceInfo{
@@ -123,7 +123,7 @@ func TestMissingIDWithOverride(t *testing.T) {
 }
 
 func TestMissingIDUnmapped(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	stderr, err := test(t, tfbridge.ProviderInfo{
 		P:              pfbridge.ShimProvider(testProvider{missingID: true}),
 		IgnoreMappings: []string{"test_res"},
@@ -134,7 +134,7 @@ func TestMissingIDUnmapped(t *testing.T) {
 }
 
 func TestSensitiveID(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	stderr, err := test(t, tfbridge.ProviderInfo{
 		P: pfbridge.ShimProvider(testProvider{sensitiveID: true}),
 	})
@@ -145,7 +145,7 @@ func TestSensitiveID(t *testing.T) {
 }
 
 func TestSensitiveIDWithOverride(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	t.Run("false", func(t *testing.T) {
 		stderr, err := test(t, tfbridge.ProviderInfo{
 			P: pfbridge.ShimProvider(testProvider{sensitiveID: true}),
@@ -173,7 +173,7 @@ func TestSensitiveIDWithOverride(t *testing.T) {
 }
 
 func TestInvalidInputID(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	tests := []struct {
 		name     string
 		idSchema idSchema
@@ -267,7 +267,7 @@ func TestInvalidInputID(t *testing.T) {
 }
 
 func TestMuxedProvider(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	stderr, err := test(t, tfbridge.ProviderInfo{
 		P: pfbridge.MuxShimWithPF(context.Background(),
 			sdkv2.NewProvider(testSDKv2Provider()),

--- a/pkg/pf/internal/check/checks.go
+++ b/pkg/pf/internal/check/checks.go
@@ -126,6 +126,7 @@ func (err errWrongIDType) Error() string {
 type errMissingIDAttribute struct{}
 
 func (errMissingIDAttribute) Error() string {
+	//nolint:lll
 	return `no "id" attribute. To map this resource consider specifying ResourceInfo.ComputeID to a valid field on the upstream resource`
 }
 

--- a/pkg/pf/internal/check/not_supported.go
+++ b/pkg/pf/internal/check/not_supported.go
@@ -45,7 +45,7 @@ func notSupported(sink diag.Sink, prov tfbridge.ProviderInfo, isPFResource, isPF
 			" pf/tfbridge.ShimProvider or pf/tfbridge.ShimProviderWithContext.\nMuxed SDK and" +
 			" Plugin Framework based providers must have ProviderInfo.P be created from" +
 			" pf/tfbridge.MuxShimWithPF or pf/tfbridgepf/tfbridge.MuxShimWithDisjointgPF."
-		u.warn(warning)
+		u.warnf(warning)
 	}
 
 	if prov.Resources != nil {
@@ -83,7 +83,7 @@ type notSupportedUtil struct {
 	sink diag.Sink
 }
 
-func (u *notSupportedUtil) warn(format string, arg ...interface{}) {
+func (u *notSupportedUtil) warnf(format string, arg ...interface{}) {
 	u.sink.Warningf(&diag.Diag{Message: format}, arg...)
 }
 
@@ -92,7 +92,7 @@ func (u *notSupportedUtil) assertIsZero(path string, shouldBeZero interface{}) {
 	if va.IsZero() {
 		return
 	}
-	u.warn("%s received a non-zero custom value %v that is being ignored."+
+	u.warnf("%s received a non-zero custom value %v that is being ignored."+
 		" Plugin Framework based providers do not yet support this feature.",
 		path, shouldBeZero)
 }

--- a/pkg/pf/internal/check/not_supported_test.go
+++ b/pkg/pf/internal/check/not_supported_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestZeroRecognizer(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	u := &notSupportedUtil{

--- a/pkg/pf/internal/configencoding/provider.go
+++ b/pkg/pf/internal/configencoding/provider.go
@@ -85,7 +85,8 @@ func (p *provider[T]) CheckConfigWithContext(
 
 func (p *provider[T]) DiffConfigWithContext(
 	ctx context.Context, urn resource.URN, oldInputs, olds, news resource.PropertyMap,
-	allowUnknowns bool, ignoreChanges []string) (plugin.DiffResult, error) {
+	allowUnknowns bool, ignoreChanges []string,
+) (plugin.DiffResult, error) {
 	encoding := p.GetConfigEncoding(ctx)
 	oldInputs, err := encoding.UnfoldProperties(oldInputs)
 	if err != nil {

--- a/pkg/pf/internal/defaults/defaults.go
+++ b/pkg/pf/internal/defaults/defaults.go
@@ -92,7 +92,6 @@ func getDefaultValue(
 		for _, n := range defaultInfo.EnvVars {
 			// Following code in v3/tfbridge, ignoring set but empty env vars.
 			if str, ok := os.LookupEnv(n); ok && str != "" {
-
 				v, err := parseValueFromEnv(fieldSchema, str)
 				if err != nil {
 					msg := fmt.Errorf("Cannot parse the value of environment variable '%s'"+

--- a/pkg/pf/internal/defaults/defaults_test.go
+++ b/pkg/pf/internal/defaults/defaults_test.go
@@ -355,5 +355,4 @@ func TestApplyDefaultInfoValues(t *testing.T) {
 			assert.Equal(t, tc.expected, actual)
 		})
 	}
-
 }

--- a/pkg/pf/internal/muxer/muxer.go
+++ b/pkg/pf/internal/muxer/muxer.go
@@ -99,7 +99,6 @@ func (m *ProviderShim) ResourceIsPF(token string) bool {
 		}
 		_, ok := p.(pf.ShimProvider)
 		return ok
-
 	}
 	return false
 }
@@ -114,7 +113,6 @@ func (m *ProviderShim) DataSourceIsPF(token string) bool {
 		}
 		_, ok := p.(pf.ShimProvider)
 		return ok
-
 	}
 	return false
 }

--- a/pkg/pf/internal/muxer/union_test.go
+++ b/pkg/pf/internal/muxer/union_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestUnionMap(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	m1 := testMap{
 		"one": "n1",
 		"two": "n2",

--- a/pkg/pf/internal/pfutils/eq.go
+++ b/pkg/pf/internal/pfutils/eq.go
@@ -54,7 +54,8 @@ func NonComputedEq(schema tftypes.AttributePathStepper) Eq {
 }
 
 func replaceComputedAttributesWithNull(schema tftypes.AttributePathStepper,
-	offset *tftypes.AttributePath, val tftypes.Value) (tftypes.Value, error) {
+	offset *tftypes.AttributePath, val tftypes.Value,
+) (tftypes.Value, error) {
 	return tftypes.Transform(val, func(p *tftypes.AttributePath, v tftypes.Value) (tftypes.Value, error) {
 		realPath := joinPaths(offset, p)
 		if ab, err := LookupTerraformPath(schema, realPath); err == nil && ab.IsAttr && ab.Attr.IsComputed() {

--- a/pkg/pf/internal/pfutils/proposed_new_test.go
+++ b/pkg/pf/internal/pfutils/proposed_new_test.go
@@ -40,7 +40,7 @@ type runtimeSchemaAdapter struct{ Schema }
 func (runtimeSchemaAdapter) Shim() shim.SchemaMap { panic("UNIMPLEMENTED") }
 
 func TestComputedOptionalBecomingUnknown(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	schema := rschema.Schema{Attributes: map[string]rschema.Attribute{
 		"foo": rschema.SingleNestedAttribute{
 			Attributes: map[string]rschema.Attribute{
@@ -65,7 +65,7 @@ func TestComputedOptionalBecomingUnknown(t *testing.T) {
 //
 // https://github.com/hashicorp/terraform/blob/v1.3.6/internal/plans/objchange/objchange.go
 func TestProposedNewBaseCases(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	schema := rschema.Schema{Attributes: map[string]rschema.Attribute{
 		"foo": rschema.StringAttribute{
 			Optional: true,
@@ -223,7 +223,7 @@ func TestProposedNewBaseCases(t *testing.T) {
 //
 // https://github.com/hashicorp/terraform/blob/v1.3.6/internal/plans/objchange/objchange_test.go#L12
 func TestProposedNewWithPortedCases(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	testAttributes := map[string]rschema.Attribute{
 		"optional": rschema.StringAttribute{
 			Optional: true,
@@ -241,7 +241,6 @@ func TestProposedNewWithPortedCases(t *testing.T) {
 	}
 
 	tests := map[string]testcase{
-
 		"empty": {
 			runtimeSchemaAdapter{
 				FromResourceSchema(rschema.Schema{Attributes: map[string]rschema.Attribute{}}),

--- a/pkg/pf/internal/plugin/provider_context.go
+++ b/pkg/pf/internal/plugin/provider_context.go
@@ -195,7 +195,6 @@ func (prov *provider) Invoke(
 ) (plugin.InvokeResponse, error) {
 	p, f, err := prov.ProviderWithContext.InvokeWithContext(ctx, req.Tok, req.Args)
 	return plugin.InvokeResponse{Properties: p, Failures: f}, err
-
 }
 
 func (prov *provider) StreamInvoke(

--- a/pkg/pf/internal/schemashim/attr_schema.go
+++ b/pkg/pf/internal/schemashim/attr_schema.go
@@ -50,9 +50,11 @@ func (s *attrSchema) Required() bool {
 func (*attrSchema) Default() interface{} {
 	panic("Default() should not be called during schema generation")
 }
+
 func (*attrSchema) DefaultFunc() shim.SchemaDefaultFunc {
 	panic("DefaultFunc() should not be called during schema generation")
 }
+
 func (*attrSchema) DefaultValue() (interface{}, error) {
 	// DefaultValue() should not be called by tfgen, but it currently may be called by ExtractInputsFromOutputs, so
 	// returning nil is better than a panic.
@@ -118,8 +120,8 @@ func (*attrSchema) MinItems() int {
 
 func (*attrSchema) ConflictsWith() []string {
 	panic("ConflictsWith() should not be called during schema generation")
-
 }
+
 func (*attrSchema) ExactlyOneOf() []string {
 	panic("ExactlyOneOf() should not be called during schema generation")
 }

--- a/pkg/pf/internal/schemashim/block_schema.go
+++ b/pkg/pf/internal/schemashim/block_schema.go
@@ -54,7 +54,6 @@ func (s *blockSchema) Description() string {
 
 // Needs to return a shim.Schema, a shim.Resource, or nil. See docstring on shim.Schema.Elem().
 func (s *blockSchema) Elem() interface{} {
-
 	asObjectType := func(typ any) (shim.Resource, bool) {
 		if tt, ok := typ.(basetypes.ObjectTypable); ok {
 			var res shim.Resource = newObjectPseudoResource(tt,

--- a/pkg/pf/internal/schemashim/custom_object_type_test.go
+++ b/pkg/pf/internal/schemashim/custom_object_type_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestCustomObject(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	ctx := context.Background()
 
 	obj := newObjectPseudoResource(NewObjectTypeOf[SomeType](ctx), nil, nil)
@@ -105,7 +105,6 @@ func (t objectTypeOf[T]) ValueFromObject(
 
 func (t objectTypeOf[T]) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
 	attrValue, err := t.ObjectType.ValueFromTerraform(ctx, in)
-
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/pf/internal/schemashim/custom_type_test.go
+++ b/pkg/pf/internal/schemashim/custom_type_test.go
@@ -29,7 +29,7 @@ import (
 
 // This example is taken from aws:resourceexplorer/index:Index "timeouts" property.
 func TestCustomTypeEmbeddingObjectType(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	type timeoutsType struct {
 		basetypes.ObjectType
 	}
@@ -62,7 +62,7 @@ func TestCustomTypeEmbeddingObjectType(t *testing.T) {
 }
 
 func TestCustomListType(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	ctx := context.Background()
 
 	raw := schema.ListNestedBlock{
@@ -91,7 +91,7 @@ func TestCustomListType(t *testing.T) {
 }
 
 func TestCustomListAttribute(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	ctx := context.Background()
 
 	raw := schema.ListNestedAttribute{
@@ -120,7 +120,7 @@ func TestCustomListAttribute(t *testing.T) {
 }
 
 func TestCustomSetType(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	ctx := context.Background()
 
 	raw := schema.SetNestedBlock{
@@ -160,9 +160,7 @@ type setNestedObjectTypeOf[T any] struct {
 	basetypes.SetType
 }
 
-var (
-	_ basetypes.ListTypable = (*listNestedObjectTypeOf[struct{}])(nil)
-)
+var _ basetypes.ListTypable = (*listNestedObjectTypeOf[struct{}])(nil)
 
 func newListNestedObjectTypeOf[T any](ctx context.Context, elemType attr.Type) listNestedObjectTypeOf[T] {
 	return listNestedObjectTypeOf[T]{basetypes.ListType{ElemType: elemType}}

--- a/pkg/pf/internal/schemashim/datasource.go
+++ b/pkg/pf/internal/schemashim/datasource.go
@@ -46,11 +46,13 @@ func (*schemaOnlyDataSource) Timeouts() *shim.ResourceTimeout {
 }
 
 func (*schemaOnlyDataSource) InstanceState(id string, object,
-	meta map[string]interface{}) (shim.InstanceState, error) {
+	meta map[string]interface{},
+) (shim.InstanceState, error) {
 	panic("schemaOnlyDataSource does not implement runtime operation InstanceState")
 }
 
 func (*schemaOnlyDataSource) DecodeTimeouts(
-	config shim.ResourceConfig) (*shim.ResourceTimeout, error) {
+	config shim.ResourceConfig,
+) (*shim.ResourceTimeout, error) {
 	panic("schemaOnlyDataSource does not implement runtime operation DecodeTimeouts")
 }

--- a/pkg/pf/internal/schemashim/object_pseudoresource.go
+++ b/pkg/pf/internal/schemashim/object_pseudoresource.go
@@ -42,7 +42,8 @@ type objectPseudoResource struct {
 
 func newObjectPseudoResource(t basetypes.ObjectTypable,
 	nestedAttrs map[string]pfutils.Attr,
-	nestedBlocks map[string]pfutils.Block) *objectPseudoResource {
+	nestedBlocks map[string]pfutils.Block,
+) *objectPseudoResource {
 	lowerType := t.TerraformType(context.Background())
 	objType, ok := lowerType.(tftypes.Object)
 	contract.Assertf(ok, "t basetypes.ObjectTypable should produce a tftypes.Object "+
@@ -61,8 +62,10 @@ func newObjectPseudoResource(t basetypes.ObjectTypable,
 	}
 }
 
-var _ shim.Resource = (*objectPseudoResource)(nil)
-var _ shim.SchemaMap = (*objectPseudoResource)(nil)
+var (
+	_ shim.Resource  = (*objectPseudoResource)(nil)
+	_ shim.SchemaMap = (*objectPseudoResource)(nil)
+)
 
 func (r *objectPseudoResource) Validate() error {
 	return nil
@@ -92,13 +95,15 @@ func (*objectPseudoResource) Timeouts() *shim.ResourceTimeout {
 }
 
 func (*objectPseudoResource) InstanceState(id string, object,
-	meta map[string]interface{}) (shim.InstanceState, error) {
+	meta map[string]interface{},
+) (shim.InstanceState, error) {
 	panic("This is an Object type encoded as a shim.Resource, and " +
 		"InstanceState() should not be called on this entity during schema generation")
 }
 
 func (*objectPseudoResource) DecodeTimeouts(
-	config shim.ResourceConfig) (*shim.ResourceTimeout, error) {
+	config shim.ResourceConfig,
+) (*shim.ResourceTimeout, error) {
 	panic("This is an Object type encoded as a shim.Resource, and " +
 		"DecodeTimeouts() should not be called on this entity during schema generation")
 }
@@ -187,7 +192,8 @@ func newTuplePseudoResource(t attr.TypeWithElementTypes) shim.Resource {
 	return &tuplePseudoResource{
 		schemaOnly: schemaOnly{"tuplePseudoResource"},
 		attrs:      attrs,
-		tuple:      t}
+		tuple:      t,
+	}
 }
 
 func (*tuplePseudoResource) SchemaVersion() int         { panic("TODO") }
@@ -236,7 +242,7 @@ type schemaOnly struct{ typ string }
 
 func (s *schemaOnly) Importer() shim.ImportFunc {
 	m := "type"
-	if s != nil || s.typ != "" {
+	if s != nil && s.typ != "" {
 		m = s.typ
 	}
 	panic(m + " does not implement runtime operation ImporterFunc")
@@ -244,25 +250,27 @@ func (s *schemaOnly) Importer() shim.ImportFunc {
 
 func (s *schemaOnly) Timeouts() *shim.ResourceTimeout {
 	m := "type"
-	if s != nil || s.typ != "" {
+	if s != nil && s.typ != "" {
 		m = s.typ
 	}
 	panic(m + " does not implement runtime operation Timeouts")
 }
 
 func (s *schemaOnly) InstanceState(id string, object,
-	meta map[string]interface{}) (shim.InstanceState, error) {
+	meta map[string]interface{},
+) (shim.InstanceState, error) {
 	m := "type"
-	if s != nil || s.typ != "" {
+	if s != nil && s.typ != "" {
 		m = s.typ
 	}
 	panic(m + " does not implement runtime operation InstanceState")
 }
 
 func (s *schemaOnly) DecodeTimeouts(
-	config shim.ResourceConfig) (*shim.ResourceTimeout, error) {
+	config shim.ResourceConfig,
+) (*shim.ResourceTimeout, error) {
 	m := "type"
-	if s != nil || s.typ != "" {
+	if s != nil && s.typ != "" {
 		m = s.typ
 	}
 	panic(m + " does not implement runtime operation DecodeTimeouts")

--- a/pkg/pf/internal/schemashim/object_type_test.go
+++ b/pkg/pf/internal/schemashim/object_type_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func TestObjectAttribute(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	objectAttr := schema.ObjectAttribute{
 		AttributeTypes: map[string]attr.Type{
 			"s": basetypes.StringType{},
@@ -44,7 +44,7 @@ func TestObjectAttribute(t *testing.T) {
 }
 
 func TestTypeSchemaDescriptionIsEmpty(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	shimmedType := &typeSchema{
 		t:      basetypes.StringType{},
 		nested: nil,
@@ -53,7 +53,7 @@ func TestTypeSchemaDescriptionIsEmpty(t *testing.T) {
 }
 
 func TestSingleNestedBlock(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	b := schema.SingleNestedBlock{
 		Attributes: simpleObjectAttributes(),
 	}
@@ -66,7 +66,7 @@ func TestSingleNestedBlock(t *testing.T) {
 }
 
 func TestListNestedBlock(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	b := schema.ListNestedBlock{
 		NestedObject: schema.NestedBlockObject{
 			Attributes: simpleObjectAttributes(),
@@ -80,7 +80,7 @@ func TestListNestedBlock(t *testing.T) {
 }
 
 func TestSetNestedBlock(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	b := schema.SetNestedBlock{
 		NestedObject: schema.NestedBlockObject{
 			Attributes: simpleObjectAttributes(),
@@ -94,7 +94,7 @@ func TestSetNestedBlock(t *testing.T) {
 }
 
 func TestDeeplyNestedBlock(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	b := schema.ListNestedBlock{
 		NestedObject: schema.NestedBlockObject{
 			Blocks: map[string]schema.Block{

--- a/pkg/pf/internal/schemashim/provider.go
+++ b/pkg/pf/internal/schemashim/provider.go
@@ -32,9 +32,9 @@ import (
 var _ = pf.ShimProvider(&SchemaOnlyProvider{})
 
 type SchemaOnlyProvider struct {
-	ctx         context.Context
-	tf          pfprovider.Provider
-	resourceMap shim.ResourceMap
+	ctx           context.Context
+	tf            pfprovider.Provider
+	resourceMap   shim.ResourceMap
 	dataSourceMap shim.ResourceMap
 }
 
@@ -106,7 +106,8 @@ func (p *SchemaOnlyProvider) ValidateResource(
 }
 
 func (p *SchemaOnlyProvider) ValidateDataSource(
-	context.Context, string, shim.ResourceConfig) ([]string, []error) {
+	context.Context, string, shim.ResourceConfig,
+) ([]string, []error) {
 	panic("schemaOnlyProvider does not implement runtime operation ValidateDataSource")
 }
 
@@ -167,6 +168,7 @@ func (p *SchemaOnlyProvider) NewResourceConfig(context.Context, map[string]inter
 func (p *SchemaOnlyProvider) NewProviderConfig(context.Context, map[string]interface{}) shim.ResourceConfig {
 	panic("schemaOnlyProvider does not implement runtime operation ProviderConfig")
 }
+
 func (p *SchemaOnlyProvider) IsSet(context.Context, interface{}) ([]interface{}, bool) {
 	panic("schemaOnlyProvider does not implement runtime operation IsSet")
 }

--- a/pkg/pf/internal/schemashim/resource.go
+++ b/pkg/pf/internal/schemashim/resource.go
@@ -46,11 +46,13 @@ func (*schemaOnlyResource) Timeouts() *shim.ResourceTimeout {
 }
 
 func (*schemaOnlyResource) InstanceState(id string, object,
-	meta map[string]interface{}) (shim.InstanceState, error) {
+	meta map[string]interface{},
+) (shim.InstanceState, error) {
 	panic("schemaOnlyResource does not implement runtime operation InstanceState")
 }
 
 func (*schemaOnlyResource) DecodeTimeouts(
-	config shim.ResourceConfig) (*shim.ResourceTimeout, error) {
+	config shim.ResourceConfig,
+) (*shim.ResourceTimeout, error) {
 	panic("schemaOnlyResource does not implement runtime operation DecodeTimeouts")
 }

--- a/pkg/pf/internal/schemashim/type_schema_test.go
+++ b/pkg/pf/internal/schemashim/type_schema_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestMapAttribute(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	mapAttr := schema.MapAttribute{
 		Optional:    true,
 		ElementType: basetypes.StringType{},

--- a/pkg/pf/proto/attribute.go
+++ b/pkg/pf/proto/attribute.go
@@ -82,7 +82,6 @@ func (a attribute) Elem() interface{} {
 		}
 	}
 	return element{a.attr.ValueType(), a.Optional()}.Elem()
-
 }
 
 // Defaults are applied in the provider binary, not here

--- a/pkg/pf/proto/element.go
+++ b/pkg/pf/proto/element.go
@@ -20,8 +20,10 @@ import (
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
-var _ = shim.Schema(element{})
-var _ = shim.Resource(elementObject{})
+var (
+	_ = shim.Schema(element{})
+	_ = shim.Resource(elementObject{})
+)
 
 type element struct {
 	typ      tftypes.Type
@@ -55,7 +57,6 @@ func (e element) Type() shim.ValueType {
 	default:
 		return shim.TypeInvalid
 	}
-
 }
 
 func (e element) Elem() interface{} {

--- a/pkg/pf/proto/protov6_test.go
+++ b/pkg/pf/proto/protov6_test.go
@@ -46,12 +46,12 @@ func marshalProviderShim(t *testing.T, p shim.Provider) []byte {
 }
 
 func TestShimSchema(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	autogold.Expect("{}\n").Equal(t, string(marshalProviderShim(t, proto.Empty())))
 }
 
 func TestDynamicType(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	b := marshalProviderShim(t,
 		proto.New(context.Background(), providerServer{
 			SchemaResponse: &tfprotov6.GetProviderSchemaResponse{
@@ -78,7 +78,7 @@ func TestDynamicType(t *testing.T) {
 }
 
 func TestBlockSchemaGeneration(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	p := proto.New(context.Background(), providerServer{
 		SchemaResponse: &tfprotov6.GetProviderSchemaResponse{
 			ResourceSchemas: map[string]*tfprotov6.Schema{

--- a/pkg/pf/proto/resource.go
+++ b/pkg/pf/proto/resource.go
@@ -81,6 +81,7 @@ func (r resource) Timeouts() *shim.ResourceTimeout {
 func (r resource) InstanceState(id string, object, meta map[string]interface{}) (shim.InstanceState, error) {
 	panic("Cannot call InstanceState for a schema only resource")
 }
+
 func (r resource) DecodeTimeouts(config shim.ResourceConfig) (*shim.ResourceTimeout, error) {
 	panic("Cannot call DecodeTimeouts for a schema only resource")
 }

--- a/pkg/pf/proto/schema.go
+++ b/pkg/pf/proto/schema.go
@@ -29,13 +29,15 @@ func (pseudoResource) Timeouts() *shim.ResourceTimeout { return nil }
 func (pseudoResource) InstanceState(id string, object, meta map[string]interface{}) (shim.InstanceState, error) {
 	panic("Cannot invoke InstanceState on a pseudoResource")
 }
+
 func (pseudoResource) DecodeTimeouts(config shim.ResourceConfig) (*shim.ResourceTimeout, error) {
 	panic("Cannot invoke DecodeTimeouts on a pseudoResource")
 }
 
 func getSchemaMap[T any](m interface {
 	GetOk(string) (T, bool)
-}, key string) T {
+}, key string,
+) T {
 	v, _ := m.GetOk(key)
 	// Some functions (such as terraformToPulumiName; link: [1]) do not correctly use
 	// GetOk, so we can't panic on Get for a missing value, even though that is the

--- a/pkg/pf/proto/unsupported.go
+++ b/pkg/pf/proto/unsupported.go
@@ -24,9 +24,11 @@ func (Provider) InternalValidate() error { panic("Unimplemented") }
 func (Provider) Validate(ctx context.Context, c shim.ResourceConfig) ([]string, []error) {
 	panic("Unimplemented")
 }
+
 func (Provider) ValidateResource(ctx context.Context, t string, c shim.ResourceConfig) ([]string, []error) {
 	panic("Unimplemented")
 }
+
 func (Provider) ValidateDataSource(ctx context.Context, t string, c shim.ResourceConfig) ([]string, []error) {
 	panic("Unimplemented")
 }
@@ -60,6 +62,7 @@ func (Provider) Refresh(
 func (Provider) ReadDataDiff(ctx context.Context, t string, c shim.ResourceConfig) (shim.InstanceDiff, error) {
 	panic("Unimplemented")
 }
+
 func (Provider) ReadDataApply(ctx context.Context, t string, d shim.InstanceDiff) (shim.InstanceState, error) {
 	panic("Unimplemented")
 }

--- a/pkg/pf/tests/diff_list_test.go
+++ b/pkg/pf/tests/diff_list_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hexops/autogold/v2"
 	crosstests "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/cross-tests"
+	pb "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/providerbuilder"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -217,8 +218,12 @@ func TestDetailedDiffList(t *testing.T) {
 					initialValue := schemaValueMakerPair.valueMaker(scenario.initialValue)
 					changeValue := schemaValueMakerPair.valueMaker(scenario.changeValue)
 
+					res := pb.NewResource(pb.NewResourceArgs{
+						ResourceSchema: schemaValueMakerPair.schema,
+					})
+
 					diff := crosstests.Diff(
-						t, schemaValueMakerPair.schema, map[string]cty.Value{"key": initialValue}, map[string]cty.Value{"key": changeValue})
+						t, res, map[string]cty.Value{"key": initialValue}, map[string]cty.Value{"key": changeValue})
 
 					autogold.ExpectFile(t, testOutput{
 						initialValue: scenario.initialValue,

--- a/pkg/pf/tests/diff_list_test.go
+++ b/pkg/pf/tests/diff_list_test.go
@@ -9,9 +9,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hexops/autogold/v2"
+	"github.com/zclconf/go-cty/cty"
+
 	crosstests "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/cross-tests"
 	pb "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/providerbuilder"
-	"github.com/zclconf/go-cty/cty"
 )
 
 func TestDetailedDiffList(t *testing.T) {

--- a/pkg/pf/tests/diff_map_test.go
+++ b/pkg/pf/tests/diff_map_test.go
@@ -9,9 +9,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hexops/autogold/v2"
+	"github.com/zclconf/go-cty/cty"
+
 	crosstests "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/cross-tests"
 	pb "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/providerbuilder"
-	"github.com/zclconf/go-cty/cty"
 )
 
 func TestDetailedDiffMap(t *testing.T) {

--- a/pkg/pf/tests/diff_map_test.go
+++ b/pkg/pf/tests/diff_map_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hexops/autogold/v2"
 	crosstests "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/cross-tests"
+	pb "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/providerbuilder"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -171,8 +172,11 @@ func TestDetailedDiffMap(t *testing.T) {
 					t.Parallel()
 					initialValue := schemaValueMakerPair.valueMaker(scenario.initialValue)
 					changeValue := schemaValueMakerPair.valueMaker(scenario.changeValue)
+					res := pb.NewResource(pb.NewResourceArgs{
+						ResourceSchema: schemaValueMakerPair.schema,
+					})
 
-					diff := crosstests.Diff(t, schemaValueMakerPair.schema, map[string]cty.Value{"key": initialValue}, map[string]cty.Value{"key": changeValue})
+					diff := crosstests.Diff(t, res, map[string]cty.Value{"key": initialValue}, map[string]cty.Value{"key": changeValue})
 
 					autogold.ExpectFile(t, testOutput{
 						initialValue: scenario.initialValue,

--- a/pkg/pf/tests/diff_object_test.go
+++ b/pkg/pf/tests/diff_object_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hexops/autogold/v2"
 	crosstests "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/cross-tests"
+	pb "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/providerbuilder"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -331,7 +332,10 @@ func TestDetailedDiffObject(t *testing.T) {
 					t.Parallel()
 					initialValue := map[string]cty.Value{"key": makeValue(scenario.initialValue)}
 					changeValue := map[string]cty.Value{"key": makeValue(scenario.changeValue)}
-					diff := crosstests.Diff(t, schema.schema, initialValue, changeValue)
+					res := pb.NewResource(pb.NewResourceArgs{
+						ResourceSchema: schema.schema,
+					})
+					diff := crosstests.Diff(t, res, initialValue, changeValue)
 					autogold.ExpectFile(t, testOutput{
 						initialValue: scenario.initialValue,
 						changeValue:  scenario.changeValue,
@@ -347,7 +351,10 @@ func TestDetailedDiffObject(t *testing.T) {
 						t.Parallel()
 						initialValue := map[string]cty.Value{"key": makeValue(scenario.initialValue)}
 						changeValue := map[string]cty.Value{"key": makeValue(scenario.changeValue)}
-						diff := crosstests.Diff(t, schema.schema, initialValue, changeValue)
+						res := pb.NewResource(pb.NewResourceArgs{
+							ResourceSchema: schema.schema,
+						})
+						diff := crosstests.Diff(t, res, initialValue, changeValue)
 						autogold.ExpectFile(t, testOutput{
 							initialValue: scenario.initialValue,
 							changeValue:  scenario.changeValue,

--- a/pkg/pf/tests/diff_object_test.go
+++ b/pkg/pf/tests/diff_object_test.go
@@ -14,9 +14,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hexops/autogold/v2"
+	"github.com/zclconf/go-cty/cty"
+
 	crosstests "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/cross-tests"
 	pb "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/providerbuilder"
-	"github.com/zclconf/go-cty/cty"
 )
 
 type objectDefault basetypes.ObjectValue

--- a/pkg/pf/tests/diff_set_test.go
+++ b/pkg/pf/tests/diff_set_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hexops/autogold/v2"
 	crosstests "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/cross-tests"
+	pb "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/providerbuilder"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -225,7 +226,10 @@ func TestDetailedDiffSet(t *testing.T) {
 					initialValue := schemaValueMakerPair.valueMaker(scenario.initialValue)
 					changeValue := schemaValueMakerPair.valueMaker(scenario.changeValue)
 
-					diff := crosstests.Diff(t, schemaValueMakerPair.schema, map[string]cty.Value{"key": initialValue}, map[string]cty.Value{"key": changeValue})
+					res := pb.NewResource(pb.NewResourceArgs{
+						ResourceSchema: schemaValueMakerPair.schema,
+					})
+					diff := crosstests.Diff(t, res, map[string]cty.Value{"key": initialValue}, map[string]cty.Value{"key": changeValue})
 
 					autogold.ExpectFile(t, testOutput{
 						initialValue: scenario.initialValue,

--- a/pkg/pf/tests/diff_set_test.go
+++ b/pkg/pf/tests/diff_set_test.go
@@ -9,9 +9,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hexops/autogold/v2"
+	"github.com/zclconf/go-cty/cty"
+
 	crosstests "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/cross-tests"
 	pb "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/providerbuilder"
-	"github.com/zclconf/go-cty/cty"
 )
 
 func TestDetailedDiffSet(t *testing.T) {

--- a/pkg/pf/tests/diff_test.go
+++ b/pkg/pf/tests/diff_test.go
@@ -10,9 +10,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hexops/autogold/v2"
+	"github.com/zclconf/go-cty/cty"
+
 	crosstests "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/cross-tests"
 	pb "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/providerbuilder"
-	"github.com/zclconf/go-cty/cty"
 )
 
 func ref[T any](t T) *T { return &t }

--- a/pkg/pf/tests/dynamic_types_test.go
+++ b/pkg/pf/tests/dynamic_types_test.go
@@ -16,10 +16,9 @@ package tfbridgetests
 
 import (
 	"context"
+	"encoding/json"
 	"math/big"
 	"testing"
-
-	"encoding/json"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -27,15 +26,16 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
-	pb "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/providerbuilder"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
+
+	pb "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/providerbuilder"
 )
 
 func TestCreateResourceWithDynamicAttribute(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	type testCase struct {
 		name                     string                 // test case name
 		manifestToSend           any                    // assumes a Pulumi YAML expression

--- a/pkg/pf/tests/dynamic_types_test.go
+++ b/pkg/pf/tests/dynamic_types_test.go
@@ -231,7 +231,7 @@ func TestCreateResourceWithDynamicAttribute(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			r := pb.Resource{
+			r := pb.NewResource(pb.NewResourceArgs{
 				Name: "r",
 				CreateFunc: func(
 					ctx context.Context,
@@ -266,10 +266,10 @@ func TestCreateResourceWithDynamicAttribute(t *testing.T) {
 						},
 					},
 				},
-			}
+			})
 
 			// Define an aux resource to produce unknown values for testing.
-			r0 := pb.Resource{
+			r0 := pb.NewResource(pb.NewResourceArgs{
 				Name: "r0",
 				CreateFunc: func(
 					ctx context.Context,
@@ -298,7 +298,7 @@ func TestCreateResourceWithDynamicAttribute(t *testing.T) {
 						},
 					},
 				},
-			}
+			})
 
 			p := pb.NewProvider(pb.NewProviderArgs{
 				AllResources: []pb.Resource{r, r0},

--- a/pkg/pf/tests/extract_inputs_test.go
+++ b/pkg/pf/tests/extract_inputs_test.go
@@ -11,15 +11,16 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hexops/autogold/v2"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/schemashim"
 	pb "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/providerbuilder"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/stretchr/testify/require"
 )
 
 func TestExtractInputsFromOutputsPF(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	type testCase struct {
 		name      string
 		props     resource.PropertyMap

--- a/pkg/pf/tests/extract_inputs_test.go
+++ b/pkg/pf/tests/extract_inputs_test.go
@@ -904,10 +904,10 @@ func TestExtractInputsFromOutputsPF(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			prov := pb.NewProvider(pb.NewProviderArgs{
 				AllResources: []pb.Resource{
-					{
+					pb.NewResource(pb.NewResourceArgs{
 						Name:           "test",
 						ResourceSchema: tc.resSchema,
-					},
+					}),
 				},
 			})
 

--- a/pkg/pf/tests/genrandom_test.go
+++ b/pkg/pf/tests/genrandom_test.go
@@ -18,8 +18,9 @@ import (
 	"testing"
 
 	testutils "github.com/pulumi/providertest/replay"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/testprovider"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/testprovider"
 )
 
 // These tests replay gRPC logs from a well-behaved test program in testdatagen/genrandom to verify
@@ -28,7 +29,7 @@ import (
 //
 // See testdatagen/genrandom/generate.sh for regenerating the test data.
 func TestGenRandom(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	traces := []string{
 		// TODO enable once Configure replay is implemented.
 		// "testdata/genrandom/random-delete-preview.json",

--- a/pkg/pf/tests/genupdate_test.go
+++ b/pkg/pf/tests/genupdate_test.go
@@ -18,8 +18,9 @@ import (
 	"testing"
 
 	testutils "github.com/pulumi/providertest/replay"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/testprovider"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/testprovider"
 )
 
 // These tests replay Update gRPC logs to get some unit test coverage for Update.
@@ -30,7 +31,7 @@ import (
 //	PULUMI_DEBUG_GPRC=$PWD/grpc.json go test -run TestUpdateProgram
 //	jq -s . grpc.json
 func TestGenUpdates(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	trace := "testdata/updateprogram.json"
 
 	server, err := newProviderServer(t, testprovider.SyntheticTestBridgeProvider())

--- a/pkg/pf/tests/integration/attach_test.go
+++ b/pkg/pf/tests/integration/attach_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestAttach(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	if testing.Short() {
 		t.Skip()
 	}
@@ -42,7 +42,7 @@ func TestAttach(t *testing.T) {
 }
 
 func TestAttachMuxed(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	if testing.Short() {
 		t.Skip()
 	}

--- a/pkg/pf/tests/integration/program_test.go
+++ b/pkg/pf/tests/integration/program_test.go
@@ -231,7 +231,6 @@ func TestTracePropagation(t *testing.T) {
 			return prepareStateFolder(info.Root)
 		},
 	})
-
 }
 
 // Note that random_bytes is an interesting resource that does not specify an ID where Pulumi requires it. Add a test
@@ -255,7 +254,7 @@ func TestResourceWithoutID(t *testing.T) {
 }
 
 func prepareStateFolder(root string) error {
-	err := os.Mkdir(filepath.Join(root, "state"), 0777)
+	err := os.Mkdir(filepath.Join(root, "state"), 0o777)
 	if os.IsExist(err) {
 		return nil
 	}
@@ -274,7 +273,6 @@ func ensureTestBridgeProviderCompiled(wd string) error {
 		return err
 	}
 	return ensure("pulumi-resource-muxedrandom")
-
 }
 
 // Stacks may define tests inline by a simple convention of providing

--- a/pkg/pf/tests/internal/cross-tests/configure.go
+++ b/pkg/pf/tests/internal/cross-tests/configure.go
@@ -27,6 +27,14 @@ import (
 	"github.com/pulumi/providertest/providers"
 	"github.com/pulumi/providertest/pulumitest"
 	"github.com/pulumi/providertest/pulumitest/opttest"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+	"gopkg.in/yaml.v3"
+
 	crosstests "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/tests/cross-tests"
 	crosstestsimpl "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/tests/cross-tests/impl"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/tests/cross-tests/impl/hclwrite"
@@ -36,13 +44,6 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/tfcheck"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/tokens"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/zclconf/go-cty/cty"
-	"gopkg.in/yaml.v3"
 )
 
 // MakeConfigure returns a [testing] subtest of [Configure].

--- a/pkg/pf/tests/internal/cross-tests/configure.go
+++ b/pkg/pf/tests/internal/cross-tests/configure.go
@@ -100,9 +100,11 @@ func Configure(t T, schema pschema.Schema, tfConfig map[string]cty.Value, option
 			ConfigureFunc: func(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
 				*config = req.Config
 			},
-			AllResources: []pb.Resource{{
-				Name: "res",
-			}},
+			AllResources: []pb.Resource{
+				pb.NewResource(pb.NewResourceArgs{
+					Name: "res",
+				}),
+			},
 		})
 	}
 

--- a/pkg/pf/tests/internal/cross-tests/diff.go
+++ b/pkg/pf/tests/internal/cross-tests/diff.go
@@ -17,6 +17,12 @@ package crosstests
 import (
 	"bytes"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/auto/optpreview"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+	"gopkg.in/yaml.v3"
+
 	crosstests "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/tests/cross-tests"
 	crosstestsimpl "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/tests/cross-tests/impl"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/tests/cross-tests/impl/hclwrite"
@@ -25,11 +31,6 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/tfcheck"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
-	"github.com/pulumi/pulumi/sdk/v3/go/auto/optpreview"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/stretchr/testify/require"
-	"github.com/zclconf/go-cty/cty"
-	"gopkg.in/yaml.v3"
 )
 
 func yamlResource(t T, properties resource.PropertyMap) map[string]any {

--- a/pkg/pf/tests/internal/cross-tests/tfwrite.go
+++ b/pkg/pf/tests/internal/cross-tests/tfwrite.go
@@ -3,8 +3,9 @@ package crosstests
 import (
 	pschema "github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/tests/cross-tests/impl/hclwrite"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/tests/cross-tests/impl/hclwrite"
 )
 
 // This is a copy of the BlockNestingMode enum in the Terraform Plugin Framework.

--- a/pkg/pf/tests/internal/cross-tests/tfwrite_test.go
+++ b/pkg/pf/tests/internal/cross-tests/tfwrite_test.go
@@ -7,9 +7,10 @@ import (
 	pschema "github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hexops/autogold/v2"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/tests/cross-tests/impl/hclwrite"
 	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/tests/cross-tests/impl/hclwrite"
 )
 
 func TestWritePFHCLProvider(t *testing.T) {

--- a/pkg/pf/tests/internal/cross-tests/util.go
+++ b/pkg/pf/tests/internal/cross-tests/util.go
@@ -20,14 +20,15 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+
 	crosstestsimpl "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/tests/cross-tests/impl"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/providerbuilder"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
 	tfbridge0 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/tokens"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
 type T = crosstestsimpl.T

--- a/pkg/pf/tests/internal/pftfcheck/pftf_test.go
+++ b/pkg/pf/tests/internal/pftfcheck/pftf_test.go
@@ -5,13 +5,14 @@ import (
 
 	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/stretchr/testify/require"
+
 	pb "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/providerbuilder"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/tfcheck"
-	"github.com/stretchr/testify/require"
 )
 
 func TestBasic(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	prov := pb.NewProvider(pb.NewProviderArgs{
 		AllResources: []pb.Resource{
 			pb.NewResource(pb.NewResourceArgs{
@@ -45,7 +46,7 @@ output "s_val" {
 }
 
 func TestDefaults(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	prov := pb.NewProvider(pb.NewProviderArgs{
 		AllResources: []pb.Resource{
 			pb.NewResource(pb.NewResourceArgs{

--- a/pkg/pf/tests/internal/pftfcheck/pftf_test.go
+++ b/pkg/pf/tests/internal/pftfcheck/pftf_test.go
@@ -14,14 +14,14 @@ func TestBasic(t *testing.T) {
     t.Parallel()
 	prov := pb.NewProvider(pb.NewProviderArgs{
 		AllResources: []pb.Resource{
-			{
+			pb.NewResource(pb.NewResourceArgs{
 				Name: "res",
 				ResourceSchema: rschema.Schema{
 					Attributes: map[string]rschema.Attribute{
 						"s": rschema.StringAttribute{Optional: true},
 					},
 				},
-			},
+			}),
 		},
 	})
 
@@ -48,7 +48,7 @@ func TestDefaults(t *testing.T) {
     t.Parallel()
 	prov := pb.NewProvider(pb.NewProviderArgs{
 		AllResources: []pb.Resource{
-			{
+			pb.NewResource(pb.NewResourceArgs{
 				Name: "res",
 				ResourceSchema: rschema.Schema{
 					Attributes: map[string]rschema.Attribute{
@@ -59,7 +59,7 @@ func TestDefaults(t *testing.T) {
 						},
 					},
 				},
-			},
+			}),
 		},
 	})
 

--- a/pkg/pf/tests/internal/providerbuilder/build_provider.go
+++ b/pkg/pf/tests/internal/providerbuilder/build_provider.go
@@ -18,14 +18,10 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	dschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 )
@@ -112,33 +108,6 @@ func NewProvider(params NewProviderArgs) *Provider {
 	}
 	if prov.Version == "" {
 		prov.Version = "0.0.1"
-	}
-
-	for i := range prov.AllResources {
-		r := &prov.AllResources[i]
-		if r.ResourceSchema.Attributes == nil {
-			r.ResourceSchema.Attributes = map[string]rschema.Attribute{}
-		}
-
-		if r.ResourceSchema.Attributes["id"] == nil {
-			r.ResourceSchema.Attributes["id"] = rschema.StringAttribute{
-				Computed: true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			}
-		}
-		if r.CreateFunc == nil {
-			r.CreateFunc = func(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-				resp.State = tfsdk.State(req.Plan)
-				resp.State.SetAttribute(ctx, path.Root("id"), "test-id")
-			}
-		}
-		if r.UpdateFunc == nil {
-			r.UpdateFunc = func(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-				resp.State = tfsdk.State(req.Plan)
-			}
-		}
 	}
 
 	for i := range prov.AllDataSources {

--- a/pkg/pf/tests/internal/providerbuilder/build_resource.go
+++ b/pkg/pf/tests/internal/providerbuilder/build_resource.go
@@ -71,6 +71,7 @@ func NewResource(args NewResourceArgs) Resource {
 	return Resource(args)
 }
 
+// Resource is a utility type that helps define PF resources. Prefer creating via NewResource.
 type Resource struct {
 	Name           string
 	ResourceSchema schema.Schema

--- a/pkg/pf/tests/internal/providerbuilder/build_resource.go
+++ b/pkg/pf/tests/internal/providerbuilder/build_resource.go
@@ -26,6 +26,7 @@ import (
 )
 
 type NewResourceArgs struct {
+	// Name is the name of the resource. Defaults to "test".
 	Name           string
 	ResourceSchema schema.Schema
 
@@ -36,6 +37,7 @@ type NewResourceArgs struct {
 	ImportStateFunc func(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse)
 }
 
+// NewResource creates a new Resource with the given parameters, filling reasonable defaults.
 func NewResource(args NewResourceArgs) Resource {
 	if args.Name == "" {
 		args.Name = "test"

--- a/pkg/pf/tests/internal/testprovider/assert_provider.go
+++ b/pkg/pf/tests/internal/testprovider/assert_provider.go
@@ -103,6 +103,7 @@ func (e *assertRes) Schema(_ context.Context, _ resource.SchemaRequest, resp *re
 		},
 	}
 }
+
 func (e *assertRes) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_echo"
 }

--- a/pkg/pf/tests/internal/testprovider/cmd/pulumi-resource-testbridge/main.go
+++ b/pkg/pf/tests/internal/testprovider/cmd/pulumi-resource-testbridge/main.go
@@ -18,6 +18,7 @@ package main
 import (
 	"context"
 	_ "embed"
+
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/testprovider"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
 )

--- a/pkg/pf/tests/internal/testprovider/cmd/pulumi-resource-tls/main.go
+++ b/pkg/pf/tests/internal/testprovider/cmd/pulumi-resource-tls/main.go
@@ -18,6 +18,7 @@ package main
 import (
 	"context"
 	_ "embed"
+
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/testprovider"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
 )

--- a/pkg/pf/tests/internal/testprovider/plan_modifiers.go
+++ b/pkg/pf/tests/internal/testprovider/plan_modifiers.go
@@ -28,11 +28,13 @@ type PropagatesNullFrom struct {
 	AnotherAttribute string
 }
 
-var _ planmodifier.String = PropagatesNullFrom{}
-var _ planmodifier.Number = PropagatesNullFrom{}
-var _ planmodifier.Bool = PropagatesNullFrom{}
-var _ planmodifier.List = PropagatesNullFrom{}
-var _ planmodifier.Map = PropagatesNullFrom{}
+var (
+	_ planmodifier.String = PropagatesNullFrom{}
+	_ planmodifier.Number = PropagatesNullFrom{}
+	_ planmodifier.Bool   = PropagatesNullFrom{}
+	_ planmodifier.List   = PropagatesNullFrom{}
+	_ planmodifier.Map    = PropagatesNullFrom{}
+)
 
 func (mod PropagatesNullFrom) Description(_ context.Context) string {
 	return "Sets plan to null if AnotherAttribute is null in config"
@@ -43,35 +45,40 @@ func (mod PropagatesNullFrom) MarkdownDescription(ctx context.Context) string {
 }
 
 func (mod PropagatesNullFrom) PlanModifyNumber(ctx context.Context, req planmodifier.NumberRequest,
-	resp *planmodifier.NumberResponse) {
+	resp *planmodifier.NumberResponse,
+) {
 	if mod.anotherAttributeIsNull(req.Config) {
 		resp.PlanValue = types.NumberNull()
 	}
 }
 
 func (mod PropagatesNullFrom) PlanModifyString(ctx context.Context, req planmodifier.StringRequest,
-	resp *planmodifier.StringResponse) {
+	resp *planmodifier.StringResponse,
+) {
 	if mod.anotherAttributeIsNull(req.Config) {
 		resp.PlanValue = types.StringNull()
 	}
 }
 
 func (mod PropagatesNullFrom) PlanModifyBool(ctx context.Context, req planmodifier.BoolRequest,
-	resp *planmodifier.BoolResponse) {
+	resp *planmodifier.BoolResponse,
+) {
 	if mod.anotherAttributeIsNull(req.Config) {
 		resp.PlanValue = types.BoolNull()
 	}
 }
 
 func (mod PropagatesNullFrom) PlanModifyList(ctx context.Context, req planmodifier.ListRequest,
-	resp *planmodifier.ListResponse) {
+	resp *planmodifier.ListResponse,
+) {
 	if mod.anotherAttributeIsNull(req.Config) {
 		resp.PlanValue = types.ListNull(req.PlanValue.ElementType(ctx))
 	}
 }
 
 func (mod PropagatesNullFrom) PlanModifyMap(ctx context.Context, req planmodifier.MapRequest,
-	resp *planmodifier.MapResponse) {
+	resp *planmodifier.MapResponse,
+) {
 	if mod.anotherAttributeIsNull(req.Config) {
 		resp.PlanValue = types.MapNull(req.PlanValue.ElementType(ctx))
 	}

--- a/pkg/pf/tests/internal/testprovider/random.go
+++ b/pkg/pf/tests/internal/testprovider/random.go
@@ -22,14 +22,12 @@ import (
 	"strings"
 	"unicode"
 
+	sdk2schema "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/randomshim"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/testprovider/sdkv2randomprovider"
-
-	sdk2schema "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
 	tfpf "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	sdkv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"

--- a/pkg/pf/tests/internal/testprovider/testbridge.go
+++ b/pkg/pf/tests/internal/testprovider/testbridge.go
@@ -232,7 +232,6 @@ func validateNested(
 	req provider.ConfigureRequest,
 	resp *provider.ConfigureResponse,
 ) {
-
 	check := func(path path.Path, expected, actual any) {
 		if !reflect.DeepEqual(expected, actual) {
 			resp.Diagnostics.AddAttributeError(path, "mismatched expectations",

--- a/pkg/pf/tests/internal/testprovider/testbridge_datasource_echo.go
+++ b/pkg/pf/tests/internal/testprovider/testbridge_datasource_echo.go
@@ -29,7 +29,8 @@ func newEchoDataSource() datasource.DataSource {
 type echoDataSource struct{}
 
 func (*echoDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest,
-	resp *datasource.MetadataResponse) {
+	resp *datasource.MetadataResponse,
+) {
 	resp.TypeName = req.ProviderTypeName + "_echo"
 }
 

--- a/pkg/pf/tests/internal/testprovider/testbridge_datasource_smac.go
+++ b/pkg/pf/tests/internal/testprovider/testbridge_datasource_smac.go
@@ -47,8 +47,8 @@ func (*smacDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, res
 func (ds *smacDataSource) Configure(
 	_ context.Context,
 	rq datasource.ConfigureRequest,
-	re *datasource.ConfigureResponse) {
-
+	re *datasource.ConfigureResponse,
+) {
 	data, ok := rq.ProviderData.(resourceData)
 	if ok {
 		ds.smac = data.skipMetadataAPICheck

--- a/pkg/pf/tests/internal/testprovider/testbridge_datasource_test_defaultinfo.go
+++ b/pkg/pf/tests/internal/testprovider/testbridge_datasource_test_defaultinfo.go
@@ -29,7 +29,8 @@ func newTestDefaultInfoDataSource() datasource.DataSource {
 type testDefaultInfoDataSource struct{}
 
 func (*testDefaultInfoDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest,
-	resp *datasource.MetadataResponse) {
+	resp *datasource.MetadataResponse,
+) {
 	resp.TypeName = req.ProviderTypeName + "_test_defaultinfo"
 }
 

--- a/pkg/pf/tests/internal/testprovider/testbridge_resouce_testconfigres.go
+++ b/pkg/pf/tests/internal/testprovider/testbridge_resouce_testconfigres.go
@@ -26,8 +26,10 @@ type testconfigres struct {
 	config string
 }
 
-var _ resource.Resource = (*testconfigres)(nil)
-var _ resource.ResourceWithConfigure = (*testconfigres)(nil)
+var (
+	_ resource.Resource              = (*testconfigres)(nil)
+	_ resource.ResourceWithConfigure = (*testconfigres)(nil)
+)
 
 func newTestConfigRes() resource.Resource {
 	return &testconfigres{}

--- a/pkg/pf/tests/internal/testprovider/testbridge_resource_testnest.go
+++ b/pkg/pf/tests/internal/testprovider/testbridge_resource_testnest.go
@@ -28,8 +28,10 @@ import (
 
 type testnest struct{}
 
-var _ resource.Resource = &testnest{}
-var _ resource.ResourceWithImportState = &testnest{}
+var (
+	_ resource.Resource                = &testnest{}
+	_ resource.ResourceWithImportState = &testnest{}
+)
 
 func newTestnest() resource.Resource {
 	return &testnest{}

--- a/pkg/pf/tests/internal/testprovider/testbridge_resource_testnestattr.go
+++ b/pkg/pf/tests/internal/testprovider/testbridge_resource_testnestattr.go
@@ -16,11 +16,11 @@ package testprovider
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -28,8 +28,10 @@ import (
 
 type testnestattr struct{}
 
-var _ resource.Resource = &testnestattr{}
-var _ resource.ResourceWithImportState = &testnestattr{}
+var (
+	_ resource.Resource                = &testnestattr{}
+	_ resource.ResourceWithImportState = &testnestattr{}
+)
 
 func newTestnestattr() resource.Resource {
 	return &testnestattr{}
@@ -117,7 +119,6 @@ func (e *testnestattr) Delete(ctx context.Context, req resource.DeleteRequest, r
 // If setting an attribute with the import identifier, it is recommended to use the ImportStatePassthroughID() call in
 // this method.
 func (e *testnestattr) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-
 	type model struct {
 		ID       types.String   `tfsdk:"id"`
 		Services []ServiceModel `tfsdk:"services"`

--- a/pkg/pf/tests/internal/testprovider/testbridge_resource_testres.go
+++ b/pkg/pf/tests/internal/testprovider/testbridge_resource_testres.go
@@ -39,7 +39,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
-
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/fsutil"
 )
 
@@ -539,7 +538,7 @@ func (e *testres) freshID(statedir string) (string, error) {
 		}
 	}
 
-	if err := os.WriteFile(cF, []byte(fmt.Sprintf("%d", i+1)), 0600); err != nil {
+	if err := os.WriteFile(cF, []byte(fmt.Sprintf("%d", i+1)), 0o600); err != nil {
 		return "", err
 	}
 
@@ -574,7 +573,7 @@ func (e *testres) writeCloudState(ctx context.Context, file string, state tfsdk.
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(file, stateBytes, 0600)
+	return os.WriteFile(file, stateBytes, 0o600)
 }
 
 func (*testres) stateToBytes(ctx context.Context, state tfsdk.State) ([]byte, error) {

--- a/pkg/pf/tests/internal/testprovider/tls.go
+++ b/pkg/pf/tests/internal/testprovider/tls.go
@@ -20,10 +20,11 @@ import (
 	"path/filepath"
 	"unicode"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/tlsshim"
 	tfpf "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 )
 
 //go:embed cmd/pulumi-resource-tls/bridge-metadata.json

--- a/pkg/pf/tests/internal/testprovider/tuple_type.go
+++ b/pkg/pf/tests/internal/testprovider/tuple_type.go
@@ -62,8 +62,10 @@ func (c TupleType) ApplyTerraform5AttributePathStep(step tftypes.AttributePathSt
 	return c.attr(int(i)), nil
 }
 
-var _ attr.TypeWithElementTypes = ((*TupleType)(nil))
-var _ pfutils.BlockLike = ((*TupleType)(nil))
+var (
+	_ attr.TypeWithElementTypes = ((*TupleType)(nil))
+	_ pfutils.BlockLike         = ((*TupleType)(nil))
+)
 
 func (c TupleType) GetDeprecationMessage() string  { return "" }
 func (c TupleType) GetDescription() string         { return "" }

--- a/pkg/pf/tests/muxwith_test.go
+++ b/pkg/pf/tests/muxwith_test.go
@@ -30,7 +30,7 @@ func TestNewMuxProvider(t *testing.T) {
     t.Parallel()
 	createCallCount := 0
 
-	r := pb.Resource{
+	r := pb.NewResource(pb.NewResourceArgs{
 		Name: "r",
 		CreateFunc: func(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 			t.Logf("CREATE called: %v", req.Plan.Raw.String())
@@ -45,7 +45,7 @@ func TestNewMuxProvider(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	p := pb.NewProvider(pb.NewProviderArgs{
 		AllResources: []pb.Resource{r},

--- a/pkg/pf/tests/muxwith_test.go
+++ b/pkg/pf/tests/muxwith_test.go
@@ -21,13 +21,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	pb "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/providerbuilder"
 	"github.com/stretchr/testify/require"
+
+	pb "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/providerbuilder"
 )
 
 // Add coverage for pf.NewMuxProvider.
 func TestNewMuxProvider(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	createCallCount := 0
 
 	r := pb.NewResource(pb.NewResourceArgs{

--- a/pkg/pf/tests/nested_attr_test.go
+++ b/pkg/pf/tests/nested_attr_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestNestedType(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	ctx := context.Background()
 	info := testprovider.SyntheticTestBridgeProvider()
 	res, err := info.P.(pf.ShimProvider).Resources(ctx)

--- a/pkg/pf/tests/prestateupgradehook_test.go
+++ b/pkg/pf/tests/prestateupgradehook_test.go
@@ -18,14 +18,15 @@ import (
 	"testing"
 
 	testutils "github.com/pulumi/providertest/replay"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/testprovider"
-	tfbridge "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/testprovider"
+	tfbridge "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 )
 
 func TestPreStateUpgradeHook(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	info := testprovider.RandomProvider()
 	info.Resources["random_string"].PreStateUpgradeHook = func(args tfbridge.PreStateUpgradeHookArgs) (int64, resource.PropertyMap, error) {
 		// Assume that if prior state is missing a schema version marker, it really is a corrupt state at version 2.

--- a/pkg/pf/tests/provider_check_test.go
+++ b/pkg/pf/tests/provider_check_test.go
@@ -319,10 +319,12 @@ func TestCheck(t *testing.T) {
 						},
 					},
 				},
-				AllResources: []providerbuilder.Resource{{
-					Name:           "res",
-					ResourceSchema: tc.schema,
-				}},
+				AllResources: []providerbuilder.Resource{
+					pb.NewResource(pb.NewResourceArgs{
+						Name:           "res",
+						ResourceSchema: tc.schema,
+					}),
+				},
 			})
 			res := tfbridge0.ResourceInfo{
 				Tok: "testprovider:index/res:Res",

--- a/pkg/pf/tests/provider_check_test.go
+++ b/pkg/pf/tests/provider_check_test.go
@@ -23,11 +23,11 @@ import (
 	pschema "github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	testutils "github.com/pulumi/providertest/replay"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	testutils "github.com/pulumi/providertest/replay"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/providerbuilder"
 	pb "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/providerbuilder"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/testprovider"
@@ -36,7 +36,7 @@ import (
 )
 
 func TestCheck(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	type testCase struct {
 		name        string
 		schema      schema.Schema
@@ -359,7 +359,7 @@ func TestCheck(t *testing.T) {
 }
 
 func TestCheckWithIntID(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	server, err := newProviderServer(t, testprovider.SyntheticTestBridgeProvider())
 	require.NoError(t, err)
 	testCase := `

--- a/pkg/pf/tests/provider_checkconfig_test.go
+++ b/pkg/pf/tests/provider_checkconfig_test.go
@@ -20,22 +20,20 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hexops/autogold/v2"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/types/known/structpb"
-
+	testutils "github.com/pulumi/providertest/replay"
 	hostclient "github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
-	testutils "github.com/pulumi/providertest/replay"
 	pb "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/providerbuilder"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
 	tfbridge0 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
@@ -43,7 +41,7 @@ import (
 )
 
 func TestCheckConfig(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	t.Run("minimal", func(t *testing.T) {
 		schema := schema.Schema{}
 		testutils.Replay(t, makeProviderServer(t, schema), `
@@ -215,7 +213,7 @@ func TestCheckConfig(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(resp.Failures))
-		//nolint:lll
+
 		autogold.Expect("`testprovider:cofnigValue` is not a valid configuration key for the testprovider provider. Did you mean `testprovider:configValue`? If the referenced key is not intended for the provider, please choose a different namespace from `testprovider:`.").Equal(t, resp.Failures[0].Reason)
 	})
 
@@ -469,7 +467,7 @@ func TestCheckConfig(t *testing.T) {
 }
 
 func TestPreConfigureCallback(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	t.Run("PreConfigureCallback called by CheckConfig", func(t *testing.T) {
 		schema := schema.Schema{
 			Attributes: map[string]schema.Attribute{

--- a/pkg/pf/tests/provider_configure_test.go
+++ b/pkg/pf/tests/provider_configure_test.go
@@ -23,14 +23,15 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/pulumi/providertest/replay"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+
 	crosstests "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/cross-tests"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/testprovider"
 	tfpf "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/stretchr/testify/require"
-	"github.com/zclconf/go-cty/cty"
 )
 
 func TestConfigure(t *testing.T) {

--- a/pkg/pf/tests/provider_create_test.go
+++ b/pkg/pf/tests/provider_create_test.go
@@ -20,13 +20,14 @@ import (
 	"testing"
 
 	testutils "github.com/pulumi/providertest/replay"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/testprovider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/testprovider"
 )
 
 func TestCreateWithComputedOptionals(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	server, err := newProviderServer(t, testprovider.SyntheticTestBridgeProvider())
 	require.NoError(t, err)
 	testCase := `
@@ -52,7 +53,7 @@ func TestCreateWithComputedOptionals(t *testing.T) {
 }
 
 func TestCreateWithIntID(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	server, err := newProviderServer(t, testprovider.SyntheticTestBridgeProvider())
 	require.NoError(t, err)
 	testCase := `
@@ -75,7 +76,7 @@ func TestCreateWithIntID(t *testing.T) {
 }
 
 func TestCreateWritesSchemaVersion(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	server, err := newProviderServer(t, testprovider.RandomProvider())
 	require.NoError(t, err)
 
@@ -111,7 +112,7 @@ func TestCreateWritesSchemaVersion(t *testing.T) {
 }
 
 func TestPreviewCreate(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	server, err := newProviderServer(t, testprovider.RandomProvider())
 	require.NoError(t, err)
 
@@ -145,7 +146,7 @@ func TestPreviewCreate(t *testing.T) {
 }
 
 func TestMuxedAliasCreate(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	server := newMuxedProviderServer(t, testprovider.MuxedRandomProvider())
 
 	testCase := func(typ string) string {
@@ -185,7 +186,7 @@ func TestMuxedAliasCreate(t *testing.T) {
 }
 
 func TestCreateWithFirstClassSecrets(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	server, err := newProviderServer(t, testprovider.RandomProvider())
 	require.NoError(t, err)
 	testCase := `
@@ -213,7 +214,7 @@ func TestCreateWithFirstClassSecrets(t *testing.T) {
 }
 
 func TestCreateWithSchemaBasedSecrets(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	// Ensure that resources that mark output properties as secret in the schema return them as secrets.
 	// RandomPassword is a good example. Surprisingly this test requires a Configure call first, otherwise the
 	// plubming is confused about secrets bits and retursn the wrong result. The test represents production use.
@@ -269,7 +270,7 @@ func TestCreateWithSchemaBasedSecrets(t *testing.T) {
 }
 
 func TestCreateSupportsCustomID(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	p := testprovider.RandomProvider()
 	p.Resources["random_pet"].ComputeID = func(
 		ctx context.Context, state resource.PropertyMap,

--- a/pkg/pf/tests/provider_diff_test.go
+++ b/pkg/pf/tests/provider_diff_test.go
@@ -18,13 +18,14 @@ import (
 	"testing"
 
 	testutils "github.com/pulumi/providertest/replay"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/testprovider"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/testprovider"
 )
 
 // Test that preview diff in presence of computed attributes results in an empty diff.
 func TestEmptyTestresDiff(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	server, err := newProviderServer(t, testprovider.SyntheticTestBridgeProvider())
 	require.NoError(t, err)
 	testCase := `
@@ -54,7 +55,7 @@ func TestEmptyTestresDiff(t *testing.T) {
 
 // Test removing an optional input.
 func TestOptionRemovalTestresDiff(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	server, err := newProviderServer(t, testprovider.SyntheticTestBridgeProvider())
 	require.NoError(t, err)
 	testCase := `
@@ -88,7 +89,7 @@ func TestOptionRemovalTestresDiff(t *testing.T) {
 
 // Make sure optionalInputBoolCopy does not cause non-empty diff when not actually changing.
 func TestEmptyTestresDiffWithOptionalComputed(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	server, err := newProviderServer(t, testprovider.SyntheticTestBridgeProvider())
 	require.NoError(t, err)
 	testCase := `
@@ -119,7 +120,7 @@ func TestEmptyTestresDiffWithOptionalComputed(t *testing.T) {
 }
 
 func TestDiffWithSecrets(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	server, err := newProviderServer(t, testprovider.RandomProvider())
 	require.NoError(t, err)
 
@@ -163,7 +164,7 @@ func TestDiffWithSecrets(t *testing.T) {
 
 // See https://github.com/pulumi/pulumi-random/issues/258
 func TestDiffVersionUpgrade(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	server, err := newProviderServer(t, testprovider.RandomProvider())
 	require.NoError(t, err)
 	testCase := `
@@ -208,7 +209,7 @@ func TestDiffVersionUpgrade(t *testing.T) {
 }
 
 func TestSetNestedObjectAdded(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	server, err := newProviderServer(t, testprovider.SyntheticTestBridgeProvider())
 	require.NoError(t, err)
 	testCase := `
@@ -259,7 +260,7 @@ func TestSetNestedObjectAdded(t *testing.T) {
 }
 
 func TestSetNestedObjectAddedOtherDiff(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	server, err := newProviderServer(t, testprovider.SyntheticTestBridgeProvider())
 	require.NoError(t, err)
 	testCase := `

--- a/pkg/pf/tests/provider_get_mapping_test.go
+++ b/pkg/pf/tests/provider_get_mapping_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -26,11 +27,10 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/testprovider"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
 	tfbridge0 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 )
 
 func TestGetMapping(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	ctx := context.Background()
 	info := testprovider.RandomProvider()
 
@@ -88,7 +88,7 @@ func TestGetMapping(t *testing.T) {
 }
 
 func TestMuxedGetMapping(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	ctx := context.Background()
 
 	info := testprovider.MuxedRandomProvider()

--- a/pkg/pf/tests/provider_init_benchmark_test.go
+++ b/pkg/pf/tests/provider_init_benchmark_test.go
@@ -2,10 +2,11 @@ package tfbridgetests
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/testprovider"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/testprovider/sdkv2randomprovider"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
-	"testing"
 )
 
 // Benchmark tests based on init of an example large provider

--- a/pkg/pf/tests/provider_invoke_test.go
+++ b/pkg/pf/tests/provider_invoke_test.go
@@ -18,12 +18,13 @@ import (
 	"testing"
 
 	testutils "github.com/pulumi/providertest/replay"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/testprovider"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/testprovider"
 )
 
 func TestBasicInvoke(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	server, err := newProviderServer(t, testprovider.TLSProvider())
 	require.NoError(t, err)
 
@@ -64,7 +65,7 @@ func TestBasicInvoke(t *testing.T) {
 }
 
 func TestInvokeWithInvalidData(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	p := testprovider.TLSProvider()
 	server, err := newProviderServer(t, p)
 	require.NoError(t, err)

--- a/pkg/pf/tests/provider_nested_custom_types_test.go
+++ b/pkg/pf/tests/provider_nested_custom_types_test.go
@@ -14,16 +14,17 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/convert"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/providerbuilder"
 	pb "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/providerbuilder"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
 	tfbridge0 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestNestedCustomTypeEncoding(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 
 	testProvider := pb.NewProvider(pb.NewProviderArgs{
 		// This resource is modified from AWS Bedrockagent.
@@ -31,22 +32,22 @@ func TestNestedCustomTypeEncoding(t *testing.T) {
 			pb.NewResource(pb.NewResourceArgs{
 				Name: "bedrockagent",
 				ResourceSchema: schema.Schema{
-				Attributes: map[string]schema.Attribute{
-					"prompt_override_configuration": schema.ListAttribute{ // proto5 Optional+Computed nested block.
-						CustomType: NewListNestedObjectTypeOf[promptOverrideConfigurationModel](context.Background()),
-						Optional:   true,
-						Computed:   true,
-						PlanModifiers: []planmodifier.List{
-							listplanmodifier.UseStateForUnknown(),
-						},
-						Validators: []validator.List{
-							listvalidator.SizeAtMost(1),
-						},
-						ElementType: basetypes.ObjectType{
-							AttrTypes: AttributeTypesMust[promptOverrideConfigurationModel](context.Background()),
+					Attributes: map[string]schema.Attribute{
+						"prompt_override_configuration": schema.ListAttribute{ // proto5 Optional+Computed nested block.
+							CustomType: NewListNestedObjectTypeOf[promptOverrideConfigurationModel](context.Background()),
+							Optional:   true,
+							Computed:   true,
+							PlanModifiers: []planmodifier.List{
+								listplanmodifier.UseStateForUnknown(),
+							},
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							ElementType: basetypes.ObjectType{
+								AttrTypes: AttributeTypesMust[promptOverrideConfigurationModel](context.Background()),
+							},
 						},
 					},
-				},
 				},
 			}),
 		},
@@ -150,6 +151,7 @@ func (setNested SetNestedObjectValueOf[T]) Equal(o attr.Value) bool {
 func (setNested SetNestedObjectValueOf[T]) Type(ctx context.Context) attr.Type {
 	return NewSetNestedObjectTypeOf[T](ctx)
 }
+
 func NewSetNestedObjectTypeOf[T any](ctx context.Context) SetNestedObjectTypeOf[T] {
 	return SetNestedObjectTypeOf[T]{basetypes.SetType{ElemType: NewObjectTypeOf[T](ctx)}}
 }

--- a/pkg/pf/tests/provider_nested_custom_types_test.go
+++ b/pkg/pf/tests/provider_nested_custom_types_test.go
@@ -27,9 +27,10 @@ func TestNestedCustomTypeEncoding(t *testing.T) {
 
 	testProvider := pb.NewProvider(pb.NewProviderArgs{
 		// This resource is modified from AWS Bedrockagent.
-		AllResources: []providerbuilder.Resource{{
-			Name: "bedrockagent",
-			ResourceSchema: schema.Schema{
+		AllResources: []providerbuilder.Resource{
+			pb.NewResource(pb.NewResourceArgs{
+				Name: "bedrockagent",
+				ResourceSchema: schema.Schema{
 				Attributes: map[string]schema.Attribute{
 					"prompt_override_configuration": schema.ListAttribute{ // proto5 Optional+Computed nested block.
 						CustomType: NewListNestedObjectTypeOf[promptOverrideConfigurationModel](context.Background()),
@@ -46,8 +47,9 @@ func TestNestedCustomTypeEncoding(t *testing.T) {
 						},
 					},
 				},
-			},
-		}},
+				},
+			}),
+		},
 	})
 	res := tfbridge0.ResourceInfo{
 		Tok: "testprovider:index/bedrockagent:Bedrockagent",

--- a/pkg/pf/tests/provider_read_test.go
+++ b/pkg/pf/tests/provider_read_test.go
@@ -344,7 +344,7 @@ func TestRefreshMissingResources(t *testing.T) {
 // See https://github.com/pulumi/pulumi-terraform-bridge/issues/1919
 func TestRefreshResourceNotFound(t *testing.T) {
     t.Parallel()
-	r := pb.Resource{
+	r := pb.NewResource(pb.NewResourceArgs{
 		Name: "resource",
 		ResourceSchema: fwsch.Schema{
 			Attributes: map[string]fwsch.Attribute{
@@ -358,7 +358,7 @@ func TestRefreshResourceNotFound(t *testing.T) {
 			// Indicate that it was no found and should be removed from state.
 			resp.State.RemoveResource(ctx)
 		},
-	}
+	})
 
 	p := pb.NewProvider(pb.NewProviderArgs{
 		TypeName: "my",

--- a/pkg/pf/tests/provider_read_test.go
+++ b/pkg/pf/tests/provider_read_test.go
@@ -22,17 +22,18 @@ import (
 	fwres "github.com/hashicorp/terraform-plugin-framework/resource"
 	fwsch "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	testutils "github.com/pulumi/providertest/replay"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/require"
+
 	pb "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/providerbuilder"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/testprovider"
 	tfpf "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/stretchr/testify/require"
 )
 
 func TestReadFromRefresh(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	// This test case was obtained by running `pulumi refresh` on a simple stack with one RandomPassword.
 	//
 	// Specifically testing for:
@@ -151,7 +152,7 @@ func TestReadFromRefresh(t *testing.T) {
 }
 
 func TestImportRandomPassword(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	server, err := newProviderServer(t, testprovider.RandomProvider())
 	require.NoError(t, err)
 	testCase := `
@@ -194,7 +195,7 @@ func TestImportRandomPassword(t *testing.T) {
 }
 
 func TestImportingResourcesWithBlocks(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	// Importing a resource that has blocks such as Testnest resource used to panic. Ensure that it minimally
 	// succeeds.
 	server, err := newProviderServer(t, testprovider.SyntheticTestBridgeProvider())
@@ -225,7 +226,7 @@ func TestImportingResourcesWithBlocks(t *testing.T) {
 }
 
 func TestImportingResourcesWithoutDefaults(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	// Importing a resource that has blocks used to add a `__defaults: []` entry to the `response.inputs`
 	// ensure that it no longer does so
 	server, err := newProviderServer(t, testprovider.SyntheticTestBridgeProvider())
@@ -264,7 +265,7 @@ func TestImportingResourcesWithoutDefaults(t *testing.T) {
 // Check that importing a resource that does not exist returns an empty property bag and
 // no ID.
 func TestImportingMissingResources(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	server, err := newProviderServer(t, testprovider.SyntheticTestBridgeProvider())
 	require.NoError(t, err)
 	testCase := `
@@ -284,7 +285,7 @@ func TestImportingMissingResources(t *testing.T) {
 }
 
 func TestImportingResourcesWithNestedAttributes(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	// Importing a resource that has attribute blocks such as Testnest resource used to panic. Ensure that it minimally
 	// succeeds.
 	server, err := newProviderServer(t, testprovider.SyntheticTestBridgeProvider())
@@ -312,7 +313,7 @@ func TestImportingResourcesWithNestedAttributes(t *testing.T) {
 // Check that refreshing a resource that does not exist returns an empty property bag and
 // no ID.
 func TestRefreshMissingResources(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	server, err := newProviderServer(t, testprovider.SyntheticTestBridgeProvider())
 	require.NoError(t, err)
 	testCase := `
@@ -343,7 +344,7 @@ func TestRefreshMissingResources(t *testing.T) {
 //
 // See https://github.com/pulumi/pulumi-terraform-bridge/issues/1919
 func TestRefreshResourceNotFound(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	r := pb.NewResource(pb.NewResourceArgs{
 		Name: "resource",
 		ResourceSchema: fwsch.Schema{
@@ -408,7 +409,7 @@ func TestRefreshResourceNotFound(t *testing.T) {
 }
 
 func TestRefreshSupportsCustomID(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	p := testprovider.RandomProvider()
 	server, err := newProviderServer(t, p)
 	require.NoError(t, err)
@@ -510,7 +511,7 @@ func TestRefreshSupportsCustomID(t *testing.T) {
 }
 
 func TestImportSupportsCustomID(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	p := testprovider.RandomProvider()
 	p.Resources["random_password"].ComputeID = func(
 		ctx context.Context, state resource.PropertyMap,

--- a/pkg/pf/tests/provider_transform_outputs_test.go
+++ b/pkg/pf/tests/provider_transform_outputs_test.go
@@ -20,18 +20,18 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	testutils "github.com/pulumi/providertest/replay"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	testutils "github.com/pulumi/providertest/replay"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/testprovider"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 )
 
 func TestTransformOutputs(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	p := testprovider.SyntheticTestBridgeProvider()
 
 	p.Resources["testbridge_testcompres"].TransformOutputs = func(
@@ -152,7 +152,7 @@ func TestTransformOutputs(t *testing.T) {
 }
 
 func TestTransformFromState(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	provider := func(t *testing.T) pulumirpc.ResourceProviderServer {
 		p := testprovider.AssertProvider(func(config tfsdk.Config, old, new *tfsdk.State) {
 			// GetRawState is not available during deletes.

--- a/pkg/pf/tests/provider_update_test.go
+++ b/pkg/pf/tests/provider_update_test.go
@@ -18,12 +18,13 @@ import (
 	"testing"
 
 	testutils "github.com/pulumi/providertest/replay"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/testprovider"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/testprovider"
 )
 
 func TestUpdateWritesSchemaVersion(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	server, err := newProviderServer(t, testprovider.RandomProvider())
 	require.NoError(t, err)
 	testutils.Replay(t, server, `
@@ -63,7 +64,7 @@ func TestUpdateWritesSchemaVersion(t *testing.T) {
 }
 
 func TestUpdateWithIntID(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	server, err := newProviderServer(t, testprovider.SyntheticTestBridgeProvider())
 	require.NoError(t, err)
 	testCase := `

--- a/pkg/pf/tests/pulcheck/pulcheck.go
+++ b/pkg/pf/tests/pulcheck/pulcheck.go
@@ -49,6 +49,7 @@ func genMetadata(t T, info tfbridge0.ProviderInfo) (tfbridge.ProviderMetadata, e
 	generated, err := tfgen.GenerateSchema(context.Background(), tfgen.GenerateSchemaOptions{
 		ProviderInfo:    info,
 		DiagnosticsSink: testSink(t),
+		XInMemoryDocs:   true,
 	})
 	if err != nil {
 		return tfbridge.ProviderMetadata{}, err

--- a/pkg/pf/tests/pulcheck/pulcheck.go
+++ b/pkg/pf/tests/pulcheck/pulcheck.go
@@ -11,17 +11,18 @@ import (
 	"github.com/pulumi/providertest/providers"
 	"github.com/pulumi/providertest/pulumitest"
 	"github.com/pulumi/providertest/pulumitest/opttest"
-	crosstestsimpl "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/tests/cross-tests/impl"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfgen"
-	tfbridge0 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+
+	crosstestsimpl "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/tests/cross-tests/impl"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfgen"
+	tfbridge0 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
 )
 
 type T = crosstestsimpl.T

--- a/pkg/pf/tests/pulumi_test.go
+++ b/pkg/pf/tests/pulumi_test.go
@@ -21,12 +21,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	sdkv2schema "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/pulumi/providertest/pulumitest"
+	"github.com/stretchr/testify/require"
+
 	pf "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/pulcheck"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/tokens"
 	sdkv2shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
-	"github.com/stretchr/testify/require"
 )
 
 // Quick setup for integration-testing PF-based providers.

--- a/pkg/pf/tests/schema_and_program_test.go
+++ b/pkg/pf/tests/schema_and_program_test.go
@@ -33,14 +33,13 @@ func TestBasic(t *testing.T) {
 	provBuilder := providerbuilder.NewProvider(
 		providerbuilder.NewProviderArgs{
 			AllResources: []providerbuilder.Resource{
-				{
-					Name: "test",
+				providerbuilder.NewResource(providerbuilder.NewResourceArgs{
 					ResourceSchema: rschema.Schema{
 						Attributes: map[string]rschema.Attribute{
 							"s": rschema.StringAttribute{Optional: true},
 						},
 					},
-				},
+				}),
 			},
 		})
 
@@ -66,8 +65,7 @@ func TestComputedSetNoDiffWhenElementRemoved(t *testing.T) {
 	// Regression test for [pulumi/pulumi-terraform-bridge#2192]
 	provBuilder := pb.NewProvider(pb.NewProviderArgs{
 		AllResources: []providerbuilder.Resource{
-			{
-				Name: "test",
+			providerbuilder.NewResource(providerbuilder.NewResourceArgs{
 				ResourceSchema: rschema.Schema{
 					Attributes: map[string]rschema.Attribute{
 						"vlan_names": rschema.SetNestedAttribute{
@@ -99,7 +97,7 @@ func TestComputedSetNoDiffWhenElementRemoved(t *testing.T) {
 						},
 					},
 				},
-			},
+			}),
 		},
 	})
 
@@ -238,8 +236,7 @@ func TestIDAttribute(t *testing.T) {
 				Version:        "0.0.1",
 				ProviderSchema: pschema.Schema{},
 				AllResources: []providerbuilder.Resource{
-					{
-						Name: "test",
+					providerbuilder.NewResource(providerbuilder.NewResourceArgs{
 						ResourceSchema: rschema.Schema{
 							Attributes: map[string]rschema.Attribute{
 								"id": tc.attribute,
@@ -252,7 +249,7 @@ func TestIDAttribute(t *testing.T) {
 							resp.State.SetAttribute(ctx, path.Root("id"), "test-id")
 							resp.State.SetAttribute(ctx, path.Root("x"), "x-id")
 						},
-					},
+					}),
 				},
 			}
 
@@ -314,8 +311,7 @@ func TestDefaults(t *testing.T) {
 	t.Parallel()
 	provBuilder := pb.NewProvider(pb.NewProviderArgs{
 		AllResources: []providerbuilder.Resource{
-			{
-				Name: "test",
+			providerbuilder.NewResource(providerbuilder.NewResourceArgs{
 				ResourceSchema: rschema.Schema{
 					Attributes: map[string]rschema.Attribute{
 						"other_prop": rschema.StringAttribute{
@@ -328,7 +324,7 @@ func TestDefaults(t *testing.T) {
 						},
 					},
 				},
-			},
+			}),
 		},
 	})
 
@@ -375,8 +371,7 @@ func TestPlanModifiers(t *testing.T) {
 	t.Parallel()
 	provBuilder := pb.NewProvider(pb.NewProviderArgs{
 		AllResources: []providerbuilder.Resource{
-			{
-				Name: "test",
+			providerbuilder.NewResource(providerbuilder.NewResourceArgs{
 				ResourceSchema: rschema.Schema{
 					Attributes: map[string]rschema.Attribute{
 						"other_prop": rschema.StringAttribute{
@@ -391,7 +386,7 @@ func TestPlanModifiers(t *testing.T) {
 						},
 					},
 				},
-			},
+			}),
 		},
 	})
 

--- a/pkg/pf/tests/schema_and_program_test.go
+++ b/pkg/pf/tests/schema_and_program_test.go
@@ -17,15 +17,16 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/pulumi/pulumi/sdk/v3/go/auto/optpreview"
+	presource "github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/providerbuilder"
 	pb "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/providerbuilder"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/pulcheck"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
-	"github.com/pulumi/pulumi/sdk/v3/go/auto/optpreview"
-	presource "github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestBasic(t *testing.T) {

--- a/pkg/pf/tests/schema_test.go
+++ b/pkg/pf/tests/schema_test.go
@@ -17,14 +17,12 @@ package tfbridgetests
 import (
 	"encoding/json"
 	"os"
+	"runtime"
 	"testing"
 
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
-
-	"runtime"
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/testprovider"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
@@ -32,7 +30,7 @@ import (
 )
 
 func TestSchemaGen(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	t.Run("random", func(t *testing.T) {
 		_, err := genMetadata(t, testprovider.RandomProvider())
 		require.NoError(t, err)
@@ -71,7 +69,7 @@ func TestSchemaGen(t *testing.T) {
 }
 
 func TestSchemaGenInSync(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("Skipping on Windows due to a minor path discrepancy in actual vs generated schema")
 	}
@@ -149,5 +147,4 @@ func TestSchemaGenInSync(t *testing.T) {
 				tc.name)
 		})
 	}
-
 }

--- a/pkg/pf/tests/schemas.go
+++ b/pkg/pf/tests/schemas.go
@@ -36,6 +36,7 @@ func genMetadata(t *testing.T, info tfbridge0.ProviderInfo) (tfpf.ProviderMetada
 	generated, err := tfgen.GenerateSchema(context.Background(), tfgen.GenerateSchemaOptions{
 		ProviderInfo:    info,
 		DiagnosticsSink: testSink(t),
+		XInMemoryDocs:   true,
 	})
 	if err != nil {
 		return tfpf.ProviderMetadata{}, err

--- a/pkg/pf/tests/schemas.go
+++ b/pkg/pf/tests/schemas.go
@@ -21,10 +21,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/stretchr/testify/require"
 
 	tfpf "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfgen"

--- a/pkg/pf/tests/schemashim_test.go
+++ b/pkg/pf/tests/schemashim_test.go
@@ -35,19 +35,20 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hexops/autogold/v2"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/schemashim"
 	pb "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/providerbuilder"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"github.com/stretchr/testify/require"
 )
 
 func TestShimBoolAttr(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	checkShim(t, shimTestCase{
 		stdProvider(schema.Schema{
 			Attributes: map[string]schema.Attribute{
@@ -92,7 +93,7 @@ func TestShimBoolAttr(t *testing.T) {
 }
 
 func TestShimStringAttr(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	checkShim(t, shimTestCase{
 		stdProvider(schema.Schema{
 			Attributes: map[string]schema.Attribute{
@@ -137,7 +138,7 @@ func TestShimStringAttr(t *testing.T) {
 }
 
 func TestShimNumberAttr(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	checkShim(t, shimTestCase{
 		stdProvider(schema.Schema{
 			Attributes: map[string]schema.Attribute{
@@ -182,7 +183,7 @@ func TestShimNumberAttr(t *testing.T) {
 }
 
 func TestShimListOfStringAttr(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	checkShim(t, shimTestCase{
 		stdProvider(schema.Schema{
 			Attributes: map[string]schema.Attribute{
@@ -244,7 +245,7 @@ func TestShimListOfStringAttr(t *testing.T) {
 }
 
 func TestShimMapOfStringAttr(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	checkShim(t, shimTestCase{
 		stdProvider(schema.Schema{
 			Attributes: map[string]schema.Attribute{
@@ -306,7 +307,7 @@ func TestShimMapOfStringAttr(t *testing.T) {
 }
 
 func TestShimSetOfStringAttr(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	checkShim(t, shimTestCase{
 		stdProvider(schema.Schema{
 			Attributes: map[string]schema.Attribute{
@@ -368,7 +369,7 @@ func TestShimSetOfStringAttr(t *testing.T) {
 }
 
 func TestShimListNestedAttr(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	checkShim(t, shimTestCase{
 		stdProvider(schema.Schema{
 			Attributes: map[string]schema.Attribute{
@@ -451,7 +452,7 @@ func TestShimListNestedAttr(t *testing.T) {
 }
 
 func TestShimSetNestedAttr(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	checkShim(t, shimTestCase{
 		stdProvider(schema.Schema{
 			Attributes: map[string]schema.Attribute{
@@ -534,7 +535,7 @@ func TestShimSetNestedAttr(t *testing.T) {
 }
 
 func TestShimMapNestedAttr(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	checkShim(t, shimTestCase{
 		stdProvider(schema.Schema{
 			Attributes: map[string]schema.Attribute{
@@ -617,7 +618,7 @@ func TestShimMapNestedAttr(t *testing.T) {
 }
 
 func TestShimSingleNestedAttr(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	checkShim(t, shimTestCase{
 		stdProvider(schema.Schema{
 			Attributes: map[string]schema.Attribute{
@@ -684,7 +685,7 @@ func TestShimSingleNestedAttr(t *testing.T) {
 }
 
 func TestShimObjectAttr(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	checkShim(t, shimTestCase{
 		stdProvider(schema.Schema{
 			Attributes: map[string]schema.Attribute{
@@ -753,7 +754,7 @@ func TestShimObjectAttr(t *testing.T) {
 }
 
 func TestShimDynamicAttr(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	checkShim(t, shimTestCase{
 		stdProvider(schema.Schema{
 			Attributes: map[string]schema.Attribute{
@@ -800,7 +801,7 @@ func TestShimDynamicAttr(t *testing.T) {
 }
 
 func TestShimSingleNestedBlock(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	checkShim(t, shimTestCase{
 		stdProvider(schema.Schema{
 			Blocks: map[string]schema.Block{
@@ -866,7 +867,7 @@ func TestShimSingleNestedBlock(t *testing.T) {
 }
 
 func TestShimListNestedBlock(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	checkShim(t, shimTestCase{
 		stdProvider(schema.Schema{
 			Blocks: map[string]schema.Block{
@@ -945,7 +946,7 @@ func TestShimListNestedBlock(t *testing.T) {
 // The bridge attempts some heuristics to infer listvalidator.SizeAtMost(1) and apply flattening. It is unclear how
 // often it is used but there are non-0 actual examples, such as data_storage on elasticache serverless_cache in AWS.
 func TestShimListNestedFlattenedBlock(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	checkShim(t, shimTestCase{
 		stdProvider(schema.Schema{
 			Blocks: map[string]schema.Block{
@@ -1017,7 +1018,7 @@ func TestShimListNestedFlattenedBlock(t *testing.T) {
 }
 
 func TestShimSetNestedBlock(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	checkShim(t, shimTestCase{
 		stdProvider(schema.Schema{
 			Blocks: map[string]schema.Block{

--- a/pkg/pf/tests/schemashim_test.go
+++ b/pkg/pf/tests/schemashim_test.go
@@ -1150,9 +1150,11 @@ func checkShim(t *testing.T, tc shimTestCase) {
 func stdProvider(resourceSchema schema.Schema) *pb.Provider {
 	return &pb.Provider{
 		TypeName: "testprov",
-		AllResources: []pb.Resource{{
-			Name:           "r1",
-			ResourceSchema: resourceSchema,
-		}},
+		AllResources: []pb.Resource{
+			pb.NewResource(pb.NewResourceArgs{
+				Name:           "r1",
+				ResourceSchema: resourceSchema,
+			}),
+		},
 	}
 }

--- a/pkg/pf/tests/schemashim_test.go
+++ b/pkg/pf/tests/schemashim_test.go
@@ -1150,11 +1150,9 @@ func checkShim(t *testing.T, tc shimTestCase) {
 func stdProvider(resourceSchema schema.Schema) *pb.Provider {
 	return &pb.Provider{
 		TypeName: "testprov",
-		AllResources: []pb.Resource{
-			pb.NewResource(pb.NewResourceArgs{
-				Name:           "r1",
-				ResourceSchema: resourceSchema,
-			}),
-		},
+		AllResources: []pb.Resource{{
+			Name:           "r1",
+			ResourceSchema: resourceSchema,
+		}},
 	}
 }

--- a/pkg/pf/tests/tfgen_test.go
+++ b/pkg/pf/tests/tfgen_test.go
@@ -20,16 +20,17 @@ import (
 	"os"
 	"testing"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/muxer"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/providerbuilder"
 	pb "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/providerbuilder"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen"
 	helper "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"github.com/stretchr/testify/require"
 )
 
 func TestRenameResourceWithAliasInAugmentedProvider(t *testing.T) {

--- a/pkg/pf/tests/tfgen_test.go
+++ b/pkg/pf/tests/tfgen_test.go
@@ -44,7 +44,9 @@ func TestRenameResourceWithAliasInAugmentedProvider(t *testing.T) {
 	pfProvider := pb.NewProvider(pb.NewProviderArgs{
 		TypeName: providerID,
 		AllResources: []providerbuilder.Resource{
-			{Name: resourceID},
+			pb.NewResource(pb.NewResourceArgs{
+				Name: resourceID,
+			}),
 		},
 	})
 	legacyToken := tokens.Type(fmt.Sprintf("my:%s:Resource", resModule))

--- a/pkg/pf/tests/util.go
+++ b/pkg/pf/tests/util.go
@@ -18,9 +18,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/providerbuilder"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"

--- a/pkg/pf/tfbridge/detect_check_failures.go
+++ b/pkg/pf/tfbridge/detect_check_failures.go
@@ -86,7 +86,6 @@ func formatAttributePathAsPropertyPath(
 	}
 	p := tfbridge.NewCheckFailurePath(schemaMap, schemaInfos, string(n))
 	for _, s := range steps[1:] {
-
 		switch s := s.(type) {
 		case tftypes.AttributeName:
 			p = p.Attribute(string(s))
@@ -99,7 +98,6 @@ func formatAttributePathAsPropertyPath(
 		default:
 			contract.Failf("Unhandled match case for tftypes.AttributePathStep")
 		}
-
 	}
 	return p, nil
 }

--- a/pkg/pf/tfbridge/detect_check_failures_test.go
+++ b/pkg/pf/tfbridge/detect_check_failures_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestDetectCheckFailures(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	ctx := context.Background()
 	p := &provider{}
 	urn := resource.NewURN("stack", "project", "", "typ", "name")

--- a/pkg/pf/tfbridge/main.go
+++ b/pkg/pf/tfbridge/main.go
@@ -127,7 +127,6 @@ func MainWithMuxer(ctx context.Context, pkg string, info tfbridge.ProviderInfo, 
 func MakeMuxedServer(
 	ctx context.Context, pkg string, info tfbridge.ProviderInfo, schema []byte,
 ) func(host *rprovider.HostClient) (pulumirpc.ResourceProviderServer, error) {
-
 	shim, ok := info.P.(*pfmuxer.ProviderShim)
 	contract.Assertf(ok, "MainWithMuxer must have a ProviderInfo.P created with AugmentShimWithPF")
 	_, err := shim.ResolveDispatch(&info)
@@ -175,12 +174,14 @@ func MakeMuxedServer(
 						infoCopy.P = prov
 						return NewProviderServer(ctx, host,
 							infoCopy, ProviderMetadata{PackageSchema: schema})
-					}})
+					},
+				})
 			default:
 				m.Servers = append(m.Servers, muxer.Endpoint{
 					Server: func(host *rprovider.HostClient) (pulumirpc.ResourceProviderServer, error) {
 						return tfbridge.NewProvider(ctx, host, pkg, version, prov, info, schema), nil
-					}})
+					},
+				})
 			}
 		}
 		return m.Server(host, pkg, version)

--- a/pkg/pf/tfbridge/provider.go
+++ b/pkg/pf/tfbridge/provider.go
@@ -93,7 +93,8 @@ func ShimProviderWithContext(ctx context.Context, p pfprovider.Provider) shim.Pr
 }
 
 func newProviderWithContext(ctx context.Context, info tfbridge.ProviderInfo,
-	meta ProviderMetadata) (configencoding.Provider[*provider], error) {
+	meta ProviderMetadata,
+) (configencoding.Provider[*provider], error) {
 	const infoPErrMSg string = "info.P must be constructed with ShimProvider or ShimProviderWithContext"
 
 	if info.P == nil {
@@ -273,7 +274,8 @@ func (p *provider) terraformDatasourceName(functionToken tokens.ModuleMember) (s
 // NOT IMPLEMENTED: Call dynamically executes a method in the provider associated with a component resource.
 func (p *provider) CallWithContext(_ context.Context,
 	tok tokens.ModuleMember, args resource.PropertyMap, info plugin.CallInfo,
-	options plugin.CallOptions) (plugin.CallResult, error) {
+	options plugin.CallOptions,
+) (plugin.CallResult, error) {
 	return plugin.CallResult{},
 		fmt.Errorf("Call is not implemented for Terraform Plugin Framework bridged providers")
 }
@@ -281,7 +283,8 @@ func (p *provider) CallWithContext(_ context.Context,
 // NOT IMPLEMENTED: Construct creates a new component resource.
 func (p *provider) ConstructWithContext(_ context.Context,
 	info plugin.ConstructInfo, typ tokens.Type, name tokens.QName, parent resource.URN,
-	inputs resource.PropertyMap, options plugin.ConstructOptions) (plugin.ConstructResult, error) {
+	inputs resource.PropertyMap, options plugin.ConstructOptions,
+) (plugin.ConstructResult, error) {
 	return plugin.ConstructResult{},
 		fmt.Errorf("Construct is not implemented for Terraform Plugin Framework bridged providers")
 }

--- a/pkg/pf/tfbridge/provider_check.go
+++ b/pkg/pf/tfbridge/provider_check.go
@@ -95,7 +95,6 @@ func (p *provider) validateResourceConfig(
 	rh resourceHandle,
 	inputs resource.PropertyMap,
 ) ([]plugin.CheckFailure, error) {
-
 	tfType := rh.schema.Type(ctx).(tftypes.Object)
 
 	encodedInputs, err := convert.EncodePropertyMapToDynamic(rh.encoder, tfType, inputs)

--- a/pkg/pf/tfbridge/provider_delete.go
+++ b/pkg/pf/tfbridge/provider_delete.go
@@ -33,7 +33,6 @@ func (p *provider) DeleteWithContext(
 	outputs resource.PropertyMap,
 	timeout float64,
 ) (resource.Status, error) {
-
 	ctx = p.initLogging(ctx, p.logSink, urn)
 
 	rh, err := p.resourceHandle(ctx, urn)

--- a/pkg/pf/tfbridge/provider_diff_test.go
+++ b/pkg/pf/tfbridge/provider_diff_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestTopLevelPropertyKeySet(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	str := (&schema.Schema{
 		Type: shim.TypeString,
 	}).Shim()

--- a/pkg/pf/tfbridge/provider_get_mapping.go
+++ b/pkg/pf/tfbridge/provider_get_mapping.go
@@ -33,7 +33,6 @@ func (p *provider) GetMappingWithContext(ctx context.Context, key, provider stri
 	// The prototype converter uses the key "tf", but the new plugin converter uses "terraform". For now support
 	// both, eventually we can remove the "tf" key.
 	if key == "tf" || key == "terraform" {
-
 		// The provider key should either be empty (old engines) or the name of the provider we support (new engines)
 		if provider != "" && provider != mapped {
 			return nil, "", fmt.Errorf("unknown provider %q", provider)

--- a/pkg/pf/tfbridge/provider_info_test.go
+++ b/pkg/pf/tfbridge/provider_info_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestSetAutoNamingDoesNotPanic(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	prov := tfbridge.ProviderInfo{
 		P: nil,
 		Resources: map[string]*tfbridge.ResourceInfo{

--- a/pkg/pf/tfbridge/provider_invoke.go
+++ b/pkg/pf/tfbridge/provider_invoke.go
@@ -68,7 +68,8 @@ func (p *provider) InvokeWithContext(
 }
 
 func (p *provider) validateDataResourceConfig(ctx context.Context, handle datasourceHandle,
-	config *tfprotov6.DynamicValue) ([]plugin.CheckFailure, error) {
+	config *tfprotov6.DynamicValue,
+) ([]plugin.CheckFailure, error) {
 	req := &tfprotov6.ValidateDataResourceConfigRequest{
 		TypeName: handle.terraformDataSourceName,
 		Config:   config,
@@ -81,8 +82,8 @@ func (p *provider) validateDataResourceConfig(ctx context.Context, handle dataso
 }
 
 func (p *provider) readDataSource(ctx context.Context, handle datasourceHandle,
-	config *tfprotov6.DynamicValue) (resource.PropertyMap, []plugin.CheckFailure, error) {
-
+	config *tfprotov6.DynamicValue,
+) (resource.PropertyMap, []plugin.CheckFailure, error) {
 	typ := handle.schema.Type(ctx).(tftypes.Object)
 
 	req := &tfprotov6.ReadDataSourceRequest{
@@ -126,7 +127,8 @@ func (p *provider) readDataSource(ctx context.Context, handle datasourceHandle,
 }
 
 func (p *provider) processInvokeDiagnostics(ds datasourceHandle,
-	diags []*tfprotov6.Diagnostic) ([]plugin.CheckFailure, error) {
+	diags []*tfprotov6.Diagnostic,
+) ([]plugin.CheckFailure, error) {
 	failures, rest := p.parseInvokePropertyCheckFailures(ds, diags)
 	return failures, p.processDiagnostics(rest)
 }
@@ -134,7 +136,8 @@ func (p *provider) processInvokeDiagnostics(ds datasourceHandle,
 // Some of the diagnostics pertain to an individual property and should be returned as plugin.CheckFailure for an
 // optimal rendering by Pulumi CLI.
 func (p *provider) parseInvokePropertyCheckFailures(ds datasourceHandle, diags []*tfprotov6.Diagnostic) (
-	[]plugin.CheckFailure, []*tfprotov6.Diagnostic) {
+	[]plugin.CheckFailure, []*tfprotov6.Diagnostic,
+) {
 	rest := []*tfprotov6.Diagnostic{}
 	failures := []plugin.CheckFailure{}
 

--- a/pkg/pf/tfbridge/provider_read.go
+++ b/pkg/pf/tfbridge/provider_read.go
@@ -125,7 +125,6 @@ func (p *provider) readResource(
 	rh *resourceHandle,
 	currentStateMap resource.PropertyMap,
 ) (plugin.ReadResult, error) {
-
 	currentStateRaw, err := parseResourceState(rh, currentStateMap)
 	if err != nil {
 		return plugin.ReadResult{}, fmt.Errorf("failed to get current raw state: %w", err)

--- a/pkg/pf/tfbridge/provider_read_test.go
+++ b/pkg/pf/tfbridge/provider_read_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestDeleteNestedDefaults(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	tests := []struct {
 		name     string
 		inputs   resource.PropertyMap

--- a/pkg/pf/tfbridge/provider_streaminvoke.go
+++ b/pkg/pf/tfbridge/provider_streaminvoke.go
@@ -24,6 +24,7 @@ import (
 
 func (p *provider) StreamInvokeWithContext(_ context.Context,
 	tok tokens.ModuleMember, args resource.PropertyMap,
-	onNext func(resource.PropertyMap) error) ([]plugin.CheckFailure, error) {
+	onNext func(resource.PropertyMap) error,
+) ([]plugin.CheckFailure, error) {
 	panic("StreamInvoke() should not be called for bridged providers")
 }

--- a/pkg/pf/tfbridge/provider_test.go
+++ b/pkg/pf/tfbridge/provider_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestTerraformResourceName(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	urn := resource.URN("urn:pulumi:dev::stack1::random:index/randomInteger:RandomInteger::priority")
 	p := &provider{
 		info: tfbridge.ProviderInfo{

--- a/pkg/pf/tfbridge/resource_state_test.go
+++ b/pkg/pf/tfbridge/resource_state_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestParseResourceStateFromTFInner(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	ctx := context.Background()
 
 	ty := tftypes.Object{

--- a/pkg/pf/tfgen/gen.go
+++ b/pkg/pf/tfgen/gen.go
@@ -32,6 +32,7 @@ import (
 type GenerateSchemaOptions struct {
 	ProviderInfo    sdkbridge.ProviderInfo
 	DiagnosticsSink diag.Sink
+	XInMemoryDocs   bool
 }
 
 type GenerateSchemaResult struct {
@@ -58,8 +59,8 @@ func GenerateSchema(_ context.Context, opts GenerateSchemaOptions) (*GenerateSch
 	generated, err := realtfgen.GenerateSchemaWithOptions(realtfgen.GenerateSchemaOptions{
 		ProviderInfo:    opts.ProviderInfo,
 		DiagnosticsSink: sink,
+		XInMemoryDocs:   opts.XInMemoryDocs,
 	})
-
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/pf/tfgen/tfgen_test.go
+++ b/pkg/pf/tfgen/tfgen_test.go
@@ -41,7 +41,7 @@ import (
 // Regressing an issue with AWS provider not recognizing that assume_role config setting is singular via
 // listvalidator.SizeAtMost(1).
 func TestMaxItemsOne(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	ctx := context.Background()
 	s := pschema.Schema{
 		Blocks: map[string]pschema.Block{

--- a/pkg/tests/acc_secrets_test.go
+++ b/pkg/tests/acc_secrets_test.go
@@ -15,9 +15,8 @@
 package tests
 
 import (
-	"testing"
-
 	"encoding/json"
+	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 	"github.com/stretchr/testify/assert"

--- a/pkg/tests/configure_test.go
+++ b/pkg/tests/configure_test.go
@@ -7,9 +7,10 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/pulcheck"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/tfcheck"
-	"github.com/stretchr/testify/require"
 )
 
 func TestConfigureGetRawConfigDoesNotPanic(t *testing.T) {

--- a/pkg/tests/custom_timeout_test.go
+++ b/pkg/tests/custom_timeout_test.go
@@ -8,12 +8,12 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/pulcheck"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/tfcheck"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-)
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/pulcheck"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/tfcheck"
+)
 
 func TestCreateCustomTimeoutsCrossTest(t *testing.T) {
 	t.Parallel()

--- a/pkg/tests/detailed_diff_set_test.go
+++ b/pkg/tests/detailed_diff_set_test.go
@@ -12,10 +12,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hexops/autogold/v2"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/pulcheck"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/tfcheck"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optpreview"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/pulcheck"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/tfcheck"
 )
 
 func runDetailedDiffTest(

--- a/pkg/tests/detailed_diff_test.go
+++ b/pkg/tests/detailed_diff_test.go
@@ -12,10 +12,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hexops/autogold/v2"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/pulcheck"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optpreview"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/pulcheck"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
 )
 
 func TestUnknownHandling(t *testing.T) {

--- a/pkg/tests/import_test.go
+++ b/pkg/tests/import_test.go
@@ -10,11 +10,12 @@ import (
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/pulcheck"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optpreview"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/pulcheck"
 )
 
 func TestFullyComputedNestedAttribute(t *testing.T) {

--- a/pkg/tests/internal/webaclschema/schemas.go
+++ b/pkg/tests/internal/webaclschema/schemas.go
@@ -12,7 +12,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/wafv2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	// "github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
 var listOfEmptyObjectSchema *schema.Schema = &schema.Schema{
@@ -161,7 +160,7 @@ func ipSetReferenceStatementSchema() *schema.Schema {
 				"arn": {
 					Type:     schema.TypeString,
 					Required: true,
-					//ValidateFunc: verify.ValidARN,
+					// ValidateFunc: verify.ValidARN,
 				},
 				"ip_set_forwarded_ip_config": {
 					Type:     schema.TypeList,
@@ -1050,7 +1049,7 @@ func ruleGroupReferenceStatementSchema() *schema.Schema {
 				"arn": {
 					Type:     schema.TypeString,
 					Required: true,
-					//ValidateFunc: verify.ValidARN,
+					// ValidateFunc: verify.ValidARN,
 				},
 				"rule_action_override": ruleActionOverrideSchema(),
 			},

--- a/pkg/tests/internal/webaclschema/webacl.go
+++ b/pkg/tests/internal/webaclschema/webacl.go
@@ -144,7 +144,7 @@ func ResourceWebACL() *schema.Resource {
 						// before := "action:(<allow:(<custom_request_handling:();>;);"
 						// after := "action:(<allow:(<>;);"
 						s := buf.String()
-						//s = strings.ReplaceAll(s, before, after)
+						// s = strings.ReplaceAll(s, before, after)
 						n := hashcodeString(s)
 						if 1+2 == 18 {
 							fmt.Printf("PRE-HASH:\n%s\n\n", s)
@@ -159,7 +159,7 @@ func ResourceWebACL() *schema.Resource {
 					Type:     schema.TypeString,
 					Required: true,
 					ForceNew: true,
-					//ValidateFunc: validation.StringInSlice(wafv2.Scope_Values(), false),
+					// ValidateFunc: validation.StringInSlice(wafv2.Scope_Values(), false),
 				},
 				// names.AttrTags:    tftags.TagsSchema(),
 				// names.AttrTagsAll: tftags.TagsSchemaTrulyComputed(),
@@ -180,7 +180,7 @@ func ResourceWebACL() *schema.Resource {
 			}
 		},
 
-		//CustomizeDiff: verify.SetTagsDiff,
+		// CustomizeDiff: verify.SetTagsDiff,
 	}
 }
 

--- a/pkg/tests/invoke_raw_config_test.go
+++ b/pkg/tests/invoke_raw_config_test.go
@@ -16,18 +16,18 @@ package tests
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
 	testutils "github.com/pulumi/providertest/replay"
+
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
 )
 
 func TestInvokeRawConfigDoesNotPanic(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	ctx := context.Background()
 
 	resource := &schema.Resource{

--- a/pkg/tests/mux_with_test.go
+++ b/pkg/tests/mux_with_test.go
@@ -23,9 +23,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	testutils "github.com/pulumi/providertest/replay"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen"
-	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
 	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
@@ -35,6 +32,10 @@ import (
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen"
+	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
 )
 
 func newTFProvider() *schema.Provider {
@@ -116,7 +117,7 @@ func newProviderServer(info tfbridge.ProviderInfo) (server pulumirpc.ResourcePro
 }
 
 func TestMuxWithProvider(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	info := tfbridge.ProviderInfo{
 		P:          shimv2.NewProvider(newTFProvider()),
 		Name:       "random",

--- a/pkg/tests/plan_state_edit_test.go
+++ b/pkg/tests/plan_state_edit_test.go
@@ -7,11 +7,12 @@ import (
 
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/pulcheck"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/stretchr/testify/assert"
 )
 
 // TestPlanStateEdit tests that [shimv2.WithPlanStateEdit] can be used to effectively edit

--- a/pkg/tests/pulcheck/pulcheck.go
+++ b/pkg/tests/pulcheck/pulcheck.go
@@ -15,11 +15,6 @@ import (
 	"github.com/pulumi/providertest/providers"
 	"github.com/pulumi/providertest/pulumitest"
 	"github.com/pulumi/providertest/pulumitest/opttest"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/tokens"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen"
-	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
 	pulumidiag "github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
@@ -27,6 +22,12 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"gotest.tools/assert"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/tokens"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen"
+	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
 )
 
 func propNeedsUpdate(prop *schema.Schema) bool {

--- a/pkg/tests/refresh_test.go
+++ b/pkg/tests/refresh_test.go
@@ -7,20 +7,20 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/pulcheck"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optpreview"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optrefresh"
 	"github.com/stretchr/testify/require"
-)
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/pulcheck"
+)
 
 func TestCollectionsNullEmptyRefreshClean(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
-		name               string
-		schemaType         schema.ValueType
-		cloudVal           interface{}
-		programVal         string
+		name       string
+		schemaType schema.ValueType
+		cloudVal   interface{}
+		programVal string
 		// If true, the cloud value will be set in the CreateContext
 		// This is behaviour observed in both AWS and GCP providers, as well as a few others
 		// where the provider returns an empty collections when a nil one was specified in inputs.

--- a/pkg/tests/regress_1020_test.go
+++ b/pkg/tests/regress_1020_test.go
@@ -20,10 +20,9 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
+	testutils "github.com/pulumi/providertest/replay"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 
-	testutils "github.com/pulumi/providertest/replay"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
@@ -31,7 +30,7 @@ import (
 
 // See https://github.com/pulumi/pulumi-terraform-bridge/issues/1020
 func TestRegress1020(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	ctx := context.Background()
 
 	CIDRBlocksEqual := func(cidr1, cidr2 string) bool {

--- a/pkg/tests/regress_923_test.go
+++ b/pkg/tests/regress_923_test.go
@@ -22,12 +22,13 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	testutils "github.com/pulumi/providertest/replay"
+
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
 )
 
 func TestRegress923(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	ctx := context.Background()
 
 	resource := &schema.Resource{

--- a/pkg/tests/regress_aws_2352_test.go
+++ b/pkg/tests/regress_aws_2352_test.go
@@ -22,14 +22,14 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
 	testutils "github.com/pulumi/providertest/replay"
+
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
 )
 
 func TestRegressAws2352(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	ctx := context.Background()
 
 	createDotStringHashcode := func(s string) int {

--- a/pkg/tests/regress_hcloud_175_test.go
+++ b/pkg/tests/regress_hcloud_175_test.go
@@ -20,12 +20,13 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	testutils "github.com/pulumi/providertest/replay"
+
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
 )
 
 func TestRegressHCloud175(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	ctx := context.Background()
 
 	subnetResource := func() *schema.Resource {

--- a/pkg/tests/schema_pulumi_test.go
+++ b/pkg/tests/schema_pulumi_test.go
@@ -10,11 +10,12 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/pulcheck"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/pulcheck"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 )
 
 func TestBasic(t *testing.T) {

--- a/pkg/tests/state_func_test.go
+++ b/pkg/tests/state_func_test.go
@@ -6,12 +6,12 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/pulcheck"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optpreview"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-)
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/pulcheck"
+)
 
 func TestStateFunc(t *testing.T) {
 	t.Parallel()

--- a/pkg/tests/tfcheck/exec.go
+++ b/pkg/tests/tfcheck/exec.go
@@ -19,8 +19,9 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/pulcheck"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/pulcheck"
 )
 
 func (d *TFDriver) execTf(t pulcheck.T, args ...string) ([]byte, error) {

--- a/pkg/tests/tfcheck/tf_test.go
+++ b/pkg/tests/tfcheck/tf_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestTfComputed(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	prov := schema.Provider{
 		ResourcesMap: map[string]*schema.Resource{
 			"test_resource": {
@@ -69,7 +69,7 @@ resource "test_resource" "test" {
 //
 // - https://github.com/pulumi/pulumi-nomad/issues/389
 func TestTfMapMissingElem(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	prov := schema.Provider{
 		ResourcesMap: map[string]*schema.Resource{
 			"test_resource": {
@@ -128,7 +128,7 @@ resource "test_resource" "test" {
 }
 
 func TestTfUnknownObjects(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	prov := schema.Provider{
 		ResourcesMap: map[string]*schema.Resource{
 			"test_resource": {

--- a/pkg/tests/tfcheck/tfcheck.go
+++ b/pkg/tests/tfcheck/tfcheck.go
@@ -20,9 +20,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server"
 	"github.com/hashicorp/terraform-plugin-mux/tf5to6server"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/pulcheck"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/pulcheck"
 )
 
 type TFDriver struct {

--- a/pkg/tests/type_checker_test.go
+++ b/pkg/tests/type_checker_test.go
@@ -7,8 +7,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/pulumi/providertest/pulumitest/opttest"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/pulcheck"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/pulcheck"
 )
 
 func TestTypeChecker(t *testing.T) {

--- a/pkg/tfshim/sdk-v2/cty.go
+++ b/pkg/tfshim/sdk-v2/cty.go
@@ -160,7 +160,7 @@ func recoverScalarCtyValue(dT cty.Type, value interface{}) (cty.Value, error) {
 		if value > math.MaxInt64 {
 			return cty.NilVal, fmt.Errorf("cannot convert %d (uint) to a int64: overflow", value)
 		}
-
+		//nolint:gosec
 		return cty.NumberIntVal(int64(value)), nil
 	case int64:
 		return cty.NumberIntVal(value), nil

--- a/pkg/tfshim/sdk-v2/cty.go
+++ b/pkg/tfshim/sdk-v2/cty.go
@@ -160,7 +160,7 @@ func recoverScalarCtyValue(dT cty.Type, value interface{}) (cty.Value, error) {
 		if value > math.MaxInt64 {
 			return cty.NilVal, fmt.Errorf("cannot convert %d (uint) to a int64: overflow", value)
 		}
-		//nolint:gosec
+
 		return cty.NumberIntVal(int64(value)), nil
 	case int64:
 		return cty.NumberIntVal(value), nil

--- a/pkg/x/muxer/main.go
+++ b/pkg/x/muxer/main.go
@@ -21,7 +21,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	rpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
 // Mux multiple rpc servers into a single server by routing based on request type and urn.
@@ -96,8 +96,8 @@ type Main struct {
 	GetMappingHandler map[string]MultiMappingHandler
 }
 
-func (m Main) Server(host *provider.HostClient, module, version string) (rpc.ResourceProviderServer, error) {
-	servers := make([]rpc.ResourceProviderServer, len(m.Servers))
+func (m Main) Server(host *provider.HostClient, module, version string) (pulumirpc.ResourceProviderServer, error) {
+	servers := make([]pulumirpc.ResourceProviderServer, len(m.Servers))
 	for i, s := range m.Servers {
 		var err error
 		servers[i], err = s.Server(host)
@@ -108,7 +108,7 @@ func (m Main) Server(host *provider.HostClient, module, version string) (rpc.Res
 
 	dispatchTable, pulumiSchema := m.DispatchTable.dispatchTable, m.Schema
 	if dispatchTable.isEmpty() || len(pulumiSchema) == 0 {
-		req := &rpc.GetSchemaRequest{Version: SchemaVersion}
+		req := &pulumirpc.GetSchemaRequest{Version: SchemaVersion}
 		primary, err := servers[0].GetSchema(context.Background(), req)
 		contract.AssertNoErrorf(err, "Muxing requires GetSchema for dispatch")
 		targetSchema := new(schema.PackageSpec)
@@ -139,5 +139,5 @@ func (m Main) Server(host *provider.HostClient, module, version string) (rpc.Res
 }
 
 type Endpoint struct {
-	Server func(*provider.HostClient) (rpc.ResourceProviderServer, error)
+	Server func(*provider.HostClient) (pulumirpc.ResourceProviderServer, error)
 }

--- a/pkg/x/muxer/mapping_test.go
+++ b/pkg/x/muxer/mapping_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestMergeSchemasAndComputeDispatchTable(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	s1 := schema.PackageSpec{
 		Name: "pkg",
 		Resources: map[string]schema.ResourceSpec{

--- a/pkg/x/muxer/muxer_test.go
+++ b/pkg/x/muxer/muxer_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestAttach(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	req := &pulumirpc.PluginAttach{Address: "test"}
 	ctx := context.Background()
 
@@ -49,7 +49,8 @@ func TestAttach(t *testing.T) {
 			servers: []server{
 				&attach{t: t, expected: "test"},
 				&attach{t: t, expected: "test"},
-			}}
+			},
+		}
 		_, err := m.Attach(ctx, req)
 		assert.NoError(t, err)
 		for i, s := range m.servers {
@@ -92,7 +93,7 @@ func (h *host) Log(context.Context, diag.Severity, urn.URN, string) error {
 }
 
 func TestDiffConfig(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	type testCase struct {
 		name           string
 		request        *pulumirpc.DiffRequest

--- a/pkg/x/testing/json_match_test.go
+++ b/pkg/x/testing/json_match_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestJsonMatch(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	AssertJSONMatchesPattern(t, []byte(`1`), []byte(`1`))
 	AssertJSONMatchesPattern(t, []byte(`"*"`), []byte(`1`))
 	AssertJSONMatchesPattern(t, []byte(`"*"`), []byte(`2`))

--- a/pkg/x/testing/replay.go
+++ b/pkg/x/testing/replay.go
@@ -90,7 +90,6 @@ func Replay(t *testing.T, server pulumirpc.ResourceProviderServer, jsonLog strin
 	assert.NoError(t, err)
 
 	switch entry.Method {
-
 	case "/pulumirpc.ResourceProvider/GetSchema":
 		replay(t, entry, new(pulumirpc.GetSchemaRequest), server.GetSchema)
 


### PR DESCRIPTION
This enables the golangci-lint linters for more directories, notably `pkg/pf` which wasn't linted before

fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/2474