### PR TITLE
SDKv2 Diff cross tests for replacement of computed properties

### DIFF
--- a/pkg/internal/tests/cross-tests/diff_check.go
+++ b/pkg/internal/tests/cross-tests/diff_check.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/auto/optpreview"
 	"github.com/stretchr/testify/require"
 
 	crosstestsimpl "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/tests/cross-tests/impl"
@@ -79,7 +80,7 @@ func runDiffCheck(t T, tc diffTestCase) crosstestsimpl.DiffResult {
 	err := os.WriteFile(filepath.Join(pt.CurrentStack().Workspace().WorkDir(), "Pulumi.yaml"), yamlProgram, 0o600)
 	require.NoErrorf(t, err, "writing Pulumi.yaml")
 
-	previewRes := pt.Preview(t)
+	previewRes := pt.Preview(t, optpreview.Diff())
 	diffResponse := crosstestsimpl.GetPulumiDiffResponse(t, pt.GrpcLog(t).Entries)
 	x := pt.Up(t)
 

--- a/pkg/internal/tests/cross-tests/testdata/TestComputedProperty/no_change.golden
+++ b/pkg/internal/tests/cross-tests/testdata/TestComputedProperty/no_change.golden
@@ -1,0 +1,24 @@
+crosstests.testOutput{
+	initialValue: cty.Value{
+		ty: cty.Type{typeImpl: cty.typeObject{
+			AttrTypes: map[string]cty.Type{},
+		}},
+		v: map[string]interface{}{},
+	},
+	changeValue: cty.Value{
+		ty: cty.Type{typeImpl: cty.typeObject{AttrTypes: map[string]cty.Type{}}},
+		v:  map[string]interface{}{},
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/internal/tests/cross-tests/testdata/TestComputedProperty/non-computed_added.golden
+++ b/pkg/internal/tests/cross-tests/testdata/TestComputedProperty/non-computed_added.golden
@@ -1,0 +1,45 @@
+crosstests.testOutput{
+	initialValue: cty.Value{
+		ty: cty.Type{typeImpl: cty.typeObject{
+			AttrTypes: map[string]cty.Type{},
+		}},
+		v: map[string]interface{}{},
+	},
+	changeValue: cty.Value{
+		ty: cty.Type{typeImpl: cty.typeObject{AttrTypes: map[string]cty.Type{
+			"other": {typeImpl: cty.primitiveType{
+				Kind: cty.primitiveTypeKind(83),
+			}},
+		}}},
+		v: map[string]interface{}{"other": "other_value"},
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ computed = "computed_value" -> (known after apply)
+      ~ id       = "r1" -> (known after apply)
+      + other    = "other_value" # forces replacement
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=r1]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + other: "other_value"
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"other": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/internal/tests/cross-tests/testdata/TestComputedProperty/non-computed_changed.golden
+++ b/pkg/internal/tests/cross-tests/testdata/TestComputedProperty/non-computed_changed.golden
@@ -1,0 +1,47 @@
+crosstests.testOutput{
+	initialValue: cty.Value{
+		ty: cty.Type{typeImpl: cty.typeObject{
+			AttrTypes: map[string]cty.Type{"other": {
+				typeImpl: cty.primitiveType{Kind: cty.primitiveTypeKind(83)},
+			}},
+		}},
+		v: map[string]interface{}{"other": "other_value"},
+	},
+	changeValue: cty.Value{
+		ty: cty.Type{typeImpl: cty.typeObject{AttrTypes: map[string]cty.Type{
+			"other": {typeImpl: cty.primitiveType{
+				Kind: cty.primitiveTypeKind(83),
+			}},
+		}}},
+		v: map[string]interface{}{"other": "other_value_2"},
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ computed = "computed_value" -> (known after apply)
+      ~ id       = "r1" -> (known after apply)
+      ~ other    = "other_value" -> "other_value_2" # forces replacement
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=r1]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ other: "other_value" => "other_value_2"
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"other": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
+}

--- a/pkg/internal/tests/cross-tests/testdata/TestComputedProperty/non-computed_removed.golden
+++ b/pkg/internal/tests/cross-tests/testdata/TestComputedProperty/non-computed_removed.golden
@@ -1,0 +1,43 @@
+crosstests.testOutput{
+	initialValue: cty.Value{
+		ty: cty.Type{typeImpl: cty.typeObject{
+			AttrTypes: map[string]cty.Type{"other": {
+				typeImpl: cty.primitiveType{Kind: cty.primitiveTypeKind(83)},
+			}},
+		}},
+		v: map[string]interface{}{"other": "other_value"},
+	},
+	changeValue: cty.Value{
+		ty: cty.Type{typeImpl: cty.typeObject{AttrTypes: map[string]cty.Type{}}},
+		v:  map[string]interface{}{},
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ computed = "computed_value" -> (known after apply)
+      ~ id       = "r1" -> (known after apply)
+      - other    = "other_value" -> null # forces replacement
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=r1]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      - other: "other_value"
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"other": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/internal/tests/cross-tests/testdata/TestDetailedDiffReplacementComputedProperty/no_change.golden
+++ b/pkg/internal/tests/cross-tests/testdata/TestDetailedDiffReplacementComputedProperty/no_change.golden
@@ -1,0 +1,24 @@
+crosstests.testOutput{
+	initialValue: cty.Value{
+		ty: cty.Type{typeImpl: cty.typeObject{
+			AttrTypes: map[string]cty.Type{},
+		}},
+		v: map[string]interface{}{},
+	},
+	changeValue: cty.Value{
+		ty: cty.Type{typeImpl: cty.typeObject{AttrTypes: map[string]cty.Type{}}},
+		v:  map[string]interface{}{},
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/internal/tests/cross-tests/testdata/TestDetailedDiffReplacementComputedProperty/non-computed_added.golden
+++ b/pkg/internal/tests/cross-tests/testdata/TestDetailedDiffReplacementComputedProperty/non-computed_added.golden
@@ -1,0 +1,45 @@
+crosstests.testOutput{
+	initialValue: cty.Value{
+		ty: cty.Type{typeImpl: cty.typeObject{
+			AttrTypes: map[string]cty.Type{},
+		}},
+		v: map[string]interface{}{},
+	},
+	changeValue: cty.Value{
+		ty: cty.Type{typeImpl: cty.typeObject{AttrTypes: map[string]cty.Type{
+			"other": {typeImpl: cty.primitiveType{
+				Kind: cty.primitiveTypeKind(83),
+			}},
+		}}},
+		v: map[string]interface{}{"other": "other_value"},
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ computed = "computed_value" -> (known after apply)
+      ~ id       = "r1" -> (known after apply)
+      + other    = "other_value" # forces replacement
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=r1]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + other: "other_value"
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"other": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/internal/tests/cross-tests/testdata/TestDetailedDiffReplacementComputedProperty/non-computed_changed.golden
+++ b/pkg/internal/tests/cross-tests/testdata/TestDetailedDiffReplacementComputedProperty/non-computed_changed.golden
@@ -1,0 +1,47 @@
+crosstests.testOutput{
+	initialValue: cty.Value{
+		ty: cty.Type{typeImpl: cty.typeObject{
+			AttrTypes: map[string]cty.Type{"other": {
+				typeImpl: cty.primitiveType{Kind: cty.primitiveTypeKind(83)},
+			}},
+		}},
+		v: map[string]interface{}{"other": "other_value"},
+	},
+	changeValue: cty.Value{
+		ty: cty.Type{typeImpl: cty.typeObject{AttrTypes: map[string]cty.Type{
+			"other": {typeImpl: cty.primitiveType{
+				Kind: cty.primitiveTypeKind(83),
+			}},
+		}}},
+		v: map[string]interface{}{"other": "other_value_2"},
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ computed = "computed_value" -> (known after apply)
+      ~ id       = "r1" -> (known after apply)
+      ~ other    = "other_value" -> "other_value_2" # forces replacement
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=r1]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ other: "other_value" => "other_value_2"
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"other": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
+}

--- a/pkg/internal/tests/cross-tests/testdata/TestDetailedDiffReplacementComputedProperty/non-computed_removed.golden
+++ b/pkg/internal/tests/cross-tests/testdata/TestDetailedDiffReplacementComputedProperty/non-computed_removed.golden
@@ -1,0 +1,43 @@
+crosstests.testOutput{
+	initialValue: cty.Value{
+		ty: cty.Type{typeImpl: cty.typeObject{
+			AttrTypes: map[string]cty.Type{"other": {
+				typeImpl: cty.primitiveType{Kind: cty.primitiveTypeKind(83)},
+			}},
+		}},
+		v: map[string]interface{}{"other": "other_value"},
+	},
+	changeValue: cty.Value{
+		ty: cty.Type{typeImpl: cty.typeObject{AttrTypes: map[string]cty.Type{}}},
+		v:  map[string]interface{}{},
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ computed = "computed_value" -> (known after apply)
+      ~ id       = "r1" -> (known after apply)
+      - other    = "other_value" -> null # forces replacement
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=r1]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      - other: "other_value"
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"other": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}


### PR DESCRIPTION
This PR adds Diff cross-tests for the SDKv2 bridge to test the re-computation of computed properties when the resource is marked for replacement. We display an incorrect preview in such cases in the PF and this also affects the SDKv2.

related to https://github.com/pulumi/pulumi-terraform-bridge/issues/2660