### PR TITLE
Add `info.Schema` option: `XAlwaysIncludeInImport`

### DIFF
--- a/pkg/tfbridge/info/info.go
+++ b/pkg/tfbridge/info/info.go
@@ -560,6 +560,40 @@ type Schema struct {
 	//
 	// Experimental.
 	TypeName *string
+
+	// XAlwaysIncludeInImport prevents the field from pruning zero values when generating import inputs.
+	//
+	// This is necessary to accommodate Terraform providers that distinguish between the zero value of a property
+	// and no value of the property.
+	//
+	// For example, consider cloudflare_ruleset resource (https://github.com/pulumi/pulumi-cloudflare/issues/957):
+	//
+	//	resources:
+	//	  cache_rules:
+	//	    type: cloudflare:Ruleset
+	//	    properties:
+	//	      kind: zone
+	//	      rules:
+	//	      - action: set_cache_settings
+	//	        action_parameters:
+	//	          cache: false
+	//
+	// Importing cache_rules will result in the following code:
+	//
+	//	resources:
+	//	  cache_rules:
+	//	    type: cloudflare:Ruleset
+	//	    properties:
+	//	      kind: zone
+	//	      rules:
+	//	      - action: set_cache_settings
+	//
+	// action_parameters.cache is dropped because "false" is the default value of boolean. Unfortunately, the
+	// cloudflare provider treats "cache: false" very differently from "cache: null". Setting XAlwaysIncludeInImport
+	// ensures that "cache: false" is always included in the resulting output.
+	//
+	// Experimental.
+	XAlwaysIncludeInImport bool
 }
 
 // Config represents a synthetic configuration variable that is Pulumi-only, and not passed to Terraform.

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -1778,6 +1778,7 @@ func extractSchemaInputsObject(
 	for k, e := range state {
 		_, etfs, eps := getInfoFromPulumiName(k, tfs, ps)
 		typeKnown := tfs != nil && etfs != nil
+		allowDrop := eps == nil || !eps.XAlwaysIncludeInImport
 
 		// We drop fields that are not present in the schema.
 		//
@@ -1793,7 +1794,7 @@ func extractSchemaInputsObject(
 
 		ev := extractSchemaInputs(e, etfs, eps)
 
-		if !etfs.Required() && isDefaultOrZeroValue(etfs, eps, ev) {
+		if allowDrop && !etfs.Required() && isDefaultOrZeroValue(etfs, eps, ev) {
 			glog.V(9).Infof("skipping '%v' (not required + default or zero value)", k)
 			continue
 		}


### PR DESCRIPTION
This allows a provider author to specify that a field should *always* be included in an import's inputs when present - even when the input is it's zero value.

This is related to fixing https://github.com/pulumi/pulumi-cloudflare/issues/957