### PR TITLE
PF Diff cross tests for computed in set blocks

### DIFF
--- a/pkg/pf/tests/diff_set_test.go
+++ b/pkg/pf/tests/diff_set_test.go
@@ -11,11 +11,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hexops/autogold/v2"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/zclconf/go-cty/cty"
 
 	crosstests "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/cross-tests"
 	pb "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/providerbuilder"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 func TestDetailedDiffSet(t *testing.T) {

--- a/pkg/pf/tests/diff_set_test.go
+++ b/pkg/pf/tests/diff_set_test.go
@@ -21,119 +21,135 @@ import (
 func TestDetailedDiffSet(t *testing.T) {
 	t.Parallel()
 
-	attributeSchema := rschema.Schema{
-		Attributes: map[string]rschema.Attribute{
-			"key": rschema.SetAttribute{
-				Optional:    true,
-				ElementType: types.StringType,
-			},
-		},
-	}
-
-	attributeReplaceSchema := rschema.Schema{
-		Attributes: map[string]rschema.Attribute{
-			"key": rschema.SetAttribute{
-				Optional:    true,
-				ElementType: types.StringType,
-				PlanModifiers: []planmodifier.Set{
-					setplanmodifier.RequiresReplace(),
+	attributeSchema := pb.NewResource(pb.NewResourceArgs{
+		ResourceSchema: rschema.Schema{
+			Attributes: map[string]rschema.Attribute{
+				"key": rschema.SetAttribute{
+					Optional:    true,
+					ElementType: types.StringType,
 				},
 			},
 		},
-	}
+	})
 
-	nestedAttributeSchema := rschema.Schema{
-		Attributes: map[string]rschema.Attribute{
-			"key": rschema.SetNestedAttribute{
-				Optional: true,
-				NestedObject: rschema.NestedAttributeObject{
-					Attributes: map[string]rschema.Attribute{
-						"nested": rschema.StringAttribute{Optional: true},
+	attributeReplaceSchema := pb.NewResource(pb.NewResourceArgs{
+		ResourceSchema: rschema.Schema{
+			Attributes: map[string]rschema.Attribute{
+				"key": rschema.SetAttribute{
+					Optional:    true,
+					ElementType: types.StringType,
+					PlanModifiers: []planmodifier.Set{
+						setplanmodifier.RequiresReplace(),
 					},
 				},
 			},
 		},
-	}
+	})
 
-	nestedAttributeReplaceSchema := rschema.Schema{
-		Attributes: map[string]rschema.Attribute{
-			"key": rschema.SetNestedAttribute{
-				Optional: true,
-				NestedObject: rschema.NestedAttributeObject{
-					Attributes: map[string]rschema.Attribute{
-						"nested": rschema.StringAttribute{Optional: true},
+	nestedAttributeSchema := pb.NewResource(pb.NewResourceArgs{
+		ResourceSchema: rschema.Schema{
+			Attributes: map[string]rschema.Attribute{
+				"key": rschema.SetNestedAttribute{
+					Optional: true,
+					NestedObject: rschema.NestedAttributeObject{
+						Attributes: map[string]rschema.Attribute{
+							"nested": rschema.StringAttribute{Optional: true},
+						},
 					},
-				},
-				PlanModifiers: []planmodifier.Set{
-					setplanmodifier.RequiresReplace(),
 				},
 			},
 		},
-	}
+	})
 
-	nestedAttributeNestedReplaceSchema := rschema.Schema{
-		Attributes: map[string]rschema.Attribute{
-			"key": rschema.SetNestedAttribute{
-				Optional: true,
-				NestedObject: rschema.NestedAttributeObject{
-					Attributes: map[string]rschema.Attribute{
-						"nested": rschema.StringAttribute{
-							Optional: true,
-							PlanModifiers: []planmodifier.String{
-								stringplanmodifier.RequiresReplace(),
+	nestedAttributeReplaceSchema := pb.NewResource(pb.NewResourceArgs{
+		ResourceSchema: rschema.Schema{
+			Attributes: map[string]rschema.Attribute{
+				"key": rschema.SetNestedAttribute{
+					Optional: true,
+					NestedObject: rschema.NestedAttributeObject{
+						Attributes: map[string]rschema.Attribute{
+							"nested": rschema.StringAttribute{Optional: true},
+						},
+					},
+					PlanModifiers: []planmodifier.Set{
+						setplanmodifier.RequiresReplace(),
+					},
+				},
+			},
+		},
+	})
+
+	nestedAttributeNestedReplaceSchema := pb.NewResource(pb.NewResourceArgs{
+		ResourceSchema: rschema.Schema{
+			Attributes: map[string]rschema.Attribute{
+				"key": rschema.SetNestedAttribute{
+					Optional: true,
+					NestedObject: rschema.NestedAttributeObject{
+						Attributes: map[string]rschema.Attribute{
+							"nested": rschema.StringAttribute{
+								Optional: true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.RequiresReplace(),
+								},
 							},
 						},
 					},
 				},
 			},
 		},
-	}
+	})
 
-	blockSchema := rschema.Schema{
-		Blocks: map[string]rschema.Block{
-			"key": rschema.SetNestedBlock{
-				NestedObject: rschema.NestedBlockObject{
-					Attributes: map[string]rschema.Attribute{
-						"nested": rschema.StringAttribute{Optional: true},
-					},
-				},
-			},
-		},
-	}
-
-	blockReplaceSchema := rschema.Schema{
-		Blocks: map[string]rschema.Block{
-			"key": rschema.SetNestedBlock{
-				NestedObject: rschema.NestedBlockObject{
-					Attributes: map[string]rschema.Attribute{
-						"nested": rschema.StringAttribute{
-							Optional: true,
+	blockSchema := pb.NewResource(pb.NewResourceArgs{
+		ResourceSchema: rschema.Schema{
+			Blocks: map[string]rschema.Block{
+				"key": rschema.SetNestedBlock{
+					NestedObject: rschema.NestedBlockObject{
+						Attributes: map[string]rschema.Attribute{
+							"nested": rschema.StringAttribute{Optional: true},
 						},
 					},
 				},
-				PlanModifiers: []planmodifier.Set{
-					setplanmodifier.RequiresReplace(),
+			},
+		},
+	})
+
+	blockReplaceSchema := pb.NewResource(pb.NewResourceArgs{
+		ResourceSchema: rschema.Schema{
+			Blocks: map[string]rschema.Block{
+				"key": rschema.SetNestedBlock{
+					NestedObject: rschema.NestedBlockObject{
+						Attributes: map[string]rschema.Attribute{
+							"nested": rschema.StringAttribute{
+								Optional: true,
+							},
+						},
+					},
+					PlanModifiers: []planmodifier.Set{
+						setplanmodifier.RequiresReplace(),
+					},
 				},
 			},
 		},
-	}
+	})
 
-	blockNestedReplaceSchema := rschema.Schema{
-		Blocks: map[string]rschema.Block{
-			"key": rschema.SetNestedBlock{
-				NestedObject: rschema.NestedBlockObject{
-					Attributes: map[string]rschema.Attribute{
-						"nested": rschema.StringAttribute{
-							Optional: true,
-							PlanModifiers: []planmodifier.String{
-								stringplanmodifier.RequiresReplace(),
+	blockNestedReplaceSchema := pb.NewResource(pb.NewResourceArgs{
+		ResourceSchema: rschema.Schema{
+			Blocks: map[string]rschema.Block{
+				"key": rschema.SetNestedBlock{
+					NestedObject: rschema.NestedBlockObject{
+						Attributes: map[string]rschema.Attribute{
+							"nested": rschema.StringAttribute{
+								Optional: true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.RequiresReplace(),
+								},
 							},
 						},
 					},
 				},
 			},
 		},
-	}
+	})
 
 	computedCreateFunc := func(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 		type Nested struct {
@@ -344,9 +360,28 @@ func TestDetailedDiffSet(t *testing.T) {
 		return cty.ListVal(slice)
 	}
 
+	nestedAttrListWithComputedSpecified := func(arr *[]string) cty.Value {
+		if arr == nil {
+			return cty.NullVal(cty.DynamicPseudoType)
+		}
+		slice := make([]cty.Value, len(*arr))
+		for i, v := range *arr {
+			slice[i] = cty.ObjectVal(
+				map[string]cty.Value{
+					"nested":   cty.StringVal(v),
+					"computed": cty.StringVal("non-computed-" + v),
+				},
+			)
+		}
+		if len(slice) == 0 {
+			return cty.ListValEmpty(cty.Object(map[string]cty.Type{"nested": cty.String}))
+		}
+		return cty.ListVal(slice)
+	}
+
 	schemaValueMakerPairs := []struct {
 		name       string
-		schema     rschema.Schema
+		res        pb.Resource
 		valueMaker func(*[]string) cty.Value
 	}{
 		{"attribute no replace", attributeSchema, attrList},
@@ -420,10 +455,7 @@ func TestDetailedDiffSet(t *testing.T) {
 					initialValue := schemaValueMakerPair.valueMaker(scenario.initialValue)
 					changeValue := schemaValueMakerPair.valueMaker(scenario.changeValue)
 
-					res := pb.NewResource(pb.NewResourceArgs{
-						ResourceSchema: schemaValueMakerPair.schema,
-					})
-					diff := crosstests.Diff(t, res, map[string]cty.Value{"key": initialValue}, map[string]cty.Value{"key": changeValue})
+					diff := crosstests.Diff(t, schemaValueMakerPair.res, map[string]cty.Value{"key": initialValue}, map[string]cty.Value{"key": changeValue})
 
 					autogold.ExpectFile(t, testOutput{
 						initialValue: scenario.initialValue,

--- a/pkg/pf/tests/diff_set_test.go
+++ b/pkg/pf/tests/diff_set_test.go
@@ -1,8 +1,10 @@
 package tfbridgetests
 
 import (
+	"context"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/resource"
 	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
@@ -13,6 +15,7 @@ import (
 
 	crosstests "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/cross-tests"
 	pb "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/providerbuilder"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 func TestDetailedDiffSet(t *testing.T) {
@@ -132,6 +135,183 @@ func TestDetailedDiffSet(t *testing.T) {
 		},
 	}
 
+	computedCreateFunc := func(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+		type Nested struct {
+			Nested   types.String `tfsdk:"nested"`
+			Computed types.String `tfsdk:"computed"`
+		}
+
+		type ObjectModel struct {
+			ID   types.String `tfsdk:"id"`
+			Keys []Nested     `tfsdk:"key"`
+		}
+
+		reqObj := ObjectModel{}
+		diags := req.Plan.Get(ctx, &reqObj)
+		contract.Assertf(diags.ErrorsCount() == 0, "failed to get attribute: %v", diags)
+
+		respObj := ObjectModel{
+			ID:   types.StringValue("test-id"),
+			Keys: make([]Nested, len(reqObj.Keys)),
+		}
+
+		for i, key := range reqObj.Keys {
+			newKey := Nested{}
+			if key.Computed.IsNull() || key.Computed.IsUnknown() {
+				nestedVal := ""
+				if !key.Nested.IsNull() && !key.Nested.IsUnknown() {
+					nestedVal = key.Nested.ValueString()
+				}
+				computedVal := "computed-" + nestedVal
+				newKey.Nested = types.StringValue(nestedVal)
+				newKey.Computed = types.StringValue(computedVal)
+			} else {
+				newKey.Nested = key.Nested
+				newKey.Computed = key.Computed
+			}
+			respObj.Keys[i] = newKey
+		}
+
+		diags = resp.State.Set(ctx, &respObj)
+		contract.Assertf(diags.ErrorsCount() == 0, "failed to set attribute: %v", diags)
+	}
+
+	computedUpdateFunc := func(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+		createResp := resource.CreateResponse{
+			State:       resp.State,
+			Diagnostics: resp.Diagnostics,
+		}
+		computedCreateFunc(ctx, resource.CreateRequest{
+			Plan:         req.Plan,
+			Config:       req.Config,
+			ProviderMeta: req.ProviderMeta,
+		}, &createResp)
+
+		resp.State = createResp.State
+		resp.Diagnostics = createResp.Diagnostics
+	}
+
+	blockSchemaWithComputed := pb.NewResource(pb.NewResourceArgs{
+		ResourceSchema: rschema.Schema{
+			Blocks: map[string]rschema.Block{
+				"key": rschema.SetNestedBlock{
+					NestedObject: rschema.NestedBlockObject{
+						Attributes: map[string]rschema.Attribute{
+							"nested": rschema.StringAttribute{Optional: true},
+							"computed": rschema.StringAttribute{
+								Computed: true,
+								Optional: true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.UseStateForUnknown(),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		CreateFunc: computedCreateFunc,
+		UpdateFunc: computedUpdateFunc,
+	})
+
+	blockSchemaWithComputedNoStateForUnknown := pb.NewResource(pb.NewResourceArgs{
+		ResourceSchema: rschema.Schema{
+			Blocks: map[string]rschema.Block{
+				"key": rschema.SetNestedBlock{
+					NestedObject: rschema.NestedBlockObject{
+						Attributes: map[string]rschema.Attribute{
+							"nested": rschema.StringAttribute{Optional: true},
+							"computed": rschema.StringAttribute{
+								Computed: true,
+								Optional: true,
+							},
+						},
+					},
+				},
+			},
+		},
+		CreateFunc: computedCreateFunc,
+		UpdateFunc: computedUpdateFunc,
+	})
+
+	blockSchemaWithComputedReplace := pb.NewResource(pb.NewResourceArgs{
+		ResourceSchema: rschema.Schema{
+			Blocks: map[string]rschema.Block{
+				"key": rschema.SetNestedBlock{
+					NestedObject: rschema.NestedBlockObject{
+						Attributes: map[string]rschema.Attribute{
+							"nested": rschema.StringAttribute{Optional: true},
+							"computed": rschema.StringAttribute{
+								Computed: true,
+								Optional: true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.UseStateForUnknown(),
+								},
+							},
+						},
+					},
+					PlanModifiers: []planmodifier.Set{
+						setplanmodifier.RequiresReplace(),
+					},
+				},
+			},
+		},
+		CreateFunc: computedCreateFunc,
+		UpdateFunc: computedUpdateFunc,
+	})
+
+	blockSchemaWithComputedNestedReplace := pb.NewResource(pb.NewResourceArgs{
+		ResourceSchema: rschema.Schema{
+			Blocks: map[string]rschema.Block{
+				"key": rschema.SetNestedBlock{
+					NestedObject: rschema.NestedBlockObject{
+						Attributes: map[string]rschema.Attribute{
+							"nested": rschema.StringAttribute{
+								Optional: true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.RequiresReplace(),
+								},
+							},
+							"computed": rschema.StringAttribute{
+								Computed: true,
+								Optional: true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.UseStateForUnknown(),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		CreateFunc: computedCreateFunc,
+		UpdateFunc: computedUpdateFunc,
+	})
+
+	blockSchemaWithComputedComputedRequiresReplace := pb.NewResource(pb.NewResourceArgs{
+		ResourceSchema: rschema.Schema{
+			Blocks: map[string]rschema.Block{
+				"key": rschema.SetNestedBlock{
+					NestedObject: rschema.NestedBlockObject{
+						Attributes: map[string]rschema.Attribute{
+							"nested": rschema.StringAttribute{Optional: true},
+							"computed": rschema.StringAttribute{
+								Computed: true,
+								Optional: true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.UseStateForUnknown(),
+									stringplanmodifier.RequiresReplace(),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		CreateFunc: computedCreateFunc,
+		UpdateFunc: computedUpdateFunc,
+	})
+
 	attrList := func(arr *[]string) cty.Value {
 		if arr == nil {
 			return cty.NullVal(cty.DynamicPseudoType)
@@ -177,6 +357,19 @@ func TestDetailedDiffSet(t *testing.T) {
 		{"block no replace", blockSchema, nestedAttrList},
 		{"block requires replace", blockReplaceSchema, nestedAttrList},
 		{"block nested requires replace", blockNestedReplaceSchema, nestedAttrList},
+
+		// Computed, each state we test both the behaviour when the computed value is specified in the program and when it is not.
+		{"block with computed no replace computed", blockSchemaWithComputed, nestedAttrList},
+		{"block with computed no replace computed specified in program", blockSchemaWithComputed, nestedAttrListWithComputedSpecified},
+		{"block with computed requires replace", blockSchemaWithComputedReplace, nestedAttrList},
+		{"block with computed requires replace computed specified in program", blockSchemaWithComputedReplace, nestedAttrListWithComputedSpecified},
+		{"block with computed and nested requires replace", blockSchemaWithComputedNestedReplace, nestedAttrList},
+		{"block with computed and nested requires replace computed specified in program", blockSchemaWithComputedNestedReplace, nestedAttrListWithComputedSpecified},
+		{"block with computed and computed requires replace", blockSchemaWithComputedComputedRequiresReplace, nestedAttrList},
+		{"block with computed and computed requires replace computed specified in program", blockSchemaWithComputedComputedRequiresReplace, nestedAttrListWithComputedSpecified},
+		// Rarely used, but supported
+		{"block with computed no state for unknown", blockSchemaWithComputedNoStateForUnknown, nestedAttrList},
+		{"block with computed no state for unknown computed specified in program", blockSchemaWithComputedNoStateForUnknown, nestedAttrListWithComputedSpecified},
 	}
 
 	scenarios := []struct {

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/added.golden
@@ -1,0 +1,41 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{"value"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "value"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          + [0]: {
+                  + computed: output<string>
+                  + nested  : "value"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/added_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/added_end.golden
@@ -1,0 +1,72 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "computed-val1" => output<string>
+                    nested  : "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "computed-val2" => output<string>
+                    nested  : "val2"
+                }
+          + [2]: {
+                  + computed: output<string>
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/added_end_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/added_end_unordered.golden
@@ -1,0 +1,72 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "computed-val2" => output<string>
+                  ~ nested  : "val2" => "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "computed-val3" => output<string>
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed: output<string>
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/added_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/added_front.golden
@@ -1,0 +1,72 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "computed-val2" => output<string>
+                  ~ nested  : "val2" => "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "computed-val3" => output<string>
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed: output<string>
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/added_front_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/added_front_unordered.golden
@@ -1,0 +1,72 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "computed-val1" => output<string>
+                    nested  : "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "computed-val3" => output<string>
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed: output<string>
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/added_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/added_middle.golden
@@ -1,0 +1,72 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "computed-val1" => output<string>
+                    nested  : "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "computed-val3" => output<string>
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed: output<string>
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/added_middle_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/added_middle_unordered.golden
@@ -1,0 +1,72 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "computed-val1" => output<string>
+                    nested  : "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "computed-val2" => output<string>
+                    nested  : "val2"
+                }
+          + [2]: {
+                  + computed: output<string>
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/changed_empty_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/changed_empty_to_null.golden
@@ -1,0 +1,15 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/changed_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/changed_non-null.golden
@@ -1,0 +1,45 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "computed-value" -> null
+          - nested   = "value" -> null
+        }
+      + key {
+          + computed = "computed-value"
+          + nested   = "value1"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          ~ [0]: {
+                  ~ nested: "value" => "value1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/changed_non-null_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/changed_non-null_to_null.golden
@@ -1,0 +1,40 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "computed-value" -> null
+          - nested   = "value" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      - keys: [
+      -     [0]: {
+              - nested: "value"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/changed_null_to_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/changed_null_to_empty.golden
@@ -1,0 +1,15 @@
+tfbridgetests.testOutput{
+	changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/changed_null_to_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/changed_null_to_non-null.golden
@@ -1,0 +1,42 @@
+tfbridgetests.testOutput{
+	changeValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "value"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          + [0]: {
+                  + computed: output<string>
+                  + nested  : "value"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/removed.golden
@@ -1,0 +1,41 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "computed-value" -> null
+          - nested   = "value" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          - [0]: {
+                  - nested: "value"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/removed_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/removed_end.golden
@@ -1,0 +1,54 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    nested: "val1"
+                }
+            [1]: {
+                    nested: "val2"
+                }
+          - [2]: {
+                  - nested: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/removed_end_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/removed_end_unordered.golden
@@ -1,0 +1,72 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "computed-val1" => output<string>
+                  ~ nested  : "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ computed: "computed-val2" => output<string>
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/removed_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/removed_front.golden
@@ -1,0 +1,72 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "computed-val1" => output<string>
+                  ~ nested  : "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ computed: "computed-val2" => output<string>
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/removed_front_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/removed_front_unordered.golden
@@ -1,0 +1,72 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "computed-val1" => output<string>
+                    nested  : "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "computed-val2" => output<string>
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/removed_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/removed_middle.golden
@@ -1,0 +1,72 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "computed-val1" => output<string>
+                    nested  : "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "computed-val2" => output<string>
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/removed_middle_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/removed_middle_unordered.golden
@@ -1,0 +1,72 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "computed-val1" => output<string>
+                    nested  : "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "computed-val2" => output<string>
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/shuffled.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/shuffled.golden
@@ -1,0 +1,24 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/shuffled_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/shuffled_unordered.golden
@@ -1,0 +1,24 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/unchanged_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/unchanged_non-empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/unchanged_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/unchanged_null.golden
@@ -1,0 +1,11 @@
+tfbridgetests.testOutput{tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`, pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/added.golden
@@ -1,0 +1,41 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{"value"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      + key { # forces replacement
+          + computed = "non-computed-value"
+          + nested   = "value"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          + [0]: {
+                  + computed: "non-computed-value"
+                  + nested  : "value"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/added_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/added_end.golden
@@ -1,0 +1,58 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      + key { # forces replacement
+          + computed = "non-computed-val3"
+          + nested   = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+            [0]: {
+                    computed: "non-computed-val1"
+                    nested  : "val1"
+                }
+            [1]: {
+                    computed: "non-computed-val2"
+                    nested  : "val2"
+                }
+          + [2]: {
+                  + computed: "non-computed-val3"
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/added_end_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/added_end_unordered.golden
@@ -1,0 +1,58 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      + key { # forces replacement
+          + computed = "non-computed-val1"
+          + nested   = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "non-computed-val2" => "non-computed-val1"
+                  ~ nested  : "val2" => "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "non-computed-val3" => "non-computed-val2"
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed: "non-computed-val3"
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/added_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/added_front.golden
@@ -1,0 +1,58 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      + key { # forces replacement
+          + computed = "non-computed-val1"
+          + nested   = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "non-computed-val2" => "non-computed-val1"
+                  ~ nested  : "val2" => "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "non-computed-val3" => "non-computed-val2"
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed: "non-computed-val3"
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/added_front_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/added_front_unordered.golden
@@ -1,0 +1,58 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      + key { # forces replacement
+          + computed = "non-computed-val2"
+          + nested   = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+            [0]: {
+                    computed: "non-computed-val1"
+                    nested  : "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "non-computed-val3" => "non-computed-val2"
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed: "non-computed-val3"
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/added_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/added_middle.golden
@@ -1,0 +1,58 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      + key { # forces replacement
+          + computed = "non-computed-val2"
+          + nested   = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+            [0]: {
+                    computed: "non-computed-val1"
+                    nested  : "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "non-computed-val3" => "non-computed-val2"
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed: "non-computed-val3"
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/added_middle_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/added_middle_unordered.golden
@@ -1,0 +1,58 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      + key { # forces replacement
+          + computed = "non-computed-val3"
+          + nested   = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+            [0]: {
+                    computed: "non-computed-val1"
+                    nested  : "val1"
+                }
+            [1]: {
+                    computed: "non-computed-val2"
+                    nested  : "val2"
+                }
+          + [2]: {
+                  + computed: "non-computed-val3"
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/changed_empty_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/changed_empty_to_null.golden
@@ -1,0 +1,15 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/changed_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/changed_non-null.golden
@@ -1,0 +1,47 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "non-computed-value" -> null
+          - nested   = "value" -> null
+        }
+      + key { # forces replacement
+          + computed = "non-computed-value1"
+          + nested   = "value1"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "non-computed-value" => "non-computed-value1"
+                  ~ nested  : "value" => "value1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/changed_non-null_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/changed_non-null_to_null.golden
@@ -1,0 +1,41 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "non-computed-value" -> null
+          - nested   = "value" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      - keys: [
+      -     [0]: {
+              - computed: "non-computed-value"
+              - nested  : "value"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/changed_null_to_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/changed_null_to_empty.golden
@@ -1,0 +1,15 @@
+tfbridgetests.testOutput{
+	changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/changed_null_to_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/changed_null_to_non-null.golden
@@ -1,0 +1,42 @@
+tfbridgetests.testOutput{
+	changeValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      + key { # forces replacement
+          + computed = "non-computed-value"
+          + nested   = "value"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          + [0]: {
+                  + computed: "non-computed-value"
+                  + nested  : "value"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/removed.golden
@@ -1,0 +1,42 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "non-computed-value" -> null
+          - nested   = "value" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          - [0]: {
+                  - computed: "non-computed-value"
+                  - nested  : "value"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/removed_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/removed_end.golden
@@ -1,0 +1,57 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    computed: "non-computed-val1"
+                    nested  : "val1"
+                }
+            [1]: {
+                    computed: "non-computed-val2"
+                    nested  : "val2"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/removed_end_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/removed_end_unordered.golden
@@ -1,0 +1,58 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "non-computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "non-computed-val1" => "non-computed-val2"
+                  ~ nested  : "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ computed: "non-computed-val2" => "non-computed-val3"
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/removed_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/removed_front.golden
@@ -1,0 +1,58 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "non-computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "non-computed-val1" => "non-computed-val2"
+                  ~ nested  : "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ computed: "non-computed-val2" => "non-computed-val3"
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/removed_front_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/removed_front_unordered.golden
@@ -1,0 +1,58 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+            [0]: {
+                    computed: "non-computed-val1"
+                    nested  : "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "non-computed-val2" => "non-computed-val3"
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/removed_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/removed_middle.golden
@@ -1,0 +1,58 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+            [0]: {
+                    computed: "non-computed-val1"
+                    nested  : "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "non-computed-val2" => "non-computed-val3"
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/removed_middle_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/removed_middle_unordered.golden
@@ -1,0 +1,58 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+            [0]: {
+                    computed: "non-computed-val1"
+                    nested  : "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "non-computed-val2" => "non-computed-val3"
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/shuffled.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/shuffled.golden
@@ -1,0 +1,24 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/shuffled_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/shuffled_unordered.golden
@@ -1,0 +1,24 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/unchanged_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/unchanged_non-empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/unchanged_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/unchanged_null.golden
@@ -1,0 +1,11 @@
+tfbridgetests.testOutput{tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`, pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/added.golden
@@ -1,0 +1,41 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{"value"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "value"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          + [0]: {
+                  + computed: output<string>
+                  + nested  : "value"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/added_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/added_end.golden
@@ -1,0 +1,72 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "computed-val1" => output<string>
+                    nested  : "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "computed-val2" => output<string>
+                    nested  : "val2"
+                }
+          + [2]: {
+                  + computed: output<string>
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/added_end_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/added_end_unordered.golden
@@ -1,0 +1,72 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "computed-val2" => output<string>
+                  ~ nested  : "val2" => "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "computed-val3" => output<string>
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed: output<string>
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/added_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/added_front.golden
@@ -1,0 +1,72 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "computed-val2" => output<string>
+                  ~ nested  : "val2" => "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "computed-val3" => output<string>
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed: output<string>
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/added_front_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/added_front_unordered.golden
@@ -1,0 +1,72 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "computed-val1" => output<string>
+                    nested  : "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "computed-val3" => output<string>
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed: output<string>
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/added_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/added_middle.golden
@@ -1,0 +1,72 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "computed-val1" => output<string>
+                    nested  : "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "computed-val3" => output<string>
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed: output<string>
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/added_middle_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/added_middle_unordered.golden
@@ -1,0 +1,72 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "computed-val1" => output<string>
+                    nested  : "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "computed-val2" => output<string>
+                    nested  : "val2"
+                }
+          + [2]: {
+                  + computed: output<string>
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/changed_empty_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/changed_empty_to_null.golden
@@ -1,0 +1,15 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/changed_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/changed_non-null.golden
@@ -1,0 +1,47 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "computed-value" -> null
+          - nested   = "value" -> null
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "value1"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "computed-value" => output<string>
+                  ~ nested  : "value" => "value1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/changed_non-null_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/changed_non-null_to_null.golden
@@ -1,0 +1,40 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "computed-value" -> null
+          - nested   = "value" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      - keys: [
+      -     [0]: {
+              - nested: "value"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/changed_null_to_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/changed_null_to_empty.golden
@@ -1,0 +1,15 @@
+tfbridgetests.testOutput{
+	changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/changed_null_to_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/changed_null_to_non-null.golden
@@ -1,0 +1,42 @@
+tfbridgetests.testOutput{
+	changeValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "value"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          + [0]: {
+                  + computed: output<string>
+                  + nested  : "value"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/removed.golden
@@ -1,0 +1,41 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "computed-value" -> null
+          - nested   = "value" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          - [0]: {
+                  - nested: "value"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/removed_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/removed_end.golden
@@ -1,0 +1,54 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    nested: "val1"
+                }
+            [1]: {
+                    nested: "val2"
+                }
+          - [2]: {
+                  - nested: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/removed_end_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/removed_end_unordered.golden
@@ -1,0 +1,72 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "computed-val1" => output<string>
+                  ~ nested  : "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ computed: "computed-val2" => output<string>
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/removed_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/removed_front.golden
@@ -1,0 +1,72 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "computed-val1" => output<string>
+                  ~ nested  : "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ computed: "computed-val2" => output<string>
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/removed_front_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/removed_front_unordered.golden
@@ -1,0 +1,72 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "computed-val1" => output<string>
+                    nested  : "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "computed-val2" => output<string>
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/removed_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/removed_middle.golden
@@ -1,0 +1,72 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "computed-val1" => output<string>
+                    nested  : "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "computed-val2" => output<string>
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/removed_middle_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/removed_middle_unordered.golden
@@ -1,0 +1,72 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "computed-val1" => output<string>
+                    nested  : "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "computed-val2" => output<string>
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/shuffled.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/shuffled.golden
@@ -1,0 +1,24 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/shuffled_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/shuffled_unordered.golden
@@ -1,0 +1,24 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/unchanged_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/unchanged_non-empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/unchanged_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/unchanged_null.golden
@@ -1,0 +1,11 @@
+tfbridgetests.testOutput{tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`, pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/added.golden
@@ -1,0 +1,41 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{"value"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      + key { # forces replacement
+          + computed = "non-computed-value"
+          + nested   = "value"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          + [0]: {
+                  + computed: "non-computed-value"
+                  + nested  : "value"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/added_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/added_end.golden
@@ -1,0 +1,58 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      + key { # forces replacement
+          + computed = "non-computed-val3"
+          + nested   = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+            [0]: {
+                    computed: "non-computed-val1"
+                    nested  : "val1"
+                }
+            [1]: {
+                    computed: "non-computed-val2"
+                    nested  : "val2"
+                }
+          + [2]: {
+                  + computed: "non-computed-val3"
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/added_end_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/added_end_unordered.golden
@@ -1,0 +1,58 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      + key { # forces replacement
+          + computed = "non-computed-val1"
+          + nested   = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "non-computed-val2" => "non-computed-val1"
+                  ~ nested  : "val2" => "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "non-computed-val3" => "non-computed-val2"
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed: "non-computed-val3"
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/added_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/added_front.golden
@@ -1,0 +1,58 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      + key { # forces replacement
+          + computed = "non-computed-val1"
+          + nested   = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "non-computed-val2" => "non-computed-val1"
+                  ~ nested  : "val2" => "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "non-computed-val3" => "non-computed-val2"
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed: "non-computed-val3"
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/added_front_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/added_front_unordered.golden
@@ -1,0 +1,58 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      + key { # forces replacement
+          + computed = "non-computed-val2"
+          + nested   = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+            [0]: {
+                    computed: "non-computed-val1"
+                    nested  : "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "non-computed-val3" => "non-computed-val2"
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed: "non-computed-val3"
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/added_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/added_middle.golden
@@ -1,0 +1,58 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      + key { # forces replacement
+          + computed = "non-computed-val2"
+          + nested   = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+            [0]: {
+                    computed: "non-computed-val1"
+                    nested  : "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "non-computed-val3" => "non-computed-val2"
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed: "non-computed-val3"
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/added_middle_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/added_middle_unordered.golden
@@ -1,0 +1,58 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      + key { # forces replacement
+          + computed = "non-computed-val3"
+          + nested   = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+            [0]: {
+                    computed: "non-computed-val1"
+                    nested  : "val1"
+                }
+            [1]: {
+                    computed: "non-computed-val2"
+                    nested  : "val2"
+                }
+          + [2]: {
+                  + computed: "non-computed-val3"
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/changed_empty_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/changed_empty_to_null.golden
@@ -1,0 +1,15 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/changed_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/changed_non-null.golden
@@ -1,0 +1,47 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "non-computed-value" -> null
+          - nested   = "value" -> null
+        }
+      + key { # forces replacement
+          + computed = "non-computed-value1"
+          + nested   = "value1"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "non-computed-value" => "non-computed-value1"
+                  ~ nested  : "value" => "value1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/changed_non-null_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/changed_non-null_to_null.golden
@@ -1,0 +1,41 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "non-computed-value" -> null
+          - nested   = "value" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      - keys: [
+      -     [0]: {
+              - computed: "non-computed-value"
+              - nested  : "value"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/changed_null_to_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/changed_null_to_empty.golden
@@ -1,0 +1,15 @@
+tfbridgetests.testOutput{
+	changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/changed_null_to_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/changed_null_to_non-null.golden
@@ -1,0 +1,42 @@
+tfbridgetests.testOutput{
+	changeValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      + key { # forces replacement
+          + computed = "non-computed-value"
+          + nested   = "value"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          + [0]: {
+                  + computed: "non-computed-value"
+                  + nested  : "value"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/removed.golden
@@ -1,0 +1,42 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "non-computed-value" -> null
+          - nested   = "value" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          - [0]: {
+                  - computed: "non-computed-value"
+                  - nested  : "value"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/removed_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/removed_end.golden
@@ -1,0 +1,57 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    computed: "non-computed-val1"
+                    nested  : "val1"
+                }
+            [1]: {
+                    computed: "non-computed-val2"
+                    nested  : "val2"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/removed_end_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/removed_end_unordered.golden
@@ -1,0 +1,58 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "non-computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "non-computed-val1" => "non-computed-val2"
+                  ~ nested  : "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ computed: "non-computed-val2" => "non-computed-val3"
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/removed_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/removed_front.golden
@@ -1,0 +1,58 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "non-computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "non-computed-val1" => "non-computed-val2"
+                  ~ nested  : "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ computed: "non-computed-val2" => "non-computed-val3"
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/removed_front_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/removed_front_unordered.golden
@@ -1,0 +1,58 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+            [0]: {
+                    computed: "non-computed-val1"
+                    nested  : "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "non-computed-val2" => "non-computed-val3"
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/removed_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/removed_middle.golden
@@ -1,0 +1,58 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+            [0]: {
+                    computed: "non-computed-val1"
+                    nested  : "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "non-computed-val2" => "non-computed-val3"
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/removed_middle_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/removed_middle_unordered.golden
@@ -1,0 +1,58 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+            [0]: {
+                    computed: "non-computed-val1"
+                    nested  : "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "non-computed-val2" => "non-computed-val3"
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/shuffled.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/shuffled.golden
@@ -1,0 +1,24 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/shuffled_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/shuffled_unordered.golden
@@ -1,0 +1,24 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/unchanged_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/unchanged_non-empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/unchanged_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/unchanged_null.golden
@@ -1,0 +1,11 @@
+tfbridgetests.testOutput{tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`, pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/added.golden
@@ -1,0 +1,39 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{"value"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      + key {
+          + computed = (known after apply)
+          + nested   = "value"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          + [0]: {
+                  + nested: "value"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/added_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/added_end.golden
@@ -1,0 +1,54 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      + key {
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    nested: "val1"
+                }
+            [1]: {
+                    nested: "val2"
+                }
+          + [2]: {
+                  + nested: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/added_end_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/added_end_unordered.golden
@@ -1,0 +1,54 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      + key {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    nested: "val2"
+                }
+            [1]: {
+                    nested: "val3"
+                }
+          + [2]: {
+                  + nested: "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/added_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/added_front.golden
@@ -1,0 +1,54 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      + key {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          ~ [0]: {
+                  ~ nested: "val2" => "val1"
+                }
+          ~ [1]: {
+                  ~ nested: "val3" => "val2"
+                }
+          + [2]: {
+                  + nested: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/added_front_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/added_front_unordered.golden
@@ -1,0 +1,54 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      + key {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          ~ [0]: {
+                  ~ nested: "val3" => "val2"
+                }
+          ~ [1]: {
+                  ~ nested: "val1" => "val3"
+                }
+          + [2]: {
+                  + nested: "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/added_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/added_middle.golden
@@ -1,0 +1,54 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      + key {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    nested: "val1"
+                }
+          ~ [1]: {
+                  ~ nested: "val3" => "val2"
+                }
+          + [2]: {
+                  + nested: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/added_middle_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/added_middle_unordered.golden
@@ -1,0 +1,54 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      + key {
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    nested: "val2"
+                }
+          ~ [1]: {
+                  ~ nested: "val1" => "val3"
+                }
+          + [2]: {
+                  + nested: "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/changed_empty_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/changed_empty_to_null.golden
@@ -1,0 +1,15 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/changed_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/changed_non-null.golden
@@ -1,0 +1,45 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "computed-value" -> null
+          - nested   = "value" -> null
+        }
+      + key {
+          + computed = "computed-value"
+          + nested   = "value1"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          ~ [0]: {
+                  ~ nested: "value" => "value1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/changed_non-null_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/changed_non-null_to_null.golden
@@ -1,0 +1,40 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "computed-value" -> null
+          - nested   = "value" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      - keys: [
+      -     [0]: {
+              - nested: "value"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/changed_null_to_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/changed_null_to_empty.golden
@@ -1,0 +1,15 @@
+tfbridgetests.testOutput{
+	changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/changed_null_to_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/changed_null_to_non-null.golden
@@ -1,0 +1,40 @@
+tfbridgetests.testOutput{
+	changeValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      + key {
+          + computed = (known after apply)
+          + nested   = "value"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      + keys: [
+      +     [0]: {
+              + nested: "value"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/removed.golden
@@ -1,0 +1,41 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "computed-value" -> null
+          - nested   = "value" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          - [0]: {
+                  - nested: "value"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/removed_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/removed_end.golden
@@ -1,0 +1,54 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    nested: "val1"
+                }
+            [1]: {
+                    nested: "val2"
+                }
+          - [2]: {
+                  - nested: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/removed_end_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/removed_end_unordered.golden
@@ -1,0 +1,54 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    nested: "val2"
+                }
+            [1]: {
+                    nested: "val3"
+                }
+          - [2]: {
+                  - nested: "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/removed_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/removed_front.golden
@@ -1,0 +1,54 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          ~ [0]: {
+                  ~ nested: "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ nested: "val2" => "val3"
+                }
+          - [2]: {
+                  - nested: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/removed_front_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/removed_front_unordered.golden
@@ -1,0 +1,54 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          ~ [0]: {
+                  ~ nested: "val2" => "val3"
+                }
+          ~ [1]: {
+                  ~ nested: "val3" => "val1"
+                }
+          - [2]: {
+                  - nested: "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/removed_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/removed_middle.golden
@@ -1,0 +1,54 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    nested: "val1"
+                }
+          ~ [1]: {
+                  ~ nested: "val2" => "val3"
+                }
+          - [2]: {
+                  - nested: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/removed_middle_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/removed_middle_unordered.golden
@@ -1,0 +1,54 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    nested: "val3"
+                }
+            [1]: {
+                    nested: "val1"
+                }
+          - [2]: {
+                  - nested: "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/shuffled.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/shuffled.golden
@@ -1,0 +1,24 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/shuffled_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/shuffled_unordered.golden
@@ -1,0 +1,24 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/unchanged_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/unchanged_non-empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/unchanged_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/unchanged_null.golden
@@ -1,0 +1,11 @@
+tfbridgetests.testOutput{tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`, pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added.golden
@@ -1,0 +1,40 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{"value"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      + key {
+          + computed = "non-computed-value"
+          + nested   = "value"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          + [0]: {
+                  + computed: "non-computed-value"
+                  + nested  : "value"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added_end.golden
@@ -1,0 +1,57 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      + key {
+          + computed = "non-computed-val3"
+          + nested   = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    computed: "non-computed-val1"
+                    nested  : "val1"
+                }
+            [1]: {
+                    computed: "non-computed-val2"
+                    nested  : "val2"
+                }
+          + [2]: {
+                  + computed: "non-computed-val3"
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added_end_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added_end_unordered.golden
@@ -1,0 +1,57 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      + key {
+          + computed = "non-computed-val1"
+          + nested   = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    computed: "non-computed-val2"
+                    nested  : "val2"
+                }
+            [1]: {
+                    computed: "non-computed-val3"
+                    nested  : "val3"
+                }
+          + [2]: {
+                  + computed: "non-computed-val1"
+                  + nested  : "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added_front.golden
@@ -1,0 +1,57 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      + key {
+          + computed = "non-computed-val1"
+          + nested   = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "non-computed-val2" => "non-computed-val1"
+                  ~ nested  : "val2" => "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "non-computed-val3" => "non-computed-val2"
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed: "non-computed-val3"
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added_front_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added_front_unordered.golden
@@ -1,0 +1,57 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      + key {
+          + computed = "non-computed-val2"
+          + nested   = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "non-computed-val3" => "non-computed-val2"
+                  ~ nested  : "val3" => "val2"
+                }
+          ~ [1]: {
+                  ~ computed: "non-computed-val1" => "non-computed-val3"
+                  ~ nested  : "val1" => "val3"
+                }
+          + [2]: {
+                  + computed: "non-computed-val1"
+                  + nested  : "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added_middle.golden
@@ -1,0 +1,57 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      + key {
+          + computed = "non-computed-val2"
+          + nested   = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    computed: "non-computed-val1"
+                    nested  : "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "non-computed-val3" => "non-computed-val2"
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed: "non-computed-val3"
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added_middle_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added_middle_unordered.golden
@@ -1,0 +1,57 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      + key {
+          + computed = "non-computed-val3"
+          + nested   = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    computed: "non-computed-val2"
+                    nested  : "val2"
+                }
+          ~ [1]: {
+                  ~ computed: "non-computed-val1" => "non-computed-val3"
+                  ~ nested  : "val1" => "val3"
+                }
+          + [2]: {
+                  + computed: "non-computed-val1"
+                  + nested  : "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/changed_empty_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/changed_empty_to_null.golden
@@ -1,0 +1,15 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/changed_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/changed_non-null.golden
@@ -1,0 +1,46 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "non-computed-value" -> null
+          - nested   = "value" -> null
+        }
+      + key {
+          + computed = "non-computed-value1"
+          + nested   = "value1"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "non-computed-value" => "non-computed-value1"
+                  ~ nested  : "value" => "value1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/changed_non-null_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/changed_non-null_to_null.golden
@@ -1,0 +1,41 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "non-computed-value" -> null
+          - nested   = "value" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      - keys: [
+      -     [0]: {
+              - computed: "non-computed-value"
+              - nested  : "value"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/changed_null_to_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/changed_null_to_empty.golden
@@ -1,0 +1,15 @@
+tfbridgetests.testOutput{
+	changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/changed_null_to_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/changed_null_to_non-null.golden
@@ -1,0 +1,41 @@
+tfbridgetests.testOutput{
+	changeValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      + key {
+          + computed = "non-computed-value"
+          + nested   = "value"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      + keys: [
+      +     [0]: {
+              + computed: "non-computed-value"
+              + nested  : "value"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed.golden
@@ -1,0 +1,42 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "non-computed-value" -> null
+          - nested   = "value" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          - [0]: {
+                  - computed: "non-computed-value"
+                  - nested  : "value"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed_end.golden
@@ -1,0 +1,57 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    computed: "non-computed-val1"
+                    nested  : "val1"
+                }
+            [1]: {
+                    computed: "non-computed-val2"
+                    nested  : "val2"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed_end_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed_end_unordered.golden
@@ -1,0 +1,57 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "non-computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    computed: "non-computed-val2"
+                    nested  : "val2"
+                }
+            [1]: {
+                    computed: "non-computed-val3"
+                    nested  : "val3"
+                }
+          - [2]: {
+                  - computed: "non-computed-val1"
+                  - nested  : "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed_front.golden
@@ -1,0 +1,57 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "non-computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "non-computed-val1" => "non-computed-val2"
+                  ~ nested  : "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ computed: "non-computed-val2" => "non-computed-val3"
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed_front_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed_front_unordered.golden
@@ -1,0 +1,57 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "non-computed-val2" => "non-computed-val3"
+                  ~ nested  : "val2" => "val3"
+                }
+          ~ [1]: {
+                  ~ computed: "non-computed-val3" => "non-computed-val1"
+                  ~ nested  : "val3" => "val1"
+                }
+          - [2]: {
+                  - computed: "non-computed-val1"
+                  - nested  : "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed_middle.golden
@@ -1,0 +1,57 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    computed: "non-computed-val1"
+                    nested  : "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "non-computed-val2" => "non-computed-val3"
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed_middle_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed_middle_unordered.golden
@@ -1,0 +1,57 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    computed: "non-computed-val3"
+                    nested  : "val3"
+                }
+            [1]: {
+                    computed: "non-computed-val1"
+                    nested  : "val1"
+                }
+          - [2]: {
+                  - computed: "non-computed-val2"
+                  - nested  : "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/shuffled.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/shuffled.golden
@@ -1,0 +1,24 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/shuffled_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/shuffled_unordered.golden
@@ -1,0 +1,24 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/unchanged_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/unchanged_non-empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/unchanged_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/unchanged_null.golden
@@ -1,0 +1,11 @@
+tfbridgetests.testOutput{tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`, pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/added.golden
@@ -1,0 +1,39 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{"value"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      + key {
+          + computed = (known after apply)
+          + nested   = "value"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          + [0]: {
+                  + nested: "value"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/added_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/added_end.golden
@@ -1,0 +1,54 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      + key {
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    nested: "val1"
+                }
+            [1]: {
+                    nested: "val2"
+                }
+          + [2]: {
+                  + nested: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/added_end_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/added_end_unordered.golden
@@ -1,0 +1,54 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      + key {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    nested: "val2"
+                }
+            [1]: {
+                    nested: "val3"
+                }
+          + [2]: {
+                  + nested: "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/added_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/added_front.golden
@@ -1,0 +1,54 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      + key {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          ~ [0]: {
+                  ~ nested: "val2" => "val1"
+                }
+          ~ [1]: {
+                  ~ nested: "val3" => "val2"
+                }
+          + [2]: {
+                  + nested: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/added_front_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/added_front_unordered.golden
@@ -1,0 +1,54 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      + key {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          ~ [0]: {
+                  ~ nested: "val3" => "val2"
+                }
+          ~ [1]: {
+                  ~ nested: "val1" => "val3"
+                }
+          + [2]: {
+                  + nested: "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/added_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/added_middle.golden
@@ -1,0 +1,54 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      + key {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    nested: "val1"
+                }
+          ~ [1]: {
+                  ~ nested: "val3" => "val2"
+                }
+          + [2]: {
+                  + nested: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/added_middle_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/added_middle_unordered.golden
@@ -1,0 +1,54 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      + key {
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    nested: "val2"
+                }
+          ~ [1]: {
+                  ~ nested: "val1" => "val3"
+                }
+          + [2]: {
+                  + nested: "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/changed_empty_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/changed_empty_to_null.golden
@@ -1,0 +1,15 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/changed_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/changed_non-null.golden
@@ -1,0 +1,45 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "computed-value" -> null
+          - nested   = "value" -> null
+        }
+      + key {
+          + computed = (known after apply)
+          + nested   = "value1"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          ~ [0]: {
+                  ~ nested: "value" => "value1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/changed_non-null_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/changed_non-null_to_null.golden
@@ -1,0 +1,40 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "computed-value" -> null
+          - nested   = "value" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      - keys: [
+      -     [0]: {
+              - nested: "value"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/changed_null_to_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/changed_null_to_empty.golden
@@ -1,0 +1,15 @@
+tfbridgetests.testOutput{
+	changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/changed_null_to_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/changed_null_to_non-null.golden
@@ -1,0 +1,40 @@
+tfbridgetests.testOutput{
+	changeValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      + key {
+          + computed = (known after apply)
+          + nested   = "value"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      + keys: [
+      +     [0]: {
+              + nested: "value"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/removed.golden
@@ -1,0 +1,41 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "computed-value" -> null
+          - nested   = "value" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          - [0]: {
+                  - nested: "value"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/removed_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/removed_end.golden
@@ -1,0 +1,54 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    nested: "val1"
+                }
+            [1]: {
+                    nested: "val2"
+                }
+          - [2]: {
+                  - nested: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/removed_end_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/removed_end_unordered.golden
@@ -1,0 +1,54 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    nested: "val2"
+                }
+            [1]: {
+                    nested: "val3"
+                }
+          - [2]: {
+                  - nested: "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/removed_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/removed_front.golden
@@ -1,0 +1,54 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          ~ [0]: {
+                  ~ nested: "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ nested: "val2" => "val3"
+                }
+          - [2]: {
+                  - nested: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/removed_front_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/removed_front_unordered.golden
@@ -1,0 +1,54 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          ~ [0]: {
+                  ~ nested: "val2" => "val3"
+                }
+          ~ [1]: {
+                  ~ nested: "val3" => "val1"
+                }
+          - [2]: {
+                  - nested: "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/removed_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/removed_middle.golden
@@ -1,0 +1,54 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    nested: "val1"
+                }
+          ~ [1]: {
+                  ~ nested: "val2" => "val3"
+                }
+          - [2]: {
+                  - nested: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/removed_middle_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/removed_middle_unordered.golden
@@ -1,0 +1,54 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    nested: "val3"
+                }
+            [1]: {
+                    nested: "val1"
+                }
+          - [2]: {
+                  - nested: "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/shuffled.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/shuffled.golden
@@ -1,0 +1,24 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/shuffled_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/shuffled_unordered.golden
@@ -1,0 +1,24 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/unchanged_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/unchanged_non-empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/unchanged_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/unchanged_null.golden
@@ -1,0 +1,11 @@
+tfbridgetests.testOutput{tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`, pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/added.golden
@@ -1,0 +1,40 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{"value"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      + key {
+          + computed = "non-computed-value"
+          + nested   = "value"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          + [0]: {
+                  + computed: "non-computed-value"
+                  + nested  : "value"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/added_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/added_end.golden
@@ -1,0 +1,57 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      + key {
+          + computed = "non-computed-val3"
+          + nested   = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    computed: "non-computed-val1"
+                    nested  : "val1"
+                }
+            [1]: {
+                    computed: "non-computed-val2"
+                    nested  : "val2"
+                }
+          + [2]: {
+                  + computed: "non-computed-val3"
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/added_end_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/added_end_unordered.golden
@@ -1,0 +1,57 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      + key {
+          + computed = "non-computed-val1"
+          + nested   = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    computed: "non-computed-val2"
+                    nested  : "val2"
+                }
+            [1]: {
+                    computed: "non-computed-val3"
+                    nested  : "val3"
+                }
+          + [2]: {
+                  + computed: "non-computed-val1"
+                  + nested  : "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/added_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/added_front.golden
@@ -1,0 +1,57 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      + key {
+          + computed = "non-computed-val1"
+          + nested   = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "non-computed-val2" => "non-computed-val1"
+                  ~ nested  : "val2" => "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "non-computed-val3" => "non-computed-val2"
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed: "non-computed-val3"
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/added_front_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/added_front_unordered.golden
@@ -1,0 +1,57 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      + key {
+          + computed = "non-computed-val2"
+          + nested   = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "non-computed-val3" => "non-computed-val2"
+                  ~ nested  : "val3" => "val2"
+                }
+          ~ [1]: {
+                  ~ computed: "non-computed-val1" => "non-computed-val3"
+                  ~ nested  : "val1" => "val3"
+                }
+          + [2]: {
+                  + computed: "non-computed-val1"
+                  + nested  : "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/added_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/added_middle.golden
@@ -1,0 +1,57 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      + key {
+          + computed = "non-computed-val2"
+          + nested   = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    computed: "non-computed-val1"
+                    nested  : "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "non-computed-val3" => "non-computed-val2"
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed: "non-computed-val3"
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/added_middle_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/added_middle_unordered.golden
@@ -1,0 +1,57 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      + key {
+          + computed = "non-computed-val3"
+          + nested   = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    computed: "non-computed-val2"
+                    nested  : "val2"
+                }
+          ~ [1]: {
+                  ~ computed: "non-computed-val1" => "non-computed-val3"
+                  ~ nested  : "val1" => "val3"
+                }
+          + [2]: {
+                  + computed: "non-computed-val1"
+                  + nested  : "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/changed_empty_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/changed_empty_to_null.golden
@@ -1,0 +1,15 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/changed_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/changed_non-null.golden
@@ -1,0 +1,46 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "non-computed-value" -> null
+          - nested   = "value" -> null
+        }
+      + key {
+          + computed = "non-computed-value1"
+          + nested   = "value1"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "non-computed-value" => "non-computed-value1"
+                  ~ nested  : "value" => "value1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/changed_non-null_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/changed_non-null_to_null.golden
@@ -1,0 +1,41 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "non-computed-value" -> null
+          - nested   = "value" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      - keys: [
+      -     [0]: {
+              - computed: "non-computed-value"
+              - nested  : "value"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/changed_null_to_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/changed_null_to_empty.golden
@@ -1,0 +1,15 @@
+tfbridgetests.testOutput{
+	changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/changed_null_to_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/changed_null_to_non-null.golden
@@ -1,0 +1,41 @@
+tfbridgetests.testOutput{
+	changeValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      + key {
+          + computed = "non-computed-value"
+          + nested   = "value"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      + keys: [
+      +     [0]: {
+              + computed: "non-computed-value"
+              + nested  : "value"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/removed.golden
@@ -1,0 +1,42 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "non-computed-value" -> null
+          - nested   = "value" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          - [0]: {
+                  - computed: "non-computed-value"
+                  - nested  : "value"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/removed_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/removed_end.golden
@@ -1,0 +1,57 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    computed: "non-computed-val1"
+                    nested  : "val1"
+                }
+            [1]: {
+                    computed: "non-computed-val2"
+                    nested  : "val2"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/removed_end_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/removed_end_unordered.golden
@@ -1,0 +1,57 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "non-computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    computed: "non-computed-val2"
+                    nested  : "val2"
+                }
+            [1]: {
+                    computed: "non-computed-val3"
+                    nested  : "val3"
+                }
+          - [2]: {
+                  - computed: "non-computed-val1"
+                  - nested  : "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/removed_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/removed_front.golden
@@ -1,0 +1,57 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "non-computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "non-computed-val1" => "non-computed-val2"
+                  ~ nested  : "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ computed: "non-computed-val2" => "non-computed-val3"
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/removed_front_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/removed_front_unordered.golden
@@ -1,0 +1,57 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "non-computed-val2" => "non-computed-val3"
+                  ~ nested  : "val2" => "val3"
+                }
+          ~ [1]: {
+                  ~ computed: "non-computed-val3" => "non-computed-val1"
+                  ~ nested  : "val3" => "val1"
+                }
+          - [2]: {
+                  - computed: "non-computed-val1"
+                  - nested  : "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/removed_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/removed_middle.golden
@@ -1,0 +1,57 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    computed: "non-computed-val1"
+                    nested  : "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "non-computed-val2" => "non-computed-val3"
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/removed_middle_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/removed_middle_unordered.golden
@@ -1,0 +1,57 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    computed: "non-computed-val3"
+                    nested  : "val3"
+                }
+            [1]: {
+                    computed: "non-computed-val1"
+                    nested  : "val1"
+                }
+          - [2]: {
+                  - computed: "non-computed-val2"
+                  - nested  : "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/shuffled.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/shuffled.golden
@@ -1,0 +1,24 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/shuffled_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/shuffled_unordered.golden
@@ -1,0 +1,24 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/unchanged_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/unchanged_non-empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/unchanged_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/unchanged_null.golden
@@ -1,0 +1,11 @@
+tfbridgetests.testOutput{tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`, pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/added.golden
@@ -1,0 +1,41 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{"value"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "value"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          + [0]: {
+                  + computed: output<string>
+                  + nested  : "value"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/added_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/added_end.golden
@@ -1,0 +1,72 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "computed-val1" => output<string>
+                    nested  : "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "computed-val2" => output<string>
+                    nested  : "val2"
+                }
+          + [2]: {
+                  + computed: output<string>
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/added_end_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/added_end_unordered.golden
@@ -1,0 +1,72 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "computed-val2" => output<string>
+                  ~ nested  : "val2" => "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "computed-val3" => output<string>
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed: output<string>
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/added_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/added_front.golden
@@ -1,0 +1,72 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "computed-val2" => output<string>
+                  ~ nested  : "val2" => "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "computed-val3" => output<string>
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed: output<string>
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/added_front_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/added_front_unordered.golden
@@ -1,0 +1,72 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "computed-val1" => output<string>
+                    nested  : "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "computed-val3" => output<string>
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed: output<string>
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/added_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/added_middle.golden
@@ -1,0 +1,72 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "computed-val1" => output<string>
+                    nested  : "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "computed-val3" => output<string>
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed: output<string>
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/added_middle_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/added_middle_unordered.golden
@@ -1,0 +1,72 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "computed-val1" => output<string>
+                    nested  : "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "computed-val2" => output<string>
+                    nested  : "val2"
+                }
+          + [2]: {
+                  + computed: output<string>
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/changed_empty_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/changed_empty_to_null.golden
@@ -1,0 +1,15 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/changed_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/changed_non-null.golden
@@ -1,0 +1,47 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "computed-value" -> null
+          - nested   = "value" -> null
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "value1"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "computed-value" => output<string>
+                  ~ nested  : "value" => "value1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/changed_non-null_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/changed_non-null_to_null.golden
@@ -1,0 +1,42 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "computed-value" -> null
+          - nested   = "value" -> null
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          - [0]: {
+                  - computed: "computed-value"
+                  - nested  : "value"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/changed_null_to_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/changed_null_to_empty.golden
@@ -1,0 +1,15 @@
+tfbridgetests.testOutput{
+	changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/changed_null_to_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/changed_null_to_non-null.golden
@@ -1,0 +1,42 @@
+tfbridgetests.testOutput{
+	changeValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "value"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          + [0]: {
+                  + computed: output<string>
+                  + nested  : "value"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/removed.golden
@@ -1,0 +1,43 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "computed-value" -> null
+          - nested   = "value" -> null
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          - [0]: {
+                  - computed: "computed-value"
+                  - nested  : "value"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/removed_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/removed_end.golden
@@ -1,0 +1,72 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "computed-val1" => output<string>
+                    nested  : "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "computed-val2" => output<string>
+                    nested  : "val2"
+                }
+          - [2]: {
+                  - computed: "computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/removed_end_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/removed_end_unordered.golden
@@ -1,0 +1,72 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "computed-val1" => output<string>
+                  ~ nested  : "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ computed: "computed-val2" => output<string>
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/removed_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/removed_front.golden
@@ -1,0 +1,72 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "computed-val1" => output<string>
+                  ~ nested  : "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ computed: "computed-val2" => output<string>
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/removed_front_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/removed_front_unordered.golden
@@ -1,0 +1,72 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "computed-val1" => output<string>
+                    nested  : "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "computed-val2" => output<string>
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/removed_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/removed_middle.golden
@@ -1,0 +1,72 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "computed-val1" => output<string>
+                    nested  : "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "computed-val2" => output<string>
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/removed_middle_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/removed_middle_unordered.golden
@@ -1,0 +1,72 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+      - key { # forces replacement
+          - computed = "computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + key { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "computed-val1" => output<string>
+                    nested  : "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "computed-val2" => output<string>
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/shuffled.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/shuffled.golden
@@ -1,0 +1,24 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/shuffled_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/shuffled_unordered.golden
@@ -1,0 +1,24 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/unchanged_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/unchanged_non-empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/unchanged_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/unchanged_null.golden
@@ -1,0 +1,11 @@
+tfbridgetests.testOutput{tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`, pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/added.golden
@@ -1,0 +1,41 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{"value"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      + key { # forces replacement
+          + computed = "non-computed-value"
+          + nested   = "value"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          + [0]: {
+                  + computed: "non-computed-value"
+                  + nested  : "value"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/added_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/added_end.golden
@@ -1,0 +1,58 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      + key { # forces replacement
+          + computed = "non-computed-val3"
+          + nested   = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+            [0]: {
+                    computed: "non-computed-val1"
+                    nested  : "val1"
+                }
+            [1]: {
+                    computed: "non-computed-val2"
+                    nested  : "val2"
+                }
+          + [2]: {
+                  + computed: "non-computed-val3"
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/added_end_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/added_end_unordered.golden
@@ -1,0 +1,58 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      + key { # forces replacement
+          + computed = "non-computed-val1"
+          + nested   = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "non-computed-val2" => "non-computed-val1"
+                  ~ nested  : "val2" => "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "non-computed-val3" => "non-computed-val2"
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed: "non-computed-val3"
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/added_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/added_front.golden
@@ -1,0 +1,58 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      + key { # forces replacement
+          + computed = "non-computed-val1"
+          + nested   = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "non-computed-val2" => "non-computed-val1"
+                  ~ nested  : "val2" => "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "non-computed-val3" => "non-computed-val2"
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed: "non-computed-val3"
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/added_front_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/added_front_unordered.golden
@@ -1,0 +1,58 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      + key { # forces replacement
+          + computed = "non-computed-val2"
+          + nested   = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+            [0]: {
+                    computed: "non-computed-val1"
+                    nested  : "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "non-computed-val3" => "non-computed-val2"
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed: "non-computed-val3"
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/added_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/added_middle.golden
@@ -1,0 +1,58 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      + key { # forces replacement
+          + computed = "non-computed-val2"
+          + nested   = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+            [0]: {
+                    computed: "non-computed-val1"
+                    nested  : "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "non-computed-val3" => "non-computed-val2"
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed: "non-computed-val3"
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/added_middle_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/added_middle_unordered.golden
@@ -1,0 +1,58 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      + key { # forces replacement
+          + computed = "non-computed-val3"
+          + nested   = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+            [0]: {
+                    computed: "non-computed-val1"
+                    nested  : "val1"
+                }
+            [1]: {
+                    computed: "non-computed-val2"
+                    nested  : "val2"
+                }
+          + [2]: {
+                  + computed: "non-computed-val3"
+                  + nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/changed_empty_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/changed_empty_to_null.golden
@@ -1,0 +1,15 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/changed_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/changed_non-null.golden
@@ -1,0 +1,47 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "non-computed-value" -> null
+          - nested   = "value" -> null
+        }
+      + key { # forces replacement
+          + computed = "non-computed-value1"
+          + nested   = "value1"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "non-computed-value" => "non-computed-value1"
+                  ~ nested  : "value" => "value1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/changed_non-null_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/changed_non-null_to_null.golden
@@ -1,0 +1,42 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "non-computed-value" -> null
+          - nested   = "value" -> null
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          - [0]: {
+                  - computed: "non-computed-value"
+                  - nested  : "value"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/changed_null_to_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/changed_null_to_empty.golden
@@ -1,0 +1,15 @@
+tfbridgetests.testOutput{
+	changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/changed_null_to_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/changed_null_to_non-null.golden
@@ -1,0 +1,42 @@
+tfbridgetests.testOutput{
+	changeValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      + key { # forces replacement
+          + computed = "non-computed-value"
+          + nested   = "value"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          + [0]: {
+                  + computed: "non-computed-value"
+                  + nested  : "value"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/removed.golden
@@ -1,0 +1,43 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "non-computed-value" -> null
+          - nested   = "value" -> null
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          - [0]: {
+                  - computed: "non-computed-value"
+                  - nested  : "value"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/removed_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/removed_end.golden
@@ -1,0 +1,58 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+            [0]: {
+                    computed: "non-computed-val1"
+                    nested  : "val1"
+                }
+            [1]: {
+                    computed: "non-computed-val2"
+                    nested  : "val2"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/removed_end_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/removed_end_unordered.golden
@@ -1,0 +1,58 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "non-computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "non-computed-val1" => "non-computed-val2"
+                  ~ nested  : "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ computed: "non-computed-val2" => "non-computed-val3"
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/removed_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/removed_front.golden
@@ -1,0 +1,58 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "non-computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ computed: "non-computed-val1" => "non-computed-val2"
+                  ~ nested  : "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ computed: "non-computed-val2" => "non-computed-val3"
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/removed_front_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/removed_front_unordered.golden
@@ -1,0 +1,58 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+            [0]: {
+                    computed: "non-computed-val1"
+                    nested  : "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "non-computed-val2" => "non-computed-val3"
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/removed_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/removed_middle.golden
@@ -1,0 +1,58 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+            [0]: {
+                    computed: "non-computed-val1"
+                    nested  : "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "non-computed-val2" => "non-computed-val3"
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/removed_middle_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/removed_middle_unordered.golden
@@ -1,0 +1,58 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      - key { # forces replacement
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+            [0]: {
+                    computed: "non-computed-val1"
+                    nested  : "val1"
+                }
+          ~ [1]: {
+                  ~ computed: "non-computed-val2" => "non-computed-val3"
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/shuffled.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/shuffled.golden
@@ -1,0 +1,24 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/shuffled_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/shuffled_unordered.golden
@@ -1,0 +1,24 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/unchanged_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/unchanged_non-empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/unchanged_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/unchanged_null.golden
@@ -1,0 +1,11 @@
+tfbridgetests.testOutput{tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`, pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`}


### PR DESCRIPTION
This change adds additional testing for Diff in PF for sets involving Computed.

The following schemas are covered:
- Set block with a Computed attribute
- Set block with a Computed attribute and RequiresReplace on the non-computed attribute
- Set block with a Computed attribute and RequiresReplace on the computed attribute
- Set block with a Computed attribute and RequiresReplace on the block
- Set block with a Computed attribute and no UseStateForUnknown on the Computed attribute

For each of these we test both when the Computed attribute is specified in the program and when it is not.

For each of these schemas we test the full set of scenarios added in https://github.com/pulumi/pulumi-terraform-bridge/pull/2592


This should give us some confidence that the changes we are making by adding Detailed Diff for PF are good for Computed properties. 

I will categorize all the issues here as a follow-up before merging https://github.com/pulumi/pulumi-terraform-bridge/pull/2629