### PR TITLE
Add a fallback for detailed diff replace decisions to ensure detailed diff is presentation-only

### DIFF
--- a/pkg/pf/tfbridge/provider_diff.go
+++ b/pkg/pf/tfbridge/provider_diff.go
@@ -135,7 +135,9 @@ func (p *provider) DiffWithContext(
 	}
 
 	if providerOpts.enableAccurateBridgePreview {
-		pluginDetailedDiff, err := calculateDetailedDiff(ctx, &rh, priorState, plannedStateValue, checkedInputs)
+		replaceOverride := len(replaceKeys) > 0
+		pluginDetailedDiff, err := calculateDetailedDiff(
+			ctx, &rh, priorState, plannedStateValue, checkedInputs, &replaceOverride)
 		if err != nil {
 			return plugin.DiffResult{}, err
 		}
@@ -148,7 +150,7 @@ func (p *provider) DiffWithContext(
 
 func calculateDetailedDiff(
 	ctx context.Context, rh *resourceHandle, priorState *upgradedResourceState,
-	plannedStateValue tftypes.Value, checkedInputs resource.PropertyMap,
+	plannedStateValue tftypes.Value, checkedInputs resource.PropertyMap, replaceOverride *bool,
 ) (map[string]plugin.PropertyDiff, error) {
 	priorProps, err := convert.DecodePropertyMap(ctx, rh.decoder, priorState.state.Value)
 	if err != nil {
@@ -167,6 +169,7 @@ func calculateDetailedDiff(
 		priorProps,
 		props,
 		checkedInputs,
+		replaceOverride,
 	)
 
 	pluginDetailedDiff := make(map[string]plugin.PropertyDiff, len(detailedDiff))

--- a/pkg/tfbridge/detailed_diff_test.go
+++ b/pkg/tfbridge/detailed_diff_test.go
@@ -2836,3 +2836,25 @@ func TestDetailedDiffReplaceOverrideTrue(t *testing.T) {
 		"__meta": {Kind: pulumirpc.PropertyDiff_UPDATE_REPLACE},
 	})
 }
+
+func TestDemoteToNoReplace(t *testing.T) {
+	t.Parallel()
+
+	diff := &pulumirpc.PropertyDiff{Kind: pulumirpc.PropertyDiff_ADD_REPLACE}
+	require.Equal(t, demoteToNoReplace(diff), &pulumirpc.PropertyDiff{Kind: pulumirpc.PropertyDiff_ADD})
+
+	diff = &pulumirpc.PropertyDiff{Kind: pulumirpc.PropertyDiff_DELETE_REPLACE}
+	require.Equal(t, demoteToNoReplace(diff), &pulumirpc.PropertyDiff{Kind: pulumirpc.PropertyDiff_DELETE})
+
+	diff = &pulumirpc.PropertyDiff{Kind: pulumirpc.PropertyDiff_UPDATE_REPLACE}
+	require.Equal(t, demoteToNoReplace(diff), &pulumirpc.PropertyDiff{Kind: pulumirpc.PropertyDiff_UPDATE})
+
+	diff = &pulumirpc.PropertyDiff{Kind: pulumirpc.PropertyDiff_ADD}
+	require.Equal(t, demoteToNoReplace(diff), &pulumirpc.PropertyDiff{Kind: pulumirpc.PropertyDiff_ADD})
+
+	diff = &pulumirpc.PropertyDiff{Kind: pulumirpc.PropertyDiff_DELETE}
+	require.Equal(t, demoteToNoReplace(diff), &pulumirpc.PropertyDiff{Kind: pulumirpc.PropertyDiff_DELETE})
+
+	diff = &pulumirpc.PropertyDiff{Kind: pulumirpc.PropertyDiff_UPDATE}
+	require.Equal(t, demoteToNoReplace(diff), &pulumirpc.PropertyDiff{Kind: pulumirpc.PropertyDiff_UPDATE})
+}

--- a/pkg/tfbridge/detailed_diff_test.go
+++ b/pkg/tfbridge/detailed_diff_test.go
@@ -299,7 +299,7 @@ func runDetailedDiffTest(
 	expected map[string]*pulumirpc.PropertyDiff,
 ) {
 	t.Helper()
-	actual := MakeDetailedDiffV2(context.Background(), tfs, ps, old, new, new)
+	actual := MakeDetailedDiffV2(context.Background(), tfs, ps, old, new, new, nil)
 
 	require.Equal(t, expected, actual)
 }
@@ -2787,4 +2787,52 @@ func TestDetailedDiffSetHashPanicCaught(t *testing.T) {
 	)
 
 	require.Contains(t, buf.String(), "Failed to calculate preview for element in foo")
+}
+
+func TestDetailedDiffReplaceOverrideFalse(t *testing.T) {
+	t.Parallel()
+
+	old := resource.NewPropertyMapFromMap(map[string]interface{}{
+		"foo": "bar",
+	})
+	new := resource.NewPropertyMapFromMap(map[string]interface{}{
+		"foo": "baz",
+	})
+
+	tfs := shimv2.NewSchemaMap(map[string]*schema.Schema{
+		"foo": {
+			Type:     schema.TypeString,
+			Optional: true,
+			ForceNew: true,
+		},
+	})
+
+	actual := MakeDetailedDiffV2(context.Background(), tfs, nil, old, new, new, ref(false))
+	require.Equal(t, actual, map[string]*pulumirpc.PropertyDiff{
+		"foo": {Kind: pulumirpc.PropertyDiff_UPDATE},
+	})
+}
+
+func TestDetailedDiffReplaceOverrideTrue(t *testing.T) {
+	t.Parallel()
+
+	old := resource.NewPropertyMapFromMap(map[string]interface{}{
+		"foo": "bar",
+	})
+	new := resource.NewPropertyMapFromMap(map[string]interface{}{
+		"foo": "baz",
+	})
+
+	tfs := shimv2.NewSchemaMap(map[string]*schema.Schema{
+		"foo": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+	})
+
+	actual := MakeDetailedDiffV2(context.Background(), tfs, nil, old, new, new, ref(true))
+	require.Equal(t, actual, map[string]*pulumirpc.PropertyDiff{
+		"foo":    {Kind: pulumirpc.PropertyDiff_UPDATE},
+		"__meta": {Kind: pulumirpc.PropertyDiff_UPDATE_REPLACE},
+	})
 }

--- a/pkg/tfbridge/detailed_diff_test.go
+++ b/pkg/tfbridge/detailed_diff_test.go
@@ -2858,3 +2858,25 @@ func TestDemoteToNoReplace(t *testing.T) {
 	diff = &pulumirpc.PropertyDiff{Kind: pulumirpc.PropertyDiff_UPDATE}
 	require.Equal(t, demoteToNoReplace(diff), &pulumirpc.PropertyDiff{Kind: pulumirpc.PropertyDiff_UPDATE})
 }
+
+func TestContainsReplace(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, containsReplace(map[string]*pulumirpc.PropertyDiff{
+		"foo": {Kind: pulumirpc.PropertyDiff_UPDATE_REPLACE},
+	}))
+
+	require.True(t, containsReplace(map[string]*pulumirpc.PropertyDiff{
+		"foo": {Kind: pulumirpc.PropertyDiff_ADD_REPLACE},
+	}))
+
+	require.True(t, containsReplace(map[string]*pulumirpc.PropertyDiff{
+		"foo": {Kind: pulumirpc.PropertyDiff_DELETE_REPLACE},
+	}))
+
+	require.False(t, containsReplace(map[string]*pulumirpc.PropertyDiff{
+		"foo": {Kind: pulumirpc.PropertyDiff_UPDATE},
+	}))
+
+	require.False(t, containsReplace(map[string]*pulumirpc.PropertyDiff{}))
+}

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -1177,8 +1177,9 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 			changes = pulumirpc.DiffResponse_DIFF_SOME
 		}
 
+		replaceDecision := diff.RequiresNew()
 		detailedDiff, err = makeDetailedDiffV2(
-			ctx, schema, fields, res.TF, p.tf, state, diff, assets, p.supportsSecrets, news)
+			ctx, schema, fields, res.TF, p.tf, state, diff, assets, p.supportsSecrets, news, &replaceDecision)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This change adds a fallback for the detailed diff replace decision. This ensures that the detailed diff is presentation only.

If we fail to identify the reason for a replace in the detailed diff calculation we mark it against `__meta`, similar to what we did before: https://github.com/pulumi/pulumi-terraform-bridge/blob/a952164c556a86f46dac2ac34e915143cfd7abd8/pkg/tfbridge/provider.go#L1262
If we incorrectly identify a non-existent replace we demote it to an update/create/delete.

This is flagged behind the Accurate Previews flag.

fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/2674
fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/2726