### PR TITLE
Bump golangci lint version

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -73,6 +73,6 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           skip-cache: true
-          version: v1.60
+          version: v1.62
       - name: Lint
         run: make lint

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -30,7 +30,7 @@ jobs:
       uses: golangci/golangci-lint-action@v6
       with:
           skip-cache: true
-          version: v1.60
+          version: v1.62
     - name: Update Pulumi/Pulumi
       id: gomod
       run: >-

--- a/pkg/tfshim/sdk-v2/cty.go
+++ b/pkg/tfshim/sdk-v2/cty.go
@@ -160,7 +160,6 @@ func recoverScalarCtyValue(dT cty.Type, value interface{}) (cty.Value, error) {
 		if value > math.MaxInt64 {
 			return cty.NilVal, fmt.Errorf("cannot convert %d (uint) to a int64: overflow", value)
 		}
-		//nolint:gosec
 		return cty.NumberIntVal(int64(value)), nil
 	case int64:
 		return cty.NumberIntVal(value), nil


### PR DESCRIPTION
@mikhailshilkov noticed that he gets a warning locally which does not trigger in CI. Bumping the golangci-lint version fixes the issue. The PR also removes the redundant nolint required by the previous version.