### PR TITLE
Fix broken docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you want to wrap a _new_ Terraform provider as a Pulumi provider, check out [
 
 The recommended way to start developing a new TF provider is with [pulumi-tf-provider-boilerplate](https://github.com/pulumi/pulumi-tf-provider-boilerplate).
 
-If you want details on how provider development works, please see [our docs](./docs/new-provider.md).
+If you want details on how provider development works, please see [our docs](./docs/guides/new-provider.md).
 
 ## Upgrading an Existing Bridged Provider
 
@@ -29,7 +29,7 @@ To upgrade a provider that was bridged from a Terraform provider built against [
 Plugin SDK](https://github.com/hashicorp/terraform-plugin-sdk) and you want to upgrade it
 to a version that has migrated some but not all resources/datasources to the [Terraform
 Plugin Framework](https://github.com/hashicorp/terraform-plugin-sdk?tab=readme-ov-file),
-see [here](./docs/upgrade-sdk-to-mux.md).
+see [here](./docs/guides/upgrade-sdk-to-mux.md).
 
 ## Overview
 

--- a/pkg/pf/README.md
+++ b/pkg/pf/README.md
@@ -6,13 +6,13 @@ Providers](https://github.com/terraform-providers) built using the [Terraform Pl
 Framework](https://developer.hashicorp.com/terraform/plugin/framework).
 
 If you need to adapt [Terraform Plugin SDK](https://github.com/hashicorp/terraform-plugin-sdk) based
-providers, see [the documentation for bridging a new SDK based provider](../docs/new-provider.md).
+providers, see [the documentation for bridging a new SDK based provider](../../docs/guides/new-provider.md).
 
 If you have a Pulumi provider that was bridged from a Terraform provider built against [Terraform Plugin
 SDK](https://github.com/hashicorp/terraform-plugin-sdk) and you want to upgrade it to a version that has
 migrated some but not all resources/datasources to the [Plugin
 Framework](https://github.com/hashicorp/terraform-plugin-sdk?tab=readme-ov-file), see
-[here](../docs/upgrade-sdk-to-mux.md).
+[here](../../docs/guides/upgrade-sdk-to-mux.md).
 
 ## How to Bridge a Provider
 


### PR DESCRIPTION
We had some docs links in the repo which were broken by some recent changes. This PR fixes the links to correctly point to the right files.

Came up in a conversation with @meagancojocar 