### PR TITLE
Prioritize Pulumi-supplied deprecation message over any TF ones

### DIFF
--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -634,12 +634,12 @@ func (v *variable) Name() string { return v.name }
 func (v *variable) Doc() string  { return v.doc }
 
 func (v *variable) deprecationMessage() string {
-	if v.schema != nil && v.schema.Deprecated() != "" {
-		return v.schema.Deprecated()
-	}
-
 	if v.info != nil && v.info.DeprecationMessage != "" {
 		return v.info.DeprecationMessage
+	}
+
+	if v.schema != nil && v.schema.Deprecated() != "" {
+		return v.schema.Deprecated()
 	}
 
 	return ""


### PR DESCRIPTION
This pull request changes the behavior of the `deprecationMessage()` method.

It now checks and returns a pulumi provider's resources.go-supplied `DeprecationMessage` before it checks and returns `Deprecated` from upstream.
This allows us to override deprecation messages in the provider.

Fixes #2703
