### PR TITLE
PF Diff tests for secrets

### DIFF
--- a/pkg/pf/tests/diff_secret_test.go
+++ b/pkg/pf/tests/diff_secret_test.go
@@ -7,13 +7,14 @@ import (
 	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hexops/autogold/v2"
+	"github.com/pulumi/pulumi/sdk/v3/go/auto/optpreview"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/providerbuilder"
 	pb "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/providerbuilder"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/pulcheck"
 	tfbridge0 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
-	"github.com/pulumi/pulumi/sdk/v3/go/auto/optpreview"
-	"github.com/stretchr/testify/require"
 )
 
 func TestSecretBasic(t *testing.T) {

--- a/pkg/pf/tests/diff_secret_test.go
+++ b/pkg/pf/tests/diff_secret_test.go
@@ -1,0 +1,310 @@
+package tfbridgetests
+
+import (
+	"fmt"
+	"testing"
+
+	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hexops/autogold/v2"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/providerbuilder"
+	pb "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/providerbuilder"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/pulcheck"
+	tfbridge0 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
+	"github.com/pulumi/pulumi/sdk/v3/go/auto/optpreview"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSecretBasic(t *testing.T) {
+	t.Parallel()
+	provBuilder := providerbuilder.NewProvider(
+		providerbuilder.NewProviderArgs{
+			AllResources: []providerbuilder.Resource{
+				providerbuilder.NewResource(providerbuilder.NewResourceArgs{
+					ResourceSchema: rschema.Schema{
+						Attributes: map[string]rschema.Attribute{
+							"s": rschema.StringAttribute{Optional: true},
+						},
+					},
+				}),
+			},
+		})
+
+	prov := bridgedProvider(provBuilder)
+
+	program := `
+name: test
+runtime: yaml
+resources:
+    mainRes:
+        type: testprovider:index:Test
+        properties:
+            s:
+                fn::secret:
+                    %s`
+
+	pt, err := pulcheck.PulCheck(t, prov, fmt.Sprintf(program, "hello"))
+	require.NoError(t, err)
+	pt.Up(t)
+
+	pt.WritePulumiYaml(t, fmt.Sprintf(program, "value2"))
+	res := pt.Preview(t, optpreview.Diff())
+	autogold.Expect(`Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::test::pulumi:pulumi:Stack::test-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::test::testprovider:index/test:Test::mainRes]
+        s: [secret]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`).Equal(t, res.StdOut)
+}
+
+func TestSecretSet(t *testing.T) {
+	t.Parallel()
+
+	provBuilder := pb.NewProvider(pb.NewProviderArgs{
+		AllResources: []providerbuilder.Resource{
+			providerbuilder.NewResource(providerbuilder.NewResourceArgs{
+				ResourceSchema: rschema.Schema{
+					Attributes: map[string]rschema.Attribute{
+						"keys": rschema.SetAttribute{
+							Optional:    true,
+							ElementType: types.StringType,
+						},
+					},
+				},
+			}),
+		},
+	})
+
+	prov := bridgedProvider(provBuilder)
+
+	program := `
+name: test
+runtime: yaml
+resources:
+    mainRes:
+        type: testprovider:index:Test
+        properties:
+            keys: %s
+`
+
+	t.Run("secret collection", func(t *testing.T) {
+		t.Parallel()
+		pt, err := pulcheck.PulCheck(t, prov, fmt.Sprintf(program, "{fn::secret: [value1, value2]}"))
+		require.NoError(t, err)
+		pt.Up(t)
+
+		pt.WritePulumiYaml(t, fmt.Sprintf(program, "{fn::secret: [value1, value3]}"))
+		res := pt.Preview(t, optpreview.Diff())
+		autogold.Expect(`Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::test::pulumi:pulumi:Stack::test-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::test::testprovider:index/test:Test::mainRes]
+        keys: [secret]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`).Equal(t, res.StdOut)
+	})
+
+	t.Run("secret collection element", func(t *testing.T) {
+		t.Parallel()
+		pt, err := pulcheck.PulCheck(t, prov, fmt.Sprintf(program, "[{fn::secret: value1}, value2]"))
+		require.NoError(t, err)
+		pt.Up(t)
+
+		pt.WritePulumiYaml(t, fmt.Sprintf(program, "[{fn::secret: value3}, value2]"))
+		res := pt.Preview(t, optpreview.Diff())
+		autogold.Expect(`Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::test::pulumi:pulumi:Stack::test-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::test::testprovider:index/test:Test::mainRes]
+        keys: [secret]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`).Equal(t, res.StdOut)
+	})
+
+	t.Run("secret collection element secret element unchanged", func(t *testing.T) {
+		pt, err := pulcheck.PulCheck(t, prov, fmt.Sprintf(program, "[{fn::secret: value1}, value2]"))
+		require.NoError(t, err)
+		pt.Up(t)
+
+		pt.WritePulumiYaml(t, fmt.Sprintf(program, "[{fn::secret: value1}, value3]"))
+		res := pt.Preview(t, optpreview.Diff())
+		autogold.Expect(`Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::test::pulumi:pulumi:Stack::test-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::test::testprovider:index/test:Test::mainRes]
+        keys: [secret]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`).Equal(t, res.StdOut)
+	})
+}
+
+func TestSecretObjectBlock(t *testing.T) {
+	t.Parallel()
+
+	provBuilder := pb.NewProvider(pb.NewProviderArgs{
+		AllResources: []providerbuilder.Resource{
+			providerbuilder.NewResource(providerbuilder.NewResourceArgs{
+				ResourceSchema: rschema.Schema{
+					Blocks: map[string]rschema.Block{
+						"key": rschema.SingleNestedBlock{
+							Attributes: map[string]rschema.Attribute{
+								"prop1": rschema.StringAttribute{Optional: true},
+								"prop2": rschema.StringAttribute{Optional: true},
+							},
+						},
+					},
+				},
+			}),
+		},
+	})
+
+	prov := bridgedProvider(provBuilder)
+
+	program := `
+name: test
+runtime: yaml
+resources:
+    mainRes:
+        type: testprovider:index:Test
+        properties:
+            key: %s`
+
+	t.Run("secret object block", func(t *testing.T) {
+		t.Parallel()
+		pt, err := pulcheck.PulCheck(t, prov, fmt.Sprintf(program, "{fn::secret: {prop1: value1, prop2: value2}}"))
+		require.NoError(t, err)
+		pt.Up(t)
+
+		pt.WritePulumiYaml(t, fmt.Sprintf(program, "{fn::secret: {prop1: value3, prop2: value2}}"))
+		res := pt.Preview(t, optpreview.Diff())
+		autogold.Expect(`Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::test::pulumi:pulumi:Stack::test-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::test::testprovider:index/test:Test::mainRes]
+        key: [secret]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`).Equal(t, res.StdOut)
+	})
+
+	t.Run("secret object block element", func(t *testing.T) {
+		t.Parallel()
+		pt, err := pulcheck.PulCheck(t, prov, fmt.Sprintf(program, "{prop1: {fn::secret: value1}, prop2: value2}"))
+		require.NoError(t, err)
+		pt.Up(t)
+
+		pt.WritePulumiYaml(t, fmt.Sprintf(program, "{prop1: {fn::secret: value3}, prop2: value2}"))
+		res := pt.Preview(t, optpreview.Diff())
+		autogold.Expect(`Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::test::pulumi:pulumi:Stack::test-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::test::testprovider:index/test:Test::mainRes]
+        key: {
+            prop1: [secret]
+            prop2: "value2"
+        }
+Resources:
+    ~ 1 to update
+    1 unchanged
+`).Equal(t, res.StdOut)
+	})
+
+	t.Run("secret object block element secret element unchanged", func(t *testing.T) {
+		t.Parallel()
+		pt, err := pulcheck.PulCheck(t, prov, fmt.Sprintf(program, "{prop1: {fn::secret: value1}, prop2: value2}"))
+		require.NoError(t, err)
+		pt.Up(t)
+
+		pt.WritePulumiYaml(t, fmt.Sprintf(program, "{prop1: {fn::secret: value1}, prop2: value3}"))
+		res := pt.Preview(t, optpreview.Diff())
+		autogold.Expect(`Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::test::pulumi:pulumi:Stack::test-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::test::testprovider:index/test:Test::mainRes]
+      ~ key: {
+            prop1: [secret]
+          ~ prop2: "value2" => "value3"
+        }
+Resources:
+    ~ 1 to update
+    1 unchanged
+`).Equal(t, res.StdOut)
+	})
+}
+
+func TestSecretPulumiSchema(t *testing.T) {
+	t.Parallel()
+
+	provBuilder := pb.NewProvider(pb.NewProviderArgs{
+		AllResources: []providerbuilder.Resource{
+			providerbuilder.NewResource(providerbuilder.NewResourceArgs{
+				ResourceSchema: rschema.Schema{
+					Attributes: map[string]rschema.Attribute{
+						"s": rschema.StringAttribute{Optional: true},
+					},
+				},
+			}),
+		},
+	})
+
+	prov := bridgedProvider(provBuilder)
+
+	prov.Resources["testprovider_test"].Fields = map[string]*info.Schema{
+		"s": {Secret: tfbridge0.True()},
+	}
+
+	program := `
+name: test
+runtime: yaml
+resources:
+    mainRes:
+        type: testprovider:index:Test
+        properties:
+            s: %s`
+
+	t.Run("secret string attribute", func(t *testing.T) {
+		t.Parallel()
+		pt, err := pulcheck.PulCheck(t, prov, fmt.Sprintf(program, "value1"))
+		require.NoError(t, err)
+		pt.Up(t)
+
+		pt.WritePulumiYaml(t, fmt.Sprintf(program, "value2"))
+		res := pt.Preview(t, optpreview.Diff())
+		autogold.Expect(`Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::test::pulumi:pulumi:Stack::test-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::test::testprovider:index/test:Test::mainRes]
+        s: [secret]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`).Equal(t, res.StdOut)
+	})
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/added.golden
@@ -1,0 +1,35 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{"value"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id  = "test-id"
+      ~ key = [
+          + "value",
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          + [0]: "value"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/added_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/added_end.golden
@@ -1,0 +1,45 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id  = "test-id"
+      ~ key = [
+          + "val3",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: "val1"
+            [1]: "val2"
+          + [2]: "val3"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/added_end_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/added_end_unordered.golden
@@ -1,0 +1,45 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id  = "test-id"
+      ~ key = [
+          + "val1",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: "val2"
+            [1]: "val3"
+          + [2]: "val1"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/added_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/added_front.golden
@@ -1,0 +1,45 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id  = "test-id"
+      ~ key = [
+          + "val1",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          ~ [0]: "val2" => "val1"
+          ~ [1]: "val3" => "val2"
+          + [2]: "val3"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/added_front_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/added_front_unordered.golden
@@ -1,0 +1,45 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id  = "test-id"
+      ~ key = [
+          + "val2",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          ~ [0]: "val3" => "val2"
+          ~ [1]: "val1" => "val3"
+          + [2]: "val1"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/added_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/added_middle.golden
@@ -1,0 +1,45 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id  = "test-id"
+      ~ key = [
+          + "val2",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: "val1"
+          ~ [1]: "val3" => "val2"
+          + [2]: "val3"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/added_middle_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/added_middle_unordered.golden
@@ -1,0 +1,45 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id  = "test-id"
+      ~ key = [
+          + "val3",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: "val2"
+          ~ [1]: "val1" => "val3"
+          + [2]: "val1"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/changed_empty_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/changed_empty_to_null.golden
@@ -1,0 +1,32 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id  = "test-id"
+      ~ key = [
+          + "value",
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      - keys: []
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/changed_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/changed_non-null.golden
@@ -1,0 +1,38 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id  = "test-id"
+      ~ key = [
+          - "value",
+          + "value1",
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          ~ [0]: "value" => "value1"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/changed_non-null_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/changed_non-null_to_null.golden
@@ -1,0 +1,17 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/changed_null_to_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/changed_null_to_empty.golden
@@ -1,0 +1,32 @@
+tfbridgetests.testOutput{
+	changeValue: &[]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id  = "test-id"
+      ~ key = [
+          - "value",
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      + keys: []
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/changed_null_to_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/changed_null_to_non-null.golden
@@ -1,0 +1,17 @@
+tfbridgetests.testOutput{
+	changeValue: &[]string{
+		"value",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/removed.golden
@@ -1,0 +1,37 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id  = "test-id"
+      ~ key = [
+          - "value",
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          - [0]: "value"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/removed_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/removed_end.golden
@@ -1,0 +1,45 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id  = "test-id"
+      ~ key = [
+          - "val3",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: "val1"
+            [1]: "val2"
+          - [2]: "val3"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/removed_end_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/removed_end_unordered.golden
@@ -1,0 +1,45 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id  = "test-id"
+      ~ key = [
+          - "val1",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: "val2"
+            [1]: "val3"
+          - [2]: "val1"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/removed_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/removed_front.golden
@@ -1,0 +1,45 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id  = "test-id"
+      ~ key = [
+          - "val1",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          ~ [0]: "val1" => "val2"
+          ~ [1]: "val2" => "val3"
+          - [2]: "val3"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/removed_front_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/removed_front_unordered.golden
@@ -1,0 +1,45 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id  = "test-id"
+      ~ key = [
+          - "val2",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          ~ [0]: "val2" => "val3"
+          ~ [1]: "val3" => "val1"
+          - [2]: "val1"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/removed_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/removed_middle.golden
@@ -1,0 +1,45 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id  = "test-id"
+      ~ key = [
+          - "val2",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: "val1"
+          ~ [1]: "val2" => "val3"
+          - [2]: "val3"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/removed_middle_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/removed_middle_unordered.golden
@@ -1,0 +1,45 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id  = "test-id"
+      ~ key = [
+          - "val2",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: "val3"
+            [1]: "val1"
+          - [2]: "val2"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/shuffled.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/shuffled.golden
@@ -1,0 +1,24 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/shuffled_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/shuffled_unordered.golden
@@ -1,0 +1,24 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/unchanged_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/unchanged_non-empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/unchanged_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/unchanged_null.golden
@@ -1,0 +1,11 @@
+tfbridgetests.testOutput{tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`, pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/added.golden
@@ -1,0 +1,38 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{"value"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      + key {
+          + nested = "value"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          + [0]: {
+                  + nested: "value"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/added_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/added_end.golden
@@ -1,0 +1,53 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      + key {
+          + nested = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    nested: "val1"
+                }
+            [1]: {
+                    nested: "val2"
+                }
+          + [2]: {
+                  + nested: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/added_end_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/added_end_unordered.golden
@@ -1,0 +1,53 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      + key {
+          + nested = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    nested: "val2"
+                }
+            [1]: {
+                    nested: "val3"
+                }
+          + [2]: {
+                  + nested: "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/added_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/added_front.golden
@@ -1,0 +1,53 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      + key {
+          + nested = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          ~ [0]: {
+                  ~ nested: "val2" => "val1"
+                }
+          ~ [1]: {
+                  ~ nested: "val3" => "val2"
+                }
+          + [2]: {
+                  + nested: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/added_front_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/added_front_unordered.golden
@@ -1,0 +1,53 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      + key {
+          + nested = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          ~ [0]: {
+                  ~ nested: "val3" => "val2"
+                }
+          ~ [1]: {
+                  ~ nested: "val1" => "val3"
+                }
+          + [2]: {
+                  + nested: "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/added_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/added_middle.golden
@@ -1,0 +1,53 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      + key {
+          + nested = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    nested: "val1"
+                }
+          ~ [1]: {
+                  ~ nested: "val3" => "val2"
+                }
+          + [2]: {
+                  + nested: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/added_middle_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/added_middle_unordered.golden
@@ -1,0 +1,53 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      + key {
+          + nested = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    nested: "val2"
+                }
+          ~ [1]: {
+                  ~ nested: "val1" => "val3"
+                }
+          + [2]: {
+                  + nested: "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/changed_empty_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/changed_empty_to_null.golden
@@ -1,0 +1,15 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/changed_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/changed_non-null.golden
@@ -1,0 +1,43 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - nested = "value" -> null
+        }
+      + key {
+          + nested = "value1"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          ~ [0]: {
+                  ~ nested: "value" => "value1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/changed_non-null_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/changed_non-null_to_null.golden
@@ -1,0 +1,39 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - nested = "value" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      - keys: [
+      -     [0]: {
+              - nested: "value"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/changed_null_to_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/changed_null_to_empty.golden
@@ -1,0 +1,15 @@
+tfbridgetests.testOutput{
+	changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/changed_null_to_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/changed_null_to_non-null.golden
@@ -1,0 +1,39 @@
+tfbridgetests.testOutput{
+	changeValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      + key {
+          + nested = "value"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      + keys: [
+      +     [0]: {
+              + nested: "value"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/removed.golden
@@ -1,0 +1,40 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - nested = "value" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          - [0]: {
+                  - nested: "value"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/removed_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/removed_end.golden
@@ -1,0 +1,53 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - nested = "val3" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    nested: "val1"
+                }
+            [1]: {
+                    nested: "val2"
+                }
+          - [2]: {
+                  - nested: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/removed_end_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/removed_end_unordered.golden
@@ -1,0 +1,53 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - nested = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    nested: "val2"
+                }
+            [1]: {
+                    nested: "val3"
+                }
+          - [2]: {
+                  - nested: "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/removed_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/removed_front.golden
@@ -1,0 +1,53 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - nested = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          ~ [0]: {
+                  ~ nested: "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ nested: "val2" => "val3"
+                }
+          - [2]: {
+                  - nested: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/removed_front_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/removed_front_unordered.golden
@@ -1,0 +1,53 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - nested = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          ~ [0]: {
+                  ~ nested: "val2" => "val3"
+                }
+          ~ [1]: {
+                  ~ nested: "val3" => "val1"
+                }
+          - [2]: {
+                  - nested: "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/removed_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/removed_middle.golden
@@ -1,0 +1,53 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - nested = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    nested: "val1"
+                }
+          ~ [1]: {
+                  ~ nested: "val2" => "val3"
+                }
+          - [2]: {
+                  - nested: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/removed_middle_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/removed_middle_unordered.golden
@@ -1,0 +1,53 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      - key {
+          - nested = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    nested: "val3"
+                }
+            [1]: {
+                    nested: "val1"
+                }
+          - [2]: {
+                  - nested: "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/shuffled.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/shuffled.golden
@@ -1,0 +1,24 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/shuffled_unordered.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/shuffled_unordered.golden
@@ -1,0 +1,24 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/unchanged_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/unchanged_non-empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/unchanged_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/unchanged_null.golden
@@ -1,0 +1,11 @@
+tfbridgetests.testOutput{tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`, pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`}


### PR DESCRIPTION
This change adds tests for PF handling of secrets in previews.

This covers:
- secret attributes
- secrets elements in set attributes,
- secret collection attributes
- secrets properties in blocks
- secret blocks
- secrets coming from pulumi schema