### PR TITLE
Fix PF extra config triggering check config errors

### DIFF
--- a/pkg/pf/tests/pulcheck/pulcheck.go
+++ b/pkg/pf/tests/pulcheck/pulcheck.go
@@ -90,6 +90,7 @@ func skipUnlessLinux(t T) {
 // PulCheck creates a new Pulumi test from a bridged provider and a program.
 func PulCheck(t T, bridgedProvider info.Provider, program string, opts ...opttest.Option) (*pulumitest.PulumiTest, error) {
 	skipUnlessLinux(t)
+	t.Helper()
 	puwd := t.TempDir()
 	p := filepath.Join(puwd, "Pulumi.yaml")
 

--- a/pkg/pf/tfbridge/provider_checkconfig.go
+++ b/pkg/pf/tfbridge/provider_checkconfig.go
@@ -197,6 +197,10 @@ func (p *provider) validateProviderConfig(
 		if k == "version" || k == "pluginDownloadURL" {
 			continue
 		}
+
+		if _, has := p.info.ExtraConfig[string(k)]; has {
+			continue
+		}
 		// TODO[https://github.com/pulumi/pulumi/issues/16757] While #16757 is
 		// outstanding, we need to filter out the keys for parameterized providers
 		// from the top level namespace.


### PR DESCRIPTION
Pulumi providers can specify an `ExtraConfig` field for provider configuration which is exclusive to Pulumi and is not passed to the underlying TF provider. This works correctly for the SDKv2 bridge but the PF bridge errors when that config is used.

This PR fixes that and adds a test.

fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/2702