### PR TITLE
Add SDKv2 Detailed Diff tests for Computed properties in sets

### DIFF
--- a/pkg/internal/tests/cross-tests/diff.go
+++ b/pkg/internal/tests/cross-tests/diff.go
@@ -37,10 +37,10 @@ func Diff(
 	config2Cty := cty.ObjectVal(config2)
 
 	return runDiffCheck(t, diffTestCase{
-		Resource:            resource,
-		Config1:             config1Cty,
-		Config2:             config2Cty,
-		DeleteBeforeReplace: o.deleteBeforeReplace,
+		Resource:                      resource,
+		Config1:                       config1Cty,
+		Config2:                       config2Cty,
+		DeleteBeforeReplace:           o.deleteBeforeReplace,
 		DisableAccurateBridgePreviews: o.disableAccurateBridgePreviews,
 	})
 }

--- a/pkg/internal/tests/cross-tests/diff.go
+++ b/pkg/internal/tests/cross-tests/diff.go
@@ -8,7 +8,8 @@ import (
 )
 
 type diffOpts struct {
-	deleteBeforeReplace bool
+	deleteBeforeReplace           bool
+	disableAccurateBridgePreviews bool
 }
 
 // An option that can be used to customize [Diff].
@@ -17,6 +18,11 @@ type DiffOption func(*diffOpts)
 // DiffDeleteBeforeReplace specifies whether to delete the resource before replacing it.
 func DiffDeleteBeforeReplace(deleteBeforeReplace bool) DiffOption {
 	return func(o *diffOpts) { o.deleteBeforeReplace = deleteBeforeReplace }
+}
+
+// DiffDisableAccurateBridgePreviews specifies whether to disable accurate bridge previews.
+func DiffDisableAccurateBridgePreviews() DiffOption {
+	return func(o *diffOpts) { o.disableAccurateBridgePreviews = true }
 }
 
 func Diff(

--- a/pkg/internal/tests/cross-tests/diff.go
+++ b/pkg/internal/tests/cross-tests/diff.go
@@ -41,5 +41,6 @@ func Diff(
 		Config1:             config1Cty,
 		Config2:             config2Cty,
 		DeleteBeforeReplace: o.deleteBeforeReplace,
+		DisableAccurateBridgePreviews: o.disableAccurateBridgePreviews,
 	})
 }

--- a/pkg/internal/tests/cross-tests/diff_check.go
+++ b/pkg/internal/tests/cross-tests/diff_check.go
@@ -41,8 +41,9 @@ type diffTestCase struct {
 	Config1, Config2 any
 
 	// Optional object type for the resource. If left nil will be inferred from Resource schema.
-	ObjectType          *tftypes.Object
-	DeleteBeforeReplace bool
+	ObjectType                    *tftypes.Object
+	DeleteBeforeReplace           bool
+	DisableAccurateBridgePreviews bool
 }
 
 func runDiffCheck(t T, tc diffTestCase) crosstestsimpl.DiffResult {
@@ -59,7 +60,13 @@ func runDiffCheck(t T, tc diffTestCase) crosstestsimpl.DiffResult {
 
 	resMap := map[string]*schema.Resource{defRtype: tc.Resource}
 	tfp := &schema.Provider{ResourcesMap: resMap}
-	bridgedProvider := pulcheck.BridgedProvider(t, defProviderShortName, tfp, pulcheck.EnableAccurateBridgePreviews())
+
+	opts := []pulcheck.BridgedProviderOpt{}
+	if !tc.DisableAccurateBridgePreviews {
+		opts = append(opts, pulcheck.EnableAccurateBridgePreviews())
+	}
+
+	bridgedProvider := pulcheck.BridgedProvider(t, defProviderShortName, tfp, opts...)
 	if tc.DeleteBeforeReplace {
 		bridgedProvider.Resources[defRtype].DeleteBeforeReplace = true
 	}

--- a/pkg/tests/detailed_diff_set_test.go
+++ b/pkg/tests/detailed_diff_set_test.go
@@ -1341,6 +1341,8 @@ func TestDetailedDiffSet(t *testing.T) {
 
 	for _, schemaValueMakerPair := range computedSchemaValueMakerPairs {
 		t.Run(schemaValueMakerPair.name, func(t *testing.T) {
+			// TODO[pulumi/pulumi-terraform-bridge#2528]
+			t.Skipf("These tests are non-deterministic under the non-Accurate Previews bridge.")
 			t.Parallel()
 			for _, scenario := range scenarios {
 				t.Run(scenario.name, func(t *testing.T) {

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_top_level_force_new/same_element_updated_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_top_level_force_new/same_element_updated_unordered.golden
@@ -36,7 +36,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
-    +-crossprovider:index/testRes:TestRes: (replace)
+    ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
@@ -48,11 +48,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
                 }
         ]
 Resources:
-    +-1 to replace
+    ~ 1 to update
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests[1]": map[string]interface{}{},
+		"tests[2]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_top_level_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_top_level_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -44,7 +44,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
-    +-crossprovider:index/testRes:TestRes: (replace)
+    ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
@@ -62,13 +62,13 @@ Plan: 0 to add, 1 to change, 0 to destroy.
                 }
         ]
 Resources:
-    +-1 to replace
+    ~ 1 to update
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests[0]": map[string]interface{}{},
+		"tests[1]": map[string]interface{}{},
+		"tests[2]": map[string]interface{}{"kind": "DELETE"},
+		"tests[3]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_top_level_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_top_level_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -46,7 +46,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
-    +-crossprovider:index/testRes:TestRes: (replace)
+    ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
@@ -61,12 +61,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
                 }
         ]
 Resources:
-    +-1 to replace
+    ~ 1 to update
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]":        map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[1]":        map[string]interface{}{},
 		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]":        map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests[3]":        map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/added.golden
@@ -1,0 +1,40 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{"value"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "value"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + tests: [
+      +     [0]: {
+              + nested    : "value"
+            }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/added.golden
@@ -27,14 +27,17 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
-      +     [0]: {
-              + nested    : "value"
-            }
+      ~ tests: [
+          + [0]: {
+                  + nested    : "value"
+                }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/added_end.golden
@@ -52,8 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val1"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val2"
                 }
           + [2]: {
                   + nested    : "val3"
@@ -64,8 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/added_end.golden
@@ -1,0 +1,71 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          + [2]: {
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/added_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/added_end_unordered.golden
@@ -1,0 +1,75 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "val2" => "val2"
+                }
+          ~ [1]: {
+                  ~ nested  : "val3" => "val3"
+                }
+          + [2]: {
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/added_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/added_end_unordered.golden
@@ -52,10 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "val2" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val3"
                 }
           + [2]: {
                   + nested    : "val1"
@@ -66,10 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/added_front.golden
@@ -1,0 +1,75 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "val2" => "val1"
+                }
+          ~ [1]: {
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/added_front.golden
@@ -52,10 +52,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "val2" => "val1"
+                  + __defaults: []
+                  - computed  : ""
+                  + nested    : "val1"
+                  + nested    : "val1"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val3" => "val2"
                 }
           + [2]: {
                   + nested    : "val3"
@@ -66,10 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/added_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/added_front_unordered.golden
@@ -1,0 +1,73 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val3" => "val3"
+                }
+          + [2]: {
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/added_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/added_front_unordered.golden
@@ -52,9 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val3"
                 }
           + [2]: {
                   + nested    : "val1"
@@ -65,9 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/added_middle.golden
@@ -1,0 +1,73 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/added_middle.golden
@@ -52,9 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val1"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val3" => "val2"
                 }
           + [2]: {
                   + nested    : "val3"
@@ -65,9 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/added_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/added_middle_unordered.golden
@@ -1,0 +1,71 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          + [2]: {
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/added_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/added_middle_unordered.golden
@@ -52,8 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val2"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val3"
                 }
           + [2]: {
                   + nested    : "val1"
@@ -64,8 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/changed_empty_to_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/changed_empty_to_null.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/changed_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/changed_non-null.golden
@@ -35,15 +35,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "value" => "value1"
+                  ~ nested: "value" => "value1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"tests[0].nested": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/changed_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/changed_non-null.golden
@@ -1,0 +1,49 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "value" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "value1"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "value" => "value1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/changed_non-null_to_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/changed_non-null_to_null.golden
@@ -1,0 +1,17 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/changed_null_to_empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/changed_null_to_empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/changed_null_to_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/changed_null_to_non-null.golden
@@ -28,14 +28,17 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
-      +     [0]: {
-              + nested    : "value"
-            }
+      ~ tests: [
+          + [0]: {
+                  + nested    : "value"
+                }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/changed_null_to_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/changed_null_to_non-null.golden
@@ -1,0 +1,41 @@
+tests.testOutput{
+	changeValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "value"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + tests: [
+      +     [0]: {
+              + nested    : "value"
+            }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/removed.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/removed_end.golden
@@ -52,8 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val1"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val2"
                 }
           - [2]: {
                   - computed: ""
@@ -65,8 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/removed_end.golden
@@ -1,0 +1,72 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/removed_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/removed_end_unordered.golden
@@ -52,10 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val3"
                 }
           - [2]: {
                   - computed: ""
@@ -67,10 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/removed_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/removed_end_unordered.golden
@@ -1,0 +1,76 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/removed_front.golden
@@ -52,10 +52,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                  - nested    : "val1"
+                  - nested    : "val1"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val3"
                 }
           - [2]: {
                   - computed: ""
@@ -67,10 +72,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/removed_front.golden
@@ -1,0 +1,76 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/removed_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/removed_front_unordered.golden
@@ -1,0 +1,74 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val1"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/removed_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/removed_front_unordered.golden
@@ -52,9 +52,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  + __defaults: []
+                  - computed  : ""
+                  - nested    : "val2"
+                  - nested    : "val2"
                 }
           - [2]: {
                   - computed: ""
@@ -66,9 +72,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/removed_middle.golden
@@ -1,0 +1,74 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/removed_middle.golden
@@ -52,9 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val1"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val3"
                 }
           - [2]: {
                   - computed: ""
@@ -66,9 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/removed_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/removed_middle_unordered.golden
@@ -1,0 +1,74 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val1"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/removed_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/removed_middle_unordered.golden
@@ -52,9 +52,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  + __defaults: []
+                  - computed  : ""
+                  - nested    : "val2"
+                  - nested    : "val2"
                 }
           - [2]: {
                   - computed: ""
@@ -66,9 +72,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/same_element_updated.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/same_element_updated.golden
@@ -56,24 +56,13 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          ~ [0]: {
-                }
           ~ [1]: {
-                  ~ nested  : "val2" => "val4"
-                }
-          ~ [2]: {
-                  ~ nested  : "val3" => "val3"
+                  ~ nested: "val2" => "val4"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"tests[1].nested": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/same_element_updated.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/same_element_updated.golden
@@ -1,0 +1,79 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val4",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val4"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val4"
+                }
+          ~ [2]: {
+                  ~ nested  : "val3" => "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/same_element_updated_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/same_element_updated_unordered.golden
@@ -1,0 +1,77 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val4",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val4"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          ~ [2]: {
+                  ~ nested  : "val3" => "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/same_element_updated_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/same_element_updated_unordered.golden
@@ -56,12 +56,11 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          ~ [0]: {
-                }
           ~ [1]: {
+                  + nested: "val4"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val1"
+                  - nested: "val3"
                 }
         ]
 Resources:
@@ -69,9 +68,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[1].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/shuffled.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/shuffled.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/shuffled_added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/shuffled_added_end.golden
@@ -1,0 +1,71 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          + [2]: {
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/shuffled_added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/shuffled_added_end.golden
@@ -52,8 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val2"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val1"
                 }
           + [2]: {
                   + nested    : "val3"
@@ -64,8 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/shuffled_added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/shuffled_added_front.golden
@@ -52,10 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "val2" => "val1"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val1"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val3"
                 }
           + [2]: {
                   + nested    : "val2"
@@ -66,10 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/shuffled_added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/shuffled_added_front.golden
@@ -1,0 +1,75 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "val2" => "val1"
+                }
+          ~ [1]: {
+                  ~ nested  : "val3" => "val3"
+                }
+          + [2]: {
+                  + nested    : "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/shuffled_added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/shuffled_added_middle.golden
@@ -1,0 +1,73 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/shuffled_added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/shuffled_added_middle.golden
@@ -52,9 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val3" => "val2"
                 }
           + [2]: {
                   + nested    : "val1"
@@ -65,9 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/shuffled_removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/shuffled_removed_end.golden
@@ -1,0 +1,72 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/shuffled_removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/shuffled_removed_end.golden
@@ -52,8 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val2"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val1"
                 }
           - [2]: {
                   - computed: ""
@@ -65,8 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/shuffled_removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/shuffled_removed_front.golden
@@ -1,0 +1,76 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "val1" => "val3"
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val2"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/shuffled_removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/shuffled_removed_front.golden
@@ -52,10 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val2"
                 }
           - [2]: {
                   - computed: ""
@@ -67,10 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/shuffled_removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/shuffled_removed_middle.golden
@@ -52,9 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val1"
                 }
           - [2]: {
                   - computed: ""
@@ -66,9 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/shuffled_removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/shuffled_removed_middle.golden
@@ -1,0 +1,74 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val1"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/shuffled_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/shuffled_unordered.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/shuffled_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/shuffled_with_duplicates.golden
@@ -1,0 +1,25 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/shuffled_with_duplicates_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/shuffled_with_duplicates_unordered.golden
@@ -1,0 +1,25 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/two_added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/two_added.golden
@@ -1,0 +1,80 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val4"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          + [2]: {
+                  + nested    : "val3"
+                }
+          + [3]: {
+                  + nested    : "val4"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[3]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/two_added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/two_added.golden
@@ -57,8 +57,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val1"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val2"
                 }
           + [2]: {
                   + nested    : "val3"
@@ -72,9 +78,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[3]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[3].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/two_added_and_two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/two_added_and_two_removed.golden
@@ -66,15 +66,11 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           ~ [2]: {
-                  ~ nested  : "val3" => "val5"
+                  ~ nested: "val3" => "val5"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val6"
+                  ~ nested: "val4" => "val6"
                 }
         ]
 Resources:
@@ -82,11 +78,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[2].nested": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[3].nested": map[string]interface{}{"kind": "UPDATE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/two_added_and_two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/two_added_and_two_removed.golden
@@ -1,0 +1,92 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val5",
+		"val6",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val4" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val5"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val6"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          ~ [2]: {
+                  ~ nested  : "val3" => "val5"
+                }
+          ~ [3]: {
+                  ~ nested  : "val4" => "val6"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -1,0 +1,92 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val5",
+		"val6",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val4" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val5"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val6"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          ~ [2]: {
+                  ~ nested  : "val3" => "val1"
+                }
+          ~ [3]: {
+                  ~ nested  : "val4" => "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -67,14 +67,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + nested: "val5"
                 }
           ~ [1]: {
+                  + nested: "val6"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val1"
+                  - nested: "val3"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val2"
+                  - nested: "val4"
                 }
         ]
 Resources:
@@ -82,11 +84,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[0].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[1].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests[3].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -66,15 +66,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          ~ [0]: {
-                }
           ~ [1]: {
+                  + nested: "val5"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val6"
+                  ~ nested: "val3" => "val6"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val2"
+                  - nested: "val4"
                 }
         ]
 Resources:
@@ -82,11 +81,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[1].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[2].nested": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[3].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -1,0 +1,92 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val5",
+		"val6",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val4" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val5"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val6"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          ~ [2]: {
+                  ~ nested  : "val3" => "val6"
+                }
+          ~ [3]: {
+                  ~ nested  : "val4" => "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -1,0 +1,94 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val5",
+		"val6",
+		"val2",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val4" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val5"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val6"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          ~ [2]: {
+                  ~ nested  : "val3" => "val6"
+                }
+          ~ [3]: {
+                  ~ nested  : "val4" => "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -68,15 +68,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          ~ [0]: {
-                }
           ~ [1]: {
+                  + nested: "val5"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val6"
+                  ~ nested: "val3" => "val6"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val2"
+                  - nested: "val4"
                 }
         ]
 Resources:
@@ -84,11 +83,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[1].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[2].nested": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[3].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/two_removed.golden
@@ -1,0 +1,82 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val4" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+          - [3]: {
+                  - computed: ""
+                  - nested  : "val4"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests[3]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/two_removed.golden
@@ -57,8 +57,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val1"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val2"
                 }
           - [2]: {
                   - computed: ""
@@ -74,9 +80,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
-		"tests[3]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests[3].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/unchanged_empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/unchanged_non-empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/unchanged_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new/unchanged_null.golden
@@ -1,0 +1,11 @@
+tests.testOutput{tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`, pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/added.golden
@@ -27,15 +27,19 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
-      +     [0]: {
-              + computed  : "non-computed-value"
-              + nested    : "value"
-            }
+      ~ tests: [
+          + [0]: {
+                  + computed  : "non-computed-value"
+                  + nested    : "value"
+                }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].computed": map[string]interface{}{},
+		"tests[0].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/added.golden
@@ -1,0 +1,41 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{"value"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-value"
+          + nested   = "value"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + tests: [
+      +     [0]: {
+              + computed  : "non-computed-value"
+              + nested    : "value"
+            }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/added_end.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-val3"
+          + nested   = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [2]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/added_end.golden
@@ -37,6 +37,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val1"
+                    nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val2"
+                    nested    : "val2"
+                }
           + [2]: {
                   + computed  : "non-computed-val3"
                   + nested    : "val3"
@@ -46,5 +56,9 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{},
+		"tests[2].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/added_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/added_end_unordered.golden
@@ -37,14 +37,28 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [0]: {
-                  + computed  : "non-computed-val2"
-                  + nested    : "val2"
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val2"
+                    nested    : "val2"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val3"
+                    nested    : "val3"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val1"
+                  + nested    : "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{},
+		"tests[2].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/added_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/added_end_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-val1"
+          + nested   = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [0]: {
+                  + computed  : "non-computed-val2"
+                  + nested    : "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/added_front.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-val1"
+          + nested   = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [0]: {
+                  + computed  : "non-computed-val1"
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/added_front.golden
@@ -37,14 +37,28 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [0]: {
-                  + computed  : "non-computed-val1"
-                  + nested    : "val1"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val1"
+                  ~ nested    : "val2" => "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val3" => "non-computed-val2"
+                  ~ nested    : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].computed": map[string]interface{}{},
+		"tests[0].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/added_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/added_front_unordered.golden
@@ -37,14 +37,28 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [1]: {
-                  + computed  : "non-computed-val3"
-                  + nested    : "val3"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val2"
+                  ~ nested    : "val1" => "val2"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val3"
+                    nested    : "val3"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val1"
+                  + nested    : "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].computed": map[string]interface{}{},
+		"tests[0].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/added_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/added_front_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-val2"
+          + nested   = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [1]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/added_middle.golden
@@ -37,14 +37,29 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [1]: {
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val1"
+                    nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
                   + computed  : "non-computed-val2"
-                  + nested    : "val2"
+                  + computed  : "non-computed-val2"
+                  ~ nested    : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/added_middle.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-val2"
+          + nested   = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [1]: {
+                  + computed  : "non-computed-val2"
+                  + nested    : "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/added_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/added_middle_unordered.golden
@@ -37,6 +37,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val2"
+                  ~ nested    : "val1" => "val2"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val3"
+                  ~ nested    : "val2" => "val3"
+                }
           + [2]: {
                   + computed  : "non-computed-val1"
                   + nested    : "val1"
@@ -46,5 +56,9 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/added_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/added_middle_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-val3"
+          + nested   = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [2]: {
+                  + computed  : "non-computed-val1"
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/changed_empty_to_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/changed_empty_to_null.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/changed_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/changed_non-null.golden
@@ -35,7 +35,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ computed: "non-computed-value" => "non-computed-value1"
+                  + computed: "non-computed-value1"
                   ~ nested  : "value" => "value1"
                 }
         ]
@@ -44,7 +44,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].computed": map[string]interface{}{},
 		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/changed_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/changed_non-null.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-value" -> null
+          - nested   = "value" -> null
+        }
+      + test { # forces replacement
+          + computed = "non-computed-value1"
+          + nested   = "value1"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ computed: "non-computed-value" => "non-computed-value1"
+                  ~ nested  : "value" => "value1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/changed_non-null_to_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/changed_non-null_to_null.golden
@@ -1,0 +1,17 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/changed_null_to_empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/changed_null_to_empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/changed_null_to_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/changed_null_to_non-null.golden
@@ -1,0 +1,42 @@
+tests.testOutput{
+	changeValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-value"
+          + nested   = "value"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + tests: [
+      +     [0]: {
+              + computed  : "non-computed-value"
+              + nested    : "value"
+            }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/changed_null_to_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/changed_null_to_non-null.golden
@@ -28,15 +28,19 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
-      +     [0]: {
-              + computed  : "non-computed-value"
-              + nested    : "value"
-            }
+      ~ tests: [
+          + [0]: {
+                  + computed  : "non-computed-value"
+                  + nested    : "value"
+                }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].computed": map[string]interface{}{},
+		"tests[0].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/removed.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/removed_end.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/removed_end.golden
@@ -37,6 +37,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val1"
+                    nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val2"
+                    nested    : "val2"
+                }
           - [2]: {
                   - computed: "non-computed-val3"
                   - nested  : "val3"
@@ -46,5 +56,8 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/removed_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/removed_end_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [0]: {
+                  - computed: "non-computed-val1"
+                  - nested  : "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/removed_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/removed_end_unordered.golden
@@ -37,14 +37,28 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [0]: {
-                  - computed: "non-computed-val1"
-                  - nested  : "val1"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val2"
+                  - nested    : "val1"
+                  - nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val3"
+                  ~ nested    : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/removed_front.golden
@@ -37,14 +37,27 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [0]: {
-                  - computed: "non-computed-val1"
-                  - nested  : "val1"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val2"
+                  ~ nested    : "val1" => "val2"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val3"
+                  ~ nested    : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/removed_front.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [0]: {
+                  - computed: "non-computed-val1"
+                  - nested  : "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/removed_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/removed_front_unordered.golden
@@ -37,14 +37,28 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val3"
+                  ~ nested    : "val1" => "val3"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val1"
+                  - nested    : "val2"
+                  - nested    : "val2"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/removed_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/removed_front_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: {
+                  - computed: "non-computed-val2"
+                  - nested  : "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/removed_middle.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: {
+                  - computed: "non-computed-val2"
+                  - nested  : "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/removed_middle.golden
@@ -37,14 +37,27 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val1"
+                    nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val3"
+                  ~ nested    : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/removed_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/removed_middle_unordered.golden
@@ -37,14 +37,27 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val3"
+                  ~ nested    : "val1" => "val3"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val1"
+                  ~ nested    : "val2" => "val1"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/removed_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/removed_middle_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: {
+                  - computed: "non-computed-val2"
+                  - nested  : "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/same_element_updated.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/same_element_updated.golden
@@ -1,0 +1,62 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val4",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+      + test { # forces replacement
+          + computed = "non-computed-val4"
+          + nested   = "val4"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: {
+                  - computed: "non-computed-val2"
+                  - nested  : "val2"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/same_element_updated.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/same_element_updated.golden
@@ -42,13 +42,9 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
-                }
-          + [2]: {
-                  + computed  : "non-computed-val3"
-                  + nested    : "val3"
+          ~ [1]: {
+                  + computed: "non-computed-val4"
+                  ~ nested  : "val2" => "val4"
                 }
         ]
 Resources:
@@ -56,7 +52,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"},
-		"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/same_element_updated_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/same_element_updated_unordered.golden
@@ -1,0 +1,58 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val4",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      + test { # forces replacement
+          + computed = "non-computed-val4"
+          + nested   = "val4"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [2]: {
+                  ~ computed: "non-computed-val3" => "non-computed-val1"
+                  ~ nested  : "val3" => "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/same_element_updated_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/same_element_updated_unordered.golden
@@ -42,9 +42,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [1]: {
+                  + computed: "non-computed-val4"
+                  + nested  : "val4"
+                }
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val1"
-                  ~ nested  : "val3" => "val1"
+                  - nested: "val3"
                 }
         ]
 Resources:
@@ -52,7 +55,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_added_end.golden
@@ -37,6 +37,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val2"
+                  ~ nested    : "val1" => "val2"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val1"
+                  ~ nested    : "val2" => "val1"
+                }
           + [2]: {
                   + computed  : "non-computed-val3"
                   + nested    : "val3"
@@ -46,5 +56,9 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{},
+		"tests[2].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_added_end.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-val3"
+          + nested   = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [2]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_added_front.golden
@@ -37,14 +37,29 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [0]: {
+          ~ [0]: {
+                  + __defaults: []
                   + computed  : "non-computed-val1"
-                  + nested    : "val1"
+                  + computed  : "non-computed-val1"
+                  ~ nested    : "val2" => "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val3"
+                    nested    : "val3"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val2"
+                  + nested    : "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].computed": map[string]interface{}{},
+		"tests[0].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_added_front.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-val1"
+          + nested   = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [0]: {
+                  + computed  : "non-computed-val1"
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_added_middle.golden
@@ -37,14 +37,30 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [1]: {
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val3"
+                  ~ nested    : "val1" => "val3"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  + computed  : "non-computed-val2"
                   + computed  : "non-computed-val2"
                   + nested    : "val2"
+                  + nested    : "val2"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val1"
+                  + nested    : "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_added_middle.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-val2"
+          + nested   = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [1]: {
+                  + computed  : "non-computed-val2"
+                  + nested    : "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_removed_end.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_removed_end.golden
@@ -37,6 +37,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val2"
+                  ~ nested    : "val1" => "val2"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val1"
+                  ~ nested    : "val2" => "val1"
+                }
           - [2]: {
                   - computed: "non-computed-val3"
                   - nested  : "val3"
@@ -46,5 +56,8 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_removed_front.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [0]: {
+                  - computed: "non-computed-val1"
+                  - nested  : "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_removed_front.golden
@@ -37,14 +37,28 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [0]: {
-                  - computed: "non-computed-val1"
-                  - nested  : "val1"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val3"
+                  - nested    : "val1"
+                  - nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val2"
+                    nested    : "val2"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_removed_middle.golden
@@ -37,14 +37,27 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val3"
+                  ~ nested    : "val1" => "val3"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val1"
+                  ~ nested    : "val2" => "val1"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_removed_middle.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: {
+                  - computed: "non-computed-val2"
+                  - nested  : "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_unordered.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_with_duplicates.golden
@@ -1,0 +1,25 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_with_duplicates_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_with_duplicates_unordered.golden
@@ -1,0 +1,25 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/two_added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/two_added.golden
@@ -42,6 +42,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val1"
+                    nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val2"
+                    nested    : "val2"
+                }
           + [2]: {
                   + computed  : "non-computed-val3"
                   + nested    : "val3"
@@ -56,7 +66,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[3]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{},
+		"tests[2].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[3].computed": map[string]interface{}{},
+		"tests[3].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/two_added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/two_added.golden
@@ -1,0 +1,62 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-val3"
+          + nested   = "val3"
+        }
+      + test { # forces replacement
+          + computed = "non-computed-val4"
+          + nested   = "val4"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [2]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
+                }
+          + [3]: {
+                  + computed  : "non-computed-val4"
+                  + nested    : "val4"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[3]": map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/two_added_and_two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/two_added_and_two_removed.golden
@@ -53,11 +53,11 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val5"
+                  + computed: "non-computed-val5"
                   ~ nested  : "val3" => "val5"
                 }
           ~ [3]: {
-                  ~ computed: "non-computed-val4" => "non-computed-val6"
+                  + computed: "non-computed-val6"
                   ~ nested  : "val4" => "val6"
                 }
         ]
@@ -66,9 +66,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{},
 		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].computed": map[string]interface{}{},
 		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/two_added_and_two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/two_added_and_two_removed.golden
@@ -1,0 +1,74 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val5",
+		"val6",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      - test { # forces replacement
+          - computed = "non-computed-val4" -> null
+          - nested   = "val4" -> null
+        }
+      + test { # forces replacement
+          + computed = "non-computed-val5"
+          + nested   = "val5"
+        }
+      + test { # forces replacement
+          + computed = "non-computed-val6"
+          + nested   = "val6"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [2]: {
+                  ~ computed: "non-computed-val3" => "non-computed-val5"
+                  ~ nested  : "val3" => "val5"
+                }
+          ~ [3]: {
+                  ~ computed: "non-computed-val4" => "non-computed-val6"
+                  ~ nested  : "val4" => "val6"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -52,13 +52,19 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + computed: "non-computed-val5"
+                  + nested  : "val5"
+                }
+          ~ [1]: {
+                  + computed: "non-computed-val6"
+                  + nested  : "val6"
+                }
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val1"
-                  ~ nested  : "val3" => "val1"
+                  - nested: "val3"
                 }
           ~ [3]: {
-                  ~ computed: "non-computed-val4" => "non-computed-val2"
-                  ~ nested  : "val4" => "val2"
+                  - nested: "val4"
                 }
         ]
 Resources:
@@ -66,9 +72,11 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[0].computed": map[string]interface{}{},
+		"tests[0].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -1,0 +1,74 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val5",
+		"val6",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      - test { # forces replacement
+          - computed = "non-computed-val4" -> null
+          - nested   = "val4" -> null
+        }
+      + test { # forces replacement
+          + computed = "non-computed-val5"
+          + nested   = "val5"
+        }
+      + test { # forces replacement
+          + computed = "non-computed-val6"
+          + nested   = "val6"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [2]: {
+                  ~ computed: "non-computed-val3" => "non-computed-val1"
+                  ~ nested  : "val3" => "val1"
+                }
+          ~ [3]: {
+                  ~ computed: "non-computed-val4" => "non-computed-val2"
+                  ~ nested  : "val4" => "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -52,13 +52,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [1]: {
+                  + computed: "non-computed-val5"
+                  + nested  : "val5"
+                }
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val6"
+                  + computed: "non-computed-val6"
                   ~ nested  : "val3" => "val6"
                 }
           ~ [3]: {
-                  ~ computed: "non-computed-val4" => "non-computed-val2"
-                  ~ nested  : "val4" => "val2"
+                  - nested: "val4"
                 }
         ]
 Resources:
@@ -66,9 +69,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[2].computed": map[string]interface{}{},
 		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -1,0 +1,74 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val5",
+		"val6",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      - test { # forces replacement
+          - computed = "non-computed-val4" -> null
+          - nested   = "val4" -> null
+        }
+      + test { # forces replacement
+          + computed = "non-computed-val5"
+          + nested   = "val5"
+        }
+      + test { # forces replacement
+          + computed = "non-computed-val6"
+          + nested   = "val6"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [2]: {
+                  ~ computed: "non-computed-val3" => "non-computed-val6"
+                  ~ nested  : "val3" => "val6"
+                }
+          ~ [3]: {
+                  ~ computed: "non-computed-val4" => "non-computed-val2"
+                  ~ nested  : "val4" => "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -54,13 +54,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [1]: {
+                  + computed: "non-computed-val5"
+                  + nested  : "val5"
+                }
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val6"
+                  + computed: "non-computed-val6"
                   ~ nested  : "val3" => "val6"
                 }
           ~ [3]: {
-                  ~ computed: "non-computed-val4" => "non-computed-val2"
-                  ~ nested  : "val4" => "val2"
+                  - nested: "val4"
                 }
         ]
 Resources:
@@ -68,9 +71,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[2].computed": map[string]interface{}{},
 		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -1,0 +1,76 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val5",
+		"val6",
+		"val2",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      - test { # forces replacement
+          - computed = "non-computed-val4" -> null
+          - nested   = "val4" -> null
+        }
+      + test { # forces replacement
+          + computed = "non-computed-val5"
+          + nested   = "val5"
+        }
+      + test { # forces replacement
+          + computed = "non-computed-val6"
+          + nested   = "val6"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [2]: {
+                  ~ computed: "non-computed-val3" => "non-computed-val6"
+                  ~ nested  : "val3" => "val6"
+                }
+          ~ [3]: {
+                  ~ computed: "non-computed-val4" => "non-computed-val2"
+                  ~ nested  : "val4" => "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/two_removed.golden
@@ -1,0 +1,62 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      - test { # forces replacement
+          - computed = "non-computed-val4" -> null
+          - nested   = "val4" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+          - [3]: {
+                  - computed: "non-computed-val4"
+                  - nested  : "val4"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/two_removed.golden
@@ -42,6 +42,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val1"
+                    nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val2"
+                    nested    : "val2"
+                }
           - [2]: {
                   - computed: "non-computed-val3"
                   - nested  : "val3"
@@ -56,7 +66,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests[3].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/unchanged_empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/unchanged_non-empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/unchanged_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_force_new_computed_specified_in_program/unchanged_null.golden
@@ -1,0 +1,11 @@
+tests.testOutput{tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`, pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/added.golden
@@ -1,0 +1,40 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{"value"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "value"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + tests: [
+      +     [0]: {
+              + nested    : "value"
+            }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/added.golden
@@ -27,14 +27,17 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
-      +     [0]: {
-              + nested    : "value"
-            }
+      ~ tests: [
+          + [0]: {
+                  + nested    : "value"
+                }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/added_end.golden
@@ -52,8 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val1"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val2"
                 }
           + [2]: {
                   + nested    : "val3"
@@ -64,8 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/added_end.golden
@@ -1,0 +1,71 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          + [2]: {
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/added_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/added_end_unordered.golden
@@ -1,0 +1,75 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "val2" => "val2"
+                }
+          ~ [1]: {
+                  ~ nested  : "val3" => "val3"
+                }
+          + [2]: {
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/added_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/added_end_unordered.golden
@@ -52,10 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "val2" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val3"
                 }
           + [2]: {
                   + nested    : "val1"
@@ -66,10 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/added_front.golden
@@ -52,10 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "val2" => "val1"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val1"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val3" => "val2"
                 }
           + [2]: {
                   + nested    : "val3"
@@ -66,10 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/added_front.golden
@@ -1,0 +1,75 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "val2" => "val1"
+                }
+          ~ [1]: {
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/added_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/added_front_unordered.golden
@@ -1,0 +1,73 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val3" => "val3"
+                }
+          + [2]: {
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/added_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/added_front_unordered.golden
@@ -52,9 +52,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  + nested    : "val2"
+                  + nested    : "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val3"
                 }
           + [2]: {
                   + nested    : "val1"
@@ -65,9 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/added_middle.golden
@@ -52,9 +52,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val1"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                  + nested    : "val2"
+                  + nested    : "val2"
                 }
           + [2]: {
                   + nested    : "val3"
@@ -65,9 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/added_middle.golden
@@ -1,0 +1,73 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/added_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/added_middle_unordered.golden
@@ -1,0 +1,71 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          + [2]: {
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/added_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/added_middle_unordered.golden
@@ -52,8 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val2"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val3"
                 }
           + [2]: {
                   + nested    : "val1"
@@ -64,8 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/changed_empty_to_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/changed_empty_to_null.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/changed_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/changed_non-null.golden
@@ -1,0 +1,49 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "value" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "value1"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "value" => "value1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/changed_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/changed_non-null.golden
@@ -35,15 +35,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "value" => "value1"
+                  ~ nested: "value" => "value1"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-	},
+	detailedDiff: map[string]interface{}{"tests[0].nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/changed_non-null_to_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/changed_non-null_to_null.golden
@@ -1,0 +1,17 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/changed_null_to_empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/changed_null_to_empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/changed_null_to_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/changed_null_to_non-null.golden
@@ -28,14 +28,17 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
-      +     [0]: {
-              + nested    : "value"
-            }
+      ~ tests: [
+          + [0]: {
+                  + nested    : "value"
+                }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/changed_null_to_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/changed_null_to_non-null.golden
@@ -1,0 +1,41 @@
+tests.testOutput{
+	changeValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "value"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + tests: [
+      +     [0]: {
+              + nested    : "value"
+            }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/removed.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/removed_end.golden
@@ -52,8 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val1"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val2"
                 }
           - [2]: {
                   - computed: ""
@@ -65,8 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/removed_end.golden
@@ -1,0 +1,72 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/removed_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/removed_end_unordered.golden
@@ -52,10 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val3"
                 }
           - [2]: {
                   - computed: ""
@@ -67,10 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/removed_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/removed_end_unordered.golden
@@ -1,0 +1,76 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/removed_front.golden
@@ -1,0 +1,76 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/removed_front.golden
@@ -52,10 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val3"
                 }
           - [2]: {
                   - computed: ""
@@ -67,10 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/removed_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/removed_front_unordered.golden
@@ -52,9 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val1"
                 }
           - [2]: {
                   - computed: ""
@@ -66,9 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/removed_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/removed_front_unordered.golden
@@ -1,0 +1,74 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val1"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/removed_middle.golden
@@ -52,9 +52,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val1"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                  - nested    : "val2"
+                  - nested    : "val2"
                 }
           - [2]: {
                   - computed: ""
@@ -66,9 +72,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/removed_middle.golden
@@ -1,0 +1,74 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/removed_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/removed_middle_unordered.golden
@@ -52,9 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val1"
                 }
           - [2]: {
                   - computed: ""
@@ -66,9 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/removed_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/removed_middle_unordered.golden
@@ -1,0 +1,74 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val1"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/same_element_updated.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/same_element_updated.golden
@@ -56,24 +56,13 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          ~ [0]: {
-                }
           ~ [1]: {
-                  ~ nested  : "val2" => "val4"
-                }
-          ~ [2]: {
-                  ~ nested  : "val3" => "val3"
+                  ~ nested: "val2" => "val4"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-	},
+	detailedDiff: map[string]interface{}{"tests[1].nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/same_element_updated.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/same_element_updated.golden
@@ -3,13 +3,11 @@ tests.testOutput{
 		"val1",
 		"val2",
 		"val3",
-		"val4",
 	},
 	changeValue: &[]string{
 		"val1",
-		"val5",
-		"val6",
-		"val2",
+		"val4",
+		"val3",
 	},
 	tfOut: `
 Terraform used the selected providers to generate the following execution
@@ -20,22 +18,32 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
-        id = "newid"
+        id = "id"
 
       - test {
-          - nested = "val3" -> null
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
         }
       - test {
-          - nested = "val4" -> null
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
         }
       + test {
-          + nested = "val5"
+          + computed = (known after apply)
+          + nested   = "val1"
         }
       + test {
-          + nested = "val6"
+          + computed = (known after apply)
+          + nested   = "val3"
         }
-
-        # (2 unchanged blocks hidden)
+      + test {
+          + computed = (known after apply)
+          + nested   = "val4"
+        }
     }
 
 Plan: 0 to add, 1 to change, 0 to destroy.
@@ -45,17 +53,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
     ~ crossprovider:index/testRes:TestRes: (update)
-        [id=newid]
+        [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [1]: {
-                  + nested    : "val5"
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val4"
                 }
           ~ [2]: {
-                  ~ nested: "val3" => "val6"
-                }
-          - [3]: {
-                  - nested: "val4"
+                  ~ nested  : "val3" => "val3"
                 }
         ]
 Resources:
@@ -63,8 +70,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]":        map[string]interface{}{},
-		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]":        map[string]interface{}{"kind": "DELETE"},
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/same_element_updated_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/same_element_updated_unordered.golden
@@ -56,12 +56,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          ~ [0]: {
-                }
           ~ [1]: {
+                  + nested: "val4"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val1"
+                  - nested: "val3"
                 }
         ]
 Resources:
@@ -69,9 +68,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/same_element_updated_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/same_element_updated_unordered.golden
@@ -1,15 +1,13 @@
 tests.testOutput{
 	initialValue: &[]string{
-		"val1",
 		"val2",
 		"val3",
-		"val4",
+		"val1",
 	},
 	changeValue: &[]string{
-		"val1",
-		"val5",
-		"val6",
 		"val2",
+		"val4",
+		"val1",
 	},
 	tfOut: `
 Terraform used the selected providers to generate the following execution
@@ -20,22 +18,32 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
-        id = "newid"
+        id = "id"
 
       - test {
-          - nested = "val3" -> null
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
         }
       - test {
-          - nested = "val4" -> null
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
         }
       + test {
-          + nested = "val5"
+          + computed = (known after apply)
+          + nested   = "val1"
         }
       + test {
-          + nested = "val6"
+          + computed = (known after apply)
+          + nested   = "val2"
         }
-
-        # (2 unchanged blocks hidden)
+      + test {
+          + computed = (known after apply)
+          + nested   = "val4"
+        }
     }
 
 Plan: 0 to add, 1 to change, 0 to destroy.
@@ -45,17 +53,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
     ~ crossprovider:index/testRes:TestRes: (update)
-        [id=newid]
+        [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [1]: {
-                  + nested    : "val5"
+          ~ [0]: {
+                }
+          ~ [1]: {
                 }
           ~ [2]: {
-                  ~ nested: "val3" => "val6"
-                }
-          - [3]: {
-                  - nested: "val4"
+                  ~ nested  : "val3" => "val1"
                 }
         ]
 Resources:
@@ -63,8 +69,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]":        map[string]interface{}{},
-		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]":        map[string]interface{}{"kind": "DELETE"},
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/shuffled.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/shuffled.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/shuffled_added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/shuffled_added_end.golden
@@ -1,0 +1,71 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          + [2]: {
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/shuffled_added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/shuffled_added_end.golden
@@ -52,8 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val2"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val1"
                 }
           + [2]: {
                   + nested    : "val3"
@@ -64,8 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/shuffled_added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/shuffled_added_front.golden
@@ -52,10 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "val2" => "val1"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val1"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val3"
                 }
           + [2]: {
                   + nested    : "val2"
@@ -66,10 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/shuffled_added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/shuffled_added_front.golden
@@ -1,0 +1,75 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "val2" => "val1"
+                }
+          ~ [1]: {
+                  ~ nested  : "val3" => "val3"
+                }
+          + [2]: {
+                  + nested    : "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/shuffled_added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/shuffled_added_middle.golden
@@ -52,9 +52,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                  + nested    : "val2"
+                  + nested    : "val2"
                 }
           + [2]: {
                   + nested    : "val1"
@@ -65,9 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/shuffled_added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/shuffled_added_middle.golden
@@ -1,0 +1,73 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/shuffled_removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/shuffled_removed_end.golden
@@ -1,0 +1,72 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/shuffled_removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/shuffled_removed_end.golden
@@ -52,8 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val2"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val1"
                 }
           - [2]: {
                   - computed: ""
@@ -65,8 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/shuffled_removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/shuffled_removed_front.golden
@@ -1,0 +1,76 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "val1" => "val3"
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val2"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/shuffled_removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/shuffled_removed_front.golden
@@ -52,10 +52,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                  - nested    : "val1"
+                  - nested    : "val1"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val2"
                 }
           - [2]: {
                   - computed: ""
@@ -67,10 +72,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/shuffled_removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/shuffled_removed_middle.golden
@@ -52,9 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val1"
                 }
           - [2]: {
                   - computed: ""
@@ -66,9 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/shuffled_removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/shuffled_removed_middle.golden
@@ -1,0 +1,74 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val1"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/shuffled_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/shuffled_unordered.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/shuffled_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/shuffled_with_duplicates.golden
@@ -1,0 +1,25 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/shuffled_with_duplicates_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/shuffled_with_duplicates_unordered.golden
@@ -1,0 +1,25 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/two_added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/two_added.golden
@@ -1,0 +1,80 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val4"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          + [2]: {
+                  + nested    : "val3"
+                }
+          + [3]: {
+                  + nested    : "val4"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[3]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/two_added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/two_added.golden
@@ -57,8 +57,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val1"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val2"
                 }
           + [2]: {
                   + nested    : "val3"
@@ -72,9 +78,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[3]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[3].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/two_added_and_two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/two_added_and_two_removed.golden
@@ -1,0 +1,92 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val5",
+		"val6",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val4" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val5"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val6"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          ~ [2]: {
+                  ~ nested  : "val3" => "val5"
+                }
+          ~ [3]: {
+                  ~ nested  : "val4" => "val6"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/two_added_and_two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/two_added_and_two_removed.golden
@@ -66,15 +66,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           ~ [2]: {
-                  ~ nested  : "val3" => "val5"
+                  ~ nested: "val3" => "val5"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val6"
+                  ~ nested: "val4" => "val6"
                 }
         ]
 Resources:
@@ -82,11 +78,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -1,0 +1,92 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val5",
+		"val6",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val4" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val5"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val6"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          ~ [2]: {
+                  ~ nested  : "val3" => "val1"
+                }
+          ~ [3]: {
+                  ~ nested  : "val4" => "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -67,14 +67,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + nested: "val5"
                 }
           ~ [1]: {
+                  + nested: "val6"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val1"
+                  - nested: "val3"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val2"
+                  - nested: "val4"
                 }
         ]
 Resources:
@@ -82,11 +84,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{},
+		"tests[1].nested": map[string]interface{}{},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE"},
+		"tests[3].nested": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -66,15 +66,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          ~ [0]: {
-                }
           ~ [1]: {
+                  + nested: "val5"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val6"
+                  ~ nested: "val3" => "val6"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val2"
+                  - nested: "val4"
                 }
         ]
 Resources:
@@ -82,11 +81,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{},
+		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -1,0 +1,92 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val5",
+		"val6",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val4" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val5"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val6"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          ~ [2]: {
+                  ~ nested  : "val3" => "val6"
+                }
+          ~ [3]: {
+                  ~ nested  : "val4" => "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -1,0 +1,94 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val5",
+		"val6",
+		"val2",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val4" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val5"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val6"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          ~ [2]: {
+                  ~ nested  : "val3" => "val6"
+                }
+          ~ [3]: {
+                  ~ nested  : "val4" => "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -68,15 +68,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          ~ [0]: {
-                }
           ~ [1]: {
+                  + nested: "val5"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val6"
+                  ~ nested: "val3" => "val6"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val2"
+                  - nested: "val4"
                 }
         ]
 Resources:
@@ -84,11 +83,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{},
+		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/two_removed.golden
@@ -1,0 +1,82 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val4" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+          - [3]: {
+                  - computed: ""
+                  - nested  : "val4"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests[3]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/two_removed.golden
@@ -57,8 +57,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val1"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val2"
                 }
           - [2]: {
                   - computed: ""
@@ -74,9 +80,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
-		"tests[3]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests[3].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/unchanged_empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/unchanged_non-empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/unchanged_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new/unchanged_null.golden
@@ -1,0 +1,11 @@
+tests.testOutput{tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`, pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/added.golden
@@ -27,15 +27,19 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
-      +     [0]: {
-              + computed  : "non-computed-value"
-              + nested    : "value"
-            }
+      ~ tests: [
+          + [0]: {
+                  + computed  : "non-computed-value"
+                  + nested    : "value"
+                }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].computed": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/added.golden
@@ -1,0 +1,41 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{"value"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-value"
+          + nested   = "value"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + tests: [
+      +     [0]: {
+              + computed  : "non-computed-value"
+              + nested    : "value"
+            }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/added_end.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-val3"
+          + nested   = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [2]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/added_end.golden
@@ -37,6 +37,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val1"
+                    nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val2"
+                    nested    : "val2"
+                }
           + [2]: {
                   + computed  : "non-computed-val3"
                   + nested    : "val3"
@@ -46,5 +56,9 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/added_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/added_end_unordered.golden
@@ -37,14 +37,28 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [0]: {
-                  + computed  : "non-computed-val2"
-                  + nested    : "val2"
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val2"
+                    nested    : "val2"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val3"
+                    nested    : "val3"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val1"
+                  + nested    : "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/added_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/added_end_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-val1"
+          + nested   = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [0]: {
+                  + computed  : "non-computed-val2"
+                  + nested    : "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/added_front.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-val1"
+          + nested   = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [0]: {
+                  + computed  : "non-computed-val1"
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/added_front.golden
@@ -37,14 +37,30 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [0]: {
+          ~ [0]: {
+                  + __defaults: []
+                  + computed  : "non-computed-val1"
                   + computed  : "non-computed-val1"
                   + nested    : "val1"
+                  + nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val3" => "non-computed-val2"
+                  ~ nested    : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].computed": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/added_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/added_front_unordered.golden
@@ -37,14 +37,29 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [1]: {
-                  + computed  : "non-computed-val3"
-                  + nested    : "val3"
+          ~ [0]: {
+                  + __defaults: []
+                  + computed  : "non-computed-val2"
+                  + computed  : "non-computed-val2"
+                  ~ nested    : "val1" => "val2"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val3"
+                    nested    : "val3"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val1"
+                  + nested    : "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].computed": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/added_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/added_front_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-val2"
+          + nested   = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [1]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/added_middle.golden
@@ -37,14 +37,29 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [1]: {
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val1"
+                    nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
                   + computed  : "non-computed-val2"
-                  + nested    : "val2"
+                  + computed  : "non-computed-val2"
+                  ~ nested    : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/added_middle.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-val2"
+          + nested   = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [1]: {
+                  + computed  : "non-computed-val2"
+                  + nested    : "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/added_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/added_middle_unordered.golden
@@ -37,6 +37,18 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val2"
+                  ~ nested    : "val1" => "val2"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  + computed  : "non-computed-val3"
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
+                  + nested    : "val3"
+                }
           + [2]: {
                   + computed  : "non-computed-val1"
                   + nested    : "val1"
@@ -46,5 +58,9 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/added_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/added_middle_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-val3"
+          + nested   = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [2]: {
+                  + computed  : "non-computed-val1"
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/changed_empty_to_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/changed_empty_to_null.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/changed_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/changed_non-null.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - computed = "non-computed-value" -> null
+          - nested   = "value" -> null
+        }
+      + test {
+          + computed = "non-computed-value1"
+          + nested   = "value1"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ computed: "non-computed-value" => "non-computed-value1"
+                  ~ nested  : "value" => "value1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/changed_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/changed_non-null.golden
@@ -35,7 +35,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ computed: "non-computed-value" => "non-computed-value1"
+                  + computed: "non-computed-value1"
                   ~ nested  : "value" => "value1"
                 }
         ]
@@ -44,7 +44,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].computed": map[string]interface{}{},
 		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/changed_non-null_to_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/changed_non-null_to_null.golden
@@ -1,0 +1,17 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/changed_null_to_empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/changed_null_to_empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/changed_null_to_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/changed_null_to_non-null.golden
@@ -1,0 +1,42 @@
+tests.testOutput{
+	changeValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-value"
+          + nested   = "value"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + tests: [
+      +     [0]: {
+              + computed  : "non-computed-value"
+              + nested    : "value"
+            }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/changed_null_to_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/changed_null_to_non-null.golden
@@ -28,15 +28,19 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
-      +     [0]: {
-              + computed  : "non-computed-value"
-              + nested    : "value"
-            }
+      ~ tests: [
+          + [0]: {
+                  + computed  : "non-computed-value"
+                  + nested    : "value"
+                }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].computed": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/removed.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/removed_end.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/removed_end.golden
@@ -37,6 +37,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val1"
+                    nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val2"
+                    nested    : "val2"
+                }
           - [2]: {
                   - computed: "non-computed-val3"
                   - nested  : "val3"
@@ -46,5 +56,8 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/removed_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/removed_end_unordered.golden
@@ -37,14 +37,27 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [0]: {
-                  - computed: "non-computed-val1"
-                  - nested  : "val1"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val2"
+                  ~ nested    : "val1" => "val2"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val3"
+                  ~ nested    : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/removed_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/removed_end_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [0]: {
+                  - computed: "non-computed-val1"
+                  - nested  : "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/removed_front.golden
@@ -37,14 +37,27 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [0]: {
-                  - computed: "non-computed-val1"
-                  - nested  : "val1"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val2"
+                  ~ nested    : "val1" => "val2"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val3"
+                  ~ nested    : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/removed_front.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [0]: {
+                  - computed: "non-computed-val1"
+                  - nested  : "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/removed_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/removed_front_unordered.golden
@@ -37,14 +37,27 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val3"
+                  ~ nested    : "val1" => "val3"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val1"
+                  ~ nested    : "val2" => "val1"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/removed_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/removed_front_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: {
+                  - computed: "non-computed-val2"
+                  - nested  : "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/removed_middle.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: {
+                  - computed: "non-computed-val2"
+                  - nested  : "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/removed_middle.golden
@@ -37,14 +37,27 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val1"
+                    nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val3"
+                  ~ nested    : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/removed_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/removed_middle_unordered.golden
@@ -37,14 +37,27 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val3"
+                  ~ nested    : "val1" => "val3"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val1"
+                  ~ nested    : "val2" => "val1"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/removed_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/removed_middle_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: {
+                  - computed: "non-computed-val2"
+                  - nested  : "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/same_element_updated.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/same_element_updated.golden
@@ -42,13 +42,9 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
-                }
-          + [2]: {
-                  + computed  : "non-computed-val3"
-                  + nested    : "val3"
+          ~ [1]: {
+                  + computed: "non-computed-val4"
+                  ~ nested  : "val2" => "val4"
                 }
         ]
 Resources:
@@ -56,7 +52,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]": map[string]interface{}{"kind": "DELETE"},
-		"tests[2]": map[string]interface{}{},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/same_element_updated.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/same_element_updated.golden
@@ -3,13 +3,11 @@ tests.testOutput{
 		"val1",
 		"val2",
 		"val3",
-		"val4",
 	},
 	changeValue: &[]string{
 		"val1",
-		"val5",
-		"val6",
-		"val2",
+		"val4",
+		"val3",
 	},
 	tfOut: `
 Terraform used the selected providers to generate the following execution
@@ -20,19 +18,15 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
-        id = "newid"
+        id = "id"
 
       - test {
-          - nested = "val3" -> null
-        }
-      - test {
-          - nested = "val4" -> null
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
         }
       + test {
-          + nested = "val5"
-        }
-      + test {
-          + nested = "val6"
+          + computed = "non-computed-val4"
+          + nested   = "val4"
         }
 
         # (2 unchanged blocks hidden)
@@ -45,17 +39,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
     ~ crossprovider:index/testRes:TestRes: (update)
-        [id=newid]
+        [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [1]: {
-                  + nested    : "val5"
+          - [1]: {
+                  - computed: "non-computed-val2"
+                  - nested  : "val2"
                 }
-          ~ [2]: {
-                  ~ nested: "val3" => "val6"
-                }
-          - [3]: {
-                  - nested: "val4"
+          + [2]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
                 }
         ]
 Resources:
@@ -63,8 +56,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]":        map[string]interface{}{},
-		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]":        map[string]interface{}{"kind": "DELETE"},
+		"tests[1]": map[string]interface{}{"kind": "DELETE"},
+		"tests[2]": map[string]interface{}{},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/same_element_updated_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/same_element_updated_unordered.golden
@@ -1,15 +1,13 @@
 tests.testOutput{
 	initialValue: &[]string{
-		"val1",
 		"val2",
 		"val3",
-		"val4",
+		"val1",
 	},
 	changeValue: &[]string{
-		"val1",
-		"val5",
-		"val6",
 		"val2",
+		"val4",
+		"val1",
 	},
 	tfOut: `
 Terraform used the selected providers to generate the following execution
@@ -20,19 +18,15 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
-        id = "newid"
+        id = "id"
 
       - test {
-          - nested = "val3" -> null
-        }
-      - test {
-          - nested = "val4" -> null
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
         }
       + test {
-          + nested = "val5"
-        }
-      + test {
-          + nested = "val6"
+          + computed = "non-computed-val4"
+          + nested   = "val4"
         }
 
         # (2 unchanged blocks hidden)
@@ -45,17 +39,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
     ~ crossprovider:index/testRes:TestRes: (update)
-        [id=newid]
+        [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [1]: {
-                  + nested    : "val5"
-                }
           ~ [2]: {
-                  ~ nested: "val3" => "val6"
-                }
-          - [3]: {
-                  - nested: "val4"
+                  ~ computed: "non-computed-val3" => "non-computed-val1"
+                  ~ nested  : "val3" => "val1"
                 }
         ]
 Resources:
@@ -63,8 +52,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]":        map[string]interface{}{},
-		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]":        map[string]interface{}{"kind": "DELETE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/same_element_updated_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/same_element_updated_unordered.golden
@@ -42,9 +42,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [1]: {
+                  + computed: "non-computed-val4"
+                  + nested  : "val4"
+                }
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val1"
-                  ~ nested  : "val3" => "val1"
+                  - nested: "val3"
                 }
         ]
 Resources:
@@ -52,7 +55,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{},
+		"tests[2].nested":   map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/shuffled.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/shuffled.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/shuffled_added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/shuffled_added_end.golden
@@ -37,6 +37,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val2"
+                  ~ nested    : "val1" => "val2"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val1"
+                  ~ nested    : "val2" => "val1"
+                }
           + [2]: {
                   + computed  : "non-computed-val3"
                   + nested    : "val3"
@@ -46,5 +56,9 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/shuffled_added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/shuffled_added_end.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-val3"
+          + nested   = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [2]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/shuffled_added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/shuffled_added_front.golden
@@ -37,14 +37,28 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [0]: {
-                  + computed  : "non-computed-val1"
-                  + nested    : "val1"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val1"
+                  ~ nested    : "val2" => "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val3"
+                    nested    : "val3"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val2"
+                  + nested    : "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].computed": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/shuffled_added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/shuffled_added_front.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-val1"
+          + nested   = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [0]: {
+                  + computed  : "non-computed-val1"
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/shuffled_added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/shuffled_added_middle.golden
@@ -37,14 +37,28 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [1]: {
-                  + computed  : "non-computed-val2"
-                  + nested    : "val2"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val3"
+                  ~ nested    : "val1" => "val3"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val3" => "non-computed-val2"
+                  ~ nested    : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val1"
+                  + nested    : "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/shuffled_added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/shuffled_added_middle.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-val2"
+          + nested   = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [1]: {
+                  + computed  : "non-computed-val2"
+                  + nested    : "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/shuffled_removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/shuffled_removed_end.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/shuffled_removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/shuffled_removed_end.golden
@@ -37,6 +37,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val2"
+                  ~ nested    : "val1" => "val2"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val1"
+                  ~ nested    : "val2" => "val1"
+                }
           - [2]: {
                   - computed: "non-computed-val3"
                   - nested  : "val3"
@@ -46,5 +56,8 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/shuffled_removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/shuffled_removed_front.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [0]: {
+                  - computed: "non-computed-val1"
+                  - nested  : "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/shuffled_removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/shuffled_removed_front.golden
@@ -37,14 +37,27 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [0]: {
-                  - computed: "non-computed-val1"
-                  - nested  : "val1"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val3"
+                  ~ nested    : "val1" => "val3"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val2"
+                    nested    : "val2"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/shuffled_removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/shuffled_removed_middle.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: {
+                  - computed: "non-computed-val2"
+                  - nested  : "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/shuffled_removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/shuffled_removed_middle.golden
@@ -37,14 +37,28 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val3"
+                  ~ nested    : "val1" => "val3"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val1"
+                  - nested    : "val2"
+                  - nested    : "val2"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/shuffled_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/shuffled_unordered.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/shuffled_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/shuffled_with_duplicates.golden
@@ -1,0 +1,25 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/shuffled_with_duplicates_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/shuffled_with_duplicates_unordered.golden
@@ -1,0 +1,25 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/two_added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/two_added.golden
@@ -42,6 +42,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val1"
+                    nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val2"
+                    nested    : "val2"
+                }
           + [2]: {
                   + computed  : "non-computed-val3"
                   + nested    : "val3"
@@ -56,7 +66,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[3]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[3].computed": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/two_added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/two_added.golden
@@ -1,0 +1,62 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-val3"
+          + nested   = "val3"
+        }
+      + test { # forces replacement
+          + computed = "non-computed-val4"
+          + nested   = "val4"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [2]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
+                }
+          + [3]: {
+                  + computed  : "non-computed-val4"
+                  + nested    : "val4"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[3]": map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/two_added_and_two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/two_added_and_two_removed.golden
@@ -53,11 +53,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val5"
+                  + computed: "non-computed-val5"
                   ~ nested  : "val3" => "val5"
                 }
           ~ [3]: {
-                  ~ computed: "non-computed-val4" => "non-computed-val6"
+                  + computed: "non-computed-val6"
                   ~ nested  : "val4" => "val6"
                 }
         ]
@@ -66,9 +66,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{},
 		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].computed": map[string]interface{}{},
 		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/two_added_and_two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/two_added_and_two_removed.golden
@@ -7,9 +7,9 @@ tests.testOutput{
 	},
 	changeValue: &[]string{
 		"val1",
+		"val2",
 		"val5",
 		"val6",
-		"val2",
 	},
 	tfOut: `
 Terraform used the selected providers to generate the following execution
@@ -20,19 +20,23 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
-        id = "newid"
+        id = "id"
 
       - test {
-          - nested = "val3" -> null
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
         }
       - test {
-          - nested = "val4" -> null
+          - computed = "non-computed-val4" -> null
+          - nested   = "val4" -> null
         }
       + test {
-          + nested = "val5"
+          + computed = "non-computed-val5"
+          + nested   = "val5"
         }
       + test {
-          + nested = "val6"
+          + computed = "non-computed-val6"
+          + nested   = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -45,17 +49,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
     ~ crossprovider:index/testRes:TestRes: (update)
-        [id=newid]
+        [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [1]: {
-                  + nested    : "val5"
-                }
           ~ [2]: {
-                  ~ nested: "val3" => "val6"
+                  ~ computed: "non-computed-val3" => "non-computed-val5"
+                  ~ nested  : "val3" => "val5"
                 }
-          - [3]: {
-                  - nested: "val4"
+          ~ [3]: {
+                  ~ computed: "non-computed-val4" => "non-computed-val6"
+                  ~ nested  : "val4" => "val6"
                 }
         ]
 Resources:
@@ -63,8 +66,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]":        map[string]interface{}{},
-		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]":        map[string]interface{}{"kind": "DELETE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -52,13 +52,19 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + computed: "non-computed-val5"
+                  + nested  : "val5"
+                }
+          ~ [1]: {
+                  + computed: "non-computed-val6"
+                  + nested  : "val6"
+                }
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val1"
-                  ~ nested  : "val3" => "val1"
+                  - nested: "val3"
                 }
           ~ [3]: {
-                  ~ computed: "non-computed-val4" => "non-computed-val2"
-                  ~ nested  : "val4" => "val2"
+                  - nested: "val4"
                 }
         ]
 Resources:
@@ -66,9 +72,11 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].computed": map[string]interface{}{},
+		"tests[0].nested":   map[string]interface{}{},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{},
+		"tests[2].nested":   map[string]interface{}{"kind": "DELETE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -6,9 +6,9 @@ tests.testOutput{
 		"val4",
 	},
 	changeValue: &[]string{
-		"val1",
 		"val5",
 		"val6",
+		"val1",
 		"val2",
 	},
 	tfOut: `
@@ -20,19 +20,23 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
-        id = "newid"
+        id = "id"
 
       - test {
-          - nested = "val3" -> null
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
         }
       - test {
-          - nested = "val4" -> null
+          - computed = "non-computed-val4" -> null
+          - nested   = "val4" -> null
         }
       + test {
-          + nested = "val5"
+          + computed = "non-computed-val5"
+          + nested   = "val5"
         }
       + test {
-          + nested = "val6"
+          + computed = "non-computed-val6"
+          + nested   = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -45,17 +49,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
     ~ crossprovider:index/testRes:TestRes: (update)
-        [id=newid]
+        [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [1]: {
-                  + nested    : "val5"
-                }
           ~ [2]: {
-                  ~ nested: "val3" => "val6"
+                  ~ computed: "non-computed-val3" => "non-computed-val1"
+                  ~ nested  : "val3" => "val1"
                 }
-          - [3]: {
-                  - nested: "val4"
+          ~ [3]: {
+                  ~ computed: "non-computed-val4" => "non-computed-val2"
+                  ~ nested  : "val4" => "val2"
                 }
         ]
 Resources:
@@ -63,8 +66,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]":        map[string]interface{}{},
-		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]":        map[string]interface{}{"kind": "DELETE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -20,19 +20,23 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
-        id = "newid"
+        id = "id"
 
       - test {
-          - nested = "val3" -> null
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
         }
       - test {
-          - nested = "val4" -> null
+          - computed = "non-computed-val4" -> null
+          - nested   = "val4" -> null
         }
       + test {
-          + nested = "val5"
+          + computed = "non-computed-val5"
+          + nested   = "val5"
         }
       + test {
-          + nested = "val6"
+          + computed = "non-computed-val6"
+          + nested   = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -45,17 +49,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
     ~ crossprovider:index/testRes:TestRes: (update)
-        [id=newid]
+        [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [1]: {
-                  + nested    : "val5"
-                }
           ~ [2]: {
-                  ~ nested: "val3" => "val6"
+                  ~ computed: "non-computed-val3" => "non-computed-val6"
+                  ~ nested  : "val3" => "val6"
                 }
-          - [3]: {
-                  - nested: "val4"
+          ~ [3]: {
+                  ~ computed: "non-computed-val4" => "non-computed-val2"
+                  ~ nested  : "val4" => "val2"
                 }
         ]
 Resources:
@@ -63,8 +66,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]":        map[string]interface{}{},
-		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]":        map[string]interface{}{"kind": "DELETE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -52,13 +52,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [1]: {
+                  + computed: "non-computed-val5"
+                  + nested  : "val5"
+                }
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val6"
+                  + computed: "non-computed-val6"
                   ~ nested  : "val3" => "val6"
                 }
           ~ [3]: {
-                  ~ computed: "non-computed-val4" => "non-computed-val2"
-                  ~ nested  : "val4" => "val2"
+                  - nested: "val4"
                 }
         ]
 Resources:
@@ -66,9 +69,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{},
+		"tests[2].computed": map[string]interface{}{},
 		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -10,6 +10,8 @@ tests.testOutput{
 		"val5",
 		"val6",
 		"val2",
+		"val1",
+		"val2",
 	},
 	tfOut: `
 Terraform used the selected providers to generate the following execution
@@ -20,19 +22,23 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
-        id = "newid"
+        id = "id"
 
       - test {
-          - nested = "val3" -> null
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
         }
       - test {
-          - nested = "val4" -> null
+          - computed = "non-computed-val4" -> null
+          - nested   = "val4" -> null
         }
       + test {
-          + nested = "val5"
+          + computed = "non-computed-val5"
+          + nested   = "val5"
         }
       + test {
-          + nested = "val6"
+          + computed = "non-computed-val6"
+          + nested   = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -45,17 +51,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
     ~ crossprovider:index/testRes:TestRes: (update)
-        [id=newid]
+        [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [1]: {
-                  + nested    : "val5"
-                }
           ~ [2]: {
-                  ~ nested: "val3" => "val6"
+                  ~ computed: "non-computed-val3" => "non-computed-val6"
+                  ~ nested  : "val3" => "val6"
                 }
-          - [3]: {
-                  - nested: "val4"
+          ~ [3]: {
+                  ~ computed: "non-computed-val4" => "non-computed-val2"
+                  ~ nested  : "val4" => "val2"
                 }
         ]
 Resources:
@@ -63,8 +68,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]":        map[string]interface{}{},
-		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]":        map[string]interface{}{"kind": "DELETE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -54,13 +54,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [1]: {
+                  + computed: "non-computed-val5"
+                  + nested  : "val5"
+                }
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val6"
+                  + computed: "non-computed-val6"
                   ~ nested  : "val3" => "val6"
                 }
           ~ [3]: {
-                  ~ computed: "non-computed-val4" => "non-computed-val2"
-                  ~ nested  : "val4" => "val2"
+                  - nested: "val4"
                 }
         ]
 Resources:
@@ -68,9 +71,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{},
+		"tests[2].computed": map[string]interface{}{},
 		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/two_removed.golden
@@ -1,0 +1,62 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      - test { # forces replacement
+          - computed = "non-computed-val4" -> null
+          - nested   = "val4" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+          - [3]: {
+                  - computed: "non-computed-val4"
+                  - nested  : "val4"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/two_removed.golden
@@ -42,6 +42,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val1"
+                    nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val2"
+                    nested    : "val2"
+                }
           - [2]: {
                   - computed: "non-computed-val3"
                   - nested  : "val3"
@@ -56,7 +66,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests[3].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/unchanged_empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/unchanged_non-empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/unchanged_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_force_new_computed_specified_in_program/unchanged_null.golden
@@ -1,0 +1,11 @@
+tests.testOutput{tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`, pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/added.golden
@@ -27,14 +27,17 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
-      +     [0]: {
-              + nested    : "value"
-            }
+      ~ tests: [
+          + [0]: {
+                  + nested    : "value"
+                }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/added.golden
@@ -1,0 +1,40 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{"value"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      + test {
+          + computed = (known after apply)
+          + nested   = "value"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + tests: [
+      +     [0]: {
+              + nested    : "value"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/added_end.golden
@@ -52,8 +52,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val1"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val2"
                 }
           + [2]: {
                   + nested    : "val3"
@@ -64,8 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/added_end.golden
@@ -1,0 +1,71 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          + [2]: {
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/added_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/added_end_unordered.golden
@@ -52,10 +52,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "val2" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val3"
                 }
           + [2]: {
                   + nested    : "val1"
@@ -66,10 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/added_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/added_end_unordered.golden
@@ -1,0 +1,75 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "val2" => "val2"
+                }
+          ~ [1]: {
+                  ~ nested  : "val3" => "val3"
+                }
+          + [2]: {
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/added_front.golden
@@ -52,10 +52,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "val2" => "val1"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val1"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val3" => "val2"
                 }
           + [2]: {
                   + nested    : "val3"
@@ -66,10 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/added_front.golden
@@ -1,0 +1,75 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "val2" => "val1"
+                }
+          ~ [1]: {
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/added_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/added_front_unordered.golden
@@ -1,0 +1,73 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val3" => "val3"
+                }
+          + [2]: {
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/added_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/added_front_unordered.golden
@@ -52,9 +52,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  + nested    : "val2"
+                  + nested    : "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val3"
                 }
           + [2]: {
                   + nested    : "val1"
@@ -65,9 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/added_middle.golden
@@ -52,9 +52,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val1"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val3" => "val2"
                 }
           + [2]: {
                   + nested    : "val3"
@@ -65,9 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/added_middle.golden
@@ -1,0 +1,73 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/added_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/added_middle_unordered.golden
@@ -52,8 +52,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val2"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                  + nested    : "val3"
+                  + nested    : "val3"
                 }
           + [2]: {
                   + nested    : "val1"
@@ -64,8 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/added_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/added_middle_unordered.golden
@@ -1,0 +1,71 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          + [2]: {
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/changed_empty_to_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/changed_empty_to_null.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/changed_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/changed_non-null.golden
@@ -1,0 +1,49 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "value" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "value1"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "value" => "value1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/changed_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/changed_non-null.golden
@@ -35,15 +35,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "value" => "value1"
+                  ~ nested: "value" => "value1"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-	},
+	detailedDiff: map[string]interface{}{"tests[0].nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/changed_non-null_to_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/changed_non-null_to_null.golden
@@ -1,0 +1,17 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/changed_null_to_empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/changed_null_to_empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/changed_null_to_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/changed_null_to_non-null.golden
@@ -28,14 +28,17 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
-      +     [0]: {
-              + nested    : "value"
-            }
+      ~ tests: [
+          + [0]: {
+                  + nested    : "value"
+                }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/changed_null_to_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/changed_null_to_non-null.golden
@@ -1,0 +1,41 @@
+tests.testOutput{
+	changeValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      + test {
+          + computed = (known after apply)
+          + nested   = "value"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + tests: [
+      +     [0]: {
+              + nested    : "value"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/removed.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/removed_end.golden
@@ -1,0 +1,72 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/removed_end.golden
@@ -52,8 +52,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val1"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val2"
                 }
           - [2]: {
                   - computed: ""
@@ -65,8 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/removed_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/removed_end_unordered.golden
@@ -1,0 +1,76 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/removed_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/removed_end_unordered.golden
@@ -52,10 +52,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                  - nested    : "val1"
+                  - nested    : "val1"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val3"
                 }
           - [2]: {
                   - computed: ""
@@ -67,10 +72,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/removed_front.golden
@@ -52,10 +52,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val3"
                 }
           - [2]: {
                   - computed: ""
@@ -67,10 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/removed_front.golden
@@ -1,0 +1,76 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/removed_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/removed_front_unordered.golden
@@ -1,0 +1,74 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val1"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/removed_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/removed_front_unordered.golden
@@ -52,9 +52,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val1"
                 }
           - [2]: {
                   - computed: ""
@@ -66,9 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/removed_middle.golden
@@ -1,0 +1,74 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/removed_middle.golden
@@ -52,9 +52,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val1"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val3"
                 }
           - [2]: {
                   - computed: ""
@@ -66,9 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/removed_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/removed_middle_unordered.golden
@@ -1,0 +1,74 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val1"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/removed_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/removed_middle_unordered.golden
@@ -52,9 +52,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  + __defaults: []
+                  - computed  : ""
+                  - nested    : "val2"
+                  - nested    : "val2"
                 }
           - [2]: {
                   - computed: ""
@@ -66,9 +72,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/same_element_updated.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/same_element_updated.golden
@@ -56,24 +56,13 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          ~ [0]: {
-                }
           ~ [1]: {
-                  ~ nested  : "val2" => "val4"
-                }
-          ~ [2]: {
-                  ~ nested  : "val3" => "val3"
+                  ~ nested: "val2" => "val4"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-	},
+	detailedDiff: map[string]interface{}{"tests[1].nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/same_element_updated.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/same_element_updated.golden
@@ -1,0 +1,79 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val4",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val4"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val4"
+                }
+          ~ [2]: {
+                  ~ nested  : "val3" => "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/same_element_updated_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/same_element_updated_unordered.golden
@@ -56,12 +56,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          ~ [0]: {
-                }
           ~ [1]: {
+                  + nested: "val4"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val1"
+                  - nested: "val3"
                 }
         ]
 Resources:
@@ -69,9 +68,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/same_element_updated_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/same_element_updated_unordered.golden
@@ -1,0 +1,77 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val4",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val4"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          ~ [2]: {
+                  ~ nested  : "val3" => "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/shuffled.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/shuffled.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/shuffled_added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/shuffled_added_end.golden
@@ -1,0 +1,71 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          + [2]: {
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/shuffled_added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/shuffled_added_end.golden
@@ -52,8 +52,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val2"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val1"
                 }
           + [2]: {
                   + nested    : "val3"
@@ -64,8 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/shuffled_added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/shuffled_added_front.golden
@@ -52,10 +52,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "val2" => "val1"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val1"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val3"
                 }
           + [2]: {
                   + nested    : "val2"
@@ -66,10 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/shuffled_added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/shuffled_added_front.golden
@@ -1,0 +1,75 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "val2" => "val1"
+                }
+          ~ [1]: {
+                  ~ nested  : "val3" => "val3"
+                }
+          + [2]: {
+                  + nested    : "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/shuffled_added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/shuffled_added_middle.golden
@@ -1,0 +1,73 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/shuffled_added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/shuffled_added_middle.golden
@@ -52,9 +52,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val3" => "val2"
                 }
           + [2]: {
                   + nested    : "val1"
@@ -65,9 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/shuffled_removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/shuffled_removed_end.golden
@@ -52,8 +52,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val2"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val1"
                 }
           - [2]: {
                   - computed: ""
@@ -65,8 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/shuffled_removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/shuffled_removed_end.golden
@@ -1,0 +1,72 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/shuffled_removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/shuffled_removed_front.golden
@@ -1,0 +1,76 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "val1" => "val3"
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val2"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/shuffled_removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/shuffled_removed_front.golden
@@ -52,10 +52,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val2"
                 }
           - [2]: {
                   - computed: ""
@@ -67,10 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/shuffled_removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/shuffled_removed_middle.golden
@@ -1,0 +1,74 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val1"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/shuffled_removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/shuffled_removed_middle.golden
@@ -52,9 +52,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  + __defaults: []
+                  - computed  : ""
+                  - nested    : "val2"
+                  - nested    : "val2"
                 }
           - [2]: {
                   - computed: ""
@@ -66,9 +72,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/shuffled_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/shuffled_unordered.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/shuffled_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/shuffled_with_duplicates.golden
@@ -1,0 +1,25 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/shuffled_with_duplicates_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/shuffled_with_duplicates_unordered.golden
@@ -1,0 +1,25 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/two_added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/two_added.golden
@@ -57,8 +57,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val1"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val2"
                 }
           + [2]: {
                   + nested    : "val3"
@@ -72,9 +78,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{},
-		"tests[3]":          map[string]interface{}{},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{},
+		"tests[3].nested": map[string]interface{}{},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/two_added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/two_added.golden
@@ -1,0 +1,80 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val4"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          + [2]: {
+                  + nested    : "val3"
+                }
+          + [3]: {
+                  + nested    : "val4"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{},
+		"tests[3]":          map[string]interface{}{},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/two_added_and_two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/two_added_and_two_removed.golden
@@ -1,0 +1,92 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val5",
+		"val6",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val4" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val5"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val6"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          ~ [2]: {
+                  ~ nested  : "val3" => "val5"
+                }
+          ~ [3]: {
+                  ~ nested  : "val4" => "val6"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/two_added_and_two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/two_added_and_two_removed.golden
@@ -66,15 +66,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           ~ [2]: {
-                  ~ nested  : "val3" => "val5"
+                  ~ nested: "val3" => "val5"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val6"
+                  ~ nested: "val4" => "val6"
                 }
         ]
 Resources:
@@ -82,11 +78,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -1,0 +1,92 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val5",
+		"val6",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val4" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val5"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val6"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          ~ [2]: {
+                  ~ nested  : "val3" => "val1"
+                }
+          ~ [3]: {
+                  ~ nested  : "val4" => "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -67,14 +67,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + nested: "val5"
                 }
           ~ [1]: {
+                  + nested: "val6"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val1"
+                  - nested: "val3"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val2"
+                  - nested: "val4"
                 }
         ]
 Resources:
@@ -82,11 +84,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{},
+		"tests[1].nested": map[string]interface{}{},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE"},
+		"tests[3].nested": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -66,15 +66,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          ~ [0]: {
-                }
           ~ [1]: {
+                  + nested: "val5"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val6"
+                  ~ nested: "val3" => "val6"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val2"
+                  - nested: "val4"
                 }
         ]
 Resources:
@@ -82,11 +81,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{},
+		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -1,0 +1,92 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val5",
+		"val6",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val4" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val5"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val6"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          ~ [2]: {
+                  ~ nested  : "val3" => "val6"
+                }
+          ~ [3]: {
+                  ~ nested  : "val4" => "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -1,0 +1,94 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val5",
+		"val6",
+		"val2",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val4" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val5"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val6"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          ~ [2]: {
+                  ~ nested  : "val3" => "val6"
+                }
+          ~ [3]: {
+                  ~ nested  : "val4" => "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -68,15 +68,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          ~ [0]: {
-                }
           ~ [1]: {
+                  + nested: "val5"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val6"
+                  ~ nested: "val3" => "val6"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val2"
+                  - nested: "val4"
                 }
         ]
 Resources:
@@ -84,11 +83,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{},
+		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/two_removed.golden
@@ -1,0 +1,82 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val4" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+          - [3]: {
+                  - computed: ""
+                  - nested  : "val4"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+		"tests[3]":          map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/two_removed.golden
@@ -57,8 +57,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val1"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val2"
                 }
           - [2]: {
                   - computed: ""
@@ -74,9 +80,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
-		"tests[3]":          map[string]interface{}{"kind": "DELETE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE"},
+		"tests[3].nested": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/unchanged_empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/unchanged_non-empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/unchanged_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace/unchanged_null.golden
@@ -1,0 +1,11 @@
+tests.testOutput{tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`, pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added.golden
@@ -27,15 +27,19 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
-      +     [0]: {
-              + computed  : "non-computed-value"
-              + nested    : "value"
-            }
+      ~ tests: [
+          + [0]: {
+                  + computed  : "non-computed-value"
+                  + nested    : "value"
+                }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].computed": map[string]interface{}{},
+		"tests[0].nested":   map[string]interface{}{},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added.golden
@@ -1,0 +1,41 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{"value"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      + test {
+          + computed = "non-computed-value"
+          + nested   = "value"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + tests: [
+      +     [0]: {
+              + computed  : "non-computed-value"
+              + nested    : "value"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added_end.golden
@@ -37,6 +37,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val1"
+                    nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val2"
+                    nested    : "val2"
+                }
           + [2]: {
                   + computed  : "non-computed-val3"
                   + nested    : "val3"
@@ -46,5 +56,9 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{},
+		"tests[2].nested":   map[string]interface{}{},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added_end.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      + test {
+          + computed = "non-computed-val3"
+          + nested   = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [2]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added_end_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      + test {
+          + computed = "non-computed-val1"
+          + nested   = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [0]: {
+                  + computed  : "non-computed-val2"
+                  + nested    : "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added_end_unordered.golden
@@ -37,14 +37,28 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [0]: {
-                  + computed  : "non-computed-val2"
-                  + nested    : "val2"
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val2"
+                    nested    : "val2"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val3"
+                    nested    : "val3"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val1"
+                  + nested    : "val1"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{},
+		"tests[2].nested":   map[string]interface{}{},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added_front.golden
@@ -37,14 +37,29 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [0]: {
+          ~ [0]: {
+                  + __defaults: []
                   + computed  : "non-computed-val1"
-                  + nested    : "val1"
+                  + computed  : "non-computed-val1"
+                  ~ nested    : "val2" => "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val3" => "non-computed-val2"
+                  ~ nested    : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].computed": map[string]interface{}{},
+		"tests[0].nested":   map[string]interface{}{},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added_front.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      + test {
+          + computed = "non-computed-val1"
+          + nested   = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [0]: {
+                  + computed  : "non-computed-val1"
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added_front_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      + test {
+          + computed = "non-computed-val2"
+          + nested   = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [1]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added_front_unordered.golden
@@ -37,14 +37,30 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [1]: {
-                  + computed  : "non-computed-val3"
-                  + nested    : "val3"
+          ~ [0]: {
+                  + __defaults: []
+                  + computed  : "non-computed-val2"
+                  + computed  : "non-computed-val2"
+                  + nested    : "val2"
+                  + nested    : "val2"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val3"
+                    nested    : "val3"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val1"
+                  + nested    : "val1"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].computed": map[string]interface{}{},
+		"tests[0].nested":   map[string]interface{}{},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added_middle.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      + test {
+          + computed = "non-computed-val2"
+          + nested   = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [1]: {
+                  + computed  : "non-computed-val2"
+                  + nested    : "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added_middle.golden
@@ -37,14 +37,28 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [1]: {
-                  + computed  : "non-computed-val2"
-                  + nested    : "val2"
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val1"
+                    nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val3" => "non-computed-val2"
+                  ~ nested    : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added_middle_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      + test {
+          + computed = "non-computed-val3"
+          + nested   = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [2]: {
+                  + computed  : "non-computed-val1"
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added_middle_unordered.golden
@@ -37,6 +37,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val2"
+                  ~ nested    : "val1" => "val2"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val3"
+                  ~ nested    : "val2" => "val3"
+                }
           + [2]: {
                   + computed  : "non-computed-val1"
                   + nested    : "val1"
@@ -46,5 +56,9 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/changed_empty_to_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/changed_empty_to_null.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/changed_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/changed_non-null.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - computed = "non-computed-value" -> null
+          - nested   = "value" -> null
+        }
+      + test {
+          + computed = "non-computed-value1"
+          + nested   = "value1"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ computed: "non-computed-value" => "non-computed-value1"
+                  ~ nested  : "value" => "value1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/changed_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/changed_non-null.golden
@@ -35,7 +35,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ computed: "non-computed-value" => "non-computed-value1"
+                  + computed: "non-computed-value1"
                   ~ nested  : "value" => "value1"
                 }
         ]
@@ -44,7 +44,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].computed": map[string]interface{}{},
 		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/changed_non-null_to_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/changed_non-null_to_null.golden
@@ -1,0 +1,17 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/changed_null_to_empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/changed_null_to_empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/changed_null_to_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/changed_null_to_non-null.golden
@@ -1,0 +1,42 @@
+tests.testOutput{
+	changeValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      + test {
+          + computed = "non-computed-value"
+          + nested   = "value"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + tests: [
+      +     [0]: {
+              + computed  : "non-computed-value"
+              + nested    : "value"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/changed_null_to_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/changed_null_to_non-null.golden
@@ -28,15 +28,19 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
-      +     [0]: {
-              + computed  : "non-computed-value"
-              + nested    : "value"
-            }
+      ~ tests: [
+          + [0]: {
+                  + computed  : "non-computed-value"
+                  + nested    : "value"
+                }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].computed": map[string]interface{}{},
+		"tests[0].nested":   map[string]interface{}{},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed_end.golden
@@ -37,6 +37,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val1"
+                    nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val2"
+                    nested    : "val2"
+                }
           - [2]: {
                   - computed: "non-computed-val3"
                   - nested  : "val3"
@@ -46,5 +56,8 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed_end.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed_end_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - computed = "non-computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [0]: {
+                  - computed: "non-computed-val1"
+                  - nested  : "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed_end_unordered.golden
@@ -37,14 +37,28 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [0]: {
-                  - computed: "non-computed-val1"
-                  - nested  : "val1"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val2"
+                  - nested    : "val1"
+                  - nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val3"
+                  ~ nested    : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed_front.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - computed = "non-computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [0]: {
+                  - computed: "non-computed-val1"
+                  - nested  : "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed_front.golden
@@ -37,14 +37,27 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [0]: {
-                  - computed: "non-computed-val1"
-                  - nested  : "val1"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val2"
+                  ~ nested    : "val1" => "val2"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val3"
+                  ~ nested    : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed_front_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: {
+                  - computed: "non-computed-val2"
+                  - nested  : "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed_front_unordered.golden
@@ -37,14 +37,27 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val3"
+                  ~ nested    : "val1" => "val3"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val1"
+                  ~ nested    : "val2" => "val1"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed_middle.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: {
+                  - computed: "non-computed-val2"
+                  - nested  : "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed_middle.golden
@@ -37,14 +37,27 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val1"
+                    nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val3"
+                  ~ nested    : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed_middle_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: {
+                  - computed: "non-computed-val2"
+                  - nested  : "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed_middle_unordered.golden
@@ -37,14 +37,27 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val3"
+                  ~ nested    : "val1" => "val3"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val1"
+                  ~ nested    : "val2" => "val1"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/same_element_updated.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/same_element_updated.golden
@@ -42,13 +42,9 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
-                }
-          + [2]: {
-                  + computed  : "non-computed-val3"
-                  + nested    : "val3"
+          ~ [1]: {
+                  + computed: "non-computed-val4"
+                  ~ nested  : "val2" => "val4"
                 }
         ]
 Resources:
@@ -56,7 +52,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]": map[string]interface{}{"kind": "DELETE"},
-		"tests[2]": map[string]interface{}{},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/same_element_updated.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/same_element_updated.golden
@@ -1,0 +1,62 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val4",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+      + test {
+          + computed = "non-computed-val4"
+          + nested   = "val4"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: {
+                  - computed: "non-computed-val2"
+                  - nested  : "val2"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[1]": map[string]interface{}{"kind": "DELETE"},
+		"tests[2]": map[string]interface{}{},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/same_element_updated_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/same_element_updated_unordered.golden
@@ -1,0 +1,58 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val4",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      + test {
+          + computed = "non-computed-val4"
+          + nested   = "val4"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [2]: {
+                  ~ computed: "non-computed-val3" => "non-computed-val1"
+                  ~ nested  : "val3" => "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/same_element_updated_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/same_element_updated_unordered.golden
@@ -42,9 +42,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [1]: {
+                  + computed: "non-computed-val4"
+                  + nested  : "val4"
+                }
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val1"
-                  ~ nested  : "val3" => "val1"
+                  - nested: "val3"
                 }
         ]
 Resources:
@@ -52,7 +55,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{},
+		"tests[2].nested":   map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/shuffled.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/shuffled.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/shuffled_added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/shuffled_added_end.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      + test {
+          + computed = "non-computed-val3"
+          + nested   = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [2]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/shuffled_added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/shuffled_added_end.golden
@@ -37,6 +37,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val2"
+                  ~ nested    : "val1" => "val2"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val1"
+                  ~ nested    : "val2" => "val1"
+                }
           + [2]: {
                   + computed  : "non-computed-val3"
                   + nested    : "val3"
@@ -46,5 +56,9 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{},
+		"tests[2].nested":   map[string]interface{}{},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/shuffled_added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/shuffled_added_front.golden
@@ -37,14 +37,30 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [0]: {
+          ~ [0]: {
+                  + __defaults: []
+                  + computed  : "non-computed-val1"
                   + computed  : "non-computed-val1"
                   + nested    : "val1"
+                  + nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val3"
+                    nested    : "val3"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val2"
+                  + nested    : "val2"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].computed": map[string]interface{}{},
+		"tests[0].nested":   map[string]interface{}{},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/shuffled_added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/shuffled_added_front.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      + test {
+          + computed = "non-computed-val1"
+          + nested   = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [0]: {
+                  + computed  : "non-computed-val1"
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/shuffled_added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/shuffled_added_middle.golden
@@ -37,14 +37,30 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [1]: {
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val3"
+                  ~ nested    : "val1" => "val3"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  + computed  : "non-computed-val2"
                   + computed  : "non-computed-val2"
                   + nested    : "val2"
+                  + nested    : "val2"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val1"
+                  + nested    : "val1"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/shuffled_added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/shuffled_added_middle.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      + test {
+          + computed = "non-computed-val2"
+          + nested   = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [1]: {
+                  + computed  : "non-computed-val2"
+                  + nested    : "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/shuffled_removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/shuffled_removed_end.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/shuffled_removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/shuffled_removed_end.golden
@@ -37,6 +37,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val2"
+                  ~ nested    : "val1" => "val2"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val1"
+                  ~ nested    : "val2" => "val1"
+                }
           - [2]: {
                   - computed: "non-computed-val3"
                   - nested  : "val3"
@@ -46,5 +56,8 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/shuffled_removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/shuffled_removed_front.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - computed = "non-computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [0]: {
+                  - computed: "non-computed-val1"
+                  - nested  : "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/shuffled_removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/shuffled_removed_front.golden
@@ -37,14 +37,28 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [0]: {
-                  - computed: "non-computed-val1"
-                  - nested  : "val1"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val3"
+                  - nested    : "val1"
+                  - nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val2"
+                    nested    : "val2"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/shuffled_removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/shuffled_removed_middle.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: {
+                  - computed: "non-computed-val2"
+                  - nested  : "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/shuffled_removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/shuffled_removed_middle.golden
@@ -37,14 +37,28 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val3"
+                  ~ nested    : "val1" => "val3"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val1"
+                  - nested    : "val2"
+                  - nested    : "val2"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/shuffled_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/shuffled_unordered.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/shuffled_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/shuffled_with_duplicates.golden
@@ -1,0 +1,25 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/shuffled_with_duplicates_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/shuffled_with_duplicates_unordered.golden
@@ -1,0 +1,25 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/two_added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/two_added.golden
@@ -42,6 +42,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val1"
+                    nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val2"
+                    nested    : "val2"
+                }
           + [2]: {
                   + computed  : "non-computed-val3"
                   + nested    : "val3"
@@ -56,7 +66,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{},
-		"tests[3]": map[string]interface{}{},
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{},
+		"tests[2].nested":   map[string]interface{}{},
+		"tests[3].computed": map[string]interface{}{},
+		"tests[3].nested":   map[string]interface{}{},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/two_added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/two_added.golden
@@ -1,0 +1,62 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      + test {
+          + computed = "non-computed-val3"
+          + nested   = "val3"
+        }
+      + test {
+          + computed = "non-computed-val4"
+          + nested   = "val4"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [2]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
+                }
+          + [3]: {
+                  + computed  : "non-computed-val4"
+                  + nested    : "val4"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2]": map[string]interface{}{},
+		"tests[3]": map[string]interface{}{},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/two_added_and_two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/two_added_and_two_removed.golden
@@ -53,11 +53,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val5"
+                  + computed: "non-computed-val5"
                   ~ nested  : "val3" => "val5"
                 }
           ~ [3]: {
-                  ~ computed: "non-computed-val4" => "non-computed-val6"
+                  + computed: "non-computed-val6"
                   ~ nested  : "val4" => "val6"
                 }
         ]
@@ -66,9 +66,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{},
 		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].computed": map[string]interface{}{},
 		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/two_added_and_two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/two_added_and_two_removed.golden
@@ -1,0 +1,74 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val5",
+		"val6",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      - test {
+          - computed = "non-computed-val4" -> null
+          - nested   = "val4" -> null
+        }
+      + test {
+          + computed = "non-computed-val5"
+          + nested   = "val5"
+        }
+      + test {
+          + computed = "non-computed-val6"
+          + nested   = "val6"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [2]: {
+                  ~ computed: "non-computed-val3" => "non-computed-val5"
+                  ~ nested  : "val3" => "val5"
+                }
+          ~ [3]: {
+                  ~ computed: "non-computed-val4" => "non-computed-val6"
+                  ~ nested  : "val4" => "val6"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -52,13 +52,19 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + computed: "non-computed-val5"
+                  + nested  : "val5"
+                }
+          ~ [1]: {
+                  + computed: "non-computed-val6"
+                  + nested  : "val6"
+                }
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val1"
-                  ~ nested  : "val3" => "val1"
+                  - nested: "val3"
                 }
           ~ [3]: {
-                  ~ computed: "non-computed-val4" => "non-computed-val2"
-                  ~ nested  : "val4" => "val2"
+                  - nested: "val4"
                 }
         ]
 Resources:
@@ -66,9 +72,11 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].computed": map[string]interface{}{},
+		"tests[0].nested":   map[string]interface{}{},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{},
+		"tests[2].nested":   map[string]interface{}{"kind": "DELETE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -1,0 +1,74 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val5",
+		"val6",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      - test {
+          - computed = "non-computed-val4" -> null
+          - nested   = "val4" -> null
+        }
+      + test {
+          + computed = "non-computed-val5"
+          + nested   = "val5"
+        }
+      + test {
+          + computed = "non-computed-val6"
+          + nested   = "val6"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [2]: {
+                  ~ computed: "non-computed-val3" => "non-computed-val1"
+                  ~ nested  : "val3" => "val1"
+                }
+          ~ [3]: {
+                  ~ computed: "non-computed-val4" => "non-computed-val2"
+                  ~ nested  : "val4" => "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -52,13 +52,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [1]: {
+                  + computed: "non-computed-val5"
+                  + nested  : "val5"
+                }
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val6"
+                  + computed: "non-computed-val6"
                   ~ nested  : "val3" => "val6"
                 }
           ~ [3]: {
-                  ~ computed: "non-computed-val4" => "non-computed-val2"
-                  ~ nested  : "val4" => "val2"
+                  - nested: "val4"
                 }
         ]
 Resources:
@@ -66,9 +69,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{},
+		"tests[2].computed": map[string]interface{}{},
 		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -1,0 +1,74 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val5",
+		"val6",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      - test {
+          - computed = "non-computed-val4" -> null
+          - nested   = "val4" -> null
+        }
+      + test {
+          + computed = "non-computed-val5"
+          + nested   = "val5"
+        }
+      + test {
+          + computed = "non-computed-val6"
+          + nested   = "val6"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [2]: {
+                  ~ computed: "non-computed-val3" => "non-computed-val6"
+                  ~ nested  : "val3" => "val6"
+                }
+          ~ [3]: {
+                  ~ computed: "non-computed-val4" => "non-computed-val2"
+                  ~ nested  : "val4" => "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -54,13 +54,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [1]: {
+                  + computed: "non-computed-val5"
+                  + nested  : "val5"
+                }
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val6"
+                  + computed: "non-computed-val6"
                   ~ nested  : "val3" => "val6"
                 }
           ~ [3]: {
-                  ~ computed: "non-computed-val4" => "non-computed-val2"
-                  ~ nested  : "val4" => "val2"
+                  - nested: "val4"
                 }
         ]
 Resources:
@@ -68,9 +71,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{},
+		"tests[2].computed": map[string]interface{}{},
 		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -1,0 +1,76 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val5",
+		"val6",
+		"val2",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      - test {
+          - computed = "non-computed-val4" -> null
+          - nested   = "val4" -> null
+        }
+      + test {
+          + computed = "non-computed-val5"
+          + nested   = "val5"
+        }
+      + test {
+          + computed = "non-computed-val6"
+          + nested   = "val6"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [2]: {
+                  ~ computed: "non-computed-val3" => "non-computed-val6"
+                  ~ nested  : "val3" => "val6"
+                }
+          ~ [3]: {
+                  ~ computed: "non-computed-val4" => "non-computed-val2"
+                  ~ nested  : "val4" => "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/two_removed.golden
@@ -1,0 +1,62 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      - test {
+          - computed = "non-computed-val4" -> null
+          - nested   = "val4" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+          - [3]: {
+                  - computed: "non-computed-val4"
+                  - nested  : "val4"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2]": map[string]interface{}{"kind": "DELETE"},
+		"tests[3]": map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/two_removed.golden
@@ -42,6 +42,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val1"
+                    nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val2"
+                    nested    : "val2"
+                }
           - [2]: {
                   - computed: "non-computed-val3"
                   - nested  : "val3"
@@ -56,7 +66,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{"kind": "DELETE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE"},
+		"tests[3].nested": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/unchanged_empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/unchanged_non-empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/unchanged_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/unchanged_null.golden
@@ -1,0 +1,11 @@
+tests.testOutput{tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`, pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/added.golden
@@ -1,0 +1,40 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{"value"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "value"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + tests: [
+      +     [0]: {
+              + nested    : "value"
+            }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/added.golden
@@ -27,14 +27,17 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
-      +     [0]: {
-              + nested    : "value"
-            }
+      ~ tests: [
+          + [0]: {
+                  + nested    : "value"
+                }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/added_end.golden
@@ -52,8 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val1"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val2"
                 }
           + [2]: {
                   + nested    : "val3"
@@ -64,8 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/added_end.golden
@@ -1,0 +1,71 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          + [2]: {
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/added_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/added_end_unordered.golden
@@ -1,0 +1,75 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "val2" => "val2"
+                }
+          ~ [1]: {
+                  ~ nested  : "val3" => "val3"
+                }
+          + [2]: {
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/added_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/added_end_unordered.golden
@@ -52,10 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "val2" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val3"
                 }
           + [2]: {
                   + nested    : "val1"
@@ -66,10 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/added_front.golden
@@ -52,10 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "val2" => "val1"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val1"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val3" => "val2"
                 }
           + [2]: {
                   + nested    : "val3"
@@ -66,10 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/added_front.golden
@@ -1,0 +1,75 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "val2" => "val1"
+                }
+          ~ [1]: {
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/added_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/added_front_unordered.golden
@@ -1,0 +1,73 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val3" => "val3"
+                }
+          + [2]: {
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/added_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/added_front_unordered.golden
@@ -52,9 +52,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  + nested    : "val2"
+                  + nested    : "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val3"
                 }
           + [2]: {
                   + nested    : "val1"
@@ -65,9 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/added_middle.golden
@@ -52,9 +52,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val1"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                  + nested    : "val2"
+                  + nested    : "val2"
                 }
           + [2]: {
                   + nested    : "val3"
@@ -65,9 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/added_middle.golden
@@ -1,0 +1,73 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/added_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/added_middle_unordered.golden
@@ -1,0 +1,71 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          + [2]: {
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/added_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/added_middle_unordered.golden
@@ -52,8 +52,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val2"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                  + nested    : "val3"
+                  + nested    : "val3"
                 }
           + [2]: {
                   + nested    : "val1"
@@ -64,8 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/changed_empty_to_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/changed_empty_to_null.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/changed_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/changed_non-null.golden
@@ -1,0 +1,49 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "value" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "value1"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "value" => "value1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/changed_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/changed_non-null.golden
@@ -35,15 +35,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "value" => "value1"
+                  ~ nested: "value" => "value1"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-	},
+	detailedDiff: map[string]interface{}{"tests[0].nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/changed_non-null_to_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/changed_non-null_to_null.golden
@@ -1,0 +1,42 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "value" -> null
+            # (1 unchanged attribute hidden)
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      - tests: [
+      -     [0]: {
+              - computed: ""
+              - nested  : "value"
+            }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/changed_non-null_to_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/changed_non-null_to_null.golden
@@ -34,9 +34,18 @@ Plan: 1 to add, 0 to change, 1 to destroy.
               - nested  : "value"
             }
         ]
+      - tests: [
+      -     [0]: {
+              - computed: ""
+              - nested  : "value"
+            }
+        ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/changed_null_to_empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/changed_null_to_empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/changed_null_to_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/changed_null_to_non-null.golden
@@ -28,14 +28,17 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
-      +     [0]: {
-              + nested    : "value"
-            }
+      ~ tests: [
+          + [0]: {
+                  + nested    : "value"
+                }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/changed_null_to_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/changed_null_to_non-null.golden
@@ -1,0 +1,41 @@
+tests.testOutput{
+	changeValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "value"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + tests: [
+      +     [0]: {
+              + nested    : "value"
+            }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/removed.golden
@@ -29,15 +29,18 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - tests: [
-      -     [0]: {
-              - computed: ""
-              - nested  : "value"
-            }
+      ~ tests: [
+          - [0]: {
+                  - computed: ""
+                  - nested  : "value"
+                }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/removed.golden
@@ -1,0 +1,43 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "value" -> null
+            # (1 unchanged attribute hidden)
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      - tests: [
+      -     [0]: {
+              - computed: ""
+              - nested  : "value"
+            }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/removed_end.golden
@@ -52,8 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val1"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val2"
                 }
           - [2]: {
                   - computed: ""
@@ -65,8 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/removed_end.golden
@@ -1,0 +1,72 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/removed_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/removed_end_unordered.golden
@@ -52,10 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val3"
                 }
           - [2]: {
                   - computed: ""
@@ -67,10 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/removed_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/removed_end_unordered.golden
@@ -1,0 +1,76 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/removed_front.golden
@@ -1,0 +1,76 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/removed_front.golden
@@ -52,10 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val3"
                 }
           - [2]: {
                   - computed: ""
@@ -67,10 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/removed_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/removed_front_unordered.golden
@@ -52,9 +52,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  + __defaults: []
+                  - computed  : ""
+                  - nested    : "val2"
+                  - nested    : "val2"
                 }
           - [2]: {
                   - computed: ""
@@ -66,9 +72,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/removed_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/removed_front_unordered.golden
@@ -1,0 +1,74 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val1"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/removed_middle.golden
@@ -52,9 +52,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val1"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                  - nested    : "val2"
+                  - nested    : "val2"
                 }
           - [2]: {
                   - computed: ""
@@ -66,9 +72,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/removed_middle.golden
@@ -1,0 +1,74 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/removed_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/removed_middle_unordered.golden
@@ -52,9 +52,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  + __defaults: []
+                  - computed  : ""
+                  - nested    : "val2"
+                  - nested    : "val2"
                 }
           - [2]: {
                   - computed: ""
@@ -66,9 +72,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/removed_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/removed_middle_unordered.golden
@@ -1,0 +1,74 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val1"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/same_element_updated.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/same_element_updated.golden
@@ -56,24 +56,13 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          ~ [0]: {
-                }
           ~ [1]: {
-                  ~ nested  : "val2" => "val4"
-                }
-          ~ [2]: {
-                  ~ nested  : "val3" => "val3"
+                  ~ nested: "val2" => "val4"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-	},
+	detailedDiff: map[string]interface{}{"tests[1].nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/same_element_updated.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/same_element_updated.golden
@@ -3,13 +3,11 @@ tests.testOutput{
 		"val1",
 		"val2",
 		"val3",
-		"val4",
 	},
 	changeValue: &[]string{
 		"val1",
-		"val5",
-		"val6",
-		"val2",
+		"val4",
+		"val3",
 	},
 	tfOut: `
 Terraform used the selected providers to generate the following execution
@@ -20,22 +18,32 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
-        id = "newid"
+        id = "id"
 
       - test {
-          - nested = "val3" -> null
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
         }
       - test {
-          - nested = "val4" -> null
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
         }
       + test {
-          + nested = "val5"
+          + computed = (known after apply)
+          + nested   = "val1"
         }
       + test {
-          + nested = "val6"
+          + computed = (known after apply)
+          + nested   = "val3"
         }
-
-        # (2 unchanged blocks hidden)
+      + test {
+          + computed = (known after apply)
+          + nested   = "val4"
+        }
     }
 
 Plan: 0 to add, 1 to change, 0 to destroy.
@@ -45,17 +53,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
     ~ crossprovider:index/testRes:TestRes: (update)
-        [id=newid]
+        [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [1]: {
-                  + nested    : "val5"
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val4"
                 }
           ~ [2]: {
-                  ~ nested: "val3" => "val6"
-                }
-          - [3]: {
-                  - nested: "val4"
+                  ~ nested  : "val3" => "val3"
                 }
         ]
 Resources:
@@ -63,8 +70,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]":        map[string]interface{}{},
-		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]":        map[string]interface{}{"kind": "DELETE"},
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/same_element_updated_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/same_element_updated_unordered.golden
@@ -56,12 +56,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          ~ [0]: {
-                }
           ~ [1]: {
+                  + nested: "val4"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val1"
+                  - nested: "val3"
                 }
         ]
 Resources:
@@ -69,9 +68,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/same_element_updated_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/same_element_updated_unordered.golden
@@ -1,15 +1,13 @@
 tests.testOutput{
 	initialValue: &[]string{
-		"val1",
 		"val2",
 		"val3",
-		"val4",
+		"val1",
 	},
 	changeValue: &[]string{
-		"val1",
-		"val5",
-		"val6",
 		"val2",
+		"val4",
+		"val1",
 	},
 	tfOut: `
 Terraform used the selected providers to generate the following execution
@@ -20,22 +18,32 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
-        id = "newid"
+        id = "id"
 
       - test {
-          - nested = "val3" -> null
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
         }
       - test {
-          - nested = "val4" -> null
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
         }
       + test {
-          + nested = "val5"
+          + computed = (known after apply)
+          + nested   = "val1"
         }
       + test {
-          + nested = "val6"
+          + computed = (known after apply)
+          + nested   = "val2"
         }
-
-        # (2 unchanged blocks hidden)
+      + test {
+          + computed = (known after apply)
+          + nested   = "val4"
+        }
     }
 
 Plan: 0 to add, 1 to change, 0 to destroy.
@@ -45,17 +53,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
     ~ crossprovider:index/testRes:TestRes: (update)
-        [id=newid]
+        [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [1]: {
-                  + nested    : "val5"
+          ~ [0]: {
+                }
+          ~ [1]: {
                 }
           ~ [2]: {
-                  ~ nested: "val3" => "val6"
-                }
-          - [3]: {
-                  - nested: "val4"
+                  ~ nested  : "val3" => "val1"
                 }
         ]
 Resources:
@@ -63,8 +69,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]":        map[string]interface{}{},
-		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]":        map[string]interface{}{"kind": "DELETE"},
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/shuffled.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/shuffled.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/shuffled_added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/shuffled_added_end.golden
@@ -1,0 +1,71 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          + [2]: {
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/shuffled_added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/shuffled_added_end.golden
@@ -52,8 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val2"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val1"
                 }
           + [2]: {
                   + nested    : "val3"
@@ -64,8 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/shuffled_added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/shuffled_added_front.golden
@@ -52,10 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "val2" => "val1"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val1"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val3"
                 }
           + [2]: {
                   + nested    : "val2"
@@ -66,10 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/shuffled_added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/shuffled_added_front.golden
@@ -1,0 +1,75 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "val2" => "val1"
+                }
+          ~ [1]: {
+                  ~ nested  : "val3" => "val3"
+                }
+          + [2]: {
+                  + nested    : "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/shuffled_added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/shuffled_added_middle.golden
@@ -52,9 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val3" => "val2"
                 }
           + [2]: {
                   + nested    : "val1"
@@ -65,9 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/shuffled_added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/shuffled_added_middle.golden
@@ -1,0 +1,73 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/shuffled_removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/shuffled_removed_end.golden
@@ -1,0 +1,72 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/shuffled_removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/shuffled_removed_end.golden
@@ -52,8 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val2"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val1"
                 }
           - [2]: {
                   - computed: ""
@@ -65,8 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/shuffled_removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/shuffled_removed_front.golden
@@ -1,0 +1,76 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "val1" => "val3"
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val2"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/shuffled_removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/shuffled_removed_front.golden
@@ -52,10 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val2"
                 }
           - [2]: {
                   - computed: ""
@@ -67,10 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/shuffled_removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/shuffled_removed_middle.golden
@@ -52,9 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val1"
                 }
           - [2]: {
                   - computed: ""
@@ -66,9 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/shuffled_removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/shuffled_removed_middle.golden
@@ -1,0 +1,74 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val1"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/shuffled_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/shuffled_unordered.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/shuffled_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/shuffled_with_duplicates.golden
@@ -1,0 +1,25 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/shuffled_with_duplicates_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/shuffled_with_duplicates_unordered.golden
@@ -1,0 +1,25 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/two_added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/two_added.golden
@@ -1,0 +1,80 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val4"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          + [2]: {
+                  + nested    : "val3"
+                }
+          + [3]: {
+                  + nested    : "val4"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[3]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/two_added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/two_added.golden
@@ -57,8 +57,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val1"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val2"
                 }
           + [2]: {
                   + nested    : "val3"
@@ -72,9 +78,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[3]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[3].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/two_added_and_two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/two_added_and_two_removed.golden
@@ -1,0 +1,92 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val5",
+		"val6",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val4" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val5"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val6"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          ~ [2]: {
+                  ~ nested  : "val3" => "val5"
+                }
+          ~ [3]: {
+                  ~ nested  : "val4" => "val6"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/two_added_and_two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/two_added_and_two_removed.golden
@@ -66,15 +66,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           ~ [2]: {
-                  ~ nested  : "val3" => "val5"
+                  ~ nested: "val3" => "val5"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val6"
+                  ~ nested: "val4" => "val6"
                 }
         ]
 Resources:
@@ -82,11 +78,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -1,0 +1,92 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val5",
+		"val6",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val4" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val5"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val6"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          ~ [2]: {
+                  ~ nested  : "val3" => "val1"
+                }
+          ~ [3]: {
+                  ~ nested  : "val4" => "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -67,14 +67,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + nested: "val5"
                 }
           ~ [1]: {
+                  + nested: "val6"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val1"
+                  - nested: "val3"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val2"
+                  - nested: "val4"
                 }
         ]
 Resources:
@@ -82,11 +84,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{},
+		"tests[1].nested": map[string]interface{}{},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE"},
+		"tests[3].nested": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -66,15 +66,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          ~ [0]: {
-                }
           ~ [1]: {
+                  + nested: "val5"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val6"
+                  ~ nested: "val3" => "val6"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val2"
+                  - nested: "val4"
                 }
         ]
 Resources:
@@ -82,11 +81,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{},
+		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -1,0 +1,92 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val5",
+		"val6",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val4" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val5"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val6"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          ~ [2]: {
+                  ~ nested  : "val3" => "val6"
+                }
+          ~ [3]: {
+                  ~ nested  : "val4" => "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -1,0 +1,94 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val5",
+		"val6",
+		"val2",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val4" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val5"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val6"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          ~ [2]: {
+                  ~ nested  : "val3" => "val6"
+                }
+          ~ [3]: {
+                  ~ nested  : "val4" => "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -68,15 +68,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          ~ [0]: {
-                }
           ~ [1]: {
+                  + nested: "val5"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val6"
+                  ~ nested: "val3" => "val6"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val2"
+                  - nested: "val4"
                 }
         ]
 Resources:
@@ -84,11 +83,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{},
+		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/two_removed.golden
@@ -1,0 +1,82 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val4" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+          - [3]: {
+                  - computed: ""
+                  - nested  : "val4"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests[3]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/two_removed.golden
@@ -57,8 +57,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val1"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val2"
                 }
           - [2]: {
                   - computed: ""
@@ -74,9 +80,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
-		"tests[3]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests[3].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/unchanged_empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/unchanged_non-empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/unchanged_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new/unchanged_null.golden
@@ -1,0 +1,11 @@
+tests.testOutput{tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`, pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/added.golden
@@ -27,15 +27,19 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
-      +     [0]: {
-              + computed  : "non-computed-value"
-              + nested    : "value"
-            }
+      ~ tests: [
+          + [0]: {
+                  + computed  : "non-computed-value"
+                  + nested    : "value"
+                }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].computed": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/added.golden
@@ -1,0 +1,41 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{"value"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-value"
+          + nested   = "value"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + tests: [
+      +     [0]: {
+              + computed  : "non-computed-value"
+              + nested    : "value"
+            }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/added_end.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-val3"
+          + nested   = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [2]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/added_end.golden
@@ -37,6 +37,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val1"
+                    nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val2"
+                    nested    : "val2"
+                }
           + [2]: {
                   + computed  : "non-computed-val3"
                   + nested    : "val3"
@@ -46,5 +56,9 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/added_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/added_end_unordered.golden
@@ -37,14 +37,28 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [0]: {
-                  + computed  : "non-computed-val2"
-                  + nested    : "val2"
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val2"
+                    nested    : "val2"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val3"
+                    nested    : "val3"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val1"
+                  + nested    : "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/added_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/added_end_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-val1"
+          + nested   = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [0]: {
+                  + computed  : "non-computed-val2"
+                  + nested    : "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/added_front.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-val1"
+          + nested   = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [0]: {
+                  + computed  : "non-computed-val1"
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/added_front.golden
@@ -37,14 +37,30 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [0]: {
+          ~ [0]: {
+                  + __defaults: []
+                  + computed  : "non-computed-val1"
                   + computed  : "non-computed-val1"
                   + nested    : "val1"
+                  + nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val3" => "non-computed-val2"
+                  ~ nested    : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].computed": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/added_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/added_front_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-val2"
+          + nested   = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [1]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/added_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/added_front_unordered.golden
@@ -37,14 +37,30 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [1]: {
-                  + computed  : "non-computed-val3"
-                  + nested    : "val3"
+          ~ [0]: {
+                  + __defaults: []
+                  + computed  : "non-computed-val2"
+                  + computed  : "non-computed-val2"
+                  + nested    : "val2"
+                  + nested    : "val2"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val3"
+                    nested    : "val3"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val1"
+                  + nested    : "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].computed": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/added_middle.golden
@@ -37,14 +37,28 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [1]: {
-                  + computed  : "non-computed-val2"
-                  + nested    : "val2"
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val1"
+                    nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val3" => "non-computed-val2"
+                  ~ nested    : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/added_middle.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-val2"
+          + nested   = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [1]: {
+                  + computed  : "non-computed-val2"
+                  + nested    : "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/added_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/added_middle_unordered.golden
@@ -37,6 +37,18 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val2"
+                  ~ nested    : "val1" => "val2"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  + computed  : "non-computed-val3"
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
+                  + nested    : "val3"
+                }
           + [2]: {
                   + computed  : "non-computed-val1"
                   + nested    : "val1"
@@ -46,5 +58,9 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/added_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/added_middle_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-val3"
+          + nested   = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [2]: {
+                  + computed  : "non-computed-val1"
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/changed_empty_to_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/changed_empty_to_null.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/changed_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/changed_non-null.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - computed = "non-computed-value" -> null
+          - nested   = "value" -> null
+        }
+      + test {
+          + computed = "non-computed-value1"
+          + nested   = "value1"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ computed: "non-computed-value" => "non-computed-value1"
+                  ~ nested  : "value" => "value1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/changed_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/changed_non-null.golden
@@ -35,7 +35,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ computed: "non-computed-value" => "non-computed-value1"
+                  + computed: "non-computed-value1"
                   ~ nested  : "value" => "value1"
                 }
         ]
@@ -44,7 +44,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].computed": map[string]interface{}{},
 		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/changed_non-null_to_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/changed_non-null_to_null.golden
@@ -1,0 +1,42 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-value" -> null
+          - nested   = "value" -> null
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      - tests: [
+      -     [0]: {
+              - computed: "non-computed-value"
+              - nested  : "value"
+            }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/changed_non-null_to_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/changed_non-null_to_null.golden
@@ -34,9 +34,18 @@ Plan: 1 to add, 0 to change, 1 to destroy.
               - nested  : "value"
             }
         ]
+      - tests: [
+      -     [0]: {
+              - computed: "non-computed-value"
+              - nested  : "value"
+            }
+        ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/changed_null_to_empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/changed_null_to_empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/changed_null_to_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/changed_null_to_non-null.golden
@@ -1,0 +1,42 @@
+tests.testOutput{
+	changeValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-value"
+          + nested   = "value"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + tests: [
+      +     [0]: {
+              + computed  : "non-computed-value"
+              + nested    : "value"
+            }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/changed_null_to_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/changed_null_to_non-null.golden
@@ -28,15 +28,19 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
-      +     [0]: {
-              + computed  : "non-computed-value"
-              + nested    : "value"
-            }
+      ~ tests: [
+          + [0]: {
+                  + computed  : "non-computed-value"
+                  + nested    : "value"
+                }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].computed": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/removed.golden
@@ -1,0 +1,43 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-value" -> null
+          - nested   = "value" -> null
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      - tests: [
+      -     [0]: {
+              - computed: "non-computed-value"
+              - nested  : "value"
+            }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/removed.golden
@@ -29,15 +29,18 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - tests: [
-      -     [0]: {
-              - computed: "non-computed-value"
-              - nested  : "value"
-            }
+      ~ tests: [
+          - [0]: {
+                  - computed: "non-computed-value"
+                  - nested  : "value"
+                }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/removed_end.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/removed_end.golden
@@ -37,6 +37,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val1"
+                    nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val2"
+                    nested    : "val2"
+                }
           - [2]: {
                   - computed: "non-computed-val3"
                   - nested  : "val3"
@@ -46,5 +56,8 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/removed_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/removed_end_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [0]: {
+                  - computed: "non-computed-val1"
+                  - nested  : "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/removed_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/removed_end_unordered.golden
@@ -37,14 +37,28 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [0]: {
-                  - computed: "non-computed-val1"
-                  - nested  : "val1"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val2"
+                  - nested    : "val1"
+                  - nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val3"
+                  ~ nested    : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/removed_front.golden
@@ -37,14 +37,27 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [0]: {
-                  - computed: "non-computed-val1"
-                  - nested  : "val1"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val2"
+                  ~ nested    : "val1" => "val2"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val3"
+                  ~ nested    : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/removed_front.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [0]: {
+                  - computed: "non-computed-val1"
+                  - nested  : "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/removed_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/removed_front_unordered.golden
@@ -37,14 +37,27 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val3"
+                  ~ nested    : "val1" => "val3"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val1"
+                  ~ nested    : "val2" => "val1"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/removed_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/removed_front_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: {
+                  - computed: "non-computed-val2"
+                  - nested  : "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/removed_middle.golden
@@ -37,14 +37,28 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val1"
+                    nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val3"
+                  - nested    : "val2"
+                  - nested    : "val2"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/removed_middle.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: {
+                  - computed: "non-computed-val2"
+                  - nested  : "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/removed_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/removed_middle_unordered.golden
@@ -37,14 +37,27 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val3"
+                  ~ nested    : "val1" => "val3"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val1"
+                  ~ nested    : "val2" => "val1"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/removed_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/removed_middle_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: {
+                  - computed: "non-computed-val2"
+                  - nested  : "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/same_element_updated.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/same_element_updated.golden
@@ -42,13 +42,9 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
-                }
-          + [2]: {
-                  + computed  : "non-computed-val3"
-                  + nested    : "val3"
+          ~ [1]: {
+                  + computed: "non-computed-val4"
+                  ~ nested  : "val2" => "val4"
                 }
         ]
 Resources:
@@ -56,7 +52,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]": map[string]interface{}{"kind": "DELETE"},
-		"tests[2]": map[string]interface{}{},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/same_element_updated.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/same_element_updated.golden
@@ -3,13 +3,11 @@ tests.testOutput{
 		"val1",
 		"val2",
 		"val3",
-		"val4",
 	},
 	changeValue: &[]string{
 		"val1",
-		"val5",
-		"val6",
-		"val2",
+		"val4",
+		"val3",
 	},
 	tfOut: `
 Terraform used the selected providers to generate the following execution
@@ -20,19 +18,15 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
-        id = "newid"
+        id = "id"
 
       - test {
-          - nested = "val3" -> null
-        }
-      - test {
-          - nested = "val4" -> null
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
         }
       + test {
-          + nested = "val5"
-        }
-      + test {
-          + nested = "val6"
+          + computed = "non-computed-val4"
+          + nested   = "val4"
         }
 
         # (2 unchanged blocks hidden)
@@ -45,17 +39,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
     ~ crossprovider:index/testRes:TestRes: (update)
-        [id=newid]
+        [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [1]: {
-                  + nested    : "val5"
+          - [1]: {
+                  - computed: "non-computed-val2"
+                  - nested  : "val2"
                 }
-          ~ [2]: {
-                  ~ nested: "val3" => "val6"
-                }
-          - [3]: {
-                  - nested: "val4"
+          + [2]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
                 }
         ]
 Resources:
@@ -63,8 +56,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]":        map[string]interface{}{},
-		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]":        map[string]interface{}{"kind": "DELETE"},
+		"tests[1]": map[string]interface{}{"kind": "DELETE"},
+		"tests[2]": map[string]interface{}{},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/same_element_updated_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/same_element_updated_unordered.golden
@@ -1,15 +1,13 @@
 tests.testOutput{
 	initialValue: &[]string{
-		"val1",
 		"val2",
 		"val3",
-		"val4",
+		"val1",
 	},
 	changeValue: &[]string{
-		"val1",
-		"val5",
-		"val6",
 		"val2",
+		"val4",
+		"val1",
 	},
 	tfOut: `
 Terraform used the selected providers to generate the following execution
@@ -20,19 +18,15 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
-        id = "newid"
+        id = "id"
 
       - test {
-          - nested = "val3" -> null
-        }
-      - test {
-          - nested = "val4" -> null
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
         }
       + test {
-          + nested = "val5"
-        }
-      + test {
-          + nested = "val6"
+          + computed = "non-computed-val4"
+          + nested   = "val4"
         }
 
         # (2 unchanged blocks hidden)
@@ -45,17 +39,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
     ~ crossprovider:index/testRes:TestRes: (update)
-        [id=newid]
+        [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [1]: {
-                  + nested    : "val5"
-                }
           ~ [2]: {
-                  ~ nested: "val3" => "val6"
-                }
-          - [3]: {
-                  - nested: "val4"
+                  ~ computed: "non-computed-val3" => "non-computed-val1"
+                  ~ nested  : "val3" => "val1"
                 }
         ]
 Resources:
@@ -63,8 +52,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]":        map[string]interface{}{},
-		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]":        map[string]interface{}{"kind": "DELETE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/same_element_updated_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/same_element_updated_unordered.golden
@@ -42,9 +42,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [1]: {
+                  + computed: "non-computed-val4"
+                  + nested  : "val4"
+                }
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val1"
-                  ~ nested  : "val3" => "val1"
+                  - nested: "val3"
                 }
         ]
 Resources:
@@ -52,7 +55,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{},
+		"tests[2].nested":   map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_added_end.golden
@@ -37,6 +37,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val2"
+                  ~ nested    : "val1" => "val2"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val1"
+                  ~ nested    : "val2" => "val1"
+                }
           + [2]: {
                   + computed  : "non-computed-val3"
                   + nested    : "val3"
@@ -46,5 +56,9 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_added_end.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-val3"
+          + nested   = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [2]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_added_front.golden
@@ -37,14 +37,28 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [0]: {
-                  + computed  : "non-computed-val1"
-                  + nested    : "val1"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val1"
+                  ~ nested    : "val2" => "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val3"
+                    nested    : "val3"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val2"
+                  + nested    : "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].computed": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_added_front.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-val1"
+          + nested   = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [0]: {
+                  + computed  : "non-computed-val1"
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_added_middle.golden
@@ -37,14 +37,30 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [1]: {
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val3"
+                  ~ nested    : "val1" => "val3"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  + computed  : "non-computed-val2"
                   + computed  : "non-computed-val2"
                   + nested    : "val2"
+                  + nested    : "val2"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val1"
+                  + nested    : "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_added_middle.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-val2"
+          + nested   = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [1]: {
+                  + computed  : "non-computed-val2"
+                  + nested    : "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_removed_end.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_removed_end.golden
@@ -37,6 +37,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val2"
+                  ~ nested    : "val1" => "val2"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val1"
+                  ~ nested    : "val2" => "val1"
+                }
           - [2]: {
                   - computed: "non-computed-val3"
                   - nested  : "val3"
@@ -46,5 +56,8 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_removed_front.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [0]: {
+                  - computed: "non-computed-val1"
+                  - nested  : "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_removed_front.golden
@@ -37,14 +37,28 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [0]: {
-                  - computed: "non-computed-val1"
-                  - nested  : "val1"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val3"
+                  - nested    : "val1"
+                  - nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val2"
+                    nested    : "val2"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_removed_middle.golden
@@ -37,14 +37,27 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val3"
+                  ~ nested    : "val1" => "val3"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val1"
+                  ~ nested    : "val2" => "val1"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_removed_middle.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: {
+                  - computed: "non-computed-val2"
+                  - nested  : "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_unordered.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_with_duplicates.golden
@@ -1,0 +1,25 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_with_duplicates_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_with_duplicates_unordered.golden
@@ -1,0 +1,25 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/two_added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/two_added.golden
@@ -42,6 +42,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val1"
+                    nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val2"
+                    nested    : "val2"
+                }
           + [2]: {
                   + computed  : "non-computed-val3"
                   + nested    : "val3"
@@ -56,7 +66,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[3]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[3].computed": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/two_added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/two_added.golden
@@ -1,0 +1,62 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-val3"
+          + nested   = "val3"
+        }
+      + test { # forces replacement
+          + computed = "non-computed-val4"
+          + nested   = "val4"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [2]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
+                }
+          + [3]: {
+                  + computed  : "non-computed-val4"
+                  + nested    : "val4"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[3]": map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/two_added_and_two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/two_added_and_two_removed.golden
@@ -53,11 +53,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val5"
+                  + computed: "non-computed-val5"
                   ~ nested  : "val3" => "val5"
                 }
           ~ [3]: {
-                  ~ computed: "non-computed-val4" => "non-computed-val6"
+                  + computed: "non-computed-val6"
                   ~ nested  : "val4" => "val6"
                 }
         ]
@@ -66,9 +66,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{},
 		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].computed": map[string]interface{}{},
 		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/two_added_and_two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/two_added_and_two_removed.golden
@@ -7,9 +7,9 @@ tests.testOutput{
 	},
 	changeValue: &[]string{
 		"val1",
+		"val2",
 		"val5",
 		"val6",
-		"val2",
 	},
 	tfOut: `
 Terraform used the selected providers to generate the following execution
@@ -20,19 +20,23 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
-        id = "newid"
+        id = "id"
 
       - test {
-          - nested = "val3" -> null
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
         }
       - test {
-          - nested = "val4" -> null
+          - computed = "non-computed-val4" -> null
+          - nested   = "val4" -> null
         }
       + test {
-          + nested = "val5"
+          + computed = "non-computed-val5"
+          + nested   = "val5"
         }
       + test {
-          + nested = "val6"
+          + computed = "non-computed-val6"
+          + nested   = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -45,17 +49,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
     ~ crossprovider:index/testRes:TestRes: (update)
-        [id=newid]
+        [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [1]: {
-                  + nested    : "val5"
-                }
           ~ [2]: {
-                  ~ nested: "val3" => "val6"
+                  ~ computed: "non-computed-val3" => "non-computed-val5"
+                  ~ nested  : "val3" => "val5"
                 }
-          - [3]: {
-                  - nested: "val4"
+          ~ [3]: {
+                  ~ computed: "non-computed-val4" => "non-computed-val6"
+                  ~ nested  : "val4" => "val6"
                 }
         ]
 Resources:
@@ -63,8 +66,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]":        map[string]interface{}{},
-		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]":        map[string]interface{}{"kind": "DELETE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -52,13 +52,19 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + computed: "non-computed-val5"
+                  + nested  : "val5"
+                }
+          ~ [1]: {
+                  + computed: "non-computed-val6"
+                  + nested  : "val6"
+                }
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val1"
-                  ~ nested  : "val3" => "val1"
+                  - nested: "val3"
                 }
           ~ [3]: {
-                  ~ computed: "non-computed-val4" => "non-computed-val2"
-                  ~ nested  : "val4" => "val2"
+                  - nested: "val4"
                 }
         ]
 Resources:
@@ -66,9 +72,11 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].computed": map[string]interface{}{},
+		"tests[0].nested":   map[string]interface{}{},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{},
+		"tests[2].nested":   map[string]interface{}{"kind": "DELETE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -6,9 +6,9 @@ tests.testOutput{
 		"val4",
 	},
 	changeValue: &[]string{
-		"val1",
 		"val5",
 		"val6",
+		"val1",
 		"val2",
 	},
 	tfOut: `
@@ -20,19 +20,23 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
-        id = "newid"
+        id = "id"
 
       - test {
-          - nested = "val3" -> null
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
         }
       - test {
-          - nested = "val4" -> null
+          - computed = "non-computed-val4" -> null
+          - nested   = "val4" -> null
         }
       + test {
-          + nested = "val5"
+          + computed = "non-computed-val5"
+          + nested   = "val5"
         }
       + test {
-          + nested = "val6"
+          + computed = "non-computed-val6"
+          + nested   = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -45,17 +49,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
     ~ crossprovider:index/testRes:TestRes: (update)
-        [id=newid]
+        [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [1]: {
-                  + nested    : "val5"
-                }
           ~ [2]: {
-                  ~ nested: "val3" => "val6"
+                  ~ computed: "non-computed-val3" => "non-computed-val1"
+                  ~ nested  : "val3" => "val1"
                 }
-          - [3]: {
-                  - nested: "val4"
+          ~ [3]: {
+                  ~ computed: "non-computed-val4" => "non-computed-val2"
+                  ~ nested  : "val4" => "val2"
                 }
         ]
 Resources:
@@ -63,8 +66,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]":        map[string]interface{}{},
-		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]":        map[string]interface{}{"kind": "DELETE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -20,19 +20,23 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
-        id = "newid"
+        id = "id"
 
       - test {
-          - nested = "val3" -> null
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
         }
       - test {
-          - nested = "val4" -> null
+          - computed = "non-computed-val4" -> null
+          - nested   = "val4" -> null
         }
       + test {
-          + nested = "val5"
+          + computed = "non-computed-val5"
+          + nested   = "val5"
         }
       + test {
-          + nested = "val6"
+          + computed = "non-computed-val6"
+          + nested   = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -45,17 +49,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
     ~ crossprovider:index/testRes:TestRes: (update)
-        [id=newid]
+        [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [1]: {
-                  + nested    : "val5"
-                }
           ~ [2]: {
-                  ~ nested: "val3" => "val6"
+                  ~ computed: "non-computed-val3" => "non-computed-val6"
+                  ~ nested  : "val3" => "val6"
                 }
-          - [3]: {
-                  - nested: "val4"
+          ~ [3]: {
+                  ~ computed: "non-computed-val4" => "non-computed-val2"
+                  ~ nested  : "val4" => "val2"
                 }
         ]
 Resources:
@@ -63,8 +66,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]":        map[string]interface{}{},
-		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]":        map[string]interface{}{"kind": "DELETE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -52,13 +52,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [1]: {
+                  + computed: "non-computed-val5"
+                  + nested  : "val5"
+                }
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val6"
+                  + computed: "non-computed-val6"
                   ~ nested  : "val3" => "val6"
                 }
           ~ [3]: {
-                  ~ computed: "non-computed-val4" => "non-computed-val2"
-                  ~ nested  : "val4" => "val2"
+                  - nested: "val4"
                 }
         ]
 Resources:
@@ -66,9 +69,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{},
+		"tests[2].computed": map[string]interface{}{},
 		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -10,6 +10,8 @@ tests.testOutput{
 		"val5",
 		"val6",
 		"val2",
+		"val1",
+		"val2",
 	},
 	tfOut: `
 Terraform used the selected providers to generate the following execution
@@ -20,19 +22,23 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
-        id = "newid"
+        id = "id"
 
       - test {
-          - nested = "val3" -> null
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
         }
       - test {
-          - nested = "val4" -> null
+          - computed = "non-computed-val4" -> null
+          - nested   = "val4" -> null
         }
       + test {
-          + nested = "val5"
+          + computed = "non-computed-val5"
+          + nested   = "val5"
         }
       + test {
-          + nested = "val6"
+          + computed = "non-computed-val6"
+          + nested   = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -45,17 +51,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
     ~ crossprovider:index/testRes:TestRes: (update)
-        [id=newid]
+        [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [1]: {
-                  + nested    : "val5"
-                }
           ~ [2]: {
-                  ~ nested: "val3" => "val6"
+                  ~ computed: "non-computed-val3" => "non-computed-val6"
+                  ~ nested  : "val3" => "val6"
                 }
-          - [3]: {
-                  - nested: "val4"
+          ~ [3]: {
+                  ~ computed: "non-computed-val4" => "non-computed-val2"
+                  ~ nested  : "val4" => "val2"
                 }
         ]
 Resources:
@@ -63,8 +68,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]":        map[string]interface{}{},
-		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]":        map[string]interface{}{"kind": "DELETE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -54,13 +54,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [1]: {
+                  + computed: "non-computed-val5"
+                  + nested  : "val5"
+                }
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val6"
+                  + computed: "non-computed-val6"
                   ~ nested  : "val3" => "val6"
                 }
           ~ [3]: {
-                  ~ computed: "non-computed-val4" => "non-computed-val2"
-                  ~ nested  : "val4" => "val2"
+                  - nested: "val4"
                 }
         ]
 Resources:
@@ -68,9 +71,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{},
+		"tests[2].computed": map[string]interface{}{},
 		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/two_removed.golden
@@ -1,0 +1,62 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      - test { # forces replacement
+          - computed = "non-computed-val4" -> null
+          - nested   = "val4" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+          - [3]: {
+                  - computed: "non-computed-val4"
+                  - nested  : "val4"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/two_removed.golden
@@ -42,6 +42,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val1"
+                    nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val2"
+                    nested    : "val2"
+                }
           - [2]: {
                   - computed: "non-computed-val3"
                   - nested  : "val3"
@@ -56,7 +66,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests[3].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/unchanged_empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/unchanged_non-empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/unchanged_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_force_new_computed_specified_in_program/unchanged_null.golden
@@ -1,0 +1,11 @@
+tests.testOutput{tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`, pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/added.golden
@@ -1,0 +1,40 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{"value"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "value"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + tests: [
+      +     [0]: {
+              + nested    : "value"
+            }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/added.golden
@@ -27,14 +27,17 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
-      +     [0]: {
-              + nested    : "value"
-            }
+      ~ tests: [
+          + [0]: {
+                  + nested    : "value"
+                }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/added_end.golden
@@ -52,8 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val1"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val2"
                 }
           + [2]: {
                   + nested    : "val3"
@@ -64,8 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/added_end.golden
@@ -1,0 +1,71 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          + [2]: {
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/added_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/added_end_unordered.golden
@@ -1,0 +1,75 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "val2" => "val2"
+                }
+          ~ [1]: {
+                  ~ nested  : "val3" => "val3"
+                }
+          + [2]: {
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/added_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/added_end_unordered.golden
@@ -52,10 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "val2" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val3"
                 }
           + [2]: {
                   + nested    : "val1"
@@ -66,10 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/added_front.golden
@@ -52,10 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "val2" => "val1"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val1"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val3" => "val2"
                 }
           + [2]: {
                   + nested    : "val3"
@@ -66,10 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/added_front.golden
@@ -1,0 +1,75 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "val2" => "val1"
+                }
+          ~ [1]: {
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/added_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/added_front_unordered.golden
@@ -1,0 +1,73 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val3" => "val3"
+                }
+          + [2]: {
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/added_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/added_front_unordered.golden
@@ -52,9 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val3"
                 }
           + [2]: {
                   + nested    : "val1"
@@ -65,9 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/added_middle.golden
@@ -1,0 +1,73 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/added_middle.golden
@@ -52,9 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val1"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val3" => "val2"
                 }
           + [2]: {
                   + nested    : "val3"
@@ -65,9 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/added_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/added_middle_unordered.golden
@@ -1,0 +1,71 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          + [2]: {
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/added_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/added_middle_unordered.golden
@@ -52,8 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val2"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val3"
                 }
           + [2]: {
                   + nested    : "val1"
@@ -64,8 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/changed_empty_to_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/changed_empty_to_null.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/changed_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/changed_non-null.golden
@@ -35,15 +35,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "value" => "value1"
+                  ~ nested: "value" => "value1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"tests[0].nested": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/changed_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/changed_non-null.golden
@@ -1,0 +1,49 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "value" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "value1"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "value" => "value1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/changed_non-null_to_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/changed_non-null_to_null.golden
@@ -1,0 +1,42 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "value" -> null
+            # (1 unchanged attribute hidden)
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      - tests: [
+      -     [0]: {
+              - computed: ""
+              - nested  : "value"
+            }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/changed_non-null_to_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/changed_non-null_to_null.golden
@@ -34,9 +34,18 @@ Plan: 1 to add, 0 to change, 1 to destroy.
               - nested  : "value"
             }
         ]
+      - tests: [
+      -     [0]: {
+              - computed: ""
+              - nested  : "value"
+            }
+        ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/changed_null_to_empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/changed_null_to_empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/changed_null_to_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/changed_null_to_non-null.golden
@@ -28,14 +28,17 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
-      +     [0]: {
-              + nested    : "value"
-            }
+      ~ tests: [
+          + [0]: {
+                  + nested    : "value"
+                }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/changed_null_to_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/changed_null_to_non-null.golden
@@ -1,0 +1,41 @@
+tests.testOutput{
+	changeValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "value"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + tests: [
+      +     [0]: {
+              + nested    : "value"
+            }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/removed.golden
@@ -29,15 +29,18 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - tests: [
-      -     [0]: {
-              - computed: ""
-              - nested  : "value"
-            }
+      ~ tests: [
+          - [0]: {
+                  - computed: ""
+                  - nested  : "value"
+                }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/removed.golden
@@ -1,0 +1,43 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "value" -> null
+            # (1 unchanged attribute hidden)
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      - tests: [
+      -     [0]: {
+              - computed: ""
+              - nested  : "value"
+            }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/removed_end.golden
@@ -52,8 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val1"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val2"
                 }
           - [2]: {
                   - computed: ""
@@ -65,8 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/removed_end.golden
@@ -1,0 +1,72 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/removed_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/removed_end_unordered.golden
@@ -52,10 +52,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                  - nested    : "val1"
+                  - nested    : "val1"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val3"
                 }
           - [2]: {
                   - computed: ""
@@ -67,10 +72,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/removed_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/removed_end_unordered.golden
@@ -1,0 +1,76 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/removed_front.golden
@@ -52,10 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val3"
                 }
           - [2]: {
                   - computed: ""
@@ -67,10 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/removed_front.golden
@@ -1,0 +1,76 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/removed_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/removed_front_unordered.golden
@@ -1,0 +1,74 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val1"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/removed_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/removed_front_unordered.golden
@@ -52,9 +52,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  + __defaults: []
+                  - computed  : ""
+                  - nested    : "val2"
+                  - nested    : "val2"
                 }
           - [2]: {
                   - computed: ""
@@ -66,9 +72,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/removed_middle.golden
@@ -1,0 +1,74 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/removed_middle.golden
@@ -52,9 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val1"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val3"
                 }
           - [2]: {
                   - computed: ""
@@ -66,9 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/removed_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/removed_middle_unordered.golden
@@ -1,0 +1,74 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val1"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/removed_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/removed_middle_unordered.golden
@@ -52,9 +52,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  + __defaults: []
+                  - computed  : ""
+                  - nested    : "val2"
+                  - nested    : "val2"
                 }
           - [2]: {
                   - computed: ""
@@ -66,9 +72,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/same_element_updated.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/same_element_updated.golden
@@ -56,24 +56,13 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          ~ [0]: {
-                }
           ~ [1]: {
-                  ~ nested  : "val2" => "val4"
-                }
-          ~ [2]: {
-                  ~ nested  : "val3" => "val3"
+                  ~ nested: "val2" => "val4"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"tests[1].nested": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/same_element_updated.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/same_element_updated.golden
@@ -1,0 +1,79 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val4",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val4"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val4"
+                }
+          ~ [2]: {
+                  ~ nested  : "val3" => "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/same_element_updated_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/same_element_updated_unordered.golden
@@ -1,0 +1,77 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val4",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val4"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          ~ [2]: {
+                  ~ nested  : "val3" => "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/same_element_updated_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/same_element_updated_unordered.golden
@@ -56,12 +56,11 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          ~ [0]: {
-                }
           ~ [1]: {
+                  + nested: "val4"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val1"
+                  - nested: "val3"
                 }
         ]
 Resources:
@@ -69,9 +68,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[1].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/shuffled.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/shuffled.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/shuffled_added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/shuffled_added_end.golden
@@ -1,0 +1,71 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          + [2]: {
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/shuffled_added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/shuffled_added_end.golden
@@ -52,8 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val2"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val1"
                 }
           + [2]: {
                   + nested    : "val3"
@@ -64,8 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/shuffled_added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/shuffled_added_front.golden
@@ -52,10 +52,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "val2" => "val1"
+                  + __defaults: []
+                  - computed  : ""
+                  + nested    : "val1"
+                  + nested    : "val1"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val3"
                 }
           + [2]: {
                   + nested    : "val2"
@@ -66,10 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/shuffled_added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/shuffled_added_front.golden
@@ -1,0 +1,75 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "val2" => "val1"
+                }
+          ~ [1]: {
+                  ~ nested  : "val3" => "val3"
+                }
+          + [2]: {
+                  + nested    : "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/shuffled_added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/shuffled_added_middle.golden
@@ -1,0 +1,73 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/shuffled_added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/shuffled_added_middle.golden
@@ -52,9 +52,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                  + nested    : "val2"
+                  + nested    : "val2"
                 }
           + [2]: {
                   + nested    : "val1"
@@ -65,9 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/shuffled_removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/shuffled_removed_end.golden
@@ -1,0 +1,72 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/shuffled_removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/shuffled_removed_end.golden
@@ -52,8 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val2"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val1"
                 }
           - [2]: {
                   - computed: ""
@@ -65,8 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/shuffled_removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/shuffled_removed_front.golden
@@ -1,0 +1,76 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "val1" => "val3"
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val2"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/shuffled_removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/shuffled_removed_front.golden
@@ -52,10 +52,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                  - nested    : "val1"
+                  - nested    : "val1"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val2"
                 }
           - [2]: {
                   - computed: ""
@@ -67,10 +72,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/shuffled_removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/shuffled_removed_middle.golden
@@ -52,9 +52,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val1"
                 }
           - [2]: {
                   - computed: ""
@@ -66,9 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/shuffled_removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/shuffled_removed_middle.golden
@@ -1,0 +1,74 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val1"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/shuffled_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/shuffled_unordered.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/shuffled_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/shuffled_with_duplicates.golden
@@ -1,0 +1,25 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/shuffled_with_duplicates_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/shuffled_with_duplicates_unordered.golden
@@ -1,0 +1,25 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/two_added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/two_added.golden
@@ -1,0 +1,80 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val4"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          + [2]: {
+                  + nested    : "val3"
+                }
+          + [3]: {
+                  + nested    : "val4"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[3]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/two_added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/two_added.golden
@@ -57,8 +57,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val1"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val2"
                 }
           + [2]: {
                   + nested    : "val3"
@@ -72,9 +78,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[3]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[3].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/two_added_and_two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/two_added_and_two_removed.golden
@@ -66,15 +66,11 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           ~ [2]: {
-                  ~ nested  : "val3" => "val5"
+                  ~ nested: "val3" => "val5"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val6"
+                  ~ nested: "val4" => "val6"
                 }
         ]
 Resources:
@@ -82,11 +78,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[2].nested": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[3].nested": map[string]interface{}{"kind": "UPDATE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/two_added_and_two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/two_added_and_two_removed.golden
@@ -1,0 +1,92 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val5",
+		"val6",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val4" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val5"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val6"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          ~ [2]: {
+                  ~ nested  : "val3" => "val5"
+                }
+          ~ [3]: {
+                  ~ nested  : "val4" => "val6"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -1,0 +1,92 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val5",
+		"val6",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val4" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val5"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val6"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          ~ [2]: {
+                  ~ nested  : "val3" => "val1"
+                }
+          ~ [3]: {
+                  ~ nested  : "val4" => "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -67,14 +67,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + nested: "val5"
                 }
           ~ [1]: {
+                  + nested: "val6"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val1"
+                  - nested: "val3"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val2"
+                  - nested: "val4"
                 }
         ]
 Resources:
@@ -82,11 +84,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[0].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[1].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests[3].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -66,15 +66,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          ~ [0]: {
-                }
           ~ [1]: {
+                  + nested: "val5"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val6"
+                  ~ nested: "val3" => "val6"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val2"
+                  - nested: "val4"
                 }
         ]
 Resources:
@@ -82,11 +81,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[1].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[2].nested": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[3].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -1,0 +1,92 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val5",
+		"val6",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val4" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val5"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val6"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          ~ [2]: {
+                  ~ nested  : "val3" => "val6"
+                }
+          ~ [3]: {
+                  ~ nested  : "val4" => "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -1,0 +1,94 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val5",
+		"val6",
+		"val2",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val4" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val5"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val6"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          ~ [2]: {
+                  ~ nested  : "val3" => "val6"
+                }
+          ~ [3]: {
+                  ~ nested  : "val4" => "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -68,15 +68,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          ~ [0]: {
-                }
           ~ [1]: {
+                  + nested: "val5"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val6"
+                  ~ nested: "val3" => "val6"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val2"
+                  - nested: "val4"
                 }
         ]
 Resources:
@@ -84,11 +83,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[1].nested": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[2].nested": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[3].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/two_removed.golden
@@ -1,0 +1,82 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test { # forces replacement
+          - nested   = "val4" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test { # forces replacement
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+          - [3]: {
+                  - computed: ""
+                  - nested  : "val4"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests[3]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/two_removed.golden
@@ -57,8 +57,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val1"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val2"
                 }
           - [2]: {
                   - computed: ""
@@ -74,9 +80,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
-		"tests[3]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests[3].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/unchanged_empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/unchanged_non-empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/unchanged_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new/unchanged_null.golden
@@ -1,0 +1,11 @@
+tests.testOutput{tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`, pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/added.golden
@@ -27,15 +27,19 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
-      +     [0]: {
-              + computed  : "non-computed-value"
-              + nested    : "value"
-            }
+      ~ tests: [
+          + [0]: {
+                  + computed  : "non-computed-value"
+                  + nested    : "value"
+                }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].computed": map[string]interface{}{},
+		"tests[0].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/added.golden
@@ -1,0 +1,41 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{"value"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-value"
+          + nested   = "value"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + tests: [
+      +     [0]: {
+              + computed  : "non-computed-value"
+              + nested    : "value"
+            }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/added_end.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-val3"
+          + nested   = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [2]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/added_end.golden
@@ -37,6 +37,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val1"
+                    nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val2"
+                    nested    : "val2"
+                }
           + [2]: {
                   + computed  : "non-computed-val3"
                   + nested    : "val3"
@@ -46,5 +56,9 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{},
+		"tests[2].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/added_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/added_end_unordered.golden
@@ -37,14 +37,28 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [0]: {
-                  + computed  : "non-computed-val2"
-                  + nested    : "val2"
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val2"
+                    nested    : "val2"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val3"
+                    nested    : "val3"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val1"
+                  + nested    : "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{},
+		"tests[2].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/added_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/added_end_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-val1"
+          + nested   = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [0]: {
+                  + computed  : "non-computed-val2"
+                  + nested    : "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/added_front.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-val1"
+          + nested   = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [0]: {
+                  + computed  : "non-computed-val1"
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/added_front.golden
@@ -37,14 +37,28 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [0]: {
-                  + computed  : "non-computed-val1"
-                  + nested    : "val1"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val1"
+                  ~ nested    : "val2" => "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val3" => "non-computed-val2"
+                  ~ nested    : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].computed": map[string]interface{}{},
+		"tests[0].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/added_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/added_front_unordered.golden
@@ -37,14 +37,28 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [1]: {
-                  + computed  : "non-computed-val3"
-                  + nested    : "val3"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val2"
+                  ~ nested    : "val1" => "val2"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val3"
+                    nested    : "val3"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val1"
+                  + nested    : "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].computed": map[string]interface{}{},
+		"tests[0].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/added_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/added_front_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-val2"
+          + nested   = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [1]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/added_middle.golden
@@ -37,14 +37,29 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [1]: {
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val1"
+                    nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
                   + computed  : "non-computed-val2"
-                  + nested    : "val2"
+                  + computed  : "non-computed-val2"
+                  ~ nested    : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/added_middle.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-val2"
+          + nested   = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [1]: {
+                  + computed  : "non-computed-val2"
+                  + nested    : "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/added_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/added_middle_unordered.golden
@@ -37,6 +37,17 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val2"
+                  ~ nested    : "val1" => "val2"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  + computed  : "non-computed-val3"
+                  + computed  : "non-computed-val3"
+                  ~ nested    : "val2" => "val3"
+                }
           + [2]: {
                   + computed  : "non-computed-val1"
                   + nested    : "val1"
@@ -46,5 +57,9 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/added_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/added_middle_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-val3"
+          + nested   = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [2]: {
+                  + computed  : "non-computed-val1"
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/changed_empty_to_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/changed_empty_to_null.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/changed_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/changed_non-null.golden
@@ -35,7 +35,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ computed: "non-computed-value" => "non-computed-value1"
+                  + computed: "non-computed-value1"
                   ~ nested  : "value" => "value1"
                 }
         ]
@@ -44,7 +44,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].computed": map[string]interface{}{},
 		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/changed_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/changed_non-null.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-value" -> null
+          - nested   = "value" -> null
+        }
+      + test { # forces replacement
+          + computed = "non-computed-value1"
+          + nested   = "value1"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ computed: "non-computed-value" => "non-computed-value1"
+                  ~ nested  : "value" => "value1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/changed_non-null_to_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/changed_non-null_to_null.golden
@@ -1,0 +1,42 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-value" -> null
+          - nested   = "value" -> null
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      - tests: [
+      -     [0]: {
+              - computed: "non-computed-value"
+              - nested  : "value"
+            }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/changed_non-null_to_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/changed_non-null_to_null.golden
@@ -34,9 +34,18 @@ Plan: 1 to add, 0 to change, 1 to destroy.
               - nested  : "value"
             }
         ]
+      - tests: [
+      -     [0]: {
+              - computed: "non-computed-value"
+              - nested  : "value"
+            }
+        ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/changed_null_to_empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/changed_null_to_empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/changed_null_to_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/changed_null_to_non-null.golden
@@ -1,0 +1,42 @@
+tests.testOutput{
+	changeValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-value"
+          + nested   = "value"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + tests: [
+      +     [0]: {
+              + computed  : "non-computed-value"
+              + nested    : "value"
+            }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/changed_null_to_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/changed_null_to_non-null.golden
@@ -28,15 +28,19 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
-      +     [0]: {
-              + computed  : "non-computed-value"
-              + nested    : "value"
-            }
+      ~ tests: [
+          + [0]: {
+                  + computed  : "non-computed-value"
+                  + nested    : "value"
+                }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].computed": map[string]interface{}{},
+		"tests[0].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/removed.golden
@@ -1,0 +1,43 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-value" -> null
+          - nested   = "value" -> null
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      - tests: [
+      -     [0]: {
+              - computed: "non-computed-value"
+              - nested  : "value"
+            }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/removed.golden
@@ -29,15 +29,18 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - tests: [
-      -     [0]: {
-              - computed: "non-computed-value"
-              - nested  : "value"
-            }
+      ~ tests: [
+          - [0]: {
+                  - computed: "non-computed-value"
+                  - nested  : "value"
+                }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/removed_end.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/removed_end.golden
@@ -37,6 +37,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val1"
+                    nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val2"
+                    nested    : "val2"
+                }
           - [2]: {
                   - computed: "non-computed-val3"
                   - nested  : "val3"
@@ -46,5 +56,8 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/removed_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/removed_end_unordered.golden
@@ -37,14 +37,27 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [0]: {
-                  - computed: "non-computed-val1"
-                  - nested  : "val1"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val2"
+                  ~ nested    : "val1" => "val2"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val3"
+                  ~ nested    : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/removed_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/removed_end_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [0]: {
+                  - computed: "non-computed-val1"
+                  - nested  : "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/removed_front.golden
@@ -37,14 +37,28 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [0]: {
-                  - computed: "non-computed-val1"
-                  - nested  : "val1"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val2"
+                  - nested    : "val1"
+                  - nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val3"
+                  ~ nested    : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/removed_front.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [0]: {
+                  - computed: "non-computed-val1"
+                  - nested  : "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/removed_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/removed_front_unordered.golden
@@ -37,14 +37,27 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val3"
+                  ~ nested    : "val1" => "val3"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val1"
+                  ~ nested    : "val2" => "val1"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/removed_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/removed_front_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: {
+                  - computed: "non-computed-val2"
+                  - nested  : "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/removed_middle.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: {
+                  - computed: "non-computed-val2"
+                  - nested  : "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/removed_middle.golden
@@ -37,14 +37,27 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val1"
+                    nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val3"
+                  ~ nested    : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/removed_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/removed_middle_unordered.golden
@@ -37,14 +37,28 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val3"
+                  ~ nested    : "val1" => "val3"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val1"
+                  - nested    : "val2"
+                  - nested    : "val2"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/removed_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/removed_middle_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: {
+                  - computed: "non-computed-val2"
+                  - nested  : "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/same_element_updated.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/same_element_updated.golden
@@ -1,0 +1,62 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val4",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+      + test { # forces replacement
+          + computed = "non-computed-val4"
+          + nested   = "val4"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: {
+                  - computed: "non-computed-val2"
+                  - nested  : "val2"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/same_element_updated.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/same_element_updated.golden
@@ -42,13 +42,9 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
-                }
-          + [2]: {
-                  + computed  : "non-computed-val3"
-                  + nested    : "val3"
+          ~ [1]: {
+                  + computed: "non-computed-val4"
+                  ~ nested  : "val2" => "val4"
                 }
         ]
 Resources:
@@ -56,7 +52,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"},
-		"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/same_element_updated_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/same_element_updated_unordered.golden
@@ -1,0 +1,58 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val4",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      + test { # forces replacement
+          + computed = "non-computed-val4"
+          + nested   = "val4"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [2]: {
+                  ~ computed: "non-computed-val3" => "non-computed-val1"
+                  ~ nested  : "val3" => "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/same_element_updated_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/same_element_updated_unordered.golden
@@ -42,9 +42,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [1]: {
+                  + computed: "non-computed-val4"
+                  + nested  : "val4"
+                }
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val1"
-                  ~ nested  : "val3" => "val1"
+                  - nested: "val3"
                 }
         ]
 Resources:
@@ -52,7 +55,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/shuffled.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/shuffled.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/shuffled_added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/shuffled_added_end.golden
@@ -37,6 +37,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val2"
+                  ~ nested    : "val1" => "val2"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val1"
+                  ~ nested    : "val2" => "val1"
+                }
           + [2]: {
                   + computed  : "non-computed-val3"
                   + nested    : "val3"
@@ -46,5 +56,9 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{},
+		"tests[2].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/shuffled_added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/shuffled_added_end.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-val3"
+          + nested   = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [2]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/shuffled_added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/shuffled_added_front.golden
@@ -37,14 +37,29 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [0]: {
+          ~ [0]: {
+                  + __defaults: []
                   + computed  : "non-computed-val1"
-                  + nested    : "val1"
+                  + computed  : "non-computed-val1"
+                  ~ nested    : "val2" => "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val3"
+                    nested    : "val3"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val2"
+                  + nested    : "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].computed": map[string]interface{}{},
+		"tests[0].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/shuffled_added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/shuffled_added_front.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-val1"
+          + nested   = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [0]: {
+                  + computed  : "non-computed-val1"
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/shuffled_added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/shuffled_added_middle.golden
@@ -37,14 +37,30 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [1]: {
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val3"
+                  ~ nested    : "val1" => "val3"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  + computed  : "non-computed-val2"
                   + computed  : "non-computed-val2"
                   + nested    : "val2"
+                  + nested    : "val2"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val1"
+                  + nested    : "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/shuffled_added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/shuffled_added_middle.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-val2"
+          + nested   = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [1]: {
+                  + computed  : "non-computed-val2"
+                  + nested    : "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/shuffled_removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/shuffled_removed_end.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/shuffled_removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/shuffled_removed_end.golden
@@ -37,6 +37,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val2"
+                  ~ nested    : "val1" => "val2"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val1"
+                  ~ nested    : "val2" => "val1"
+                }
           - [2]: {
                   - computed: "non-computed-val3"
                   - nested  : "val3"
@@ -46,5 +56,8 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/shuffled_removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/shuffled_removed_front.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [0]: {
+                  - computed: "non-computed-val1"
+                  - nested  : "val1"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/shuffled_removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/shuffled_removed_front.golden
@@ -37,14 +37,27 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [0]: {
-                  - computed: "non-computed-val1"
-                  - nested  : "val1"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val3"
+                  ~ nested    : "val1" => "val3"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val2"
+                    nested    : "val2"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/shuffled_removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/shuffled_removed_middle.golden
@@ -37,14 +37,27 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val3"
+                  ~ nested    : "val1" => "val3"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val1"
+                  ~ nested    : "val2" => "val1"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/shuffled_removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/shuffled_removed_middle.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: {
+                  - computed: "non-computed-val2"
+                  - nested  : "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/shuffled_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/shuffled_unordered.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/shuffled_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/shuffled_with_duplicates.golden
@@ -1,0 +1,25 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/shuffled_with_duplicates_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/shuffled_with_duplicates_unordered.golden
@@ -1,0 +1,25 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/two_added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/two_added.golden
@@ -42,6 +42,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val1"
+                    nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val2"
+                    nested    : "val2"
+                }
           + [2]: {
                   + computed  : "non-computed-val3"
                   + nested    : "val3"
@@ -56,7 +66,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[3]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{},
+		"tests[2].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[3].computed": map[string]interface{}{},
+		"tests[3].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/two_added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/two_added.golden
@@ -1,0 +1,62 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      + test { # forces replacement
+          + computed = "non-computed-val3"
+          + nested   = "val3"
+        }
+      + test { # forces replacement
+          + computed = "non-computed-val4"
+          + nested   = "val4"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [2]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
+                }
+          + [3]: {
+                  + computed  : "non-computed-val4"
+                  + nested    : "val4"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[3]": map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/two_added_and_two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/two_added_and_two_removed.golden
@@ -53,11 +53,11 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val5"
+                  + computed: "non-computed-val5"
                   ~ nested  : "val3" => "val5"
                 }
           ~ [3]: {
-                  ~ computed: "non-computed-val4" => "non-computed-val6"
+                  + computed: "non-computed-val6"
                   ~ nested  : "val4" => "val6"
                 }
         ]
@@ -66,9 +66,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{},
 		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].computed": map[string]interface{}{},
 		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/two_added_and_two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/two_added_and_two_removed.golden
@@ -1,0 +1,74 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val5",
+		"val6",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      - test { # forces replacement
+          - computed = "non-computed-val4" -> null
+          - nested   = "val4" -> null
+        }
+      + test { # forces replacement
+          + computed = "non-computed-val5"
+          + nested   = "val5"
+        }
+      + test { # forces replacement
+          + computed = "non-computed-val6"
+          + nested   = "val6"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [2]: {
+                  ~ computed: "non-computed-val3" => "non-computed-val5"
+                  ~ nested  : "val3" => "val5"
+                }
+          ~ [3]: {
+                  ~ computed: "non-computed-val4" => "non-computed-val6"
+                  ~ nested  : "val4" => "val6"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -52,13 +52,19 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + computed: "non-computed-val5"
+                  + nested  : "val5"
+                }
+          ~ [1]: {
+                  + computed: "non-computed-val6"
+                  + nested  : "val6"
+                }
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val1"
-                  ~ nested  : "val3" => "val1"
+                  - nested: "val3"
                 }
           ~ [3]: {
-                  ~ computed: "non-computed-val4" => "non-computed-val2"
-                  ~ nested  : "val4" => "val2"
+                  - nested: "val4"
                 }
         ]
 Resources:
@@ -66,9 +72,11 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[0].computed": map[string]interface{}{},
+		"tests[0].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -1,0 +1,74 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val5",
+		"val6",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      - test { # forces replacement
+          - computed = "non-computed-val4" -> null
+          - nested   = "val4" -> null
+        }
+      + test { # forces replacement
+          + computed = "non-computed-val5"
+          + nested   = "val5"
+        }
+      + test { # forces replacement
+          + computed = "non-computed-val6"
+          + nested   = "val6"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [2]: {
+                  ~ computed: "non-computed-val3" => "non-computed-val1"
+                  ~ nested  : "val3" => "val1"
+                }
+          ~ [3]: {
+                  ~ computed: "non-computed-val4" => "non-computed-val2"
+                  ~ nested  : "val4" => "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -52,13 +52,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [1]: {
+                  + computed: "non-computed-val5"
+                  + nested  : "val5"
+                }
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val6"
+                  + computed: "non-computed-val6"
                   ~ nested  : "val3" => "val6"
                 }
           ~ [3]: {
-                  ~ computed: "non-computed-val4" => "non-computed-val2"
-                  ~ nested  : "val4" => "val2"
+                  - nested: "val4"
                 }
         ]
 Resources:
@@ -66,9 +69,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[2].computed": map[string]interface{}{},
 		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -1,0 +1,74 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val5",
+		"val6",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      - test { # forces replacement
+          - computed = "non-computed-val4" -> null
+          - nested   = "val4" -> null
+        }
+      + test { # forces replacement
+          + computed = "non-computed-val5"
+          + nested   = "val5"
+        }
+      + test { # forces replacement
+          + computed = "non-computed-val6"
+          + nested   = "val6"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [2]: {
+                  ~ computed: "non-computed-val3" => "non-computed-val6"
+                  ~ nested  : "val3" => "val6"
+                }
+          ~ [3]: {
+                  ~ computed: "non-computed-val4" => "non-computed-val2"
+                  ~ nested  : "val4" => "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -54,13 +54,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [1]: {
+                  + computed: "non-computed-val5"
+                  + nested  : "val5"
+                }
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val6"
+                  + computed: "non-computed-val6"
                   ~ nested  : "val3" => "val6"
                 }
           ~ [3]: {
-                  ~ computed: "non-computed-val4" => "non-computed-val2"
-                  ~ nested  : "val4" => "val2"
+                  - nested: "val4"
                 }
         ]
 Resources:
@@ -68,9 +71,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[2].computed": map[string]interface{}{},
 		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -1,0 +1,76 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val5",
+		"val6",
+		"val2",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      - test { # forces replacement
+          - computed = "non-computed-val4" -> null
+          - nested   = "val4" -> null
+        }
+      + test { # forces replacement
+          + computed = "non-computed-val5"
+          + nested   = "val5"
+        }
+      + test { # forces replacement
+          + computed = "non-computed-val6"
+          + nested   = "val6"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [2]: {
+                  ~ computed: "non-computed-val3" => "non-computed-val6"
+                  ~ nested  : "val3" => "val6"
+                }
+          ~ [3]: {
+                  ~ computed: "non-computed-val4" => "non-computed-val2"
+                  ~ nested  : "val4" => "val2"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/two_removed.golden
@@ -1,0 +1,62 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "id" -> (known after apply)
+
+      - test { # forces replacement
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      - test { # forces replacement
+          - computed = "non-computed-val4" -> null
+          - nested   = "val4" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+          - [3]: {
+                  - computed: "non-computed-val4"
+                  - nested  : "val4"
+                }
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/two_removed.golden
@@ -42,6 +42,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val1"
+                    nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val2"
+                    nested    : "val2"
+                }
           - [2]: {
                   - computed: "non-computed-val3"
                   - nested  : "val3"
@@ -56,7 +66,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests[3].nested": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/unchanged_empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/unchanged_non-empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/unchanged_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_and_nested_force_new_computed_specified_in_program/unchanged_null.golden
@@ -1,0 +1,11 @@
+tests.testOutput{tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`, pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/added.golden
@@ -27,14 +27,17 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
-      +     [0]: {
-              + nested    : "value"
-            }
+      ~ tests: [
+          + [0]: {
+                  + nested    : "value"
+                }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/added.golden
@@ -1,0 +1,40 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{"value"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      + test {
+          + computed = (known after apply)
+          + nested   = "value"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + tests: [
+      +     [0]: {
+              + nested    : "value"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/added_end.golden
@@ -52,8 +52,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val1"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val2"
                 }
           + [2]: {
                   + nested    : "val3"
@@ -64,8 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/added_end.golden
@@ -1,0 +1,71 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          + [2]: {
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/added_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/added_end_unordered.golden
@@ -52,10 +52,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "val2" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val3"
                 }
           + [2]: {
                   + nested    : "val1"
@@ -66,10 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/added_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/added_end_unordered.golden
@@ -1,0 +1,75 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "val2" => "val2"
+                }
+          ~ [1]: {
+                  ~ nested  : "val3" => "val3"
+                }
+          + [2]: {
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/added_front.golden
@@ -52,10 +52,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "val2" => "val1"
+                  + __defaults: []
+                  - computed  : ""
+                  + nested    : "val1"
+                  + nested    : "val1"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val3" => "val2"
                 }
           + [2]: {
                   + nested    : "val3"
@@ -66,10 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/added_front.golden
@@ -1,0 +1,75 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "val2" => "val1"
+                }
+          ~ [1]: {
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/added_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/added_front_unordered.golden
@@ -1,0 +1,73 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val3" => "val3"
+                }
+          + [2]: {
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/added_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/added_front_unordered.golden
@@ -52,9 +52,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  + nested    : "val2"
+                  + nested    : "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val3"
                 }
           + [2]: {
                   + nested    : "val1"
@@ -65,9 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/added_middle.golden
@@ -52,9 +52,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val1"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val3" => "val2"
                 }
           + [2]: {
                   + nested    : "val3"
@@ -65,9 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/added_middle.golden
@@ -1,0 +1,73 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/added_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/added_middle_unordered.golden
@@ -1,0 +1,71 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          + [2]: {
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/added_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/added_middle_unordered.golden
@@ -52,8 +52,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val2"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val3"
                 }
           + [2]: {
                   + nested    : "val1"
@@ -64,8 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/changed_empty_to_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/changed_empty_to_null.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/changed_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/changed_non-null.golden
@@ -1,0 +1,49 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "value" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "value1"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "value" => "value1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/changed_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/changed_non-null.golden
@@ -35,15 +35,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "value" => "value1"
+                  ~ nested: "value" => "value1"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-	},
+	detailedDiff: map[string]interface{}{"tests[0].nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/changed_non-null_to_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/changed_non-null_to_null.golden
@@ -1,0 +1,42 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "value" -> null
+            # (1 unchanged attribute hidden)
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      - tests: [
+      -     [0]: {
+              - computed: ""
+              - nested  : "value"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/changed_non-null_to_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/changed_non-null_to_null.golden
@@ -34,9 +34,18 @@ Plan: 0 to add, 1 to change, 0 to destroy.
               - nested  : "value"
             }
         ]
+      - tests: [
+      -     [0]: {
+              - computed: ""
+              - nested  : "value"
+            }
+        ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/changed_null_to_empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/changed_null_to_empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/changed_null_to_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/changed_null_to_non-null.golden
@@ -28,14 +28,17 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
-      +     [0]: {
-              + nested    : "value"
-            }
+      ~ tests: [
+          + [0]: {
+                  + nested    : "value"
+                }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/changed_null_to_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/changed_null_to_non-null.golden
@@ -1,0 +1,41 @@
+tests.testOutput{
+	changeValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      + test {
+          + computed = (known after apply)
+          + nested   = "value"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + tests: [
+      +     [0]: {
+              + nested    : "value"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/removed.golden
@@ -29,15 +29,18 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - tests: [
-      -     [0]: {
-              - computed: ""
-              - nested  : "value"
-            }
+      ~ tests: [
+          - [0]: {
+                  - computed: ""
+                  - nested  : "value"
+                }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/removed.golden
@@ -1,0 +1,43 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "value" -> null
+            # (1 unchanged attribute hidden)
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      - tests: [
+      -     [0]: {
+              - computed: ""
+              - nested  : "value"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/removed_end.golden
@@ -1,0 +1,72 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/removed_end.golden
@@ -52,8 +52,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val1"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val2"
                 }
           - [2]: {
                   - computed: ""
@@ -65,8 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/removed_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/removed_end_unordered.golden
@@ -1,0 +1,76 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/removed_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/removed_end_unordered.golden
@@ -52,10 +52,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                  - nested    : "val1"
+                  - nested    : "val1"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val3"
                 }
           - [2]: {
                   - computed: ""
@@ -67,10 +72,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/removed_front.golden
@@ -52,10 +52,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val3"
                 }
           - [2]: {
                   - computed: ""
@@ -67,10 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/removed_front.golden
@@ -1,0 +1,76 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/removed_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/removed_front_unordered.golden
@@ -1,0 +1,74 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val1"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/removed_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/removed_front_unordered.golden
@@ -52,9 +52,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val1"
                 }
           - [2]: {
                   - computed: ""
@@ -66,9 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/removed_middle.golden
@@ -1,0 +1,74 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/removed_middle.golden
@@ -52,9 +52,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val1"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val3"
                 }
           - [2]: {
                   - computed: ""
@@ -66,9 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/removed_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/removed_middle_unordered.golden
@@ -1,0 +1,74 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val1"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/removed_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/removed_middle_unordered.golden
@@ -52,9 +52,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val1"
                 }
           - [2]: {
                   - computed: ""
@@ -66,9 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/same_element_updated.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/same_element_updated.golden
@@ -56,24 +56,13 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          ~ [0]: {
-                }
           ~ [1]: {
-                  ~ nested  : "val2" => "val4"
-                }
-          ~ [2]: {
-                  ~ nested  : "val3" => "val3"
+                  ~ nested: "val2" => "val4"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-	},
+	detailedDiff: map[string]interface{}{"tests[1].nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/same_element_updated.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/same_element_updated.golden
@@ -1,0 +1,79 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val4",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val4"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val4"
+                }
+          ~ [2]: {
+                  ~ nested  : "val3" => "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/same_element_updated_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/same_element_updated_unordered.golden
@@ -56,12 +56,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          ~ [0]: {
-                }
           ~ [1]: {
+                  + nested: "val4"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val1"
+                  - nested: "val3"
                 }
         ]
 Resources:
@@ -69,9 +68,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/same_element_updated_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/same_element_updated_unordered.golden
@@ -1,0 +1,77 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val4",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val4"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          ~ [2]: {
+                  ~ nested  : "val3" => "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/shuffled.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/shuffled.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/shuffled_added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/shuffled_added_end.golden
@@ -1,0 +1,71 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          + [2]: {
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/shuffled_added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/shuffled_added_end.golden
@@ -52,8 +52,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val2"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val1"
                 }
           + [2]: {
                   + nested    : "val3"
@@ -64,8 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/shuffled_added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/shuffled_added_front.golden
@@ -52,10 +52,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "val2" => "val1"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val1"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val3"
                 }
           + [2]: {
                   + nested    : "val2"
@@ -66,10 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/shuffled_added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/shuffled_added_front.golden
@@ -1,0 +1,75 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "val2" => "val1"
+                }
+          ~ [1]: {
+                  ~ nested  : "val3" => "val3"
+                }
+          + [2]: {
+                  + nested    : "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/shuffled_added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/shuffled_added_middle.golden
@@ -1,0 +1,73 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val3" => "val2"
+                }
+          + [2]: {
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/shuffled_added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/shuffled_added_middle.golden
@@ -52,9 +52,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val3" => "val2"
                 }
           + [2]: {
                   + nested    : "val1"
@@ -65,9 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/shuffled_removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/shuffled_removed_end.golden
@@ -52,8 +52,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val2"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val1"
                 }
           - [2]: {
                   - computed: ""
@@ -65,8 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/shuffled_removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/shuffled_removed_end.golden
@@ -1,0 +1,72 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/shuffled_removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/shuffled_removed_front.golden
@@ -1,0 +1,76 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested  : "val1" => "val3"
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val2"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/shuffled_removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/shuffled_removed_front.golden
@@ -52,10 +52,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val3"
+                  + __defaults: []
+                  - computed  : ""
+                  - nested    : "val1"
+                  - nested    : "val1"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val2"
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val2"
                 }
           - [2]: {
                   - computed: ""
@@ -67,10 +72,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/shuffled_removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/shuffled_removed_middle.golden
@@ -1,0 +1,74 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                  ~ nested  : "val2" => "val1"
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/shuffled_removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/shuffled_removed_middle.golden
@@ -52,9 +52,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  + __defaults: []
+                  - computed  : ""
+                  ~ nested    : "val2" => "val1"
                 }
           - [2]: {
                   - computed: ""
@@ -66,9 +71,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/shuffled_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/shuffled_unordered.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/shuffled_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/shuffled_with_duplicates.golden
@@ -1,0 +1,25 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/shuffled_with_duplicates_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/shuffled_with_duplicates_unordered.golden
@@ -1,0 +1,25 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/two_added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/two_added.golden
@@ -57,8 +57,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val1"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val2"
                 }
           + [2]: {
                   + nested    : "val3"
@@ -72,9 +78,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{},
-		"tests[3]":          map[string]interface{}{},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{},
+		"tests[3].nested": map[string]interface{}{},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/two_added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/two_added.golden
@@ -1,0 +1,80 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val3"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val4"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          + [2]: {
+                  + nested    : "val3"
+                }
+          + [3]: {
+                  + nested    : "val4"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{},
+		"tests[3]":          map[string]interface{}{},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/two_added_and_two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/two_added_and_two_removed.golden
@@ -1,0 +1,92 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val5",
+		"val6",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val4" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val5"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val6"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          ~ [2]: {
+                  ~ nested  : "val3" => "val5"
+                }
+          ~ [3]: {
+                  ~ nested  : "val4" => "val6"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/two_added_and_two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/two_added_and_two_removed.golden
@@ -66,15 +66,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           ~ [2]: {
-                  ~ nested  : "val3" => "val5"
+                  ~ nested: "val3" => "val5"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val6"
+                  ~ nested: "val4" => "val6"
                 }
         ]
 Resources:
@@ -82,11 +78,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -1,0 +1,92 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val5",
+		"val6",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val4" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val5"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val6"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          ~ [2]: {
+                  ~ nested  : "val3" => "val1"
+                }
+          ~ [3]: {
+                  ~ nested  : "val4" => "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -67,14 +67,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + nested: "val5"
                 }
           ~ [1]: {
+                  + nested: "val6"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val1"
+                  - nested: "val3"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val2"
+                  - nested: "val4"
                 }
         ]
 Resources:
@@ -82,11 +84,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{},
+		"tests[1].nested": map[string]interface{}{},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE"},
+		"tests[3].nested": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -66,15 +66,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          ~ [0]: {
-                }
           ~ [1]: {
+                  + nested: "val5"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val6"
+                  ~ nested: "val3" => "val6"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val2"
+                  - nested: "val4"
                 }
         ]
 Resources:
@@ -82,11 +81,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{},
+		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -1,0 +1,92 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val5",
+		"val6",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val4" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val5"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val6"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          ~ [2]: {
+                  ~ nested  : "val3" => "val6"
+                }
+          ~ [3]: {
+                  ~ nested  : "val4" => "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -1,0 +1,94 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val5",
+		"val6",
+		"val2",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val4" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val5"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val6"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          ~ [2]: {
+                  ~ nested  : "val3" => "val6"
+                }
+          ~ [3]: {
+                  ~ nested  : "val4" => "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -68,15 +68,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          ~ [0]: {
-                }
           ~ [1]: {
+                  + nested: "val5"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val6"
+                  ~ nested: "val3" => "val6"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val2"
+                  - nested: "val4"
                 }
         ]
 Resources:
@@ -84,11 +83,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{},
+		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/two_removed.golden
@@ -1,0 +1,82 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - nested   = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - test {
+          - nested   = "val4" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val1"
+        }
+      + test {
+          + computed = (known after apply)
+          + nested   = "val2"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                }
+          ~ [1]: {
+                }
+          - [2]: {
+                  - computed: ""
+                  - nested  : "val3"
+                }
+          - [3]: {
+                  - computed: ""
+                  - nested  : "val4"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+		"tests[3]":          map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/two_removed.golden
@@ -57,8 +57,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val1"
                 }
           ~ [1]: {
+                  + __defaults: []
+                  - computed  : ""
+                    nested    : "val2"
                 }
           - [2]: {
                   - computed: ""
@@ -74,9 +80,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
-		"tests[3]":          map[string]interface{}{"kind": "DELETE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE"},
+		"tests[3].nested": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/unchanged_empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/unchanged_non-empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/unchanged_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace/unchanged_null.golden
@@ -1,0 +1,11 @@
+tests.testOutput{tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`, pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/added.golden
@@ -27,15 +27,19 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
-      +     [0]: {
-              + computed  : "non-computed-value"
-              + nested    : "value"
-            }
+      ~ tests: [
+          + [0]: {
+                  + computed  : "non-computed-value"
+                  + nested    : "value"
+                }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].computed": map[string]interface{}{},
+		"tests[0].nested":   map[string]interface{}{},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/added.golden
@@ -1,0 +1,41 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{"value"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      + test {
+          + computed = "non-computed-value"
+          + nested   = "value"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + tests: [
+      +     [0]: {
+              + computed  : "non-computed-value"
+              + nested    : "value"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/added_end.golden
@@ -37,6 +37,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val1"
+                    nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val2"
+                    nested    : "val2"
+                }
           + [2]: {
                   + computed  : "non-computed-val3"
                   + nested    : "val3"
@@ -46,5 +56,9 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{},
+		"tests[2].nested":   map[string]interface{}{},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/added_end.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      + test {
+          + computed = "non-computed-val3"
+          + nested   = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [2]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/added_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/added_end_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      + test {
+          + computed = "non-computed-val1"
+          + nested   = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [0]: {
+                  + computed  : "non-computed-val2"
+                  + nested    : "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/added_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/added_end_unordered.golden
@@ -37,14 +37,28 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [0]: {
-                  + computed  : "non-computed-val2"
-                  + nested    : "val2"
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val2"
+                    nested    : "val2"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val3"
+                    nested    : "val3"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val1"
+                  + nested    : "val1"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{},
+		"tests[2].nested":   map[string]interface{}{},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/added_front.golden
@@ -37,14 +37,28 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [0]: {
-                  + computed  : "non-computed-val1"
-                  + nested    : "val1"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val1"
+                  ~ nested    : "val2" => "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val3" => "non-computed-val2"
+                  ~ nested    : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].computed": map[string]interface{}{},
+		"tests[0].nested":   map[string]interface{}{},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/added_front.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      + test {
+          + computed = "non-computed-val1"
+          + nested   = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [0]: {
+                  + computed  : "non-computed-val1"
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/added_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/added_front_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      + test {
+          + computed = "non-computed-val2"
+          + nested   = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [1]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/added_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/added_front_unordered.golden
@@ -37,14 +37,30 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [1]: {
-                  + computed  : "non-computed-val3"
-                  + nested    : "val3"
+          ~ [0]: {
+                  + __defaults: []
+                  + computed  : "non-computed-val2"
+                  + computed  : "non-computed-val2"
+                  + nested    : "val2"
+                  + nested    : "val2"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val3"
+                    nested    : "val3"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val1"
+                  + nested    : "val1"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].computed": map[string]interface{}{},
+		"tests[0].nested":   map[string]interface{}{},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/added_middle.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      + test {
+          + computed = "non-computed-val2"
+          + nested   = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [1]: {
+                  + computed  : "non-computed-val2"
+                  + nested    : "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/added_middle.golden
@@ -37,14 +37,29 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [1]: {
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val1"
+                    nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
                   + computed  : "non-computed-val2"
-                  + nested    : "val2"
+                  + computed  : "non-computed-val2"
+                  ~ nested    : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/added_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/added_middle_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      + test {
+          + computed = "non-computed-val3"
+          + nested   = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [2]: {
+                  + computed  : "non-computed-val1"
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/added_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/added_middle_unordered.golden
@@ -37,6 +37,17 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val2"
+                  ~ nested    : "val1" => "val2"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  + computed  : "non-computed-val3"
+                  + computed  : "non-computed-val3"
+                  ~ nested    : "val2" => "val3"
+                }
           + [2]: {
                   + computed  : "non-computed-val1"
                   + nested    : "val1"
@@ -46,5 +57,9 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/changed_empty_to_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/changed_empty_to_null.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/changed_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/changed_non-null.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - computed = "non-computed-value" -> null
+          - nested   = "value" -> null
+        }
+      + test {
+          + computed = "non-computed-value1"
+          + nested   = "value1"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ computed: "non-computed-value" => "non-computed-value1"
+                  ~ nested  : "value" => "value1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/changed_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/changed_non-null.golden
@@ -35,7 +35,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [0]: {
-                  ~ computed: "non-computed-value" => "non-computed-value1"
+                  + computed: "non-computed-value1"
                   ~ nested  : "value" => "value1"
                 }
         ]
@@ -44,7 +44,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].computed": map[string]interface{}{},
 		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/changed_non-null_to_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/changed_non-null_to_null.golden
@@ -1,0 +1,42 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - computed = "non-computed-value" -> null
+          - nested   = "value" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      - tests: [
+      -     [0]: {
+              - computed: "non-computed-value"
+              - nested  : "value"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/changed_non-null_to_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/changed_non-null_to_null.golden
@@ -34,9 +34,18 @@ Plan: 0 to add, 1 to change, 0 to destroy.
               - nested  : "value"
             }
         ]
+      - tests: [
+      -     [0]: {
+              - computed: "non-computed-value"
+              - nested  : "value"
+            }
+        ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/changed_null_to_empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/changed_null_to_empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/changed_null_to_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/changed_null_to_non-null.golden
@@ -1,0 +1,42 @@
+tests.testOutput{
+	changeValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      + test {
+          + computed = "non-computed-value"
+          + nested   = "value"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + tests: [
+      +     [0]: {
+              + computed  : "non-computed-value"
+              + nested    : "value"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/changed_null_to_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/changed_null_to_non-null.golden
@@ -28,15 +28,19 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
-      +     [0]: {
-              + computed  : "non-computed-value"
-              + nested    : "value"
-            }
+      ~ tests: [
+          + [0]: {
+                  + computed  : "non-computed-value"
+                  + nested    : "value"
+                }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].computed": map[string]interface{}{},
+		"tests[0].nested":   map[string]interface{}{},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/removed.golden
@@ -29,15 +29,18 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - tests: [
-      -     [0]: {
-              - computed: "non-computed-value"
-              - nested  : "value"
-            }
+      ~ tests: [
+          - [0]: {
+                  - computed: "non-computed-value"
+                  - nested  : "value"
+                }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/removed.golden
@@ -1,0 +1,43 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - computed = "non-computed-value" -> null
+          - nested   = "value" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      - tests: [
+      -     [0]: {
+              - computed: "non-computed-value"
+              - nested  : "value"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/removed_end.golden
@@ -37,6 +37,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val1"
+                    nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val2"
+                    nested    : "val2"
+                }
           - [2]: {
                   - computed: "non-computed-val3"
                   - nested  : "val3"
@@ -46,5 +56,8 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/removed_end.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/removed_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/removed_end_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - computed = "non-computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [0]: {
+                  - computed: "non-computed-val1"
+                  - nested  : "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/removed_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/removed_end_unordered.golden
@@ -37,14 +37,27 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [0]: {
-                  - computed: "non-computed-val1"
-                  - nested  : "val1"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val2"
+                  ~ nested    : "val1" => "val2"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val3"
+                  ~ nested    : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/removed_front.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - computed = "non-computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [0]: {
+                  - computed: "non-computed-val1"
+                  - nested  : "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/removed_front.golden
@@ -37,14 +37,27 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [0]: {
-                  - computed: "non-computed-val1"
-                  - nested  : "val1"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val2"
+                  ~ nested    : "val1" => "val2"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val3"
+                  ~ nested    : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/removed_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/removed_front_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: {
+                  - computed: "non-computed-val2"
+                  - nested  : "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/removed_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/removed_front_unordered.golden
@@ -37,14 +37,28 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val3"
+                  ~ nested    : "val1" => "val3"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val1"
+                  - nested    : "val2"
+                  - nested    : "val2"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/removed_middle.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: {
+                  - computed: "non-computed-val2"
+                  - nested  : "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/removed_middle.golden
@@ -37,14 +37,27 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val1"
+                    nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val3"
+                  ~ nested    : "val2" => "val3"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/removed_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/removed_middle_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: {
+                  - computed: "non-computed-val2"
+                  - nested  : "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/removed_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/removed_middle_unordered.golden
@@ -37,14 +37,27 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val3"
+                  ~ nested    : "val1" => "val3"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val1"
+                  ~ nested    : "val2" => "val1"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/same_element_updated.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/same_element_updated.golden
@@ -42,13 +42,9 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
-                }
-          + [2]: {
-                  + computed  : "non-computed-val3"
-                  + nested    : "val3"
+          ~ [1]: {
+                  + computed: "non-computed-val4"
+                  ~ nested  : "val2" => "val4"
                 }
         ]
 Resources:
@@ -56,7 +52,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]": map[string]interface{}{"kind": "DELETE"},
-		"tests[2]": map[string]interface{}{},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/same_element_updated.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/same_element_updated.golden
@@ -1,0 +1,62 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val4",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+      + test {
+          + computed = "non-computed-val4"
+          + nested   = "val4"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: {
+                  - computed: "non-computed-val2"
+                  - nested  : "val2"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[1]": map[string]interface{}{"kind": "DELETE"},
+		"tests[2]": map[string]interface{}{},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/same_element_updated_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/same_element_updated_unordered.golden
@@ -1,0 +1,58 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val4",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      + test {
+          + computed = "non-computed-val4"
+          + nested   = "val4"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [2]: {
+                  ~ computed: "non-computed-val3" => "non-computed-val1"
+                  ~ nested  : "val3" => "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/same_element_updated_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/same_element_updated_unordered.golden
@@ -42,9 +42,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [1]: {
+                  + computed: "non-computed-val4"
+                  + nested  : "val4"
+                }
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val1"
-                  ~ nested  : "val3" => "val1"
+                  - nested: "val3"
                 }
         ]
 Resources:
@@ -52,7 +55,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{},
+		"tests[2].nested":   map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_added_end.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      + test {
+          + computed = "non-computed-val3"
+          + nested   = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [2]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_added_end.golden
@@ -37,6 +37,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val2"
+                  ~ nested    : "val1" => "val2"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val1"
+                  ~ nested    : "val2" => "val1"
+                }
           + [2]: {
                   + computed  : "non-computed-val3"
                   + nested    : "val3"
@@ -46,5 +56,9 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{},
+		"tests[2].nested":   map[string]interface{}{},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_added_front.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      + test {
+          + computed = "non-computed-val1"
+          + nested   = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [0]: {
+                  + computed  : "non-computed-val1"
+                  + nested    : "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_added_front.golden
@@ -37,14 +37,28 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [0]: {
-                  + computed  : "non-computed-val1"
-                  + nested    : "val1"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val1"
+                  ~ nested    : "val2" => "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val3"
+                    nested    : "val3"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val2"
+                  + nested    : "val2"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].computed": map[string]interface{}{},
+		"tests[0].nested":   map[string]interface{}{},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_added_middle.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      + test {
+          + computed = "non-computed-val2"
+          + nested   = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [1]: {
+                  + computed  : "non-computed-val2"
+                  + nested    : "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_added_middle.golden
@@ -37,14 +37,28 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [1]: {
-                  + computed  : "non-computed-val2"
-                  + nested    : "val2"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val3"
+                  ~ nested    : "val1" => "val3"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val3" => "non-computed-val2"
+                  ~ nested    : "val3" => "val2"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val1"
+                  + nested    : "val1"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_removed_end.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_removed_end.golden
@@ -37,6 +37,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val2"
+                  ~ nested    : "val1" => "val2"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val1"
+                  ~ nested    : "val2" => "val1"
+                }
           - [2]: {
                   - computed: "non-computed-val3"
                   - nested  : "val3"
@@ -46,5 +56,8 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_removed_front.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - computed = "non-computed-val1" -> null
+          - nested   = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [0]: {
+                  - computed: "non-computed-val1"
+                  - nested  : "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_removed_front.golden
@@ -37,14 +37,27 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [0]: {
-                  - computed: "non-computed-val1"
-                  - nested  : "val1"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val3"
+                  ~ nested    : "val1" => "val3"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val2"
+                    nested    : "val2"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].nested": map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_removed_middle.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - computed = "non-computed-val2" -> null
+          - nested   = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: {
+                  - computed: "non-computed-val2"
+                  - nested  : "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_removed_middle.golden
@@ -37,14 +37,28 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+          ~ [0]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val1" => "non-computed-val3"
+                  ~ nested    : "val1" => "val3"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                  ~ computed  : "non-computed-val2" => "non-computed-val1"
+                  - nested    : "val2"
+                  - nested    : "val2"
+                }
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].nested": map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_unordered.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_with_duplicates.golden
@@ -1,0 +1,25 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_with_duplicates_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_with_duplicates_unordered.golden
@@ -1,0 +1,25 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/two_added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/two_added.golden
@@ -42,6 +42,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val1"
+                    nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val2"
+                    nested    : "val2"
+                }
           + [2]: {
                   + computed  : "non-computed-val3"
                   + nested    : "val3"
@@ -56,7 +66,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{},
-		"tests[3]": map[string]interface{}{},
+		"tests":             map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{},
+		"tests[2].nested":   map[string]interface{}{},
+		"tests[3].computed": map[string]interface{}{},
+		"tests[3].nested":   map[string]interface{}{},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/two_added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/two_added.golden
@@ -1,0 +1,62 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      + test {
+          + computed = "non-computed-val3"
+          + nested   = "val3"
+        }
+      + test {
+          + computed = "non-computed-val4"
+          + nested   = "val4"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [2]: {
+                  + computed  : "non-computed-val3"
+                  + nested    : "val3"
+                }
+          + [3]: {
+                  + computed  : "non-computed-val4"
+                  + nested    : "val4"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2]": map[string]interface{}{},
+		"tests[3]": map[string]interface{}{},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/two_added_and_two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/two_added_and_two_removed.golden
@@ -53,11 +53,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val5"
+                  + computed: "non-computed-val5"
                   ~ nested  : "val3" => "val5"
                 }
           ~ [3]: {
-                  ~ computed: "non-computed-val4" => "non-computed-val6"
+                  + computed: "non-computed-val6"
                   ~ nested  : "val4" => "val6"
                 }
         ]
@@ -66,9 +66,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].computed": map[string]interface{}{},
 		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].computed": map[string]interface{}{},
 		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/two_added_and_two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/two_added_and_two_removed.golden
@@ -1,0 +1,74 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val5",
+		"val6",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      - test {
+          - computed = "non-computed-val4" -> null
+          - nested   = "val4" -> null
+        }
+      + test {
+          + computed = "non-computed-val5"
+          + nested   = "val5"
+        }
+      + test {
+          + computed = "non-computed-val6"
+          + nested   = "val6"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [2]: {
+                  ~ computed: "non-computed-val3" => "non-computed-val5"
+                  ~ nested  : "val3" => "val5"
+                }
+          ~ [3]: {
+                  ~ computed: "non-computed-val4" => "non-computed-val6"
+                  ~ nested  : "val4" => "val6"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -52,13 +52,19 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + computed: "non-computed-val5"
+                  + nested  : "val5"
+                }
+          ~ [1]: {
+                  + computed: "non-computed-val6"
+                  + nested  : "val6"
+                }
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val1"
-                  ~ nested  : "val3" => "val1"
+                  - nested: "val3"
                 }
           ~ [3]: {
-                  ~ computed: "non-computed-val4" => "non-computed-val2"
-                  ~ nested  : "val4" => "val2"
+                  - nested: "val4"
                 }
         ]
 Resources:
@@ -66,9 +72,11 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[0].computed": map[string]interface{}{},
+		"tests[0].nested":   map[string]interface{}{},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{},
+		"tests[2].nested":   map[string]interface{}{"kind": "DELETE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -1,0 +1,74 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val5",
+		"val6",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      - test {
+          - computed = "non-computed-val4" -> null
+          - nested   = "val4" -> null
+        }
+      + test {
+          + computed = "non-computed-val5"
+          + nested   = "val5"
+        }
+      + test {
+          + computed = "non-computed-val6"
+          + nested   = "val6"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [2]: {
+                  ~ computed: "non-computed-val3" => "non-computed-val1"
+                  ~ nested  : "val3" => "val1"
+                }
+          ~ [3]: {
+                  ~ computed: "non-computed-val4" => "non-computed-val2"
+                  ~ nested  : "val4" => "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -52,13 +52,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [1]: {
+                  + computed: "non-computed-val5"
+                  + nested  : "val5"
+                }
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val6"
+                  + computed: "non-computed-val6"
                   ~ nested  : "val3" => "val6"
                 }
           ~ [3]: {
-                  ~ computed: "non-computed-val4" => "non-computed-val2"
-                  ~ nested  : "val4" => "val2"
+                  - nested: "val4"
                 }
         ]
 Resources:
@@ -66,9 +69,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{},
+		"tests[2].computed": map[string]interface{}{},
 		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -1,0 +1,74 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val5",
+		"val6",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      - test {
+          - computed = "non-computed-val4" -> null
+          - nested   = "val4" -> null
+        }
+      + test {
+          + computed = "non-computed-val5"
+          + nested   = "val5"
+        }
+      + test {
+          + computed = "non-computed-val6"
+          + nested   = "val6"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [2]: {
+                  ~ computed: "non-computed-val3" => "non-computed-val6"
+                  ~ nested  : "val3" => "val6"
+                }
+          ~ [3]: {
+                  ~ computed: "non-computed-val4" => "non-computed-val2"
+                  ~ nested  : "val4" => "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -54,13 +54,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [1]: {
+                  + computed: "non-computed-val5"
+                  + nested  : "val5"
+                }
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val6"
+                  + computed: "non-computed-val6"
                   ~ nested  : "val3" => "val6"
                 }
           ~ [3]: {
-                  ~ computed: "non-computed-val4" => "non-computed-val2"
-                  ~ nested  : "val4" => "val2"
+                  - nested: "val4"
                 }
         ]
 Resources:
@@ -68,9 +71,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[1].computed": map[string]interface{}{},
+		"tests[1].nested":   map[string]interface{}{},
+		"tests[2].computed": map[string]interface{}{},
 		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -1,0 +1,76 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val5",
+		"val6",
+		"val2",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      - test {
+          - computed = "non-computed-val4" -> null
+          - nested   = "val4" -> null
+        }
+      + test {
+          + computed = "non-computed-val5"
+          + nested   = "val5"
+        }
+      + test {
+          + computed = "non-computed-val6"
+          + nested   = "val6"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [2]: {
+                  ~ computed: "non-computed-val3" => "non-computed-val6"
+                  ~ nested  : "val3" => "val6"
+                }
+          ~ [3]: {
+                  ~ computed: "non-computed-val4" => "non-computed-val2"
+                  ~ nested  : "val4" => "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/two_removed.golden
@@ -1,0 +1,62 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - test {
+          - computed = "non-computed-val3" -> null
+          - nested   = "val3" -> null
+        }
+      - test {
+          - computed = "non-computed-val4" -> null
+          - nested   = "val4" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [2]: {
+                  - computed: "non-computed-val3"
+                  - nested  : "val3"
+                }
+          - [3]: {
+                  - computed: "non-computed-val4"
+                  - nested  : "val4"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2]": map[string]interface{}{"kind": "DELETE"},
+		"tests[3]": map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/two_removed.golden
@@ -42,6 +42,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: {
+                  + __defaults: []
+                    computed  : "non-computed-val1"
+                    nested    : "val1"
+                }
+          ~ [1]: {
+                  + __defaults: []
+                    computed  : "non-computed-val2"
+                    nested    : "val2"
+                }
           - [2]: {
                   - computed: "non-computed-val3"
                   - nested  : "val3"
@@ -56,7 +66,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{"kind": "DELETE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE"},
+		"tests":           map[string]interface{}{"kind": "UPDATE"},
+		"tests[2].nested": map[string]interface{}{"kind": "DELETE"},
+		"tests[3].nested": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/unchanged_empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/unchanged_non-empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/unchanged_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/block_with_nested_computed_no_replace_computed_specified_in_program/unchanged_null.golden
@@ -1,0 +1,11 @@
+tests.testOutput{tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`, pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/added.golden
@@ -25,12 +25,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
-      +     [0]: "value"
+      ~ tests: [
+          + [0]: "value"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/added.golden
@@ -1,0 +1,36 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{"value"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "id" -> (known after apply)
+      ~ test = [ # forces replacement
+          + "value",
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + tests: [
+      +     [0]: "value"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/added_end.golden
@@ -34,11 +34,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+            [0]: "val1"
+            [1]: "val2"
           + [2]: "val3"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/added_end.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "id" -> (known after apply)
+      ~ test = [ # forces replacement
+          + "val3",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [2]: "val3"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/added_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/added_end_unordered.golden
@@ -34,11 +34,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [0]: "val2"
+            [0]: "val2"
+            [1]: "val3"
+          + [2]: "val1"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/added_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/added_end_unordered.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "id" -> (known after apply)
+      ~ test = [ # forces replacement
+          + "val1",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [0]: "val2"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/added_front.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "id" -> (known after apply)
+      ~ test = [ # forces replacement
+          + "val1",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [0]: "val1"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/added_front.golden
@@ -35,10 +35,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           + [0]: "val1"
+          ~ [1]: "val3" => "val2"
+          + [2]: "val3"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/added_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/added_front_unordered.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "id" -> (known after apply)
+      ~ test = [ # forces replacement
+          + "val2",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [1]: "val3"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/added_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/added_front_unordered.golden
@@ -34,11 +34,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [1]: "val3"
+          + [0]: "val2"
+            [1]: "val3"
+          + [2]: "val1"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/added_middle.golden
@@ -34,11 +34,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+            [0]: "val1"
           + [1]: "val2"
+          + [2]: "val3"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/added_middle.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "id" -> (known after apply)
+      ~ test = [ # forces replacement
+          + "val2",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [1]: "val2"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/added_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/added_middle_unordered.golden
@@ -34,11 +34,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: "val1" => "val2"
+          ~ [1]: "val2" => "val3"
           + [2]: "val1"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/added_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/added_middle_unordered.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "id" -> (known after apply)
+      ~ test = [ # forces replacement
+          + "val3",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [2]: "val1"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/changed_empty_to_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/changed_empty_to_null.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/changed_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/changed_non-null.golden
@@ -1,0 +1,39 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "id" -> (known after apply)
+      ~ test = [ # forces replacement
+          - "value",
+          + "value1",
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: "value" => "value1"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/changed_non-null_to_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/changed_non-null_to_null.golden
@@ -1,0 +1,17 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/changed_null_to_empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/changed_null_to_empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/changed_null_to_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/changed_null_to_non-null.golden
@@ -26,12 +26,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
-      +     [0]: "value"
+      ~ tests: [
+          + [0]: "value"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/changed_null_to_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/changed_null_to_non-null.golden
@@ -1,0 +1,37 @@
+tests.testOutput{
+	changeValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "id" -> (known after apply)
+      ~ test = [ # forces replacement
+          + "value",
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + tests: [
+      +     [0]: "value"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/removed.golden
@@ -27,12 +27,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - tests: [
-      -     [0]: "value"
+      ~ tests: [
+          - [0]: "value"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/removed.golden
@@ -1,0 +1,38 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "id" -> (known after apply)
+      ~ test = [
+          - "value",
+        ] -> (known after apply) # forces replacement
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      - tests: [
+      -     [0]: "value"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/removed_end.golden
@@ -34,11 +34,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+            [0]: "val1"
+            [1]: "val2"
           - [2]: "val3"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/removed_end.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "id" -> (known after apply)
+      ~ test = [ # forces replacement
+          - "val3",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [2]: "val3"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/removed_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/removed_end_unordered.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "id" -> (known after apply)
+      ~ test = [ # forces replacement
+          - "val1",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [0]: "val1"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/removed_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/removed_end_unordered.golden
@@ -34,11 +34,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [0]: "val1"
+          ~ [0]: "val1" => "val2"
+          ~ [1]: "val2" => "val3"
+          - [2]: "val3"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/removed_front.golden
@@ -35,10 +35,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           - [0]: "val1"
+          ~ [1]: "val2" => "val3"
+          - [2]: "val3"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/removed_front.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "id" -> (known after apply)
+      ~ test = [ # forces replacement
+          - "val1",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [0]: "val1"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/removed_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/removed_front_unordered.golden
@@ -34,11 +34,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: "val1" => "val3"
           - [1]: "val2"
+          - [2]: "val3"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/removed_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/removed_front_unordered.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "id" -> (known after apply)
+      ~ test = [ # forces replacement
+          - "val2",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: "val2"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/removed_middle.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "id" -> (known after apply)
+      ~ test = [ # forces replacement
+          - "val2",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: "val2"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/removed_middle.golden
@@ -34,11 +34,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [1]: "val2"
+            [0]: "val1"
+          ~ [1]: "val2" => "val3"
+          - [2]: "val3"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/removed_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/removed_middle_unordered.golden
@@ -34,11 +34,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: "val1" => "val3"
           - [1]: "val2"
+          - [2]: "val3"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/removed_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/removed_middle_unordered.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "id" -> (known after apply)
+      ~ test = [ # forces replacement
+          - "val2",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: "val2"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/same_element_updated.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/same_element_updated.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val4",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "id" -> (known after apply)
+      ~ test = [ # forces replacement
+          - "val2",
+          + "val4",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: "val2"
+          + [2]: "val3"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/same_element_updated.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/same_element_updated.golden
@@ -36,15 +36,11 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [1]: "val2"
-          + [2]: "val3"
+          ~ [1]: "val2" => "val4"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"},
-		"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/same_element_updated_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/same_element_updated_unordered.golden
@@ -1,0 +1,46 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val4",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "id" -> (known after apply)
+      ~ test = [ # forces replacement
+          - "val3",
+          + "val4",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [2]: "val3" => "val1"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/same_element_updated_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/same_element_updated_unordered.golden
@@ -36,11 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          ~ [2]: "val3" => "val1"
+          + [1]: "val4"
+          - [2]: "val3"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/shuffled.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/shuffled.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/shuffled_added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/shuffled_added_end.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "id" -> (known after apply)
+      ~ test = [ # forces replacement
+          + "val3",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [2]: "val3"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/shuffled_added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/shuffled_added_end.golden
@@ -34,11 +34,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: "val1" => "val2"
+          ~ [1]: "val2" => "val1"
           + [2]: "val3"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/shuffled_added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/shuffled_added_front.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "id" -> (known after apply)
+      ~ test = [ # forces replacement
+          + "val1",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [0]: "val1"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/shuffled_added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/shuffled_added_front.golden
@@ -34,11 +34,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [0]: "val1"
+          ~ [0]: "val2" => "val1"
+            [1]: "val3"
+          + [2]: "val2"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/shuffled_added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/shuffled_added_middle.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "id" -> (known after apply)
+      ~ test = [ # forces replacement
+          + "val2",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [1]: "val2"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/shuffled_added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/shuffled_added_middle.golden
@@ -34,11 +34,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: "val1" => "val3"
           + [1]: "val2"
+          + [2]: "val1"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/shuffled_removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/shuffled_removed_end.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "id" -> (known after apply)
+      ~ test = [ # forces replacement
+          - "val3",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [2]: "val3"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/shuffled_removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/shuffled_removed_end.golden
@@ -34,11 +34,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: "val1" => "val2"
+          ~ [1]: "val2" => "val1"
           - [2]: "val3"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/shuffled_removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/shuffled_removed_front.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "id" -> (known after apply)
+      ~ test = [ # forces replacement
+          - "val1",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [0]: "val1"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/shuffled_removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/shuffled_removed_front.golden
@@ -35,10 +35,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           - [0]: "val1"
+            [1]: "val2"
+          - [2]: "val3"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/shuffled_removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/shuffled_removed_middle.golden
@@ -34,11 +34,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: "val1" => "val3"
           - [1]: "val2"
+          - [2]: "val3"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/shuffled_removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/shuffled_removed_middle.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "id" -> (known after apply)
+      ~ test = [ # forces replacement
+          - "val2",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: "val2"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/shuffled_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/shuffled_unordered.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/shuffled_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/shuffled_with_duplicates.golden
@@ -1,0 +1,25 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/shuffled_with_duplicates_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/shuffled_with_duplicates_unordered.golden
@@ -1,0 +1,25 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/two_added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/two_added.golden
@@ -36,6 +36,8 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+            [0]: "val1"
+            [1]: "val2"
           + [2]: "val3"
           + [3]: "val4"
         ]
@@ -44,6 +46,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
 		"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
 		"tests[3]": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/two_added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/two_added.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "id" -> (known after apply)
+      ~ test = [ # forces replacement
+          + "val3",
+          + "val4",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [2]: "val3"
+          + [3]: "val4"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[3]": map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/two_added_and_two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/two_added_and_two_removed.golden
@@ -1,0 +1,54 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val5",
+		"val6",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "id" -> (known after apply)
+      ~ test = [ # forces replacement
+          - "val3",
+          - "val4",
+          + "val5",
+          + "val6",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [2]: "val3" => "val5"
+          ~ [3]: "val4" => "val6"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[3]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -40,15 +40,19 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          ~ [2]: "val3" => "val1"
-          ~ [3]: "val4" => "val2"
+          + [0]: "val5"
+          + [1]: "val6"
+          - [2]: "val3"
+          - [3]: "val4"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -1,0 +1,54 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val5",
+		"val6",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "id" -> (known after apply)
+      ~ test = [ # forces replacement
+          - "val3",
+          - "val4",
+          + "val5",
+          + "val6",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [2]: "val3" => "val1"
+          ~ [3]: "val4" => "val2"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[3]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -1,0 +1,54 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val5",
+		"val6",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "id" -> (known after apply)
+      ~ test = [ # forces replacement
+          - "val3",
+          - "val4",
+          + "val5",
+          + "val6",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [2]: "val3" => "val6"
+          ~ [3]: "val4" => "val2"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[3]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -40,15 +40,17 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          + [1]: "val5"
           ~ [2]: "val3" => "val6"
-          ~ [3]: "val4" => "val2"
+          - [3]: "val4"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
+		"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"},
 		"tests[2]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -1,0 +1,56 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val5",
+		"val6",
+		"val2",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "id" -> (known after apply)
+      ~ test = [ # forces replacement
+          - "val3",
+          - "val4",
+          + "val5",
+          + "val6",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [2]: "val3" => "val6"
+          ~ [3]: "val4" => "val2"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[3]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -42,15 +42,17 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          + [1]: "val5"
           ~ [2]: "val3" => "val6"
-          ~ [3]: "val4" => "val2"
+          - [3]: "val4"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
+		"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"},
 		"tests[2]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"tests[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/two_removed.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "id" -> (known after apply)
+      ~ test = [ # forces replacement
+          - "val3",
+          - "val4",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [2]: "val3"
+          - [3]: "val4"
+        ]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"tests[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/two_removed.golden
@@ -36,6 +36,8 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+            [0]: "val1"
+            [1]: "val2"
           - [2]: "val3"
           - [3]: "val4"
         ]
@@ -44,6 +46,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
 		"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
 		"tests[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/unchanged_empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/unchanged_non-empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/unchanged_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_force_new/unchanged_null.golden
@@ -1,0 +1,11 @@
+tests.testOutput{tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`, pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/added.golden
@@ -1,0 +1,37 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{"value"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ test = [
+          - "computed",
+          + "value",
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: "computed" => "value"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "UPDATE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/added_end.golden
@@ -34,11 +34,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+            [0]: "val1"
+            [1]: "val2"
           + [2]: "val3"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]": map[string]interface{}{},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/added_end.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ test = [
+          + "val3",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [2]: "val3"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/added_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/added_end_unordered.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ test = [
+          + "val1",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [0]: "val2"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/added_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/added_end_unordered.golden
@@ -34,11 +34,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [0]: "val2"
+            [0]: "val2"
+            [1]: "val3"
+          + [2]: "val1"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]": map[string]interface{}{},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/added_front.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ test = [
+          + "val1",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [0]: "val1"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/added_front.golden
@@ -34,11 +34,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [0]: "val1"
+          ~ [0]: "val2" => "val1"
+          ~ [1]: "val3" => "val2"
+          + [2]: "val3"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[0]": map[string]interface{}{},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/added_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/added_front_unordered.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ test = [
+          + "val2",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [1]: "val3"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/added_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/added_front_unordered.golden
@@ -34,11 +34,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [1]: "val3"
+          + [0]: "val2"
+            [1]: "val3"
+          + [2]: "val1"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[0]": map[string]interface{}{},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/added_middle.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ test = [
+          + "val2",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [1]: "val2"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/added_middle.golden
@@ -34,11 +34,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [1]: "val2"
+            [0]: "val1"
+          ~ [1]: "val3" => "val2"
+          + [2]: "val3"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[1]": map[string]interface{}{},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/added_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/added_middle_unordered.golden
@@ -34,11 +34,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: "val1" => "val2"
+          + [1]: "val3"
           + [2]: "val1"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[1]": map[string]interface{}{},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/added_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/added_middle_unordered.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ test = [
+          + "val3",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [2]: "val1"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/changed_empty_to_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/changed_empty_to_null.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/changed_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/changed_non-null.golden
@@ -1,0 +1,39 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ test = [
+          - "value",
+          + "value1",
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: "value" => "value1"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "UPDATE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/changed_non-null_to_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/changed_non-null_to_null.golden
@@ -1,0 +1,17 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/changed_null_to_empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/changed_null_to_empty.golden
@@ -24,12 +24,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - tests: [
-      -     [0]: "computed"
+      ~ tests: [
+          - [0]: "computed"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[0]": map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/changed_null_to_empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/changed_null_to_empty.golden
@@ -1,0 +1,35 @@
+tests.testOutput{
+	changeValue: &[]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ test = [
+          - "computed",
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      - tests: [
+      -     [0]: "computed"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/changed_null_to_non-null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/changed_null_to_non-null.golden
@@ -1,0 +1,38 @@
+tests.testOutput{
+	changeValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ test = [
+          - "computed",
+          + "value",
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: "computed" => "value"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "UPDATE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/removed.golden
@@ -1,0 +1,38 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ test = [
+          - "value",
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      - tests: [
+      -     [0]: "value"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/removed.golden
@@ -27,12 +27,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - tests: [
-      -     [0]: "value"
+      ~ tests: [
+          - [0]: "value"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[0]": map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/removed_end.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ test = [
+          - "val3",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [2]: "val3"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/removed_end.golden
@@ -34,11 +34,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+            [0]: "val1"
+            [1]: "val2"
           - [2]: "val3"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]": map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/removed_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/removed_end_unordered.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ test = [
+          - "val1",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [0]: "val1"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/removed_end_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/removed_end_unordered.golden
@@ -35,10 +35,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
           - [0]: "val1"
+          ~ [1]: "val2" => "val3"
+          - [2]: "val3"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[0]": map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/removed_front.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ test = [
+          - "val1",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [0]: "val1"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/removed_front.golden
@@ -34,11 +34,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [0]: "val1"
+          ~ [0]: "val1" => "val2"
+          ~ [1]: "val2" => "val3"
+          - [2]: "val3"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[0]": map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/removed_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/removed_front_unordered.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ test = [
+          - "val2",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: "val2"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/removed_front_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/removed_front_unordered.golden
@@ -34,11 +34,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [1]: "val2"
+          ~ [0]: "val1" => "val3"
+          ~ [1]: "val2" => "val1"
+          - [2]: "val3"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[1]": map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/removed_middle.golden
@@ -34,11 +34,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+            [0]: "val1"
           - [1]: "val2"
+          - [2]: "val3"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[1]": map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/removed_middle.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ test = [
+          - "val2",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: "val2"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/removed_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/removed_middle_unordered.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ test = [
+          - "val2",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: "val2"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/removed_middle_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/removed_middle_unordered.golden
@@ -34,11 +34,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: "val1" => "val3"
           - [1]: "val2"
+          - [2]: "val3"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[1]": map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/same_element_updated.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/same_element_updated.golden
@@ -36,15 +36,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [1]: "val2"
-          + [2]: "val3"
+          ~ [1]: "val2" => "val4"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"tests[1]": map[string]interface{}{"kind": "DELETE"},
-		"tests[2]": map[string]interface{}{},
-	},
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/same_element_updated.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/same_element_updated.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val4",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ test = [
+          - "val2",
+          + "val4",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: "val2"
+          + [2]: "val3"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[1]": map[string]interface{}{"kind": "DELETE"},
+		"tests[2]": map[string]interface{}{},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/same_element_updated_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/same_element_updated_unordered.golden
@@ -1,0 +1,46 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val4",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ test = [
+          - "val3",
+          + "val4",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [2]: "val3" => "val1"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "UPDATE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/same_element_updated_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/same_element_updated_unordered.golden
@@ -36,11 +36,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          ~ [2]: "val3" => "val1"
+          + [1]: "val4"
+          - [2]: "val3"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "UPDATE"}},
+	detailedDiff: map[string]interface{}{
+		"tests[1]": map[string]interface{}{},
+		"tests[2]": map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/shuffled.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/shuffled.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/shuffled_added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/shuffled_added_end.golden
@@ -34,11 +34,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: "val1" => "val2"
+          ~ [1]: "val2" => "val1"
           + [2]: "val3"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]": map[string]interface{}{},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/shuffled_added_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/shuffled_added_end.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ test = [
+          + "val3",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [2]: "val3"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/shuffled_added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/shuffled_added_front.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ test = [
+          + "val1",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [0]: "val1"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/shuffled_added_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/shuffled_added_front.golden
@@ -34,11 +34,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          + [0]: "val1"
+          ~ [0]: "val2" => "val1"
+            [1]: "val3"
+          + [2]: "val2"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[0]": map[string]interface{}{},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/shuffled_added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/shuffled_added_middle.golden
@@ -34,11 +34,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: "val1" => "val3"
           + [1]: "val2"
+          + [2]: "val1"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[1]": map[string]interface{}{},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/shuffled_added_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/shuffled_added_middle.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ test = [
+          + "val2",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [1]: "val2"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/shuffled_removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/shuffled_removed_end.golden
@@ -34,11 +34,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: "val1" => "val2"
+          ~ [1]: "val2" => "val1"
           - [2]: "val3"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[2]": map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/shuffled_removed_end.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/shuffled_removed_end.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ test = [
+          - "val3",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [2]: "val3"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/shuffled_removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/shuffled_removed_front.golden
@@ -34,11 +34,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          - [0]: "val1"
+          ~ [0]: "val1" => "val3"
+            [1]: "val2"
+          - [2]: "val3"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[0]": map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/shuffled_removed_front.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/shuffled_removed_front.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ test = [
+          - "val1",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [0]: "val1"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/shuffled_removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/shuffled_removed_middle.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ test = [
+          - "val2",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: "val2"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/shuffled_removed_middle.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/shuffled_removed_middle.golden
@@ -34,11 +34,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          ~ [0]: "val1" => "val3"
           - [1]: "val2"
+          - [2]: "val3"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[1]": map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/shuffled_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/shuffled_unordered.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/shuffled_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/shuffled_with_duplicates.golden
@@ -1,0 +1,25 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/shuffled_with_duplicates_unordered.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/shuffled_with_duplicates_unordered.golden
@@ -1,0 +1,25 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/two_added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/two_added.golden
@@ -36,6 +36,8 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+            [0]: "val1"
+            [1]: "val2"
           + [2]: "val3"
           + [3]: "val4"
         ]
@@ -44,6 +46,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
 		"tests[2]": map[string]interface{}{},
 		"tests[3]": map[string]interface{}{},
 	},

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/two_added.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/two_added.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ test = [
+          + "val3",
+          + "val4",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [2]: "val3"
+          + [3]: "val4"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2]": map[string]interface{}{},
+		"tests[3]": map[string]interface{}{},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/two_added_and_two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/two_added_and_two_removed.golden
@@ -1,0 +1,54 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val5",
+		"val6",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ test = [
+          - "val3",
+          - "val4",
+          + "val5",
+          + "val6",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [2]: "val3" => "val5"
+          ~ [3]: "val4" => "val6"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2]": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3]": map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -40,15 +40,19 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
-          ~ [2]: "val3" => "val1"
-          ~ [3]: "val4" => "val2"
+          + [0]: "val5"
+          + [1]: "val6"
+          - [2]: "val3"
+          - [3]: "val4"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]": map[string]interface{}{"kind": "UPDATE"},
+		"tests[0]": map[string]interface{}{},
+		"tests[1]": map[string]interface{}{},
+		"tests[2]": map[string]interface{}{"kind": "DELETE"},
+		"tests[3]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -1,0 +1,54 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val5",
+		"val6",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ test = [
+          - "val3",
+          - "val4",
+          + "val5",
+          + "val6",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [2]: "val3" => "val1"
+          ~ [3]: "val4" => "val2"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2]": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3]": map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -1,0 +1,54 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val5",
+		"val6",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ test = [
+          - "val3",
+          - "val4",
+          + "val5",
+          + "val6",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [2]: "val3" => "val6"
+          ~ [3]: "val4" => "val2"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2]": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3]": map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -40,15 +40,17 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          + [1]: "val5"
           ~ [2]: "val3" => "val6"
-          ~ [3]: "val4" => "val2"
+          - [3]: "val4"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
+		"tests[1]": map[string]interface{}{},
 		"tests[2]": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -42,15 +42,17 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+          + [1]: "val5"
           ~ [2]: "val3" => "val6"
-          ~ [3]: "val4" => "val2"
+          - [3]: "val4"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
+		"tests[1]": map[string]interface{}{},
 		"tests[2]": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -1,0 +1,56 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val5",
+		"val6",
+		"val2",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ test = [
+          - "val3",
+          - "val4",
+          + "val5",
+          + "val6",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [2]: "val3" => "val6"
+          ~ [3]: "val4" => "val2"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2]": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3]": map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/two_removed.golden
@@ -36,6 +36,8 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ tests: [
+            [0]: "val1"
+            [1]: "val2"
           - [2]: "val3"
           - [3]: "val4"
         ]
@@ -44,6 +46,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
 		"tests[2]": map[string]interface{}{"kind": "DELETE"},
 		"tests[3]": map[string]interface{}{"kind": "DELETE"},
 	},

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/two_removed.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/two_removed.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ test = [
+          - "val3",
+          - "val4",
+            # (2 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [2]: "val3"
+          - [3]: "val4"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2]": map[string]interface{}{"kind": "DELETE"},
+		"tests[3]": map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/unchanged_empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/unchanged_empty.golden
@@ -25,12 +25,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - tests: [
-      -     [0]: "computed"
+      ~ tests: [
+          - [0]: "computed"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{
+		"tests":    map[string]interface{}{"kind": "UPDATE"},
+		"tests[0]": map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/unchanged_empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/unchanged_empty.golden
@@ -1,0 +1,36 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ test = [
+          - "computed",
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      - tests: [
+      -     [0]: "computed"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/unchanged_non-empty.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/unchanged_null.golden
+++ b/pkg/tests/testdata/TestDetailedDiffSet/computed_attribute_no_force_new/unchanged_null.golden
@@ -1,0 +1,11 @@
+tests.testOutput{tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`, pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`}


### PR DESCRIPTION
This PR adds tests around Computed properties in Sets for SDKv2, similar to what we have on the PF side.

set attributes:
- with computed
- with computed and force new

For the block tests each test has a variant with the computed property unspecified in the program and one where the property is specified in the user program.
set blocks:
- with computed at the top level
- with computed at the top level and ForceNew at the top level
- with computed at the top level and a nested ForceNew
- with computed at the nested level
- with computed at the nested level and ForceNew at the top level
- with computed at the nested level and a nested ForceNew

Note that all these tests are currently run without Accurate Previews, because of https://github.com/pulumi/pulumi-terraform-bridge/issues/2528. I will enable the Accurate Previews feature flag for these tests along with the fix for 2528, so that we can evaluate the differences compared to not running the feature flag.

The output is non-deterministic without Accurate Previews, so the tests are recorded but skipped.

necessary for https://github.com/pulumi/pulumi-terraform-bridge/issues/2528