### PR TITLE
PF Diff cross-tests for computed set attributes

### DIFF
--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/added.golden
@@ -1,0 +1,35 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{"value"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id  = "test-id"
+      ~ key = [
+          + "value",
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          + [0]: "value"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/added_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/added_end.golden
@@ -1,0 +1,45 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id  = "test-id"
+      ~ key = [
+          + "val3",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: "val1"
+            [1]: "val2"
+          + [2]: "val3"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/added_end_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/added_end_unordered.golden
@@ -1,0 +1,45 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id  = "test-id"
+      ~ key = [
+          + "val1",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: "val2"
+            [1]: "val3"
+          + [2]: "val1"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/added_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/added_front.golden
@@ -1,0 +1,45 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id  = "test-id"
+      ~ key = [
+          + "val1",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          ~ [0]: "val2" => "val1"
+          ~ [1]: "val3" => "val2"
+          + [2]: "val3"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/added_front_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/added_front_unordered.golden
@@ -1,0 +1,45 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id  = "test-id"
+      ~ key = [
+          + "val2",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          ~ [0]: "val3" => "val2"
+          ~ [1]: "val1" => "val3"
+          + [2]: "val1"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/added_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/added_middle.golden
@@ -1,0 +1,45 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id  = "test-id"
+      ~ key = [
+          + "val2",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: "val1"
+          ~ [1]: "val3" => "val2"
+          + [2]: "val3"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/added_middle_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/added_middle_unordered.golden
@@ -1,0 +1,45 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id  = "test-id"
+      ~ key = [
+          + "val3",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: "val2"
+          ~ [1]: "val1" => "val3"
+          + [2]: "val1"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/changed_empty_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/changed_empty_to_null.golden
@@ -1,0 +1,15 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/changed_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/changed_non-null.golden
@@ -1,0 +1,38 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id  = "test-id"
+      ~ key = [
+          - "value",
+          + "value1",
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          ~ [0]: "value" => "value1"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/changed_non-null_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/changed_non-null_to_null.golden
@@ -1,0 +1,17 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/changed_null_to_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/changed_null_to_empty.golden
@@ -1,0 +1,32 @@
+tfbridgetests.testOutput{
+	changeValue: &[]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id  = "test-id"
+      ~ key = [
+          - "value",
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      + keys: []
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/changed_null_to_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/changed_null_to_non-null.golden
@@ -1,0 +1,17 @@
+tfbridgetests.testOutput{
+	changeValue: &[]string{
+		"value",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/removed.golden
@@ -1,0 +1,37 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id  = "test-id"
+      ~ key = [
+          - "value",
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          - [0]: "value"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/removed_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/removed_end.golden
@@ -1,0 +1,45 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id  = "test-id"
+      ~ key = [
+          - "val3",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: "val1"
+            [1]: "val2"
+          - [2]: "val3"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/removed_end_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/removed_end_unordered.golden
@@ -1,0 +1,45 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id  = "test-id"
+      ~ key = [
+          - "val1",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: "val2"
+            [1]: "val3"
+          - [2]: "val1"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/removed_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/removed_front.golden
@@ -1,0 +1,45 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id  = "test-id"
+      ~ key = [
+          - "val1",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          ~ [0]: "val1" => "val2"
+          ~ [1]: "val2" => "val3"
+          - [2]: "val3"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/removed_front_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/removed_front_unordered.golden
@@ -1,0 +1,45 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id  = "test-id"
+      ~ key = [
+          - "val2",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          ~ [0]: "val2" => "val3"
+          ~ [1]: "val3" => "val1"
+          - [2]: "val1"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/removed_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/removed_middle.golden
@@ -1,0 +1,45 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id  = "test-id"
+      ~ key = [
+          - "val2",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: "val1"
+          ~ [1]: "val2" => "val3"
+          - [2]: "val3"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/removed_middle_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/removed_middle_unordered.golden
@@ -1,0 +1,45 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id  = "test-id"
+      ~ key = [
+          - "val2",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: "val3"
+            [1]: "val1"
+          - [2]: "val2"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/shuffled.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/shuffled.golden
@@ -1,0 +1,24 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/shuffled_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/shuffled_unordered.golden
@@ -1,0 +1,24 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/unchanged_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/unchanged_non-empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/unchanged_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/unchanged_null.golden
@@ -1,0 +1,11 @@
+tfbridgetests.testOutput{tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`, pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/added.golden
@@ -1,0 +1,36 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{"value"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id  = "test-id" -> (known after apply)
+      ~ key = [ # forces replacement
+          + "value",
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          + [0]: "value"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/added_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/added_end.golden
@@ -1,0 +1,46 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id  = "test-id" -> (known after apply)
+      ~ key = [ # forces replacement
+          + "val3",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+            [0]: "val1"
+            [1]: "val2"
+          + [2]: "val3"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/added_end_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/added_end_unordered.golden
@@ -1,0 +1,46 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id  = "test-id" -> (known after apply)
+      ~ key = [ # forces replacement
+          + "val1",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: "val2" => "val1"
+          ~ [1]: "val3" => "val2"
+          + [2]: "val3"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/added_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/added_front.golden
@@ -1,0 +1,46 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id  = "test-id" -> (known after apply)
+      ~ key = [ # forces replacement
+          + "val1",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: "val2" => "val1"
+          ~ [1]: "val3" => "val2"
+          + [2]: "val3"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/added_front_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/added_front_unordered.golden
@@ -1,0 +1,46 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id  = "test-id" -> (known after apply)
+      ~ key = [ # forces replacement
+          + "val2",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+            [0]: "val1"
+          ~ [1]: "val3" => "val2"
+          + [2]: "val3"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/added_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/added_middle.golden
@@ -1,0 +1,46 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id  = "test-id" -> (known after apply)
+      ~ key = [ # forces replacement
+          + "val2",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+            [0]: "val1"
+          ~ [1]: "val3" => "val2"
+          + [2]: "val3"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/added_middle_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/added_middle_unordered.golden
@@ -1,0 +1,46 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id  = "test-id" -> (known after apply)
+      ~ key = [ # forces replacement
+          + "val3",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+            [0]: "val1"
+            [1]: "val2"
+          + [2]: "val3"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/changed_empty_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/changed_empty_to_null.golden
@@ -1,0 +1,15 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/changed_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/changed_non-null.golden
@@ -1,0 +1,39 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id  = "test-id" -> (known after apply)
+      ~ key = [ # forces replacement
+          - "value",
+          + "value1",
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: "value" => "value1"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/changed_non-null_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/changed_non-null_to_null.golden
@@ -1,0 +1,17 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/changed_null_to_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/changed_null_to_empty.golden
@@ -1,0 +1,35 @@
+tfbridgetests.testOutput{
+	changeValue: &[]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id  = "test-id" -> (known after apply)
+      ~ key = [ # forces replacement
+          - "value",
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          - [0]: "value"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/changed_null_to_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/changed_null_to_non-null.golden
@@ -1,0 +1,17 @@
+tfbridgetests.testOutput{
+	changeValue: &[]string{
+		"value",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/removed.golden
@@ -1,0 +1,38 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id  = "test-id" -> (known after apply)
+      ~ key = [ # forces replacement
+          - "value",
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          - [0]: "value"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/removed_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/removed_end.golden
@@ -1,0 +1,46 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id  = "test-id" -> (known after apply)
+      ~ key = [ # forces replacement
+          - "val3",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+            [0]: "val1"
+            [1]: "val2"
+          - [2]: "val3"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/removed_end_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/removed_end_unordered.golden
@@ -1,0 +1,46 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id  = "test-id" -> (known after apply)
+      ~ key = [ # forces replacement
+          - "val1",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: "val1" => "val2"
+          ~ [1]: "val2" => "val3"
+          - [2]: "val3"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/removed_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/removed_front.golden
@@ -1,0 +1,46 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id  = "test-id" -> (known after apply)
+      ~ key = [ # forces replacement
+          - "val1",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: "val1" => "val2"
+          ~ [1]: "val2" => "val3"
+          - [2]: "val3"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/removed_front_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/removed_front_unordered.golden
@@ -1,0 +1,46 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id  = "test-id" -> (known after apply)
+      ~ key = [ # forces replacement
+          - "val2",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+            [0]: "val1"
+          ~ [1]: "val2" => "val3"
+          - [2]: "val3"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/removed_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/removed_middle.golden
@@ -1,0 +1,46 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id  = "test-id" -> (known after apply)
+      ~ key = [ # forces replacement
+          - "val2",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+            [0]: "val1"
+          ~ [1]: "val2" => "val3"
+          - [2]: "val3"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/removed_middle_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/removed_middle_unordered.golden
@@ -1,0 +1,46 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id  = "test-id" -> (known after apply)
+      ~ key = [ # forces replacement
+          - "val2",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+            [0]: "val1"
+          ~ [1]: "val2" => "val3"
+          - [2]: "val3"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/shuffled.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/shuffled.golden
@@ -1,0 +1,24 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/shuffled_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/shuffled_unordered.golden
@@ -1,0 +1,24 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/unchanged_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/unchanged_non-empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/unchanged_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/unchanged_null.golden
@@ -1,0 +1,11 @@
+tfbridgetests.testOutput{tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`, pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`}


### PR DESCRIPTION
This PR adds cross-tests for computed set attributes in PF. Similar to https://github.com/pulumi/pulumi-terraform-bridge/pull/2638 but for set attributes, not blocks.