### PR TITLE
Remove unused TerraformVersion field from tf2pulumi and tfgen

### DIFF
--- a/pkg/tf2pulumi/convert/convert.go
+++ b/pkg/tf2pulumi/convert/convert.go
@@ -89,7 +89,6 @@ func Convert(opts Options) (map[string][]byte, Diagnostics, error) {
 		Logger:                     opts.Logger,
 		SkipResourceTypechecking:   opts.SkipResourceTypechecking,
 		TargetSDKVersion:           opts.TargetSDKVersion,
-		TerraformVersion:           opts.TerraformVersion,
 	}
 
 	tfFiles, program, diagnostics, err := internalEject(ejectOpts)
@@ -176,6 +175,8 @@ type Options struct {
 	// The target SDK version.
 	TargetSDKVersion string
 	// The version of Terraform targeteds by the input configuration.
+	//
+	// Deprecated: This field no longer has any effect, and will be removed in a future version of the bridge.
 	TerraformVersion string
 
 	// TargetOptions captures any target-specific options.

--- a/pkg/tf2pulumi/convert/eject.go
+++ b/pkg/tf2pulumi/convert/eject.go
@@ -71,7 +71,9 @@ type EjectOptions struct {
 	SkipResourceTypechecking bool
 	// The target SDK version.
 	TargetSDKVersion string
-	// The version of Terraform targeteds by the input configuration.
+	// The version of Terraform targeted by the input configuration.
+	//
+	// Deprecated: This field no longer has any effect, and will be removed in a future version of the bridge.
 	TerraformVersion string
 }
 

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -1764,7 +1764,6 @@ func (g *Generator) convert(
 		PluginHost:               g.pluginHost,
 		ProviderInfoSource:       g.infoSource,
 		SkipResourceTypechecking: true,
-		TerraformVersion:         g.terraformVersion,
 	})
 
 	return

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -58,21 +58,20 @@ const (
 )
 
 type Generator struct {
-	pkg              tokens.Package        // the Pulumi package name (e.g. `gcp`)
-	version          string                // the package version.
-	language         Language              // the language runtime to generate.
-	info             tfbridge.ProviderInfo // the provider info for customizing code generation
-	root             afero.Fs              // the output virtual filesystem.
-	providerShim     *inmemoryProvider     // a provider shim to hold the provider schema during example conversion.
-	pluginHost       plugin.Host           // the plugin host for tf2pulumi.
-	packageCache     *pcl.PackageCache     // the package cache for tf2pulumi.
-	infoSource       il.ProviderInfoSource // the provider info source for tf2pulumi.
-	terraformVersion string                // the Terraform version to target for example codegen, if any
-	sink             diag.Sink
-	skipDocs         bool
-	skipExamples     bool
-	coverageTracker  *CoverageTracker
-	editRules        editRules
+	pkg             tokens.Package        // the Pulumi package name (e.g. `gcp`)
+	version         string                // the package version.
+	language        Language              // the language runtime to generate.
+	info            tfbridge.ProviderInfo // the provider info for customizing code generation
+	root            afero.Fs              // the output virtual filesystem.
+	providerShim    *inmemoryProvider     // a provider shim to hold the provider schema during example conversion.
+	pluginHost      plugin.Host           // the plugin host for tf2pulumi.
+	packageCache    *pcl.PackageCache     // the package cache for tf2pulumi.
+	infoSource      il.ProviderInfoSource // the provider info source for tf2pulumi.
+	sink            diag.Sink
+	skipDocs        bool
+	skipExamples    bool
+	coverageTracker *CoverageTracker
+	editRules       editRules
 
 	convertedCode map[string][]byte
 
@@ -813,7 +812,6 @@ type GeneratorOptions struct {
 	Root               afero.Fs
 	ProviderInfoSource il.ProviderInfoSource
 	PluginHost         plugin.Host
-	TerraformVersion   string
 	Sink               diag.Sink
 	Debug              bool
 	SkipDocs           bool
@@ -889,22 +887,21 @@ func NewGenerator(opts GeneratorOptions) (*Generator, error) {
 	}
 
 	return &Generator{
-		pkg:              pkg,
-		version:          version,
-		language:         lang,
-		info:             info,
-		root:             root,
-		providerShim:     providerShim,
-		pluginHost:       newCachingProviderHost(host),
-		packageCache:     pcl.NewPackageCache(),
-		infoSource:       host,
-		terraformVersion: opts.TerraformVersion,
-		sink:             sink,
-		skipDocs:         opts.SkipDocs,
-		skipExamples:     opts.SkipExamples,
-		coverageTracker:  opts.CoverageTracker,
-		editRules:        getEditRules(info.DocRules),
-		noDocsRepo:       opts.XInMemoryDocs,
+		pkg:             pkg,
+		version:         version,
+		language:        lang,
+		info:            info,
+		root:            root,
+		providerShim:    providerShim,
+		pluginHost:      newCachingProviderHost(host),
+		packageCache:    pcl.NewPackageCache(),
+		infoSource:      host,
+		sink:            sink,
+		skipDocs:        opts.SkipDocs,
+		skipExamples:    opts.SkipExamples,
+		coverageTracker: opts.CoverageTracker,
+		editRules:       getEditRules(info.DocRules),
+		noDocsRepo:      opts.XInMemoryDocs,
 	}, nil
 }
 


### PR DESCRIPTION
The value of this field is never actually checked, so we can safely remove it. To prevent unexpected breaking changes, I have deprecated it where public.