### PR TITLE
Set `.Repository` for un-parameterized dynamic providers

### DIFF
--- a/dynamic/main.go
+++ b/dynamic/main.go
@@ -49,6 +49,7 @@ func initialSetup() (info.Provider, pfbridge.ProviderMetadata, func() error) {
 		P:            proto.Empty(),
 		Name:         baseProviderName,
 		Keywords:     []string{"category/utility"},
+		Repository:   "https://github.com/pulumi/pulumi-terraform-provider",
 		LogoURL:      "https://raw.githubusercontent.com/pulumi/pulumi-terraform-provider/main/assets/logo.png",
 		Version:      version.Version(),
 		Description:  "Use any Terraform provider with Pulumi",

--- a/dynamic/testdata/TestSchemaGeneration/unparameterized.golden
+++ b/dynamic/testdata/TestSchemaGeneration/unparameterized.golden
@@ -7,6 +7,7 @@
         "category/utility"
     ],
     "license": "Apache-2.0",
+    "repository": "https://github.com/pulumi/pulumi-terraform-provider",
     "logoUrl": "https://raw.githubusercontent.com/pulumi/pulumi-terraform-provider/main/assets/logo.png",
     "meta": {
         "moduleFormat": "(.*)(?:/[^/]*)"


### PR DESCRIPTION
To be good citizens of the registry, we should set the `Repository` field.

Related to https://github.com/pulumi/pulumi-terraform-bridge/pull/2664#discussion_r1866358177.