### PR TITLE
Do not wipe the version when generating schemas for dynamic providers

### DIFF
--- a/dynamic/main.go
+++ b/dynamic/main.go
@@ -62,7 +62,6 @@ func initialSetup() (info.Provider, pfbridge.ProviderMetadata, func() error) {
 			spec.Attribution = ""
 			spec.Provider = schema.ResourceSpec{}
 			spec.Language = nil
-			spec.Version = version.Version()
 		},
 	}
 
@@ -90,6 +89,7 @@ func initialSetup() (info.Provider, pfbridge.ProviderMetadata, func() error) {
 			if err != nil {
 				return nil, err
 			}
+			packageSchema.PackageSpec.Version = info.Version
 
 			if info.SchemaPostProcessor != nil {
 				info.SchemaPostProcessor(&packageSchema.PackageSpec)
@@ -132,7 +132,6 @@ func initialSetup() (info.Provider, pfbridge.ProviderMetadata, func() error) {
 			if err != nil {
 				return plugin.ParameterizeResponse{}, err
 			}
-
 			v, err := semver.Parse(p.Version())
 			if err != nil {
 				return plugin.ParameterizeResponse{}, err

--- a/dynamic/main.go
+++ b/dynamic/main.go
@@ -62,6 +62,7 @@ func initialSetup() (info.Provider, pfbridge.ProviderMetadata, func() error) {
 			spec.Attribution = ""
 			spec.Provider = schema.ResourceSpec{}
 			spec.Language = nil
+			spec.Version = version.Version()
 		},
 	}
 

--- a/dynamic/testdata/TestSchemaGeneration/Backblaze/b2-0.8.9.golden
+++ b/dynamic/testdata/TestSchemaGeneration/Backblaze/b2-0.8.9.golden
@@ -1,5 +1,6 @@
 {
     "name": "b2",
+    "version": "0.8.9",
     "description": "A Pulumi provider dynamically bridged from b2.",
     "attribution": "This Pulumi package is based on the [`b2` Terraform Provider](https://github.com/backblaze/terraform-provider-b2).",
     "repository": "https://github.com/backblaze/terraform-provider-b2",

--- a/dynamic/testdata/TestSchemaGeneration/databricks/databricks-1.50.0.golden
+++ b/dynamic/testdata/TestSchemaGeneration/databricks/databricks-1.50.0.golden
@@ -1,5 +1,6 @@
 {
     "name": "databricks",
+    "version": "1.50.0",
     "description": "A Pulumi provider dynamically bridged from databricks.",
     "attribution": "This Pulumi package is based on the [`databricks` Terraform Provider](https://github.com/databricks/terraform-provider-databricks).",
     "repository": "https://github.com/databricks/terraform-provider-databricks",

--- a/dynamic/testdata/TestSchemaGeneration/hashicorp/random-3.3.0.golden
+++ b/dynamic/testdata/TestSchemaGeneration/hashicorp/random-3.3.0.golden
@@ -1,5 +1,6 @@
 {
     "name": "random",
+    "version": "3.3.0",
     "description": "A Pulumi provider dynamically bridged from random.",
     "attribution": "This Pulumi package is based on the [`random` Terraform Provider](https://github.com/hashicorp/terraform-provider-random).",
     "repository": "https://github.com/hashicorp/terraform-provider-random",

--- a/dynamic/testdata/TestSchemaGeneration/unparameterized.golden
+++ b/dynamic/testdata/TestSchemaGeneration/unparameterized.golden
@@ -1,6 +1,7 @@
 {
     "name": "terraform-provider",
     "displayName": "Any Terraform Provider",
+    "version": "v0.0.0-dev",
     "description": "Use any Terraform provider with Pulumi",
     "keywords": [
         "category/utility"

--- a/dynamic/testdata/TestSchemaGenerationFullDocs/hashicorp/random-3.6.3.golden
+++ b/dynamic/testdata/TestSchemaGenerationFullDocs/hashicorp/random-3.6.3.golden
@@ -1,5 +1,6 @@
 {
     "name": "random",
+    "version": "3.6.3",
     "description": "A Pulumi provider dynamically bridged from random.",
     "attribution": "This Pulumi package is based on the [`random` Terraform Provider](https://github.com/hashicorp/terraform-provider-random).",
     "repository": "https://github.com/hashicorp/terraform-provider-random",


### PR DESCRIPTION
#2664 introduced using the full Generator for schema gen. 
This added a call to UnstableGenerateFromSchema, which removes the version field from the package spec, a feature intended to make local builds stable.
This pull request re-adds the version in `SchemaPostProcessor`.


