### PR TITLE
Add property value transform for removing secrets and outputs

### DIFF
--- a/unstable/propertyvalue/propertyvalue.go
+++ b/unstable/propertyvalue/propertyvalue.go
@@ -128,6 +128,22 @@ func RemoveSecrets(pv resource.PropertyValue) resource.PropertyValue {
 	return Transform(unsecret, pv)
 }
 
+func RemoveSecretsAndOutputs(pv resource.PropertyValue) resource.PropertyValue {
+	return Transform(func(pv resource.PropertyValue) resource.PropertyValue {
+		if pv.IsSecret() {
+			return pv.SecretValue().Element
+		}
+		if pv.IsOutput() {
+			o := pv.OutputValue()
+			if !o.Known {
+				return resource.NewComputedProperty(resource.Computed{Element: resource.NewStringProperty("")})
+			}
+			return o.Element
+		}
+		return pv
+	}, pv)
+}
+
 func extendPath(p resource.PropertyPath, segment any) resource.PropertyPath {
 	rp := make(resource.PropertyPath, len(p)+1)
 	copy(rp, p)

--- a/unstable/propertyvalue/propertyvalue_test.go
+++ b/unstable/propertyvalue/propertyvalue_test.go
@@ -33,6 +33,26 @@ func TestRemoveSecrets(t *testing.T) {
 	})
 }
 
+func TestRemoveSecretsAndOutputs(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		randomPV := rtesting.PropertyValueGenerator(5 /* maxDepth */).Draw(t, "pv")
+		result := RemoveSecretsAndOutputs(randomPV)
+		if result.ContainsSecrets() {
+			t.Fatalf("RemoveSecretsAndOutputs(randomPV).ContainsSecrets()")
+		}
+
+		visitor := func(path resource.PropertyPath, val resource.PropertyValue) (resource.PropertyValue, error) {
+			require.False(t, val.IsSecret())
+			require.False(t, val.IsOutput())
+			return val, nil
+		}
+
+		_, err := TransformPropertyValue(resource.PropertyPath{}, visitor, result)
+		require.NoError(t, err)
+	})
+}
+
 func TestIsNilArray(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This change adds a propertyvalue Transform for removing secrets and outputs. This will be useful in the detailed diff algorithm where secrets and outputs are not relevant, since DetailedDiff only returns paths to properties. We will instead remove all secrets and inputs when passed to the algorithm so it doesn't have to handle them in the internals.