### PR TITLE
Expose internal SDKv2 Diff cross-test interface

### DIFF
--- a/pkg/internal/tests/cross-tests/diff.go
+++ b/pkg/internal/tests/cross-tests/diff.go
@@ -1,0 +1,39 @@
+package crosstests
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/zclconf/go-cty/cty"
+
+	crosstestsimpl "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/tests/cross-tests/impl"
+)
+
+type diffOpts struct {
+	deleteBeforeReplace bool
+}
+
+// An option that can be used to customize [Diff].
+type DiffOption func(*diffOpts)
+
+// DiffDeleteBeforeReplace specifies whether to delete the resource before replacing it.
+func DiffDeleteBeforeReplace(deleteBeforeReplace bool) DiffOption {
+	return func(o *diffOpts) { o.deleteBeforeReplace = deleteBeforeReplace }
+}
+
+func Diff(
+	t T, resource *schema.Resource, config1, config2 map[string]cty.Value, opts ...DiffOption,
+) crosstestsimpl.DiffResult {
+	o := &diffOpts{}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	config1Cty := cty.ObjectVal(config1)
+	config2Cty := cty.ObjectVal(config2)
+
+	return runDiffCheck(t, diffTestCase{
+		Resource:            resource,
+		Config1:             config1Cty,
+		Config2:             config2Cty,
+		DeleteBeforeReplace: o.deleteBeforeReplace,
+	})
+}


### PR DESCRIPTION
This is a test-only change. It exposes an internal Diff cross-test interface for the SDKv2 bridge. It currently just calls the `runDiffCheck` function.