### PR TITLE
Fix flaky aliasing test

### DIFF
--- a/pkg/tfbridge/tokens_test.go
+++ b/pkg/tfbridge/tokens_test.go
@@ -558,8 +558,7 @@ func TestTokenAliasing(t *testing.T) { //nolint:paralleltest
 	}
 }
 
-func TestTokenAliasing1(t *testing.T) {
-	t.Parallel()
+func TestTokenAliasing1(t *testing.T) { //nolint:paralleltest
 	testTokenAliasing(t)
 }
 


### PR DESCRIPTION
The test occasionally fails with complaints about concurrent map writes. We will just run it sequentially as before, that should fix the issue.

https://github.com/pulumi/pulumi-terraform-bridge/actions/runs/11938863967/attempts/1

