### PR TITLE
Fix ImportBasePath for dynamic bridged providers

### DIFF
--- a/dynamic/info.go
+++ b/dynamic/info.go
@@ -67,6 +67,7 @@ func providerInfo(ctx context.Context, p run.Provider, value parameterize.Value)
 				"github.com/pulumi/pulumi-terraform-provider/sdks/go",
 				p.Name(),
 				tfbridge.GetModuleMajorVersion(p.Version()),
+				p.Name(),
 			),
 			RootPackageName:              p.Name(),
 			LiftSingleValueMethodReturns: true,

--- a/dynamic/testdata/TestSchemaGeneration/Backblaze/b2-0.8.9.golden
+++ b/dynamic/testdata/TestSchemaGeneration/Backblaze/b2-0.8.9.golden
@@ -14,7 +14,7 @@
             "respectSchemaVersion": true
         },
         "go": {
-            "importBasePath": "github.com/pulumi/pulumi-terraform-provider/sdks/go/b2",
+            "importBasePath": "github.com/pulumi/pulumi-terraform-provider/sdks/go/b2/b2",
             "rootPackageName": "b2",
             "liftSingleValueMethodReturns": true,
             "generateExtraInputTypes": true,

--- a/dynamic/testdata/TestSchemaGeneration/databricks/databricks-1.50.0.golden
+++ b/dynamic/testdata/TestSchemaGeneration/databricks/databricks-1.50.0.golden
@@ -14,7 +14,7 @@
             "respectSchemaVersion": true
         },
         "go": {
-            "importBasePath": "github.com/pulumi/pulumi-terraform-provider/sdks/go/databricks",
+            "importBasePath": "github.com/pulumi/pulumi-terraform-provider/sdks/go/databricks/databricks",
             "rootPackageName": "databricks",
             "liftSingleValueMethodReturns": true,
             "generateExtraInputTypes": true,

--- a/dynamic/testdata/TestSchemaGeneration/hashicorp/random-3.3.0.golden
+++ b/dynamic/testdata/TestSchemaGeneration/hashicorp/random-3.3.0.golden
@@ -14,7 +14,7 @@
             "respectSchemaVersion": true
         },
         "go": {
-            "importBasePath": "github.com/pulumi/pulumi-terraform-provider/sdks/go/random/v3",
+            "importBasePath": "github.com/pulumi/pulumi-terraform-provider/sdks/go/random/v3/random",
             "rootPackageName": "random",
             "liftSingleValueMethodReturns": true,
             "generateExtraInputTypes": true,


### PR DESCRIPTION
The current code generates an import base path like `github.com/pulumi/pulumi-terraform-provider/sdks/something/v3`. This is a _module_ path (ends with a version number) not a package import path, we always nest our packages one level below the module.

The correct import base path should be `github.com/pulumi/pulumi-terraform-provider/sdks/something/v3/something`.