### PR TITLE
PF Diff cross-tests for long lists

### DIFF
--- a/pkg/pf/tests/diff_list_test.go
+++ b/pkg/pf/tests/diff_list_test.go
@@ -1,6 +1,7 @@
 package tfbridgetests
 
 import (
+	"fmt"
 	"testing"
 
 	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -179,6 +180,14 @@ func TestDetailedDiffList(t *testing.T) {
 		{"block nested requires replace", blockNestedReplaceSchema, nestedAttrList},
 	}
 
+	longList := &[]string{}
+	for i := 0; i < 20; i++ {
+		*longList = append(*longList, fmt.Sprintf("value%d", i))
+	}
+	longListAddedBack := append([]string{}, *longList...)
+	longListAddedBack = append(longListAddedBack, "value20")
+	longListAddedFront := append([]string{"value20"}, *longList...)
+
 	scenarios := []struct {
 		name         string
 		initialValue *[]string
@@ -201,6 +210,8 @@ func TestDetailedDiffList(t *testing.T) {
 		{"added front", &[]string{"val2", "val3"}, &[]string{"val1", "val2", "val3"}},
 		{"added middle", &[]string{"val1", "val3"}, &[]string{"val1", "val2", "val3"}},
 		{"added end", &[]string{"val1", "val2"}, &[]string{"val1", "val2", "val3"}},
+		{"long list added", longList, &longListAddedBack},
+		{"long list added front", longList, &longListAddedFront},
 	}
 
 	type testOutput struct {

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_no_replace/long_list_added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_no_replace/long_list_added.golden
@@ -1,0 +1,100 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+		"value20",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id  = "test-id"
+      ~ key = [
+            # (19 unchanged elements hidden)
+            "value19",
+          + "value20",
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: "value0"
+            [1]: "value1"
+            [2]: "value2"
+            [3]: "value3"
+            [4]: "value4"
+            [5]: "value5"
+            [6]: "value6"
+            [7]: "value7"
+            [8]: "value8"
+            [9]: "value9"
+            [10]: "value10"
+            [11]: "value11"
+            [12]: "value12"
+            [13]: "value13"
+            [14]: "value14"
+            [15]: "value15"
+            [16]: "value16"
+            [17]: "value17"
+            [18]: "value18"
+            [19]: "value19"
+          + [20]: "value20"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_no_replace/long_list_added_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_no_replace/long_list_added_front.golden
@@ -1,0 +1,100 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value20",
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id  = "test-id"
+      ~ key = [
+          + "value20",
+            "value0",
+            # (19 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          ~ [0]: "value0" => "value20"
+          ~ [1]: "value1" => "value0"
+          ~ [2]: "value2" => "value1"
+          ~ [3]: "value3" => "value2"
+          ~ [4]: "value4" => "value3"
+          ~ [5]: "value5" => "value4"
+          ~ [6]: "value6" => "value5"
+          ~ [7]: "value7" => "value6"
+          ~ [8]: "value8" => "value7"
+          ~ [9]: "value9" => "value8"
+          ~ [10]: "value10" => "value9"
+          ~ [11]: "value11" => "value10"
+          ~ [12]: "value12" => "value11"
+          ~ [13]: "value13" => "value12"
+          ~ [14]: "value14" => "value13"
+          ~ [15]: "value15" => "value14"
+          ~ [16]: "value16" => "value15"
+          ~ [17]: "value17" => "value16"
+          ~ [18]: "value18" => "value17"
+          ~ [19]: "value19" => "value18"
+          + [20]: "value19"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_requires_replace/long_list_added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_requires_replace/long_list_added.golden
@@ -1,0 +1,101 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+		"value20",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id  = "test-id" -> (known after apply)
+      ~ key = [ # forces replacement
+            # (19 unchanged elements hidden)
+            "value19",
+          + "value20",
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+            [0]: "value0"
+            [1]: "value1"
+            [2]: "value2"
+            [3]: "value3"
+            [4]: "value4"
+            [5]: "value5"
+            [6]: "value6"
+            [7]: "value7"
+            [8]: "value8"
+            [9]: "value9"
+            [10]: "value10"
+            [11]: "value11"
+            [12]: "value12"
+            [13]: "value13"
+            [14]: "value14"
+            [15]: "value15"
+            [16]: "value16"
+            [17]: "value17"
+            [18]: "value18"
+            [19]: "value19"
+          + [20]: "value20"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_requires_replace/long_list_added_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_requires_replace/long_list_added_front.golden
@@ -1,0 +1,101 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value20",
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id  = "test-id" -> (known after apply)
+      ~ key = [ # forces replacement
+          + "value20",
+            "value0",
+            # (19 unchanged elements hidden)
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: "value0" => "value20"
+          ~ [1]: "value1" => "value0"
+          ~ [2]: "value2" => "value1"
+          ~ [3]: "value3" => "value2"
+          ~ [4]: "value4" => "value3"
+          ~ [5]: "value5" => "value4"
+          ~ [6]: "value6" => "value5"
+          ~ [7]: "value7" => "value6"
+          ~ [8]: "value8" => "value7"
+          ~ [9]: "value9" => "value8"
+          ~ [10]: "value10" => "value9"
+          ~ [11]: "value11" => "value10"
+          ~ [12]: "value12" => "value11"
+          ~ [13]: "value13" => "value12"
+          ~ [14]: "value14" => "value13"
+          ~ [15]: "value15" => "value14"
+          ~ [16]: "value16" => "value15"
+          ~ [17]: "value17" => "value16"
+          ~ [18]: "value18" => "value17"
+          ~ [19]: "value19" => "value18"
+          + [20]: "value19"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_nested_requires_replace/long_list_added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_nested_requires_replace/long_list_added.golden
@@ -1,0 +1,144 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+		"value20",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      + key {
+          + nested = "value20" # forces replacement
+        }
+
+        # (20 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+            [0]: {
+                    nested: "value0"
+                }
+            [1]: {
+                    nested: "value1"
+                }
+            [2]: {
+                    nested: "value2"
+                }
+            [3]: {
+                    nested: "value3"
+                }
+            [4]: {
+                    nested: "value4"
+                }
+            [5]: {
+                    nested: "value5"
+                }
+            [6]: {
+                    nested: "value6"
+                }
+            [7]: {
+                    nested: "value7"
+                }
+            [8]: {
+                    nested: "value8"
+                }
+            [9]: {
+                    nested: "value9"
+                }
+            [10]: {
+                    nested: "value10"
+                }
+            [11]: {
+                    nested: "value11"
+                }
+            [12]: {
+                    nested: "value12"
+                }
+            [13]: {
+                    nested: "value13"
+                }
+            [14]: {
+                    nested: "value14"
+                }
+            [15]: {
+                    nested: "value15"
+                }
+            [16]: {
+                    nested: "value16"
+                }
+            [17]: {
+                    nested: "value17"
+                }
+            [18]: {
+                    nested: "value18"
+                }
+            [19]: {
+                    nested: "value19"
+                }
+          + [20]: {
+                  + nested: "value20"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_nested_requires_replace/long_list_added_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_nested_requires_replace/long_list_added_front.golden
@@ -1,0 +1,202 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value20",
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      ~ key {
+          ~ nested = "value0" -> "value20" # forces replacement
+        }
+      ~ key {
+          ~ nested = "value1" -> "value0" # forces replacement
+        }
+      ~ key {
+          ~ nested = "value2" -> "value1" # forces replacement
+        }
+      ~ key {
+          ~ nested = "value3" -> "value2" # forces replacement
+        }
+      ~ key {
+          ~ nested = "value4" -> "value3" # forces replacement
+        }
+      ~ key {
+          ~ nested = "value5" -> "value4" # forces replacement
+        }
+      ~ key {
+          ~ nested = "value6" -> "value5" # forces replacement
+        }
+      ~ key {
+          ~ nested = "value7" -> "value6" # forces replacement
+        }
+      ~ key {
+          ~ nested = "value8" -> "value7" # forces replacement
+        }
+      ~ key {
+          ~ nested = "value9" -> "value8" # forces replacement
+        }
+      ~ key {
+          ~ nested = "value10" -> "value9" # forces replacement
+        }
+      ~ key {
+          ~ nested = "value11" -> "value10" # forces replacement
+        }
+      ~ key {
+          ~ nested = "value12" -> "value11" # forces replacement
+        }
+      ~ key {
+          ~ nested = "value13" -> "value12" # forces replacement
+        }
+      ~ key {
+          ~ nested = "value14" -> "value13" # forces replacement
+        }
+      ~ key {
+          ~ nested = "value15" -> "value14" # forces replacement
+        }
+      ~ key {
+          ~ nested = "value16" -> "value15" # forces replacement
+        }
+      ~ key {
+          ~ nested = "value17" -> "value16" # forces replacement
+        }
+      ~ key {
+          ~ nested = "value18" -> "value17" # forces replacement
+        }
+      ~ key {
+          ~ nested = "value19" -> "value18" # forces replacement
+        }
+      + key {
+          + nested = "value19" # forces replacement
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ nested: "value0" => "value20"
+                }
+          ~ [1]: {
+                  ~ nested: "value1" => "value0"
+                }
+          ~ [2]: {
+                  ~ nested: "value2" => "value1"
+                }
+          ~ [3]: {
+                  ~ nested: "value3" => "value2"
+                }
+          ~ [4]: {
+                  ~ nested: "value4" => "value3"
+                }
+          ~ [5]: {
+                  ~ nested: "value5" => "value4"
+                }
+          ~ [6]: {
+                  ~ nested: "value6" => "value5"
+                }
+          ~ [7]: {
+                  ~ nested: "value7" => "value6"
+                }
+          ~ [8]: {
+                  ~ nested: "value8" => "value7"
+                }
+          ~ [9]: {
+                  ~ nested: "value9" => "value8"
+                }
+          ~ [10]: {
+                  ~ nested: "value10" => "value9"
+                }
+          ~ [11]: {
+                  ~ nested: "value11" => "value10"
+                }
+          ~ [12]: {
+                  ~ nested: "value12" => "value11"
+                }
+          ~ [13]: {
+                  ~ nested: "value13" => "value12"
+                }
+          ~ [14]: {
+                  ~ nested: "value14" => "value13"
+                }
+          ~ [15]: {
+                  ~ nested: "value15" => "value14"
+                }
+          ~ [16]: {
+                  ~ nested: "value16" => "value15"
+                }
+          ~ [17]: {
+                  ~ nested: "value17" => "value16"
+                }
+          ~ [18]: {
+                  ~ nested: "value18" => "value17"
+                }
+          ~ [19]: {
+                  ~ nested: "value19" => "value18"
+                }
+          + [20]: {
+                  + nested: "value19"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_no_replace/long_list_added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_no_replace/long_list_added.golden
@@ -1,0 +1,143 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+		"value20",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      + key {
+          + nested = "value20"
+        }
+
+        # (20 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    nested: "value0"
+                }
+            [1]: {
+                    nested: "value1"
+                }
+            [2]: {
+                    nested: "value2"
+                }
+            [3]: {
+                    nested: "value3"
+                }
+            [4]: {
+                    nested: "value4"
+                }
+            [5]: {
+                    nested: "value5"
+                }
+            [6]: {
+                    nested: "value6"
+                }
+            [7]: {
+                    nested: "value7"
+                }
+            [8]: {
+                    nested: "value8"
+                }
+            [9]: {
+                    nested: "value9"
+                }
+            [10]: {
+                    nested: "value10"
+                }
+            [11]: {
+                    nested: "value11"
+                }
+            [12]: {
+                    nested: "value12"
+                }
+            [13]: {
+                    nested: "value13"
+                }
+            [14]: {
+                    nested: "value14"
+                }
+            [15]: {
+                    nested: "value15"
+                }
+            [16]: {
+                    nested: "value16"
+                }
+            [17]: {
+                    nested: "value17"
+                }
+            [18]: {
+                    nested: "value18"
+                }
+            [19]: {
+                    nested: "value19"
+                }
+          + [20]: {
+                  + nested: "value20"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_no_replace/long_list_added_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_no_replace/long_list_added_front.golden
@@ -1,0 +1,201 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value20",
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id = "test-id"
+
+      ~ key {
+          ~ nested = "value0" -> "value20"
+        }
+      ~ key {
+          ~ nested = "value1" -> "value0"
+        }
+      ~ key {
+          ~ nested = "value2" -> "value1"
+        }
+      ~ key {
+          ~ nested = "value3" -> "value2"
+        }
+      ~ key {
+          ~ nested = "value4" -> "value3"
+        }
+      ~ key {
+          ~ nested = "value5" -> "value4"
+        }
+      ~ key {
+          ~ nested = "value6" -> "value5"
+        }
+      ~ key {
+          ~ nested = "value7" -> "value6"
+        }
+      ~ key {
+          ~ nested = "value8" -> "value7"
+        }
+      ~ key {
+          ~ nested = "value9" -> "value8"
+        }
+      ~ key {
+          ~ nested = "value10" -> "value9"
+        }
+      ~ key {
+          ~ nested = "value11" -> "value10"
+        }
+      ~ key {
+          ~ nested = "value12" -> "value11"
+        }
+      ~ key {
+          ~ nested = "value13" -> "value12"
+        }
+      ~ key {
+          ~ nested = "value14" -> "value13"
+        }
+      ~ key {
+          ~ nested = "value15" -> "value14"
+        }
+      ~ key {
+          ~ nested = "value16" -> "value15"
+        }
+      ~ key {
+          ~ nested = "value17" -> "value16"
+        }
+      ~ key {
+          ~ nested = "value18" -> "value17"
+        }
+      ~ key {
+          ~ nested = "value19" -> "value18"
+        }
+      + key {
+          + nested = "value19"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          ~ [0]: {
+                  ~ nested: "value0" => "value20"
+                }
+          ~ [1]: {
+                  ~ nested: "value1" => "value0"
+                }
+          ~ [2]: {
+                  ~ nested: "value2" => "value1"
+                }
+          ~ [3]: {
+                  ~ nested: "value3" => "value2"
+                }
+          ~ [4]: {
+                  ~ nested: "value4" => "value3"
+                }
+          ~ [5]: {
+                  ~ nested: "value5" => "value4"
+                }
+          ~ [6]: {
+                  ~ nested: "value6" => "value5"
+                }
+          ~ [7]: {
+                  ~ nested: "value7" => "value6"
+                }
+          ~ [8]: {
+                  ~ nested: "value8" => "value7"
+                }
+          ~ [9]: {
+                  ~ nested: "value9" => "value8"
+                }
+          ~ [10]: {
+                  ~ nested: "value10" => "value9"
+                }
+          ~ [11]: {
+                  ~ nested: "value11" => "value10"
+                }
+          ~ [12]: {
+                  ~ nested: "value12" => "value11"
+                }
+          ~ [13]: {
+                  ~ nested: "value13" => "value12"
+                }
+          ~ [14]: {
+                  ~ nested: "value14" => "value13"
+                }
+          ~ [15]: {
+                  ~ nested: "value15" => "value14"
+                }
+          ~ [16]: {
+                  ~ nested: "value16" => "value15"
+                }
+          ~ [17]: {
+                  ~ nested: "value17" => "value16"
+                }
+          ~ [18]: {
+                  ~ nested: "value18" => "value17"
+                }
+          ~ [19]: {
+                  ~ nested: "value19" => "value18"
+                }
+          + [20]: {
+                  + nested: "value19"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_requires_replace/long_list_added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_requires_replace/long_list_added.golden
@@ -1,0 +1,144 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+		"value20",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      + key { # forces replacement
+          + nested = "value20"
+        }
+
+        # (20 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+            [0]: {
+                    nested: "value0"
+                }
+            [1]: {
+                    nested: "value1"
+                }
+            [2]: {
+                    nested: "value2"
+                }
+            [3]: {
+                    nested: "value3"
+                }
+            [4]: {
+                    nested: "value4"
+                }
+            [5]: {
+                    nested: "value5"
+                }
+            [6]: {
+                    nested: "value6"
+                }
+            [7]: {
+                    nested: "value7"
+                }
+            [8]: {
+                    nested: "value8"
+                }
+            [9]: {
+                    nested: "value9"
+                }
+            [10]: {
+                    nested: "value10"
+                }
+            [11]: {
+                    nested: "value11"
+                }
+            [12]: {
+                    nested: "value12"
+                }
+            [13]: {
+                    nested: "value13"
+                }
+            [14]: {
+                    nested: "value14"
+                }
+            [15]: {
+                    nested: "value15"
+                }
+            [16]: {
+                    nested: "value16"
+                }
+            [17]: {
+                    nested: "value17"
+                }
+            [18]: {
+                    nested: "value18"
+                }
+            [19]: {
+                    nested: "value19"
+                }
+          + [20]: {
+                  + nested: "value20"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_requires_replace/long_list_added_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_requires_replace/long_list_added_front.golden
@@ -1,0 +1,202 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value20",
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id = "test-id" -> (known after apply)
+
+      ~ key { # forces replacement
+          ~ nested = "value0" -> "value20"
+        }
+      ~ key { # forces replacement
+          ~ nested = "value1" -> "value0"
+        }
+      ~ key { # forces replacement
+          ~ nested = "value2" -> "value1"
+        }
+      ~ key { # forces replacement
+          ~ nested = "value3" -> "value2"
+        }
+      ~ key { # forces replacement
+          ~ nested = "value4" -> "value3"
+        }
+      ~ key { # forces replacement
+          ~ nested = "value5" -> "value4"
+        }
+      ~ key { # forces replacement
+          ~ nested = "value6" -> "value5"
+        }
+      ~ key { # forces replacement
+          ~ nested = "value7" -> "value6"
+        }
+      ~ key { # forces replacement
+          ~ nested = "value8" -> "value7"
+        }
+      ~ key { # forces replacement
+          ~ nested = "value9" -> "value8"
+        }
+      ~ key { # forces replacement
+          ~ nested = "value10" -> "value9"
+        }
+      ~ key { # forces replacement
+          ~ nested = "value11" -> "value10"
+        }
+      ~ key { # forces replacement
+          ~ nested = "value12" -> "value11"
+        }
+      ~ key { # forces replacement
+          ~ nested = "value13" -> "value12"
+        }
+      ~ key { # forces replacement
+          ~ nested = "value14" -> "value13"
+        }
+      ~ key { # forces replacement
+          ~ nested = "value15" -> "value14"
+        }
+      ~ key { # forces replacement
+          ~ nested = "value16" -> "value15"
+        }
+      ~ key { # forces replacement
+          ~ nested = "value17" -> "value16"
+        }
+      ~ key { # forces replacement
+          ~ nested = "value18" -> "value17"
+        }
+      ~ key { # forces replacement
+          ~ nested = "value19" -> "value18"
+        }
+      + key { # forces replacement
+          + nested = "value19"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ nested: "value0" => "value20"
+                }
+          ~ [1]: {
+                  ~ nested: "value1" => "value0"
+                }
+          ~ [2]: {
+                  ~ nested: "value2" => "value1"
+                }
+          ~ [3]: {
+                  ~ nested: "value3" => "value2"
+                }
+          ~ [4]: {
+                  ~ nested: "value4" => "value3"
+                }
+          ~ [5]: {
+                  ~ nested: "value5" => "value4"
+                }
+          ~ [6]: {
+                  ~ nested: "value6" => "value5"
+                }
+          ~ [7]: {
+                  ~ nested: "value7" => "value6"
+                }
+          ~ [8]: {
+                  ~ nested: "value8" => "value7"
+                }
+          ~ [9]: {
+                  ~ nested: "value9" => "value8"
+                }
+          ~ [10]: {
+                  ~ nested: "value10" => "value9"
+                }
+          ~ [11]: {
+                  ~ nested: "value11" => "value10"
+                }
+          ~ [12]: {
+                  ~ nested: "value12" => "value11"
+                }
+          ~ [13]: {
+                  ~ nested: "value13" => "value12"
+                }
+          ~ [14]: {
+                  ~ nested: "value14" => "value13"
+                }
+          ~ [15]: {
+                  ~ nested: "value15" => "value14"
+                }
+          ~ [16]: {
+                  ~ nested: "value16" => "value15"
+                }
+          ~ [17]: {
+                  ~ nested: "value17" => "value16"
+                }
+          ~ [18]: {
+                  ~ nested: "value18" => "value17"
+                }
+          ~ [19]: {
+                  ~ nested: "value19" => "value18"
+                }
+          + [20]: {
+                  + nested: "value19"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_nested_requires_replace/long_list_added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_nested_requires_replace/long_list_added.golden
@@ -1,0 +1,144 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+		"value20",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id  = "test-id" -> (known after apply)
+      ~ key = [
+          + {
+              + nested = "value20" # forces replacement
+            },
+            # (20 unchanged elements hidden)
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+            [0]: {
+                    nested: "value0"
+                }
+            [1]: {
+                    nested: "value1"
+                }
+            [2]: {
+                    nested: "value2"
+                }
+            [3]: {
+                    nested: "value3"
+                }
+            [4]: {
+                    nested: "value4"
+                }
+            [5]: {
+                    nested: "value5"
+                }
+            [6]: {
+                    nested: "value6"
+                }
+            [7]: {
+                    nested: "value7"
+                }
+            [8]: {
+                    nested: "value8"
+                }
+            [9]: {
+                    nested: "value9"
+                }
+            [10]: {
+                    nested: "value10"
+                }
+            [11]: {
+                    nested: "value11"
+                }
+            [12]: {
+                    nested: "value12"
+                }
+            [13]: {
+                    nested: "value13"
+                }
+            [14]: {
+                    nested: "value14"
+                }
+            [15]: {
+                    nested: "value15"
+                }
+            [16]: {
+                    nested: "value16"
+                }
+            [17]: {
+                    nested: "value17"
+                }
+            [18]: {
+                    nested: "value18"
+                }
+            [19]: {
+                    nested: "value19"
+                }
+          + [20]: {
+                  + nested: "value20"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_nested_requires_replace/long_list_added_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_nested_requires_replace/long_list_added_front.golden
@@ -1,0 +1,203 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value20",
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id  = "test-id" -> (known after apply)
+      ~ key = [
+          ~ {
+              ~ nested = "value0" -> "value20" # forces replacement
+            },
+          ~ {
+              ~ nested = "value1" -> "value0" # forces replacement
+            },
+          ~ {
+              ~ nested = "value2" -> "value1" # forces replacement
+            },
+          ~ {
+              ~ nested = "value3" -> "value2" # forces replacement
+            },
+          ~ {
+              ~ nested = "value4" -> "value3" # forces replacement
+            },
+          ~ {
+              ~ nested = "value5" -> "value4" # forces replacement
+            },
+          ~ {
+              ~ nested = "value6" -> "value5" # forces replacement
+            },
+          ~ {
+              ~ nested = "value7" -> "value6" # forces replacement
+            },
+          ~ {
+              ~ nested = "value8" -> "value7" # forces replacement
+            },
+          ~ {
+              ~ nested = "value9" -> "value8" # forces replacement
+            },
+          ~ {
+              ~ nested = "value10" -> "value9" # forces replacement
+            },
+          ~ {
+              ~ nested = "value11" -> "value10" # forces replacement
+            },
+          ~ {
+              ~ nested = "value12" -> "value11" # forces replacement
+            },
+          ~ {
+              ~ nested = "value13" -> "value12" # forces replacement
+            },
+          ~ {
+              ~ nested = "value14" -> "value13" # forces replacement
+            },
+          ~ {
+              ~ nested = "value15" -> "value14" # forces replacement
+            },
+          ~ {
+              ~ nested = "value16" -> "value15" # forces replacement
+            },
+          ~ {
+              ~ nested = "value17" -> "value16" # forces replacement
+            },
+          ~ {
+              ~ nested = "value18" -> "value17" # forces replacement
+            },
+          ~ {
+              ~ nested = "value19" -> "value18" # forces replacement
+            },
+          + {
+              + nested = "value19" # forces replacement
+            },
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ nested: "value0" => "value20"
+                }
+          ~ [1]: {
+                  ~ nested: "value1" => "value0"
+                }
+          ~ [2]: {
+                  ~ nested: "value2" => "value1"
+                }
+          ~ [3]: {
+                  ~ nested: "value3" => "value2"
+                }
+          ~ [4]: {
+                  ~ nested: "value4" => "value3"
+                }
+          ~ [5]: {
+                  ~ nested: "value5" => "value4"
+                }
+          ~ [6]: {
+                  ~ nested: "value6" => "value5"
+                }
+          ~ [7]: {
+                  ~ nested: "value7" => "value6"
+                }
+          ~ [8]: {
+                  ~ nested: "value8" => "value7"
+                }
+          ~ [9]: {
+                  ~ nested: "value9" => "value8"
+                }
+          ~ [10]: {
+                  ~ nested: "value10" => "value9"
+                }
+          ~ [11]: {
+                  ~ nested: "value11" => "value10"
+                }
+          ~ [12]: {
+                  ~ nested: "value12" => "value11"
+                }
+          ~ [13]: {
+                  ~ nested: "value13" => "value12"
+                }
+          ~ [14]: {
+                  ~ nested: "value14" => "value13"
+                }
+          ~ [15]: {
+                  ~ nested: "value15" => "value14"
+                }
+          ~ [16]: {
+                  ~ nested: "value16" => "value15"
+                }
+          ~ [17]: {
+                  ~ nested: "value17" => "value16"
+                }
+          ~ [18]: {
+                  ~ nested: "value18" => "value17"
+                }
+          ~ [19]: {
+                  ~ nested: "value19" => "value18"
+                }
+          + [20]: {
+                  + nested: "value19"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_no_replace/long_list_added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_no_replace/long_list_added.golden
@@ -1,0 +1,143 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+		"value20",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id  = "test-id"
+      ~ key = [
+          + {
+              + nested = "value20"
+            },
+            # (20 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+            [0]: {
+                    nested: "value0"
+                }
+            [1]: {
+                    nested: "value1"
+                }
+            [2]: {
+                    nested: "value2"
+                }
+            [3]: {
+                    nested: "value3"
+                }
+            [4]: {
+                    nested: "value4"
+                }
+            [5]: {
+                    nested: "value5"
+                }
+            [6]: {
+                    nested: "value6"
+                }
+            [7]: {
+                    nested: "value7"
+                }
+            [8]: {
+                    nested: "value8"
+                }
+            [9]: {
+                    nested: "value9"
+                }
+            [10]: {
+                    nested: "value10"
+                }
+            [11]: {
+                    nested: "value11"
+                }
+            [12]: {
+                    nested: "value12"
+                }
+            [13]: {
+                    nested: "value13"
+                }
+            [14]: {
+                    nested: "value14"
+                }
+            [15]: {
+                    nested: "value15"
+                }
+            [16]: {
+                    nested: "value16"
+                }
+            [17]: {
+                    nested: "value17"
+                }
+            [18]: {
+                    nested: "value18"
+                }
+            [19]: {
+                    nested: "value19"
+                }
+          + [20]: {
+                  + nested: "value20"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_no_replace/long_list_added_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_no_replace/long_list_added_front.golden
@@ -1,0 +1,202 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value20",
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res will be updated in-place
+  ~ resource "testprovider_test" "res" {
+        id  = "test-id"
+      ~ key = [
+          ~ {
+              ~ nested = "value0" -> "value20"
+            },
+          ~ {
+              ~ nested = "value1" -> "value0"
+            },
+          ~ {
+              ~ nested = "value2" -> "value1"
+            },
+          ~ {
+              ~ nested = "value3" -> "value2"
+            },
+          ~ {
+              ~ nested = "value4" -> "value3"
+            },
+          ~ {
+              ~ nested = "value5" -> "value4"
+            },
+          ~ {
+              ~ nested = "value6" -> "value5"
+            },
+          ~ {
+              ~ nested = "value7" -> "value6"
+            },
+          ~ {
+              ~ nested = "value8" -> "value7"
+            },
+          ~ {
+              ~ nested = "value9" -> "value8"
+            },
+          ~ {
+              ~ nested = "value10" -> "value9"
+            },
+          ~ {
+              ~ nested = "value11" -> "value10"
+            },
+          ~ {
+              ~ nested = "value12" -> "value11"
+            },
+          ~ {
+              ~ nested = "value13" -> "value12"
+            },
+          ~ {
+              ~ nested = "value14" -> "value13"
+            },
+          ~ {
+              ~ nested = "value15" -> "value14"
+            },
+          ~ {
+              ~ nested = "value16" -> "value15"
+            },
+          ~ {
+              ~ nested = "value17" -> "value16"
+            },
+          ~ {
+              ~ nested = "value18" -> "value17"
+            },
+          ~ {
+              ~ nested = "value19" -> "value18"
+            },
+          + {
+              + nested = "value19"
+            },
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ testprovider:index/test:Test: (update)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ keys: [
+          ~ [0]: {
+                  ~ nested: "value0" => "value20"
+                }
+          ~ [1]: {
+                  ~ nested: "value1" => "value0"
+                }
+          ~ [2]: {
+                  ~ nested: "value2" => "value1"
+                }
+          ~ [3]: {
+                  ~ nested: "value3" => "value2"
+                }
+          ~ [4]: {
+                  ~ nested: "value4" => "value3"
+                }
+          ~ [5]: {
+                  ~ nested: "value5" => "value4"
+                }
+          ~ [6]: {
+                  ~ nested: "value6" => "value5"
+                }
+          ~ [7]: {
+                  ~ nested: "value7" => "value6"
+                }
+          ~ [8]: {
+                  ~ nested: "value8" => "value7"
+                }
+          ~ [9]: {
+                  ~ nested: "value9" => "value8"
+                }
+          ~ [10]: {
+                  ~ nested: "value10" => "value9"
+                }
+          ~ [11]: {
+                  ~ nested: "value11" => "value10"
+                }
+          ~ [12]: {
+                  ~ nested: "value12" => "value11"
+                }
+          ~ [13]: {
+                  ~ nested: "value13" => "value12"
+                }
+          ~ [14]: {
+                  ~ nested: "value14" => "value13"
+                }
+          ~ [15]: {
+                  ~ nested: "value15" => "value14"
+                }
+          ~ [16]: {
+                  ~ nested: "value16" => "value15"
+                }
+          ~ [17]: {
+                  ~ nested: "value17" => "value16"
+                }
+          ~ [18]: {
+                  ~ nested: "value18" => "value17"
+                }
+          ~ [19]: {
+                  ~ nested: "value19" => "value18"
+                }
+          + [20]: {
+                  + nested: "value19"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_requires_replace/long_list_added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_requires_replace/long_list_added.golden
@@ -1,0 +1,144 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+		"value20",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id  = "test-id" -> (known after apply)
+      ~ key = [ # forces replacement
+          + {
+              + nested = "value20"
+            },
+            # (20 unchanged elements hidden)
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+            [0]: {
+                    nested: "value0"
+                }
+            [1]: {
+                    nested: "value1"
+                }
+            [2]: {
+                    nested: "value2"
+                }
+            [3]: {
+                    nested: "value3"
+                }
+            [4]: {
+                    nested: "value4"
+                }
+            [5]: {
+                    nested: "value5"
+                }
+            [6]: {
+                    nested: "value6"
+                }
+            [7]: {
+                    nested: "value7"
+                }
+            [8]: {
+                    nested: "value8"
+                }
+            [9]: {
+                    nested: "value9"
+                }
+            [10]: {
+                    nested: "value10"
+                }
+            [11]: {
+                    nested: "value11"
+                }
+            [12]: {
+                    nested: "value12"
+                }
+            [13]: {
+                    nested: "value13"
+                }
+            [14]: {
+                    nested: "value14"
+                }
+            [15]: {
+                    nested: "value15"
+                }
+            [16]: {
+                    nested: "value16"
+                }
+            [17]: {
+                    nested: "value17"
+                }
+            [18]: {
+                    nested: "value18"
+                }
+            [19]: {
+                    nested: "value19"
+                }
+          + [20]: {
+                  + nested: "value20"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_requires_replace/long_list_added_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_requires_replace/long_list_added_front.golden
@@ -1,0 +1,203 @@
+tfbridgetests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value20",
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # testprovider_test.res must be replaced
++/- resource "testprovider_test" "res" {
+      ~ id  = "test-id" -> (known after apply)
+      ~ key = [ # forces replacement
+          ~ {
+              ~ nested = "value0" -> "value20"
+            },
+          ~ {
+              ~ nested = "value1" -> "value0"
+            },
+          ~ {
+              ~ nested = "value2" -> "value1"
+            },
+          ~ {
+              ~ nested = "value3" -> "value2"
+            },
+          ~ {
+              ~ nested = "value4" -> "value3"
+            },
+          ~ {
+              ~ nested = "value5" -> "value4"
+            },
+          ~ {
+              ~ nested = "value6" -> "value5"
+            },
+          ~ {
+              ~ nested = "value7" -> "value6"
+            },
+          ~ {
+              ~ nested = "value8" -> "value7"
+            },
+          ~ {
+              ~ nested = "value9" -> "value8"
+            },
+          ~ {
+              ~ nested = "value10" -> "value9"
+            },
+          ~ {
+              ~ nested = "value11" -> "value10"
+            },
+          ~ {
+              ~ nested = "value12" -> "value11"
+            },
+          ~ {
+              ~ nested = "value13" -> "value12"
+            },
+          ~ {
+              ~ nested = "value14" -> "value13"
+            },
+          ~ {
+              ~ nested = "value15" -> "value14"
+            },
+          ~ {
+              ~ nested = "value16" -> "value15"
+            },
+          ~ {
+              ~ nested = "value17" -> "value16"
+            },
+          ~ {
+              ~ nested = "value18" -> "value17"
+            },
+          ~ {
+              ~ nested = "value19" -> "value18"
+            },
+          + {
+              + nested = "value19"
+            },
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-testprovider:index/test:Test: (replace)
+        [id=test-id]
+        [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          ~ [0]: {
+                  ~ nested: "value0" => "value20"
+                }
+          ~ [1]: {
+                  ~ nested: "value1" => "value0"
+                }
+          ~ [2]: {
+                  ~ nested: "value2" => "value1"
+                }
+          ~ [3]: {
+                  ~ nested: "value3" => "value2"
+                }
+          ~ [4]: {
+                  ~ nested: "value4" => "value3"
+                }
+          ~ [5]: {
+                  ~ nested: "value5" => "value4"
+                }
+          ~ [6]: {
+                  ~ nested: "value6" => "value5"
+                }
+          ~ [7]: {
+                  ~ nested: "value7" => "value6"
+                }
+          ~ [8]: {
+                  ~ nested: "value8" => "value7"
+                }
+          ~ [9]: {
+                  ~ nested: "value9" => "value8"
+                }
+          ~ [10]: {
+                  ~ nested: "value10" => "value9"
+                }
+          ~ [11]: {
+                  ~ nested: "value11" => "value10"
+                }
+          ~ [12]: {
+                  ~ nested: "value12" => "value11"
+                }
+          ~ [13]: {
+                  ~ nested: "value13" => "value12"
+                }
+          ~ [14]: {
+                  ~ nested: "value14" => "value13"
+                }
+          ~ [15]: {
+                  ~ nested: "value15" => "value14"
+                }
+          ~ [16]: {
+                  ~ nested: "value16" => "value15"
+                }
+          ~ [17]: {
+                  ~ nested: "value17" => "value16"
+                }
+          ~ [18]: {
+                  ~ nested: "value18" => "value17"
+                }
+          ~ [19]: {
+                  ~ nested: "value19" => "value18"
+                }
+          + [20]: {
+                  + nested: "value19"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+}


### PR DESCRIPTION
This adds a cross-tests for handling long lists in PF Diff. Our handling is suboptimal but note that TF also struggles with this when there is a replacement.

Related to https://github.com/pulumi/pulumi-terraform-bridge/issues/2647