### PR TITLE
SDKv2 Only return a detailed diff if a diff is detected

### DIFF
--- a/pkg/pf/tests/diff_test.go
+++ b/pkg/pf/tests/diff_test.go
@@ -195,7 +195,10 @@ func TestDetailedDiffStringAttribute(t *testing.T) {
 					res := pb.NewResource(pb.NewResourceArgs{
 						ResourceSchema: schema.schema,
 					})
-					diff := crosstests.Diff(t, res, map[string]cty.Value{"key": initialValue}, map[string]cty.Value{"key": changeValue})
+					diff := crosstests.Diff(
+						t, res, map[string]cty.Value{"key": initialValue}, map[string]cty.Value{"key": changeValue},
+						crosstests.DisableAccurateBridgePreview(),
+					)
 
 					autogold.ExpectFile(t, testOutput{
 						initialValue: scenario.initialValue,

--- a/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/default/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/default/added.golden
@@ -22,10 +22,9 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ testprovider:index/test:Test: (update)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
-      ~ key: "default" => "value"
+      + key: "value"
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/default/changed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/default/changed.golden
@@ -28,5 +28,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/default/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/default/removed.golden
@@ -27,5 +27,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/default_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/default_replace/added.golden
@@ -22,10 +22,10 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       ~ key: "default" => "value"
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/default_replace/changed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/default_replace/changed.golden
@@ -23,10 +23,10 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       ~ key: "value" => "value1"
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/default_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/default_replace/removed.golden
@@ -22,10 +22,10 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
-      - key: "value"
+      ~ id : "test-id" => output<string>
+      ~ key: "value" => "default"
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/no_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/no_replace/added.golden
@@ -27,5 +27,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/no_replace/changed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/no_replace/changed.golden
@@ -28,5 +28,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/no_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/no_replace/removed.golden
@@ -27,5 +27,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/plan_modifier_default/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/plan_modifier_default/added.golden
@@ -22,10 +22,9 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ testprovider:index/test:Test: (update)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
-      ~ key: "default" => "value"
+      + key: "value"
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/plan_modifier_default/changed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/plan_modifier_default/changed.golden
@@ -28,5 +28,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/plan_modifier_default_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/plan_modifier_default_replace/added.golden
@@ -22,10 +22,10 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       ~ key: "default" => "value"
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/plan_modifier_default_replace/changed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/plan_modifier_default_replace/changed.golden
@@ -23,10 +23,10 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       ~ key: "value" => "value1"
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/replace/added.golden
@@ -22,10 +22,10 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       + key: "value"
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/replace/changed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/replace/changed.golden
@@ -23,10 +23,10 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       ~ key: "value" => "value1"
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/replace/removed.golden
@@ -22,10 +22,10 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       - key: "value"
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tfbridge/provider_diff.go
+++ b/pkg/pf/tfbridge/provider_diff.go
@@ -135,7 +135,9 @@ func (p *provider) DiffWithContext(
 	}
 
 	if providerOpts.enableAccurateBridgePreview {
-		pluginDetailedDiff, err := calculateDetailedDiff(ctx, &rh, priorState, plannedStateValue, checkedInputs)
+		replaceOverride := len(replaceKeys) > 0
+		pluginDetailedDiff, err := calculateDetailedDiff(
+			ctx, &rh, priorState, plannedStateValue, checkedInputs, &replaceOverride)
 		if err != nil {
 			return plugin.DiffResult{}, err
 		}
@@ -148,7 +150,7 @@ func (p *provider) DiffWithContext(
 
 func calculateDetailedDiff(
 	ctx context.Context, rh *resourceHandle, priorState *upgradedResourceState,
-	plannedStateValue tftypes.Value, checkedInputs resource.PropertyMap,
+	plannedStateValue tftypes.Value, checkedInputs resource.PropertyMap, replaceOverride *bool,
 ) (map[string]plugin.PropertyDiff, error) {
 	priorProps, err := convert.DecodePropertyMap(ctx, rh.decoder, priorState.state.Value)
 	if err != nil {
@@ -167,6 +169,7 @@ func calculateDetailedDiff(
 		priorProps,
 		props,
 		checkedInputs,
+		replaceOverride,
 	)
 
 	pluginDetailedDiff := make(map[string]plugin.PropertyDiff, len(detailedDiff))

--- a/pkg/tfbridge/detailed_diff_test.go
+++ b/pkg/tfbridge/detailed_diff_test.go
@@ -2836,3 +2836,25 @@ func TestDetailedDiffReplaceOverrideTrue(t *testing.T) {
 		"__meta": {Kind: pulumirpc.PropertyDiff_UPDATE_REPLACE},
 	})
 }
+
+func TestDemoteToNoReplace(t *testing.T) {
+	t.Parallel()
+
+	diff := &pulumirpc.PropertyDiff{Kind: pulumirpc.PropertyDiff_ADD_REPLACE}
+	require.Equal(t, demoteToNoReplace(diff), &pulumirpc.PropertyDiff{Kind: pulumirpc.PropertyDiff_ADD})
+
+	diff = &pulumirpc.PropertyDiff{Kind: pulumirpc.PropertyDiff_DELETE_REPLACE}
+	require.Equal(t, demoteToNoReplace(diff), &pulumirpc.PropertyDiff{Kind: pulumirpc.PropertyDiff_DELETE})
+
+	diff = &pulumirpc.PropertyDiff{Kind: pulumirpc.PropertyDiff_UPDATE_REPLACE}
+	require.Equal(t, demoteToNoReplace(diff), &pulumirpc.PropertyDiff{Kind: pulumirpc.PropertyDiff_UPDATE})
+
+	diff = &pulumirpc.PropertyDiff{Kind: pulumirpc.PropertyDiff_ADD}
+	require.Equal(t, demoteToNoReplace(diff), &pulumirpc.PropertyDiff{Kind: pulumirpc.PropertyDiff_ADD})
+
+	diff = &pulumirpc.PropertyDiff{Kind: pulumirpc.PropertyDiff_DELETE}
+	require.Equal(t, demoteToNoReplace(diff), &pulumirpc.PropertyDiff{Kind: pulumirpc.PropertyDiff_DELETE})
+
+	diff = &pulumirpc.PropertyDiff{Kind: pulumirpc.PropertyDiff_UPDATE}
+	require.Equal(t, demoteToNoReplace(diff), &pulumirpc.PropertyDiff{Kind: pulumirpc.PropertyDiff_UPDATE})
+}

--- a/pkg/tfbridge/detailed_diff_test.go
+++ b/pkg/tfbridge/detailed_diff_test.go
@@ -299,7 +299,7 @@ func runDetailedDiffTest(
 	expected map[string]*pulumirpc.PropertyDiff,
 ) {
 	t.Helper()
-	actual := MakeDetailedDiffV2(context.Background(), tfs, ps, old, new, new)
+	actual := MakeDetailedDiffV2(context.Background(), tfs, ps, old, new, new, nil)
 
 	require.Equal(t, expected, actual)
 }
@@ -2787,4 +2787,52 @@ func TestDetailedDiffSetHashPanicCaught(t *testing.T) {
 	)
 
 	require.Contains(t, buf.String(), "Failed to calculate preview for element in foo")
+}
+
+func TestDetailedDiffReplaceOverrideFalse(t *testing.T) {
+	t.Parallel()
+
+	old := resource.NewPropertyMapFromMap(map[string]interface{}{
+		"foo": "bar",
+	})
+	new := resource.NewPropertyMapFromMap(map[string]interface{}{
+		"foo": "baz",
+	})
+
+	tfs := shimv2.NewSchemaMap(map[string]*schema.Schema{
+		"foo": {
+			Type:     schema.TypeString,
+			Optional: true,
+			ForceNew: true,
+		},
+	})
+
+	actual := MakeDetailedDiffV2(context.Background(), tfs, nil, old, new, new, ref(false))
+	require.Equal(t, actual, map[string]*pulumirpc.PropertyDiff{
+		"foo": {Kind: pulumirpc.PropertyDiff_UPDATE},
+	})
+}
+
+func TestDetailedDiffReplaceOverrideTrue(t *testing.T) {
+	t.Parallel()
+
+	old := resource.NewPropertyMapFromMap(map[string]interface{}{
+		"foo": "bar",
+	})
+	new := resource.NewPropertyMapFromMap(map[string]interface{}{
+		"foo": "baz",
+	})
+
+	tfs := shimv2.NewSchemaMap(map[string]*schema.Schema{
+		"foo": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+	})
+
+	actual := MakeDetailedDiffV2(context.Background(), tfs, nil, old, new, new, ref(true))
+	require.Equal(t, actual, map[string]*pulumirpc.PropertyDiff{
+		"foo":    {Kind: pulumirpc.PropertyDiff_UPDATE},
+		"__meta": {Kind: pulumirpc.PropertyDiff_UPDATE_REPLACE},
+	})
 }

--- a/pkg/tfbridge/detailed_diff_test.go
+++ b/pkg/tfbridge/detailed_diff_test.go
@@ -2858,3 +2858,25 @@ func TestDemoteToNoReplace(t *testing.T) {
 	diff = &pulumirpc.PropertyDiff{Kind: pulumirpc.PropertyDiff_UPDATE}
 	require.Equal(t, demoteToNoReplace(diff), &pulumirpc.PropertyDiff{Kind: pulumirpc.PropertyDiff_UPDATE})
 }
+
+func TestContainsReplace(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, containsReplace(map[string]*pulumirpc.PropertyDiff{
+		"foo": {Kind: pulumirpc.PropertyDiff_UPDATE_REPLACE},
+	}))
+
+	require.True(t, containsReplace(map[string]*pulumirpc.PropertyDiff{
+		"foo": {Kind: pulumirpc.PropertyDiff_ADD_REPLACE},
+	}))
+
+	require.True(t, containsReplace(map[string]*pulumirpc.PropertyDiff{
+		"foo": {Kind: pulumirpc.PropertyDiff_DELETE_REPLACE},
+	}))
+
+	require.False(t, containsReplace(map[string]*pulumirpc.PropertyDiff{
+		"foo": {Kind: pulumirpc.PropertyDiff_UPDATE},
+	}))
+
+	require.False(t, containsReplace(map[string]*pulumirpc.PropertyDiff{}))
+}

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -1177,8 +1177,9 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 			changes = pulumirpc.DiffResponse_DIFF_SOME
 		}
 
+		replaceDecision := diff.RequiresNew()
 		detailedDiff, err = makeDetailedDiffV2(
-			ctx, schema, fields, res.TF, p.tf, state, diff, assets, p.supportsSecrets, news)
+			ctx, schema, fields, res.TF, p.tf, state, diff, assets, p.supportsSecrets, news, &replaceDecision)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -1175,13 +1175,13 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 			changes = pulumirpc.DiffResponse_DIFF_NONE
 		} else {
 			changes = pulumirpc.DiffResponse_DIFF_SOME
-		}
 
-		replaceDecision := diff.RequiresNew()
-		detailedDiff, err = makeDetailedDiffV2(
-			ctx, schema, fields, res.TF, p.tf, state, diff, assets, p.supportsSecrets, news, &replaceDecision)
-		if err != nil {
-			return nil, err
+			replaceDecision := diff.RequiresNew()
+			detailedDiff, err = makeDetailedDiffV2(
+				ctx, schema, fields, res.TF, p.tf, state, diff, assets, p.supportsSecrets, news, &replaceDecision)
+			if err != nil {
+				return nil, err
+			}
 		}
 	} else {
 		dd := makeDetailedDiffExtra(ctx, schema, fields, olds, news, diff)


### PR DESCRIPTION
Only return a detailed diff if a diff is detected. This should prevent any mismatches between the detailed diff and the diff decision. Mismatches could only happen in case of a bug somewhere and that might cause issues with the engine.
