### PR TITLE
Disable accurate previews for PF tests

### DIFF
--- a/dynamic/provider_test.go
+++ b/dynamic/provider_test.go
@@ -62,10 +62,8 @@ func TestStacktraceDisplayed(t *testing.T) {
 }
 
 func TestPrimitiveTypes(t *testing.T) {
+	t.Parallel()
 	skipWindows(t)
-	// TODO[pulumi/pulumi-terraform-bridge#2517]: fix once accurate bridge previews are enabled by default
-	t.Setenv("PULUMI_TF_BRIDGE_ACCURATE_BRIDGE_PREVIEW", "true")
-
 	ctx := context.Background()
 
 	grpc := grpcTestServer(ctx, t)

--- a/dynamic/testdata/TestPrimitiveTypes/diff(all).golden
+++ b/dynamic/testdata/TestPrimitiveTypes/diff(all).golden
@@ -1,22 +1,5 @@
 {
   "changes": "DIFF_SOME",
-  "detailedDiff": {
-    "attrBoolRequired": {
-      "kind": "UPDATE"
-    },
-    "attrIntRequired": {
-      "kind": "UPDATE"
-    },
-    "attrNumberComputed": {},
-    "attrNumberRequired": {
-      "kind": "UPDATE"
-    },
-    "attrStringDefault": {},
-    "attrStringDefaultOverridden": {},
-    "attrStringRequired": {
-      "kind": "UPDATE"
-    }
-  },
   "diffs": [
     "attrBoolRequired",
     "attrIntRequired",
@@ -25,6 +8,5 @@
     "attrStringDefault",
     "attrStringDefaultOverridden",
     "attrStringRequired"
-  ],
-  "hasDetailedDiff": true
+  ]
 }

--- a/dynamic/testdata/TestPrimitiveTypes/diff(some).golden
+++ b/dynamic/testdata/TestPrimitiveTypes/diff(some).golden
@@ -1,22 +1,10 @@
 {
   "changes": "DIFF_SOME",
-  "detailedDiff": {
-    "attrNumberComputed": {},
-    "attrNumberRequired": {
-      "kind": "DELETE"
-    },
-    "attrStringDefault": {},
-    "attrStringDefaultOverridden": {},
-    "attrStringRequired": {
-      "kind": "UPDATE"
-    }
-  },
   "diffs": [
     "attrNumberComputed",
     "attrNumberRequired",
     "attrStringDefault",
     "attrStringDefaultOverridden",
     "attrStringRequired"
-  ],
-  "hasDetailedDiff": true
+  ]
 }

--- a/pkg/pf/tests/diff_list_test.go
+++ b/pkg/pf/tests/diff_list_test.go
@@ -236,7 +236,9 @@ func TestDetailedDiffList(t *testing.T) {
 					})
 
 					diff := crosstests.Diff(
-						t, res, map[string]cty.Value{"key": initialValue}, map[string]cty.Value{"key": changeValue})
+						t, res, map[string]cty.Value{"key": initialValue}, map[string]cty.Value{"key": changeValue},
+						crosstests.DisableAccurateBridgePreview(),
+					)
 
 					autogold.ExpectFile(t, testOutput{
 						initialValue: scenario.initialValue,

--- a/pkg/pf/tests/diff_map_test.go
+++ b/pkg/pf/tests/diff_map_test.go
@@ -178,7 +178,10 @@ func TestDetailedDiffMap(t *testing.T) {
 						ResourceSchema: schemaValueMakerPair.schema,
 					})
 
-					diff := crosstests.Diff(t, res, map[string]cty.Value{"key": initialValue}, map[string]cty.Value{"key": changeValue})
+					diff := crosstests.Diff(
+						t, res, map[string]cty.Value{"key": initialValue}, map[string]cty.Value{"key": changeValue},
+						crosstests.DisableAccurateBridgePreview(),
+					)
 
 					autogold.ExpectFile(t, testOutput{
 						initialValue: scenario.initialValue,

--- a/pkg/pf/tests/diff_object_test.go
+++ b/pkg/pf/tests/diff_object_test.go
@@ -337,7 +337,10 @@ func TestDetailedDiffObject(t *testing.T) {
 					res := pb.NewResource(pb.NewResourceArgs{
 						ResourceSchema: schema.schema,
 					})
-					diff := crosstests.Diff(t, res, initialValue, changeValue)
+					diff := crosstests.Diff(
+						t, res, initialValue, changeValue,
+						crosstests.DisableAccurateBridgePreview(),
+					)
 					autogold.ExpectFile(t, testOutput{
 						initialValue: scenario.initialValue,
 						changeValue:  scenario.changeValue,
@@ -357,7 +360,10 @@ func TestDetailedDiffObject(t *testing.T) {
 						res := pb.NewResource(pb.NewResourceArgs{
 							ResourceSchema: schema.schema,
 						})
-						diff := crosstests.Diff(t, res, initialValue, changeValue)
+						diff := crosstests.Diff(
+							t, res, initialValue, changeValue,
+							crosstests.DisableAccurateBridgePreview(),
+						)
 						autogold.ExpectFile(t, testOutput{
 							initialValue: scenario.initialValue,
 							changeValue:  scenario.changeValue,

--- a/pkg/pf/tests/diff_set_test.go
+++ b/pkg/pf/tests/diff_set_test.go
@@ -595,7 +595,10 @@ func TestDetailedDiffSet(t *testing.T) {
 					initialValue := schemaValueMakerPair.valueMaker(scenario.initialValue)
 					changeValue := schemaValueMakerPair.valueMaker(scenario.changeValue)
 
-					diff := crosstests.Diff(t, schemaValueMakerPair.res, map[string]cty.Value{"key": initialValue}, map[string]cty.Value{"key": changeValue})
+					diff := crosstests.Diff(
+						t, schemaValueMakerPair.res, map[string]cty.Value{"key": initialValue}, map[string]cty.Value{"key": changeValue},
+						crosstests.DisableAccurateBridgePreview(),
+					)
 
 					autogold.ExpectFile(t, testOutput{
 						initialValue: scenario.initialValue,

--- a/pkg/pf/tests/genrandom_test.go
+++ b/pkg/pf/tests/genrandom_test.go
@@ -48,7 +48,7 @@ func TestGenRandom(t *testing.T) {
 
 		t.Run(trace, func(t *testing.T) {
 			p := testprovider.RandomProvider()
-			p.EnableAccurateBridgePreview = true
+			p.EnableAccurateBridgePreview = false
 			server, err := newProviderServer(t, p)
 			require.NoError(t, err)
 			testutils.ReplayFile(t, server, trace)

--- a/pkg/pf/tests/genupdate_test.go
+++ b/pkg/pf/tests/genupdate_test.go
@@ -35,7 +35,7 @@ func TestGenUpdates(t *testing.T) {
 	trace := "testdata/updateprogram.json"
 
 	info := testprovider.SyntheticTestBridgeProvider()
-	info.EnableAccurateBridgePreview = true
+	info.EnableAccurateBridgePreview = false
 	server, err := newProviderServer(t, info)
 	require.NoError(t, err)
 	testutils.ReplayFile(t, server, trace)

--- a/pkg/pf/tests/internal/cross-tests/diff.go
+++ b/pkg/pf/tests/internal/cross-tests/diff.go
@@ -109,7 +109,8 @@ func Diff(t T, res pb.Resource, tfConfig1, tfConfig2 map[string]cty.Value, optio
 	require.NoError(t, err)
 	t.Logf("Pulumi.yaml:\n%s", string(bytes))
 
-	pt, err := pulcheck.PulCheck(t, bridgedProvider(prov, bridgedProviderOpts{enableAccurateBridgePreview: true}), string(bytes))
+	pt, err := pulcheck.PulCheck(
+		t, bridgedProvider(prov, bridgedProviderOpts{enableAccurateBridgePreview: !opts.disableAccurateBridgePreview}), string(bytes))
 	require.NoError(t, err)
 	pt.Up(t)
 
@@ -133,7 +134,8 @@ func Diff(t T, res pb.Resource, tfConfig1, tfConfig2 map[string]cty.Value, optio
 }
 
 type diffOpts struct {
-	resourceInfo map[string]*info.Schema
+	resourceInfo                 map[string]*info.Schema
+	disableAccurateBridgePreview bool
 }
 
 type DiffOption func(*diffOpts)
@@ -141,4 +143,9 @@ type DiffOption func(*diffOpts)
 // DiffProviderInfo specifies a map of [info.Schema] to apply to the provider under test.
 func DiffProviderInfo(info map[string]*info.Schema) DiffOption {
 	return func(o *diffOpts) { o.resourceInfo = info }
+}
+
+// DisableAccurateBridgePreview disables the accurate bridge preview feature.
+func DisableAccurateBridgePreview() DiffOption {
+	return func(o *diffOpts) { o.disableAccurateBridgePreview = true }
 }

--- a/pkg/pf/tests/provider_diff_test.go
+++ b/pkg/pf/tests/provider_diff_test.go
@@ -57,7 +57,7 @@ func TestEmptyTestresDiff(t *testing.T) {
 func TestOptionRemovalTestresDiff(t *testing.T) {
 	t.Parallel()
 	info := testprovider.SyntheticTestBridgeProvider()
-	info.EnableAccurateBridgePreview = true
+	info.EnableAccurateBridgePreview = false
 	server, err := newProviderServer(t, info)
 	require.NoError(t, err)
 	testCase := `
@@ -82,13 +82,7 @@ func TestOptionRemovalTestresDiff(t *testing.T) {
             "changes": "DIFF_SOME",
             "diffs": [
                "optionalInputString"
-            ],
-            "hasDetailedDiff": true,
-            "detailedDiff": {
-              "optionalInputString": {
-                "kind": "DELETE"
-              }
-            }
+            ]
           }
         }
         `
@@ -270,7 +264,7 @@ func TestSetNestedObjectAdded(t *testing.T) {
 func TestSetNestedObjectAddedOtherDiff(t *testing.T) {
 	t.Parallel()
 	info := testprovider.SyntheticTestBridgeProvider()
-	info.EnableAccurateBridgePreview = true
+	info.EnableAccurateBridgePreview = false
 	server, err := newProviderServer(t, info)
 	require.NoError(t, err)
 	testCase := `
@@ -317,13 +311,7 @@ func TestSetNestedObjectAddedOtherDiff(t *testing.T) {
             "diffs": [
               "other",
               "vlanNames"
-            ],
-            "hasDetailedDiff": true,
-            "detailedDiff": {
-              "other": {
-                "kind": "UPDATE"
-              }
-            }
+            ]
           }
         }
         `

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_no_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_no_replace/added.golden
@@ -32,5 +32,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_no_replace/added_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_no_replace/added_end.golden
@@ -35,11 +35,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
       ~ keys: [
+            [0]: "val1"
+            [1]: "val2"
           + [2]: "val3"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[2]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_no_replace/added_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_no_replace/added_front.golden
@@ -43,9 +43,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"keys[0]": map[string]interface{}{"kind": "UPDATE"},
-		"keys[1]": map[string]interface{}{"kind": "UPDATE"},
-		"keys[2]": map[string]interface{}{},
-	},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_no_replace/added_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_no_replace/added_middle.golden
@@ -35,6 +35,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
       ~ keys: [
+            [0]: "val1"
           ~ [1]: "val3" => "val2"
           + [2]: "val3"
         ]
@@ -42,8 +43,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"keys[1]": map[string]interface{}{"kind": "UPDATE"},
-		"keys[2]": map[string]interface{}{},
-	},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_no_replace/changed_empty_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_no_replace/changed_empty_to_null.golden
@@ -27,5 +27,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_no_replace/changed_non-empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_no_replace/changed_non-empty.golden
@@ -34,5 +34,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_no_replace/changed_null_to_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_no_replace/changed_null_to_empty.golden
@@ -27,5 +27,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_no_replace/element_added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_no_replace/element_added.golden
@@ -32,11 +32,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
       ~ keys: [
+            [0]: "value"
           + [1]: "value1"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[1]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_no_replace/element_removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_no_replace/element_removed.golden
@@ -30,11 +30,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
       ~ keys: [
+            [0]: "value"
           - [1]: "value1"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_no_replace/long_list_added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_no_replace/long_list_added.golden
@@ -71,11 +71,30 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
       ~ keys: [
+            [0]: "value0"
+            [1]: "value1"
+            [2]: "value2"
+            [3]: "value3"
+            [4]: "value4"
+            [5]: "value5"
+            [6]: "value6"
+            [7]: "value7"
+            [8]: "value8"
+            [9]: "value9"
+            [10]: "value10"
+            [11]: "value11"
+            [12]: "value12"
+            [13]: "value13"
+            [14]: "value14"
+            [15]: "value15"
+            [16]: "value16"
+            [17]: "value17"
+            [18]: "value18"
+            [19]: "value19"
           + [20]: "value20"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[20]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_no_replace/long_list_added_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_no_replace/long_list_added_front.golden
@@ -97,27 +97,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"keys[0]":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[10]": map[string]interface{}{"kind": "UPDATE"},
-		"keys[11]": map[string]interface{}{"kind": "UPDATE"},
-		"keys[12]": map[string]interface{}{"kind": "UPDATE"},
-		"keys[13]": map[string]interface{}{"kind": "UPDATE"},
-		"keys[14]": map[string]interface{}{"kind": "UPDATE"},
-		"keys[15]": map[string]interface{}{"kind": "UPDATE"},
-		"keys[16]": map[string]interface{}{"kind": "UPDATE"},
-		"keys[17]": map[string]interface{}{"kind": "UPDATE"},
-		"keys[18]": map[string]interface{}{"kind": "UPDATE"},
-		"keys[19]": map[string]interface{}{"kind": "UPDATE"},
-		"keys[1]":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[20]": map[string]interface{}{},
-		"keys[2]":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[3]":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[4]":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[5]":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[6]":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[7]":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[8]":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[9]":  map[string]interface{}{"kind": "UPDATE"},
-	},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_no_replace/non-null_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_no_replace/non-null_to_null.golden
@@ -33,5 +33,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_no_replace/null_to_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_no_replace/null_to_non-null.golden
@@ -33,5 +33,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_no_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_no_replace/removed.golden
@@ -34,5 +34,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_no_replace/removed_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_no_replace/removed_end.golden
@@ -35,11 +35,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
       ~ keys: [
+            [0]: "val1"
+            [1]: "val2"
           - [2]: "val3"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[2]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_no_replace/removed_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_no_replace/removed_front.golden
@@ -43,9 +43,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"keys[0]": map[string]interface{}{"kind": "UPDATE"},
-		"keys[1]": map[string]interface{}{"kind": "UPDATE"},
-		"keys[2]": map[string]interface{}{"kind": "DELETE"},
-	},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_no_replace/removed_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_no_replace/removed_middle.golden
@@ -35,6 +35,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
       ~ keys: [
+            [0]: "val1"
           ~ [1]: "val2" => "val3"
           - [2]: "val3"
         ]
@@ -42,8 +43,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"keys[1]": map[string]interface{}{"kind": "UPDATE"},
-		"keys[2]": map[string]interface{}{"kind": "DELETE"},
-	},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_requires_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_requires_replace/added.golden
@@ -25,6 +25,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           + [0]: "value"
         ]
@@ -32,5 +33,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_requires_replace/added_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_requires_replace/added_end.golden
@@ -34,12 +34,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
+            [0]: "val1"
+            [1]: "val2"
           + [2]: "val3"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[2]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_requires_replace/added_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_requires_replace/added_front.golden
@@ -34,6 +34,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           ~ [0]: "val2" => "val1"
           ~ [1]: "val3" => "val2"
@@ -43,9 +44,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"keys[0]": map[string]interface{}{"kind": "UPDATE"},
-		"keys[1]": map[string]interface{}{"kind": "UPDATE"},
-		"keys[2]": map[string]interface{}{},
-	},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_requires_replace/added_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_requires_replace/added_middle.golden
@@ -34,7 +34,9 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
+            [0]: "val1"
           ~ [1]: "val3" => "val2"
           + [2]: "val3"
         ]
@@ -42,8 +44,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"keys[1]": map[string]interface{}{"kind": "UPDATE"},
-		"keys[2]": map[string]interface{}{},
-	},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_requires_replace/changed_empty_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_requires_replace/changed_empty_to_null.golden
@@ -22,10 +22,10 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       - keys: []
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_requires_replace/changed_non-empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_requires_replace/changed_non-empty.golden
@@ -27,6 +27,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           ~ [0]: "value" => "value1"
         ]
@@ -34,5 +35,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_requires_replace/changed_null_to_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_requires_replace/changed_null_to_empty.golden
@@ -22,10 +22,10 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       + keys: []
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_requires_replace/element_added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_requires_replace/element_added.golden
@@ -31,12 +31,13 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
+            [0]: "value"
           + [1]: "value1"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[1]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_requires_replace/element_removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_requires_replace/element_removed.golden
@@ -29,12 +29,13 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
+            [0]: "value"
           - [1]: "value1"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_requires_replace/long_list_added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_requires_replace/long_list_added.golden
@@ -70,12 +70,32 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
+            [0]: "value0"
+            [1]: "value1"
+            [2]: "value2"
+            [3]: "value3"
+            [4]: "value4"
+            [5]: "value5"
+            [6]: "value6"
+            [7]: "value7"
+            [8]: "value8"
+            [9]: "value9"
+            [10]: "value10"
+            [11]: "value11"
+            [12]: "value12"
+            [13]: "value13"
+            [14]: "value14"
+            [15]: "value15"
+            [16]: "value16"
+            [17]: "value17"
+            [18]: "value18"
+            [19]: "value19"
           + [20]: "value20"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[20]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_requires_replace/long_list_added_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_requires_replace/long_list_added_front.golden
@@ -70,6 +70,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           ~ [0]: "value0" => "value20"
           ~ [1]: "value1" => "value0"
@@ -97,27 +98,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"keys[0]":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[10]": map[string]interface{}{"kind": "UPDATE"},
-		"keys[11]": map[string]interface{}{"kind": "UPDATE"},
-		"keys[12]": map[string]interface{}{"kind": "UPDATE"},
-		"keys[13]": map[string]interface{}{"kind": "UPDATE"},
-		"keys[14]": map[string]interface{}{"kind": "UPDATE"},
-		"keys[15]": map[string]interface{}{"kind": "UPDATE"},
-		"keys[16]": map[string]interface{}{"kind": "UPDATE"},
-		"keys[17]": map[string]interface{}{"kind": "UPDATE"},
-		"keys[18]": map[string]interface{}{"kind": "UPDATE"},
-		"keys[19]": map[string]interface{}{"kind": "UPDATE"},
-		"keys[1]":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[20]": map[string]interface{}{},
-		"keys[2]":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[3]":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[4]":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[5]":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[6]":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[7]":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[8]":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[9]":  map[string]interface{}{"kind": "UPDATE"},
-	},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_requires_replace/non-null_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_requires_replace/non-null_to_null.golden
@@ -26,6 +26,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       - keys: [
       -     [0]: "value"
         ]
@@ -33,5 +34,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_requires_replace/null_to_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_requires_replace/null_to_non-null.golden
@@ -26,6 +26,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       + keys: [
       +     [0]: "value"
         ]
@@ -33,5 +34,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_requires_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_requires_replace/removed.golden
@@ -27,6 +27,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           - [0]: "value"
         ]
@@ -34,5 +35,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_requires_replace/removed_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_requires_replace/removed_end.golden
@@ -34,12 +34,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
+            [0]: "val1"
+            [1]: "val2"
           - [2]: "val3"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[2]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_requires_replace/removed_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_requires_replace/removed_front.golden
@@ -34,6 +34,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           ~ [0]: "val1" => "val2"
           ~ [1]: "val2" => "val3"
@@ -43,9 +44,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"keys[0]": map[string]interface{}{"kind": "UPDATE"},
-		"keys[1]": map[string]interface{}{"kind": "UPDATE"},
-		"keys[2]": map[string]interface{}{"kind": "DELETE"},
-	},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_requires_replace/removed_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/attribute_requires_replace/removed_middle.golden
@@ -34,7 +34,9 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
+            [0]: "val1"
           ~ [1]: "val2" => "val3"
           - [2]: "val3"
         ]
@@ -42,8 +44,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"keys[1]": map[string]interface{}{"kind": "UPDATE"},
-		"keys[2]": map[string]interface{}{"kind": "DELETE"},
-	},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_nested_requires_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_nested_requires_replace/added.golden
@@ -26,6 +26,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           + [0]: {
                   + nested: "value"
@@ -35,5 +36,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_nested_requires_replace/added_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_nested_requires_replace/added_end.golden
@@ -35,7 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
+            [0]: {
+                    nested: "val1"
+                }
+            [1]: {
+                    nested: "val2"
+                }
           + [2]: {
                   + nested: "val3"
                 }
@@ -44,5 +51,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[2]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_nested_requires_replace/added_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_nested_requires_replace/added_front.golden
@@ -39,6 +39,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           ~ [0]: {
                   ~ nested: "val2" => "val1"
@@ -54,9 +55,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"keys[0].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[1].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[2]":        map[string]interface{}{},
-	},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_nested_requires_replace/added_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_nested_requires_replace/added_middle.golden
@@ -38,7 +38,11 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
+            [0]: {
+                    nested: "val1"
+                }
           ~ [1]: {
                   ~ nested: "val3" => "val2"
                 }
@@ -50,8 +54,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"keys[1].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[2]":        map[string]interface{}{},
-	},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_nested_requires_replace/changed_non-empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_nested_requires_replace/changed_non-empty.golden
@@ -28,6 +28,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           ~ [0]: {
                   ~ nested: "value" => "value1"
@@ -37,5 +38,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0].nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_nested_requires_replace/element_added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_nested_requires_replace/element_added.golden
@@ -33,7 +33,11 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
+            [0]: {
+                    nested: "value"
+                }
           + [1]: {
                   + nested: "value1"
                 }
@@ -42,5 +46,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[1]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_nested_requires_replace/element_removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_nested_requires_replace/element_removed.golden
@@ -32,6 +32,9 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
       ~ keys: [
+            [0]: {
+                    nested: "value"
+                }
           - [1]: {
                   - nested: "value1"
                 }
@@ -40,5 +43,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_nested_requires_replace/long_list_added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_nested_requires_replace/long_list_added.golden
@@ -71,7 +71,68 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
+            [0]: {
+                    nested: "value0"
+                }
+            [1]: {
+                    nested: "value1"
+                }
+            [2]: {
+                    nested: "value2"
+                }
+            [3]: {
+                    nested: "value3"
+                }
+            [4]: {
+                    nested: "value4"
+                }
+            [5]: {
+                    nested: "value5"
+                }
+            [6]: {
+                    nested: "value6"
+                }
+            [7]: {
+                    nested: "value7"
+                }
+            [8]: {
+                    nested: "value8"
+                }
+            [9]: {
+                    nested: "value9"
+                }
+            [10]: {
+                    nested: "value10"
+                }
+            [11]: {
+                    nested: "value11"
+                }
+            [12]: {
+                    nested: "value12"
+                }
+            [13]: {
+                    nested: "value13"
+                }
+            [14]: {
+                    nested: "value14"
+                }
+            [15]: {
+                    nested: "value15"
+                }
+            [16]: {
+                    nested: "value16"
+                }
+            [17]: {
+                    nested: "value17"
+                }
+            [18]: {
+                    nested: "value18"
+                }
+            [19]: {
+                    nested: "value19"
+                }
           + [20]: {
                   + nested: "value20"
                 }
@@ -80,5 +141,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[20]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_nested_requires_replace/long_list_added_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_nested_requires_replace/long_list_added_front.golden
@@ -129,6 +129,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           ~ [0]: {
                   ~ nested: "value0" => "value20"
@@ -198,27 +199,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"keys[0].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[10].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[11].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[12].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[13].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[14].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[15].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[16].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[17].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[18].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[19].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[1].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[20]":        map[string]interface{}{},
-		"keys[2].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[3].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[4].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[5].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[6].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[7].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[8].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[9].nested":  map[string]interface{}{"kind": "UPDATE"},
-	},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_nested_requires_replace/non-null_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_nested_requires_replace/non-null_to_null.golden
@@ -36,5 +36,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_nested_requires_replace/null_to_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_nested_requires_replace/null_to_non-null.golden
@@ -27,6 +27,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           + [0]: {
                   + nested: "value"
@@ -36,5 +37,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_nested_requires_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_nested_requires_replace/removed.golden
@@ -37,5 +37,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_nested_requires_replace/removed_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_nested_requires_replace/removed_end.golden
@@ -36,6 +36,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
       ~ keys: [
+            [0]: {
+                    nested: "val1"
+                }
+            [1]: {
+                    nested: "val2"
+                }
           - [2]: {
                   - nested: "val3"
                 }
@@ -44,5 +50,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[2]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_nested_requires_replace/removed_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_nested_requires_replace/removed_front.golden
@@ -39,6 +39,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           ~ [0]: {
                   ~ nested: "val1" => "val2"
@@ -54,9 +55,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"keys[0].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[1].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[2]":        map[string]interface{}{"kind": "DELETE"},
-	},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_nested_requires_replace/removed_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_nested_requires_replace/removed_middle.golden
@@ -38,7 +38,11 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
+            [0]: {
+                    nested: "val1"
+                }
           ~ [1]: {
                   ~ nested: "val2" => "val3"
                 }
@@ -50,8 +54,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"keys[1].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[2]":        map[string]interface{}{"kind": "DELETE"},
-	},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_no_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_no_replace/added.golden
@@ -35,5 +35,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_no_replace/added_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_no_replace/added_end.golden
@@ -36,6 +36,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
       ~ keys: [
+            [0]: {
+                    nested: "val1"
+                }
+            [1]: {
+                    nested: "val2"
+                }
           + [2]: {
                   + nested: "val3"
                 }
@@ -44,5 +50,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[2]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_no_replace/added_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_no_replace/added_front.golden
@@ -54,9 +54,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"keys[0].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[1].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[2]":        map[string]interface{}{},
-	},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_no_replace/added_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_no_replace/added_middle.golden
@@ -39,6 +39,9 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
       ~ keys: [
+            [0]: {
+                    nested: "val1"
+                }
           ~ [1]: {
                   ~ nested: "val3" => "val2"
                 }
@@ -50,8 +53,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"keys[1].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[2]":        map[string]interface{}{},
-	},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_no_replace/changed_non-empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_no_replace/changed_non-empty.golden
@@ -37,5 +37,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0].nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_no_replace/element_added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_no_replace/element_added.golden
@@ -34,6 +34,9 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
       ~ keys: [
+            [0]: {
+                    nested: "value"
+                }
           + [1]: {
                   + nested: "value1"
                 }
@@ -42,5 +45,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[1]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_no_replace/element_removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_no_replace/element_removed.golden
@@ -32,6 +32,9 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
       ~ keys: [
+            [0]: {
+                    nested: "value"
+                }
           - [1]: {
                   - nested: "value1"
                 }
@@ -40,5 +43,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_no_replace/long_list_added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_no_replace/long_list_added.golden
@@ -72,6 +72,66 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
       ~ keys: [
+            [0]: {
+                    nested: "value0"
+                }
+            [1]: {
+                    nested: "value1"
+                }
+            [2]: {
+                    nested: "value2"
+                }
+            [3]: {
+                    nested: "value3"
+                }
+            [4]: {
+                    nested: "value4"
+                }
+            [5]: {
+                    nested: "value5"
+                }
+            [6]: {
+                    nested: "value6"
+                }
+            [7]: {
+                    nested: "value7"
+                }
+            [8]: {
+                    nested: "value8"
+                }
+            [9]: {
+                    nested: "value9"
+                }
+            [10]: {
+                    nested: "value10"
+                }
+            [11]: {
+                    nested: "value11"
+                }
+            [12]: {
+                    nested: "value12"
+                }
+            [13]: {
+                    nested: "value13"
+                }
+            [14]: {
+                    nested: "value14"
+                }
+            [15]: {
+                    nested: "value15"
+                }
+            [16]: {
+                    nested: "value16"
+                }
+            [17]: {
+                    nested: "value17"
+                }
+            [18]: {
+                    nested: "value18"
+                }
+            [19]: {
+                    nested: "value19"
+                }
           + [20]: {
                   + nested: "value20"
                 }
@@ -80,5 +140,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[20]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_no_replace/long_list_added_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_no_replace/long_list_added_front.golden
@@ -198,27 +198,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"keys[0].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[10].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[11].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[12].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[13].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[14].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[15].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[16].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[17].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[18].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[19].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[1].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[20]":        map[string]interface{}{},
-		"keys[2].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[3].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[4].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[5].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[6].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[7].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[8].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[9].nested":  map[string]interface{}{"kind": "UPDATE"},
-	},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_no_replace/non-null_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_no_replace/non-null_to_null.golden
@@ -36,5 +36,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_no_replace/null_to_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_no_replace/null_to_non-null.golden
@@ -27,14 +27,13 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ testprovider:index/test:Test: (update)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
-      ~ keys: [
-          + [0]: {
-                  + nested: "value"
-                }
+      + keys: [
+      +     [0]: {
+              + nested: "value"
+            }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_no_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_no_replace/removed.golden
@@ -37,5 +37,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_no_replace/removed_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_no_replace/removed_end.golden
@@ -36,6 +36,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
       ~ keys: [
+            [0]: {
+                    nested: "val1"
+                }
+            [1]: {
+                    nested: "val2"
+                }
           - [2]: {
                   - nested: "val3"
                 }
@@ -44,5 +50,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[2]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_no_replace/removed_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_no_replace/removed_front.golden
@@ -54,9 +54,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"keys[0].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[1].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[2]":        map[string]interface{}{"kind": "DELETE"},
-	},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_no_replace/removed_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_no_replace/removed_middle.golden
@@ -39,6 +39,9 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
       ~ keys: [
+            [0]: {
+                    nested: "val1"
+                }
           ~ [1]: {
                   ~ nested: "val2" => "val3"
                 }
@@ -50,8 +53,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"keys[1].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[2]":        map[string]interface{}{"kind": "DELETE"},
-	},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_requires_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_requires_replace/added.golden
@@ -26,6 +26,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           + [0]: {
                   + nested: "value"
@@ -35,5 +36,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_requires_replace/added_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_requires_replace/added_end.golden
@@ -35,7 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
+            [0]: {
+                    nested: "val1"
+                }
+            [1]: {
+                    nested: "val2"
+                }
           + [2]: {
                   + nested: "val3"
                 }
@@ -44,5 +51,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[2]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_requires_replace/added_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_requires_replace/added_front.golden
@@ -39,6 +39,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           ~ [0]: {
                   ~ nested: "val2" => "val1"
@@ -54,9 +55,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"keys[0].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[1].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[2]":        map[string]interface{}{},
-	},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_requires_replace/added_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_requires_replace/added_middle.golden
@@ -38,7 +38,11 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
+            [0]: {
+                    nested: "val1"
+                }
           ~ [1]: {
                   ~ nested: "val3" => "val2"
                 }
@@ -50,8 +54,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"keys[1].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[2]":        map[string]interface{}{},
-	},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_requires_replace/changed_non-empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_requires_replace/changed_non-empty.golden
@@ -28,6 +28,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           ~ [0]: {
                   ~ nested: "value" => "value1"
@@ -37,5 +38,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0].nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_requires_replace/element_added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_requires_replace/element_added.golden
@@ -33,7 +33,11 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
+            [0]: {
+                    nested: "value"
+                }
           + [1]: {
                   + nested: "value1"
                 }
@@ -42,5 +46,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[1]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_requires_replace/element_removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_requires_replace/element_removed.golden
@@ -31,7 +31,11 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
+            [0]: {
+                    nested: "value"
+                }
           - [1]: {
                   - nested: "value1"
                 }
@@ -40,5 +44,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_requires_replace/long_list_added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_requires_replace/long_list_added.golden
@@ -71,7 +71,68 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
+            [0]: {
+                    nested: "value0"
+                }
+            [1]: {
+                    nested: "value1"
+                }
+            [2]: {
+                    nested: "value2"
+                }
+            [3]: {
+                    nested: "value3"
+                }
+            [4]: {
+                    nested: "value4"
+                }
+            [5]: {
+                    nested: "value5"
+                }
+            [6]: {
+                    nested: "value6"
+                }
+            [7]: {
+                    nested: "value7"
+                }
+            [8]: {
+                    nested: "value8"
+                }
+            [9]: {
+                    nested: "value9"
+                }
+            [10]: {
+                    nested: "value10"
+                }
+            [11]: {
+                    nested: "value11"
+                }
+            [12]: {
+                    nested: "value12"
+                }
+            [13]: {
+                    nested: "value13"
+                }
+            [14]: {
+                    nested: "value14"
+                }
+            [15]: {
+                    nested: "value15"
+                }
+            [16]: {
+                    nested: "value16"
+                }
+            [17]: {
+                    nested: "value17"
+                }
+            [18]: {
+                    nested: "value18"
+                }
+            [19]: {
+                    nested: "value19"
+                }
           + [20]: {
                   + nested: "value20"
                 }
@@ -80,5 +141,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[20]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_requires_replace/long_list_added_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_requires_replace/long_list_added_front.golden
@@ -129,6 +129,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           ~ [0]: {
                   ~ nested: "value0" => "value20"
@@ -198,27 +199,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"keys[0].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[10].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[11].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[12].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[13].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[14].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[15].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[16].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[17].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[18].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[19].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[1].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[20]":        map[string]interface{}{},
-		"keys[2].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[3].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[4].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[5].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[6].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[7].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[8].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[9].nested":  map[string]interface{}{"kind": "UPDATE"},
-	},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_requires_replace/non-null_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_requires_replace/non-null_to_null.golden
@@ -27,14 +27,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
-      - keys: [
-      -     [0]: {
-              - nested: "value"
-            }
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          - [0]: {
+                  - nested: "value"
+                }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_requires_replace/null_to_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_requires_replace/null_to_non-null.golden
@@ -27,6 +27,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           + [0]: {
                   + nested: "value"
@@ -36,5 +37,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_requires_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_requires_replace/removed.golden
@@ -28,6 +28,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           - [0]: {
                   - nested: "value"
@@ -37,5 +38,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_requires_replace/removed_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_requires_replace/removed_end.golden
@@ -35,7 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
+            [0]: {
+                    nested: "val1"
+                }
+            [1]: {
+                    nested: "val2"
+                }
           - [2]: {
                   - nested: "val3"
                 }
@@ -44,5 +51,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[2]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_requires_replace/removed_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_requires_replace/removed_front.golden
@@ -39,6 +39,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           ~ [0]: {
                   ~ nested: "val1" => "val2"
@@ -54,9 +55,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"keys[0].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[1].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[2]":        map[string]interface{}{"kind": "DELETE"},
-	},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/block_requires_replace/removed_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/block_requires_replace/removed_middle.golden
@@ -38,7 +38,11 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
+            [0]: {
+                    nested: "val1"
+                }
           ~ [1]: {
                   ~ nested: "val2" => "val3"
                 }
@@ -50,8 +54,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"keys[1].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[2]":        map[string]interface{}{"kind": "DELETE"},
-	},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_nested_requires_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_nested_requires_replace/added.golden
@@ -27,6 +27,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           + [0]: {
                   + nested: "value"
@@ -36,5 +37,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_nested_requires_replace/added_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_nested_requires_replace/added_end.golden
@@ -35,7 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
+            [0]: {
+                    nested: "val1"
+                }
+            [1]: {
+                    nested: "val2"
+                }
           + [2]: {
                   + nested: "val3"
                 }
@@ -44,5 +51,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[2]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_nested_requires_replace/added_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_nested_requires_replace/added_front.golden
@@ -40,6 +40,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           ~ [0]: {
                   ~ nested: "val2" => "val1"
@@ -55,9 +56,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"keys[0].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[1].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[2]":        map[string]interface{}{},
-	},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_nested_requires_replace/added_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_nested_requires_replace/added_middle.golden
@@ -38,7 +38,11 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
+            [0]: {
+                    nested: "val1"
+                }
           ~ [1]: {
                   ~ nested: "val3" => "val2"
                 }
@@ -50,8 +54,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"keys[1].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[2]":        map[string]interface{}{},
-	},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_nested_requires_replace/changed_empty_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_nested_requires_replace/changed_empty_to_null.golden
@@ -27,5 +27,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_nested_requires_replace/changed_non-empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_nested_requires_replace/changed_non-empty.golden
@@ -29,6 +29,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           ~ [0]: {
                   ~ nested: "value" => "value1"
@@ -38,5 +39,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0].nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_nested_requires_replace/changed_null_to_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_nested_requires_replace/changed_null_to_empty.golden
@@ -27,5 +27,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_nested_requires_replace/element_added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_nested_requires_replace/element_added.golden
@@ -33,7 +33,11 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
+            [0]: {
+                    nested: "value"
+                }
           + [1]: {
                   + nested: "value1"
                 }
@@ -42,5 +46,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[1]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_nested_requires_replace/element_removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_nested_requires_replace/element_removed.golden
@@ -32,6 +32,9 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
       ~ keys: [
+            [0]: {
+                    nested: "value"
+                }
           - [1]: {
                   - nested: "value1"
                 }
@@ -40,5 +43,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_nested_requires_replace/long_list_added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_nested_requires_replace/long_list_added.golden
@@ -71,7 +71,68 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
+            [0]: {
+                    nested: "value0"
+                }
+            [1]: {
+                    nested: "value1"
+                }
+            [2]: {
+                    nested: "value2"
+                }
+            [3]: {
+                    nested: "value3"
+                }
+            [4]: {
+                    nested: "value4"
+                }
+            [5]: {
+                    nested: "value5"
+                }
+            [6]: {
+                    nested: "value6"
+                }
+            [7]: {
+                    nested: "value7"
+                }
+            [8]: {
+                    nested: "value8"
+                }
+            [9]: {
+                    nested: "value9"
+                }
+            [10]: {
+                    nested: "value10"
+                }
+            [11]: {
+                    nested: "value11"
+                }
+            [12]: {
+                    nested: "value12"
+                }
+            [13]: {
+                    nested: "value13"
+                }
+            [14]: {
+                    nested: "value14"
+                }
+            [15]: {
+                    nested: "value15"
+                }
+            [16]: {
+                    nested: "value16"
+                }
+            [17]: {
+                    nested: "value17"
+                }
+            [18]: {
+                    nested: "value18"
+                }
+            [19]: {
+                    nested: "value19"
+                }
           + [20]: {
                   + nested: "value20"
                 }
@@ -80,5 +141,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[20]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_nested_requires_replace/long_list_added_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_nested_requires_replace/long_list_added_front.golden
@@ -130,6 +130,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           ~ [0]: {
                   ~ nested: "value0" => "value20"
@@ -199,27 +200,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"keys[0].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[10].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[11].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[12].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[13].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[14].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[15].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[16].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[17].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[18].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[19].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[1].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[20]":        map[string]interface{}{},
-		"keys[2].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[3].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[4].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[5].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[6].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[7].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[8].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[9].nested":  map[string]interface{}{"kind": "UPDATE"},
-	},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_nested_requires_replace/non-null_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_nested_requires_replace/non-null_to_null.golden
@@ -37,5 +37,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_nested_requires_replace/null_to_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_nested_requires_replace/null_to_non-null.golden
@@ -28,6 +28,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       + keys: [
       +     [0]: {
               + nested: "value"
@@ -37,5 +38,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_nested_requires_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_nested_requires_replace/removed.golden
@@ -38,5 +38,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_nested_requires_replace/removed_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_nested_requires_replace/removed_end.golden
@@ -36,6 +36,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
       ~ keys: [
+            [0]: {
+                    nested: "val1"
+                }
+            [1]: {
+                    nested: "val2"
+                }
           - [2]: {
                   - nested: "val3"
                 }
@@ -44,5 +50,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[2]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_nested_requires_replace/removed_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_nested_requires_replace/removed_front.golden
@@ -40,6 +40,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           ~ [0]: {
                   ~ nested: "val1" => "val2"
@@ -55,9 +56,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"keys[0].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[1].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[2]":        map[string]interface{}{"kind": "DELETE"},
-	},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_nested_requires_replace/removed_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_nested_requires_replace/removed_middle.golden
@@ -38,7 +38,11 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
+            [0]: {
+                    nested: "val1"
+                }
           ~ [1]: {
                   ~ nested: "val2" => "val3"
                 }
@@ -50,8 +54,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"keys[1].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[2]":        map[string]interface{}{"kind": "DELETE"},
-	},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_no_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_no_replace/added.golden
@@ -36,5 +36,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_no_replace/added_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_no_replace/added_end.golden
@@ -36,6 +36,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
       ~ keys: [
+            [0]: {
+                    nested: "val1"
+                }
+            [1]: {
+                    nested: "val2"
+                }
           + [2]: {
                   + nested: "val3"
                 }
@@ -44,5 +50,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[2]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_no_replace/added_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_no_replace/added_front.golden
@@ -55,9 +55,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"keys[0].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[1].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[2]":        map[string]interface{}{},
-	},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_no_replace/added_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_no_replace/added_middle.golden
@@ -39,6 +39,9 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
       ~ keys: [
+            [0]: {
+                    nested: "val1"
+                }
           ~ [1]: {
                   ~ nested: "val3" => "val2"
                 }
@@ -50,8 +53,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"keys[1].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[2]":        map[string]interface{}{},
-	},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_no_replace/changed_empty_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_no_replace/changed_empty_to_null.golden
@@ -27,5 +27,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_no_replace/changed_non-empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_no_replace/changed_non-empty.golden
@@ -38,5 +38,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0].nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_no_replace/changed_null_to_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_no_replace/changed_null_to_empty.golden
@@ -27,5 +27,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_no_replace/element_added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_no_replace/element_added.golden
@@ -34,6 +34,9 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
       ~ keys: [
+            [0]: {
+                    nested: "value"
+                }
           + [1]: {
                   + nested: "value1"
                 }
@@ -42,5 +45,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[1]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_no_replace/element_removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_no_replace/element_removed.golden
@@ -32,6 +32,9 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
       ~ keys: [
+            [0]: {
+                    nested: "value"
+                }
           - [1]: {
                   - nested: "value1"
                 }
@@ -40,5 +43,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_no_replace/long_list_added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_no_replace/long_list_added.golden
@@ -72,6 +72,66 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
       ~ keys: [
+            [0]: {
+                    nested: "value0"
+                }
+            [1]: {
+                    nested: "value1"
+                }
+            [2]: {
+                    nested: "value2"
+                }
+            [3]: {
+                    nested: "value3"
+                }
+            [4]: {
+                    nested: "value4"
+                }
+            [5]: {
+                    nested: "value5"
+                }
+            [6]: {
+                    nested: "value6"
+                }
+            [7]: {
+                    nested: "value7"
+                }
+            [8]: {
+                    nested: "value8"
+                }
+            [9]: {
+                    nested: "value9"
+                }
+            [10]: {
+                    nested: "value10"
+                }
+            [11]: {
+                    nested: "value11"
+                }
+            [12]: {
+                    nested: "value12"
+                }
+            [13]: {
+                    nested: "value13"
+                }
+            [14]: {
+                    nested: "value14"
+                }
+            [15]: {
+                    nested: "value15"
+                }
+            [16]: {
+                    nested: "value16"
+                }
+            [17]: {
+                    nested: "value17"
+                }
+            [18]: {
+                    nested: "value18"
+                }
+            [19]: {
+                    nested: "value19"
+                }
           + [20]: {
                   + nested: "value20"
                 }
@@ -80,5 +140,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[20]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_no_replace/long_list_added_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_no_replace/long_list_added_front.golden
@@ -199,27 +199,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"keys[0].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[10].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[11].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[12].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[13].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[14].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[15].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[16].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[17].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[18].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[19].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[1].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[20]":        map[string]interface{}{},
-		"keys[2].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[3].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[4].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[5].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[6].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[7].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[8].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[9].nested":  map[string]interface{}{"kind": "UPDATE"},
-	},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_no_replace/non-null_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_no_replace/non-null_to_null.golden
@@ -37,5 +37,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_no_replace/null_to_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_no_replace/null_to_non-null.golden
@@ -37,5 +37,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_no_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_no_replace/removed.golden
@@ -38,5 +38,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_no_replace/removed_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_no_replace/removed_end.golden
@@ -36,6 +36,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
       ~ keys: [
+            [0]: {
+                    nested: "val1"
+                }
+            [1]: {
+                    nested: "val2"
+                }
           - [2]: {
                   - nested: "val3"
                 }
@@ -44,5 +50,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[2]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_no_replace/removed_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_no_replace/removed_front.golden
@@ -55,9 +55,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"keys[0].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[1].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[2]":        map[string]interface{}{"kind": "DELETE"},
-	},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_no_replace/removed_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_no_replace/removed_middle.golden
@@ -39,6 +39,9 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
       ~ keys: [
+            [0]: {
+                    nested: "val1"
+                }
           ~ [1]: {
                   ~ nested: "val2" => "val3"
                 }
@@ -50,8 +53,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"keys[1].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[2]":        map[string]interface{}{"kind": "DELETE"},
-	},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_requires_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_requires_replace/added.golden
@@ -27,6 +27,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           + [0]: {
                   + nested: "value"
@@ -36,5 +37,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_requires_replace/added_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_requires_replace/added_end.golden
@@ -35,7 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
+            [0]: {
+                    nested: "val1"
+                }
+            [1]: {
+                    nested: "val2"
+                }
           + [2]: {
                   + nested: "val3"
                 }
@@ -44,5 +51,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[2]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_requires_replace/added_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_requires_replace/added_front.golden
@@ -40,6 +40,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           ~ [0]: {
                   ~ nested: "val2" => "val1"
@@ -55,9 +56,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"keys[0].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[1].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[2]":        map[string]interface{}{},
-	},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_requires_replace/added_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_requires_replace/added_middle.golden
@@ -38,7 +38,11 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
+            [0]: {
+                    nested: "val1"
+                }
           ~ [1]: {
                   ~ nested: "val3" => "val2"
                 }
@@ -50,8 +54,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"keys[1].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[2]":        map[string]interface{}{},
-	},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_requires_replace/changed_empty_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_requires_replace/changed_empty_to_null.golden
@@ -22,10 +22,10 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       - keys: []
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_requires_replace/changed_non-empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_requires_replace/changed_non-empty.golden
@@ -29,6 +29,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           ~ [0]: {
                   ~ nested: "value" => "value1"
@@ -38,5 +39,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0].nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_requires_replace/changed_null_to_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_requires_replace/changed_null_to_empty.golden
@@ -22,10 +22,10 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       + keys: []
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_requires_replace/element_added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_requires_replace/element_added.golden
@@ -33,7 +33,11 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
+            [0]: {
+                    nested: "value"
+                }
           + [1]: {
                   + nested: "value1"
                 }
@@ -42,5 +46,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[1]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_requires_replace/element_removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_requires_replace/element_removed.golden
@@ -31,7 +31,11 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
+            [0]: {
+                    nested: "value"
+                }
           - [1]: {
                   - nested: "value1"
                 }
@@ -40,5 +44,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_requires_replace/long_list_added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_requires_replace/long_list_added.golden
@@ -71,7 +71,68 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
+            [0]: {
+                    nested: "value0"
+                }
+            [1]: {
+                    nested: "value1"
+                }
+            [2]: {
+                    nested: "value2"
+                }
+            [3]: {
+                    nested: "value3"
+                }
+            [4]: {
+                    nested: "value4"
+                }
+            [5]: {
+                    nested: "value5"
+                }
+            [6]: {
+                    nested: "value6"
+                }
+            [7]: {
+                    nested: "value7"
+                }
+            [8]: {
+                    nested: "value8"
+                }
+            [9]: {
+                    nested: "value9"
+                }
+            [10]: {
+                    nested: "value10"
+                }
+            [11]: {
+                    nested: "value11"
+                }
+            [12]: {
+                    nested: "value12"
+                }
+            [13]: {
+                    nested: "value13"
+                }
+            [14]: {
+                    nested: "value14"
+                }
+            [15]: {
+                    nested: "value15"
+                }
+            [16]: {
+                    nested: "value16"
+                }
+            [17]: {
+                    nested: "value17"
+                }
+            [18]: {
+                    nested: "value18"
+                }
+            [19]: {
+                    nested: "value19"
+                }
           + [20]: {
                   + nested: "value20"
                 }
@@ -80,5 +141,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[20]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_requires_replace/long_list_added_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_requires_replace/long_list_added_front.golden
@@ -130,6 +130,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           ~ [0]: {
                   ~ nested: "value0" => "value20"
@@ -199,27 +200,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"keys[0].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[10].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[11].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[12].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[13].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[14].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[15].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[16].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[17].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[18].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[19].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[1].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[20]":        map[string]interface{}{},
-		"keys[2].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[3].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[4].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[5].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[6].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[7].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[8].nested":  map[string]interface{}{"kind": "UPDATE"},
-		"keys[9].nested":  map[string]interface{}{"kind": "UPDATE"},
-	},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_requires_replace/non-null_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_requires_replace/non-null_to_null.golden
@@ -28,6 +28,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       - keys: [
       -     [0]: {
               - nested: "value"
@@ -37,5 +38,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_requires_replace/null_to_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_requires_replace/null_to_non-null.golden
@@ -28,6 +28,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       + keys: [
       +     [0]: {
               + nested: "value"
@@ -37,5 +38,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_requires_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_requires_replace/removed.golden
@@ -29,6 +29,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           - [0]: {
                   - nested: "value"
@@ -38,5 +39,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_requires_replace/removed_end.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_requires_replace/removed_end.golden
@@ -35,7 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
+            [0]: {
+                    nested: "val1"
+                }
+            [1]: {
+                    nested: "val2"
+                }
           - [2]: {
                   - nested: "val3"
                 }
@@ -44,5 +51,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[2]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_requires_replace/removed_front.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_requires_replace/removed_front.golden
@@ -40,6 +40,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           ~ [0]: {
                   ~ nested: "val1" => "val2"
@@ -55,9 +56,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"keys[0].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[1].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[2]":        map[string]interface{}{"kind": "DELETE"},
-	},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_requires_replace/removed_middle.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffList/nested_attribute_requires_replace/removed_middle.golden
@@ -38,7 +38,11 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
+            [0]: {
+                    nested: "val1"
+                }
           ~ [1]: {
                   ~ nested: "val2" => "val3"
                 }
@@ -50,8 +54,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"keys[1].nested": map[string]interface{}{"kind": "UPDATE"},
-		"keys[2]":        map[string]interface{}{"kind": "DELETE"},
-	},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffMap/attribute_no_replace/added_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffMap/attribute_no_replace/added_empty.golden
@@ -27,5 +27,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffMap/attribute_no_replace/added_non-empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffMap/attribute_no_replace/added_non-empty.golden
@@ -33,5 +33,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffMap/attribute_no_replace/changed_value_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffMap/attribute_no_replace/changed_value_non-null.golden
@@ -34,5 +34,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key.k": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffMap/attribute_no_replace/removed_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffMap/attribute_no_replace/removed_empty.golden
@@ -27,5 +27,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffMap/attribute_no_replace/removed_non-empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffMap/attribute_no_replace/removed_non-empty.golden
@@ -33,5 +33,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffMap/attribute_requires_replace/added_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffMap/attribute_requires_replace/added_empty.golden
@@ -22,10 +22,10 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       + key: {}
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffMap/attribute_requires_replace/added_non-empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffMap/attribute_requires_replace/added_non-empty.golden
@@ -26,6 +26,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       + key: {
           + k: "value"
         }
@@ -33,5 +34,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffMap/attribute_requires_replace/changed_value_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffMap/attribute_requires_replace/changed_value_non-null.golden
@@ -27,6 +27,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       ~ key: {
           ~ k: "value" => "value1"
         }
@@ -34,5 +35,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key.k": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffMap/attribute_requires_replace/removed_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffMap/attribute_requires_replace/removed_empty.golden
@@ -22,10 +22,10 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       - key: {}
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffMap/attribute_requires_replace/removed_non-empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffMap/attribute_requires_replace/removed_non-empty.golden
@@ -26,6 +26,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       - key: {
           - k: "value"
         }
@@ -33,5 +34,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffMap/nested_attribute_nested_requires_replace/added_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffMap/nested_attribute_nested_requires_replace/added_empty.golden
@@ -27,5 +27,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffMap/nested_attribute_nested_requires_replace/added_non-empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffMap/nested_attribute_nested_requires_replace/added_non-empty.golden
@@ -28,6 +28,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       + key: {
           + k: {
               + nested: "value"
@@ -37,5 +38,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffMap/nested_attribute_nested_requires_replace/changed_value_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffMap/nested_attribute_nested_requires_replace/changed_value_non-null.golden
@@ -29,6 +29,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       ~ key: {
           ~ k: {
               ~ nested: "value" => "value1"
@@ -38,5 +39,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key.k.nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffMap/nested_attribute_nested_requires_replace/removed_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffMap/nested_attribute_nested_requires_replace/removed_empty.golden
@@ -27,5 +27,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffMap/nested_attribute_nested_requires_replace/removed_non-empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffMap/nested_attribute_nested_requires_replace/removed_non-empty.golden
@@ -37,5 +37,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffMap/nested_attribute_no_replace/added_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffMap/nested_attribute_no_replace/added_empty.golden
@@ -27,5 +27,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffMap/nested_attribute_no_replace/added_non-empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffMap/nested_attribute_no_replace/added_non-empty.golden
@@ -37,5 +37,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffMap/nested_attribute_no_replace/changed_value_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffMap/nested_attribute_no_replace/changed_value_non-null.golden
@@ -38,5 +38,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key.k.nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffMap/nested_attribute_no_replace/removed_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffMap/nested_attribute_no_replace/removed_empty.golden
@@ -27,5 +27,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffMap/nested_attribute_no_replace/removed_non-empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffMap/nested_attribute_no_replace/removed_non-empty.golden
@@ -37,5 +37,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffMap/nested_attribute_requires_replace/added_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffMap/nested_attribute_requires_replace/added_empty.golden
@@ -22,10 +22,10 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       + key: {}
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffMap/nested_attribute_requires_replace/added_non-empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffMap/nested_attribute_requires_replace/added_non-empty.golden
@@ -28,6 +28,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       + key: {
           + k: {
               + nested: "value"
@@ -37,5 +38,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffMap/nested_attribute_requires_replace/changed_value_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffMap/nested_attribute_requires_replace/changed_value_non-null.golden
@@ -29,6 +29,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       ~ key: {
           ~ k: {
               ~ nested: "value" => "value1"
@@ -38,5 +39,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key.k.nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffMap/nested_attribute_requires_replace/removed_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffMap/nested_attribute_requires_replace/removed_empty.golden
@@ -22,10 +22,10 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       - key: {}
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffMap/nested_attribute_requires_replace/removed_non-empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffMap/nested_attribute_requires_replace/removed_non-empty.golden
@@ -28,6 +28,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       - key: {
           - k: {
               - nested: "value"
@@ -37,5 +38,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/attribute_default_no_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/attribute_default_no_replace/added.golden
@@ -26,12 +26,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ testprovider:index/test:Test: (update)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
-      ~ key: {
-          ~ nested: "default" => "value"
+      + key: {
+          + nested: "value"
         }
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key.nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/attribute_default_no_replace/changed_value_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/attribute_default_no_replace/changed_value_non-null.golden
@@ -34,5 +34,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key.nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/attribute_default_no_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/attribute_default_no_replace/removed.golden
@@ -33,5 +33,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key.nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/attribute_default_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/attribute_default_replace/added.golden
@@ -26,6 +26,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       ~ key: {
           ~ nested: "default" => "value"
         }
@@ -33,5 +34,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key.nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/attribute_default_replace/changed_value_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/attribute_default_replace/changed_value_non-null.golden
@@ -27,6 +27,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       ~ key: {
           ~ nested: "value" => "changed"
         }
@@ -34,5 +35,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key.nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/attribute_default_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/attribute_default_replace/removed.golden
@@ -26,12 +26,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
-      - key: {
-          - nested: "value"
+      ~ id : "test-id" => output<string>
+      ~ key: {
+          ~ nested: "value" => "default"
         }
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key.nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/attribute_no_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/attribute_no_replace/added.golden
@@ -33,5 +33,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/attribute_no_replace/changed_value_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/attribute_no_replace/changed_value_non-null.golden
@@ -34,5 +34,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key.nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/attribute_no_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/attribute_no_replace/removed.golden
@@ -33,5 +33,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/attribute_plan_modifier_default/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/attribute_plan_modifier_default/added.golden
@@ -26,12 +26,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ testprovider:index/test:Test: (update)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
-      ~ key: {
-          ~ nested: "default" => "value"
+      + key: {
+          + nested: "value"
         }
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key.nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/attribute_plan_modifier_default/changed_value_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/attribute_plan_modifier_default/changed_value_non-null.golden
@@ -34,5 +34,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key.nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/attribute_plan_modifier_default_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/attribute_plan_modifier_default_replace/added.golden
@@ -26,6 +26,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       ~ key: {
           ~ nested: "default" => "value"
         }
@@ -33,5 +34,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key.nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/attribute_plan_modifier_default_replace/changed_value_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/attribute_plan_modifier_default_replace/changed_value_non-null.golden
@@ -27,6 +27,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       ~ key: {
           ~ nested: "value" => "changed"
         }
@@ -34,5 +35,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key.nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/attribute_requires_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/attribute_requires_replace/added.golden
@@ -26,6 +26,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       + key: {
           + nested: "value"
         }
@@ -33,5 +34,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/attribute_requires_replace/changed_value_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/attribute_requires_replace/changed_value_non-null.golden
@@ -27,6 +27,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       ~ key: {
           ~ nested: "value" => "changed"
         }
@@ -34,5 +35,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key.nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/attribute_requires_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/attribute_requires_replace/removed.golden
@@ -26,6 +26,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       - key: {
           - nested: "value"
         }
@@ -33,5 +34,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_default_nested_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_default_nested_replace/added.golden
@@ -27,6 +27,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       + key: {
           + nested: "value"
         }
@@ -34,5 +35,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_default_nested_replace/changed_empty_to_non-empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_default_nested_replace/changed_empty_to_non-empty.golden
@@ -26,6 +26,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       ~ key: {
           ~ nested: "default" => "value"
         }
@@ -33,5 +34,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key.nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_default_nested_replace/changed_non-empty_to_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_default_nested_replace/changed_non-empty_to_empty.golden
@@ -28,12 +28,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       ~ key: {
-          - nested: "value"
+          ~ nested: "value" => "default"
         }
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key.nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_default_nested_replace/changed_value_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_default_nested_replace/changed_value_non-null.golden
@@ -28,6 +28,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       ~ key: {
           ~ nested: "value" => "changed"
         }
@@ -35,5 +36,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key.nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_default_nested_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_default_nested_replace/removed.golden
@@ -34,5 +34,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_default_no_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_default_no_replace/added.golden
@@ -34,5 +34,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_default_no_replace/changed_empty_to_non-empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_default_no_replace/changed_empty_to_non-empty.golden
@@ -27,11 +27,10 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
       ~ key: {
-          ~ nested: "default" => "value"
+          + nested: "value"
         }
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key.nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_default_no_replace/changed_non-empty_to_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_default_no_replace/changed_non-empty_to_empty.golden
@@ -35,5 +35,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key.nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_default_no_replace/changed_value_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_default_no_replace/changed_value_non-null.golden
@@ -35,5 +35,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key.nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_default_no_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_default_no_replace/removed.golden
@@ -34,5 +34,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_default_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_default_replace/added.golden
@@ -27,6 +27,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       + key: {
           + nested: "value"
         }
@@ -34,5 +35,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_default_replace/changed_empty_to_non-empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_default_replace/changed_empty_to_non-empty.golden
@@ -26,6 +26,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       ~ key: {
           ~ nested: "default" => "value"
         }
@@ -33,5 +34,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key.nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_default_replace/changed_non-empty_to_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_default_replace/changed_non-empty_to_empty.golden
@@ -28,12 +28,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       ~ key: {
-          - nested: "value"
+          ~ nested: "value" => "default"
         }
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key.nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_default_replace/changed_value_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_default_replace/changed_value_non-null.golden
@@ -28,6 +28,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       ~ key: {
           ~ nested: "value" => "changed"
         }
@@ -35,5 +36,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key.nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_default_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_default_replace/removed.golden
@@ -27,6 +27,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       - key: {
           - nested: "value"
         }
@@ -34,5 +35,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_nested_requires_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_nested_requires_replace/added.golden
@@ -27,6 +27,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       + key: {
           + nested: "value"
         }
@@ -34,5 +35,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_nested_requires_replace/changed_empty_to_non-empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_nested_requires_replace/changed_empty_to_non-empty.golden
@@ -26,6 +26,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       ~ key: {
           + nested: "value"
         }
@@ -33,5 +34,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key.nested": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_nested_requires_replace/changed_non-empty_to_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_nested_requires_replace/changed_non-empty_to_empty.golden
@@ -28,6 +28,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       ~ key: {
           - nested: "value"
         }
@@ -35,5 +36,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key.nested": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_nested_requires_replace/changed_value_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_nested_requires_replace/changed_value_non-null.golden
@@ -28,6 +28,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       ~ key: {
           ~ nested: "value" => "changed"
         }
@@ -35,5 +36,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key.nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_nested_requires_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_nested_requires_replace/removed.golden
@@ -34,5 +34,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_no_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_no_replace/added.golden
@@ -34,5 +34,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_no_replace/changed_empty_to_non-empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_no_replace/changed_empty_to_non-empty.golden
@@ -33,5 +33,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key.nested": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_no_replace/changed_non-empty_to_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_no_replace/changed_non-empty_to_empty.golden
@@ -35,5 +35,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key.nested": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_no_replace/changed_value_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_no_replace/changed_value_non-null.golden
@@ -35,5 +35,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key.nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_no_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_no_replace/removed.golden
@@ -34,5 +34,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_plan_modifier_no_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_plan_modifier_no_replace/added.golden
@@ -34,5 +34,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_plan_modifier_no_replace/changed_empty_to_non-empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_plan_modifier_no_replace/changed_empty_to_non-empty.golden
@@ -27,11 +27,10 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
       ~ key: {
-          ~ nested: "default" => "value"
+          + nested: "value"
         }
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key.nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_plan_modifier_no_replace/changed_value_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_plan_modifier_no_replace/changed_value_non-null.golden
@@ -35,5 +35,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key.nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_plan_modifier_no_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_plan_modifier_no_replace/removed.golden
@@ -34,5 +34,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_plan_modifier_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_plan_modifier_replace/added.golden
@@ -27,6 +27,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       + key: {
           + nested: "value"
         }
@@ -34,5 +35,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_plan_modifier_replace/changed_empty_to_non-empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_plan_modifier_replace/changed_empty_to_non-empty.golden
@@ -26,6 +26,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       ~ key: {
           ~ nested: "default" => "value"
         }
@@ -33,5 +34,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key.nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_plan_modifier_replace/changed_value_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_plan_modifier_replace/changed_value_non-null.golden
@@ -28,6 +28,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       ~ key: {
           ~ nested: "value" => "changed"
         }
@@ -35,5 +36,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key.nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_plan_modifier_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_plan_modifier_replace/removed.golden
@@ -34,5 +34,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_requires_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_requires_replace/added.golden
@@ -27,6 +27,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       + key: {
           + nested: "value"
         }
@@ -34,5 +35,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_requires_replace/changed_empty_to_non-empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_requires_replace/changed_empty_to_non-empty.golden
@@ -26,6 +26,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       ~ key: {
           + nested: "value"
         }
@@ -33,5 +34,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key.nested": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_requires_replace/changed_non-empty_to_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_requires_replace/changed_non-empty_to_empty.golden
@@ -28,6 +28,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       ~ key: {
           - nested: "value"
         }
@@ -35,5 +36,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key.nested": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_requires_replace/changed_value_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_requires_replace/changed_value_non-null.golden
@@ -28,6 +28,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       ~ key: {
           ~ nested: "value" => "changed"
         }
@@ -35,5 +36,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key.nested": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_requires_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffObject/nested_block_requires_replace/removed.golden
@@ -27,6 +27,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       - key: {
           - nested: "value"
         }
@@ -34,5 +35,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_no_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_no_replace/added.golden
@@ -32,5 +32,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_no_replace/changed_empty_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_no_replace/changed_empty_to_null.golden
@@ -27,5 +27,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_no_replace/changed_non-null_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_no_replace/changed_non-null_to_null.golden
@@ -33,5 +33,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_no_replace/changed_null_to_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_no_replace/changed_null_to_empty.golden
@@ -27,5 +27,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_no_replace/changed_null_to_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_no_replace/changed_null_to_non-null.golden
@@ -33,5 +33,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_no_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_no_replace/removed.golden
@@ -34,5 +34,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_requires_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_requires_replace/added.golden
@@ -25,6 +25,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           + [0]: "value"
         ]
@@ -32,5 +33,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_requires_replace/changed_empty_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_requires_replace/changed_empty_to_null.golden
@@ -22,10 +22,10 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       - keys: []
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_requires_replace/changed_non-null_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_requires_replace/changed_non-null_to_null.golden
@@ -26,6 +26,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       - keys: [
       -     [0]: "value"
         ]
@@ -33,5 +34,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_requires_replace/changed_null_to_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_requires_replace/changed_null_to_empty.golden
@@ -22,10 +22,10 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       + keys: []
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_requires_replace/changed_null_to_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_requires_replace/changed_null_to_non-null.golden
@@ -26,6 +26,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       + keys: [
       +     [0]: "value"
         ]
@@ -33,5 +34,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_requires_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_requires_replace/removed.golden
@@ -27,6 +27,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           - [0]: "value"
         ]
@@ -34,5 +35,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/added.golden
@@ -32,5 +32,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/changed_null_to_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/changed_null_to_empty.golden
@@ -24,12 +24,9 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ testprovider:index/test:Test: (update)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
-      ~ keys: [
-          - [0]: "value"
-        ]
+      + keys: []
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_no_replace/removed.golden
@@ -34,5 +34,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/added.golden
@@ -25,6 +25,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           + [0]: "value"
         ]
@@ -32,5 +33,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/changed_null_to_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/changed_null_to_empty.golden
@@ -24,6 +24,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           - [0]: "value"
         ]
@@ -31,5 +32,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_computed_requires_replace/removed.golden
@@ -27,6 +27,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           - [0]: "value"
         ]
@@ -34,5 +35,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/added.golden
@@ -32,5 +32,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/changed_empty_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/changed_empty_to_null.golden
@@ -29,5 +29,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/changed_null_to_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/changed_null_to_empty.golden
@@ -24,12 +24,9 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ testprovider:index/test:Test: (update)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
-      ~ keys: [
-          - [0]: "value"
-        ]
+      + keys: []
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/attribute_with_default/removed.golden
@@ -34,5 +34,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_nested_requires_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_nested_requires_replace/added.golden
@@ -26,6 +26,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           + [0]: {
                   + nested: "value"
@@ -35,5 +36,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_nested_requires_replace/changed_non-null_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_nested_requires_replace/changed_non-null_to_null.golden
@@ -36,5 +36,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_nested_requires_replace/changed_null_to_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_nested_requires_replace/changed_null_to_non-null.golden
@@ -27,6 +27,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           + [0]: {
                   + nested: "value"
@@ -36,5 +37,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_nested_requires_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_nested_requires_replace/removed.golden
@@ -37,5 +37,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_no_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_no_replace/added.golden
@@ -35,5 +35,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_no_replace/changed_non-null_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_no_replace/changed_non-null_to_null.golden
@@ -36,5 +36,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_no_replace/changed_null_to_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_no_replace/changed_null_to_non-null.golden
@@ -27,14 +27,13 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ testprovider:index/test:Test: (update)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
-      ~ keys: [
-          + [0]: {
-                  + nested: "value"
-                }
+      + keys: [
+      +     [0]: {
+              + nested: "value"
+            }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_no_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_no_replace/removed.golden
@@ -37,5 +37,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_requires_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_requires_replace/added.golden
@@ -26,6 +26,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           + [0]: {
                   + nested: "value"
@@ -35,5 +36,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_requires_replace/changed_non-null_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_requires_replace/changed_non-null_to_null.golden
@@ -27,14 +27,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
-      - keys: [
-      -     [0]: {
-              - nested: "value"
-            }
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          - [0]: {
+                  - nested: "value"
+                }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_requires_replace/changed_null_to_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_requires_replace/changed_null_to_non-null.golden
@@ -27,6 +27,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           + [0]: {
                   + nested: "value"
@@ -36,5 +37,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_requires_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_requires_replace/removed.golden
@@ -28,6 +28,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           - [0]: {
                   - nested: "value"
@@ -37,5 +38,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/added.golden
@@ -27,14 +27,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           + [0]: {
-                  + nested: "value"
+                  + computed: output<string>
+                  + nested  : "value"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/changed_non-null_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/changed_non-null_to_null.golden
@@ -30,13 +30,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
       - keys: [
       -     [0]: {
-              - computed: "computed-value"
-              - nested  : "value"
+              - nested: "value"
             }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/changed_null_to_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/changed_null_to_non-null.golden
@@ -28,14 +28,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           + [0]: {
-                  + nested: "value"
+                  + computed: output<string>
+                  + nested  : "value"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace/removed.golden
@@ -31,13 +31,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
       ~ keys: [
           - [0]: {
-                  - computed: "computed-value"
-                  - nested  : "value"
+                  - nested: "value"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/added.golden
@@ -27,6 +27,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           + [0]: {
                   + computed: "non-computed-value"
@@ -37,5 +38,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/changed_non-null_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/changed_non-null_to_null.golden
@@ -38,5 +38,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/changed_null_to_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/changed_null_to_non-null.golden
@@ -28,6 +28,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           + [0]: {
                   + computed: "non-computed-value"
@@ -38,5 +39,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_computed_requires_replace_computed_specified_in_program/removed.golden
@@ -39,5 +39,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/added.golden
@@ -27,14 +27,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           + [0]: {
-                  + nested: "value"
+                  + computed: output<string>
+                  + nested  : "value"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/changed_non-null_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/changed_non-null_to_null.golden
@@ -30,13 +30,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
       - keys: [
       -     [0]: {
-              - computed: "computed-value"
-              - nested  : "value"
+              - nested: "value"
             }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/changed_null_to_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/changed_null_to_non-null.golden
@@ -28,14 +28,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           + [0]: {
-                  + nested: "value"
+                  + computed: output<string>
+                  + nested  : "value"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace/removed.golden
@@ -31,13 +31,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
       ~ keys: [
           - [0]: {
-                  - computed: "computed-value"
-                  - nested  : "value"
+                  - nested: "value"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/added.golden
@@ -27,6 +27,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           + [0]: {
                   + computed: "non-computed-value"
@@ -37,5 +38,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/changed_non-null_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/changed_non-null_to_null.golden
@@ -38,5 +38,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/changed_null_to_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/changed_null_to_non-null.golden
@@ -28,6 +28,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           + [0]: {
                   + computed: "non-computed-value"
@@ -38,5 +39,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_and_nested_requires_replace_computed_specified_in_program/removed.golden
@@ -39,5 +39,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/added.golden
@@ -36,5 +36,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/changed_non-null_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/changed_non-null_to_null.golden
@@ -30,13 +30,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
       - keys: [
       -     [0]: {
-              - computed: "computed-value"
-              - nested  : "value"
+              - nested: "value"
             }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/changed_null_to_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/changed_null_to_non-null.golden
@@ -28,14 +28,13 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ testprovider:index/test:Test: (update)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
-      ~ keys: [
-          + [0]: {
-                  + nested: "value"
-                }
+      + keys: [
+      +     [0]: {
+              + nested: "value"
+            }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed/removed.golden
@@ -31,13 +31,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
       ~ keys: [
           - [0]: {
-                  - computed: "computed-value"
-                  - nested  : "value"
+                  - nested: "value"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/added.golden
@@ -37,5 +37,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/changed_non-null_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/changed_non-null_to_null.golden
@@ -38,5 +38,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/changed_null_to_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/changed_null_to_non-null.golden
@@ -28,15 +28,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ testprovider:index/test:Test: (update)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
-      ~ keys: [
-          + [0]: {
-                  + computed: "non-computed-value"
-                  + nested  : "value"
-                }
+      + keys: [
+      +     [0]: {
+              + computed: "non-computed-value"
+              + nested  : "value"
+            }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_replace_computed_specified_in_program/removed.golden
@@ -39,5 +39,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/added.golden
@@ -36,5 +36,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/changed_non-null_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/changed_non-null_to_null.golden
@@ -30,13 +30,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
       - keys: [
       -     [0]: {
-              - computed: "computed-value"
-              - nested  : "value"
+              - nested: "value"
             }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/changed_null_to_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/changed_null_to_non-null.golden
@@ -28,14 +28,13 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ testprovider:index/test:Test: (update)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
-      ~ keys: [
-          + [0]: {
-                  + nested: "value"
-                }
+      + keys: [
+      +     [0]: {
+              + nested: "value"
+            }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown/removed.golden
@@ -31,13 +31,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
       ~ keys: [
           - [0]: {
-                  - computed: "computed-value"
-                  - nested  : "value"
+                  - nested: "value"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/added.golden
@@ -37,5 +37,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/changed_non-null_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/changed_non-null_to_null.golden
@@ -38,5 +38,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/changed_null_to_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/changed_null_to_non-null.golden
@@ -28,15 +28,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ testprovider:index/test:Test: (update)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
-      ~ keys: [
-          + [0]: {
-                  + computed: "non-computed-value"
-                  + nested  : "value"
-                }
+      + keys: [
+      +     [0]: {
+              + computed: "non-computed-value"
+              + nested  : "value"
+            }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_no_state_for_unknown_computed_specified_in_program/removed.golden
@@ -39,5 +39,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/added.golden
@@ -27,14 +27,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           + [0]: {
-                  + nested: "value"
+                  + computed: output<string>
+                  + nested  : "value"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/changed_non-null_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/changed_non-null_to_null.golden
@@ -28,15 +28,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
-      - keys: [
-      -     [0]: {
-              - computed: "computed-value"
-              - nested  : "value"
-            }
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          - [0]: {
+                  - computed: "computed-value"
+                  - nested  : "value"
+                }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/changed_null_to_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/changed_null_to_non-null.golden
@@ -28,14 +28,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           + [0]: {
-                  + nested: "value"
+                  + computed: output<string>
+                  + nested  : "value"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace/removed.golden
@@ -29,6 +29,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           - [0]: {
                   - computed: "computed-value"
@@ -39,5 +40,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/added.golden
@@ -27,6 +27,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           + [0]: {
                   + computed: "non-computed-value"
@@ -37,5 +38,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/changed_non-null_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/changed_non-null_to_null.golden
@@ -28,15 +28,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
-      - keys: [
-      -     [0]: {
-              - computed: "non-computed-value"
-              - nested  : "value"
-            }
+      ~ id  : "test-id" => output<string>
+      ~ keys: [
+          - [0]: {
+                  - computed: "non-computed-value"
+                  - nested  : "value"
+                }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/changed_null_to_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/changed_null_to_non-null.golden
@@ -28,6 +28,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           + [0]: {
                   + computed: "non-computed-value"
@@ -38,5 +39,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_computed_requires_replace_computed_specified_in_program/removed.golden
@@ -29,6 +29,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           - [0]: {
                   - computed: "non-computed-value"
@@ -39,5 +40,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/added.golden
@@ -35,5 +35,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/changed_non-null_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/changed_non-null_to_null.golden
@@ -36,5 +36,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/changed_null_to_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/changed_null_to_non-null.golden
@@ -27,14 +27,13 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ testprovider:index/test:Test: (update)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
-      ~ keys: [
-          + [0]: {
-                  + nested: "value"
-                }
+      + keys: [
+      +     [0]: {
+              + nested: "value"
+            }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/block_with_default/removed.golden
@@ -37,5 +37,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/nested_attribute_nested_requires_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/nested_attribute_nested_requires_replace/added.golden
@@ -27,6 +27,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           + [0]: {
                   + nested: "value"
@@ -36,5 +37,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/nested_attribute_nested_requires_replace/changed_empty_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/nested_attribute_nested_requires_replace/changed_empty_to_null.golden
@@ -27,5 +27,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/nested_attribute_nested_requires_replace/changed_non-null_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/nested_attribute_nested_requires_replace/changed_non-null_to_null.golden
@@ -37,5 +37,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/nested_attribute_nested_requires_replace/changed_null_to_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/nested_attribute_nested_requires_replace/changed_null_to_empty.golden
@@ -27,5 +27,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/nested_attribute_nested_requires_replace/changed_null_to_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/nested_attribute_nested_requires_replace/changed_null_to_non-null.golden
@@ -28,6 +28,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       + keys: [
       +     [0]: {
               + nested: "value"
@@ -37,5 +38,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/nested_attribute_nested_requires_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/nested_attribute_nested_requires_replace/removed.golden
@@ -38,5 +38,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/nested_attribute_no_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/nested_attribute_no_replace/added.golden
@@ -36,5 +36,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/nested_attribute_no_replace/changed_empty_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/nested_attribute_no_replace/changed_empty_to_null.golden
@@ -27,5 +27,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/nested_attribute_no_replace/changed_non-null_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/nested_attribute_no_replace/changed_non-null_to_null.golden
@@ -37,5 +37,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/nested_attribute_no_replace/changed_null_to_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/nested_attribute_no_replace/changed_null_to_empty.golden
@@ -27,5 +27,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/nested_attribute_no_replace/changed_null_to_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/nested_attribute_no_replace/changed_null_to_non-null.golden
@@ -37,5 +37,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/nested_attribute_no_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/nested_attribute_no_replace/removed.golden
@@ -38,5 +38,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/nested_attribute_requires_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/nested_attribute_requires_replace/added.golden
@@ -27,6 +27,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           + [0]: {
                   + nested: "value"
@@ -36,5 +37,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/nested_attribute_requires_replace/changed_empty_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/nested_attribute_requires_replace/changed_empty_to_null.golden
@@ -22,10 +22,10 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       - keys: []
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/nested_attribute_requires_replace/changed_non-null_to_null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/nested_attribute_requires_replace/changed_non-null_to_null.golden
@@ -28,6 +28,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       - keys: [
       -     [0]: {
               - nested: "value"
@@ -37,5 +38,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/nested_attribute_requires_replace/changed_null_to_empty.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/nested_attribute_requires_replace/changed_null_to_empty.golden
@@ -22,10 +22,10 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       + keys: []
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/nested_attribute_requires_replace/changed_null_to_non-null.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/nested_attribute_requires_replace/changed_null_to_non-null.golden
@@ -28,6 +28,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       + keys: [
       +     [0]: {
               + nested: "value"
@@ -37,5 +38,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffSet/nested_attribute_requires_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffSet/nested_attribute_requires_replace/removed.golden
@@ -29,6 +29,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id  : "test-id" => output<string>
       ~ keys: [
           - [0]: {
                   - nested: "value"
@@ -38,5 +39,4 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"keys[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/genrandom/random-delete-preview.json
+++ b/pkg/pf/tests/testdata/genrandom/random-delete-preview.json
@@ -24,6 +24,25 @@
     }
   },
   {
+    "method": "/pulumirpc.LanguageRuntime/GetRequiredPackages",
+    "request": {
+      "info": {
+        "rootDirectory": "/Users/vvm/code/pulumi-terraform-bridge/pkg/pf/tests/testdatagen/genrandom",
+        "programDirectory": "/Users/vvm/code/pulumi-terraform-bridge/pkg/pf/tests/testdatagen/genrandom",
+        "entryPoint": ".",
+        "options": {}
+      }
+    },
+    "errors": [
+      "rpc error: code = Unimplemented desc = unknown method GetRequiredPackages for service pulumirpc.LanguageRuntime"
+    ],
+    "metadata": {
+      "kind": "language",
+      "mode": "client",
+      "runtime": "go"
+    }
+  },
+  {
     "method": "/pulumirpc.LanguageRuntime/GetRequiredPlugins",
     "request": {
       "project": "deprecated",
@@ -247,7 +266,7 @@
       "customTimeouts": {},
       "acceptResources": true,
       "sourcePosition": {
-        "uri": "project://%2FUsers%2Fvvm%2Fgo%2Fpkg%2Fmod%2Fgithub.com%2Fpulumi%2Fpulumi%2Fsdk%2Fv3@v3.137.0%2Fgo%2Fpulumi%2Frun.go",
+        "uri": "project://%2FUsers%2Fvvm%2Fgo%2Fpkg%2Fmod%2Fgithub.com%2Fpulumi%2Fpulumi%2Fsdk%2Fv3@v3.143.0%2Fgo%2Fpulumi%2Frun.go",
         "line": 98
       },
       "supportsResultReporting": true
@@ -283,7 +302,7 @@
       },
       "dryRun": true,
       "parallel": 48,
-      "monitorAddress": "127.0.0.1:52719",
+      "monitorAddress": "127.0.0.1:57567",
       "organization": "pulumi",
       "configPropertyMap": {
         "genradom:min": 0
@@ -294,7 +313,7 @@
         "entryPoint": ".",
         "options": {}
       },
-      "loaderTarget": "127.0.0.1:52720"
+      "loaderTarget": "127.0.0.1:57568"
     },
     "response": {},
     "metadata": {

--- a/pkg/pf/tests/testdata/genrandom/random-delete-update.json
+++ b/pkg/pf/tests/testdata/genrandom/random-delete-update.json
@@ -24,6 +24,25 @@
     }
   },
   {
+    "method": "/pulumirpc.LanguageRuntime/GetRequiredPackages",
+    "request": {
+      "info": {
+        "rootDirectory": "/Users/vvm/code/pulumi-terraform-bridge/pkg/pf/tests/testdatagen/genrandom",
+        "programDirectory": "/Users/vvm/code/pulumi-terraform-bridge/pkg/pf/tests/testdatagen/genrandom",
+        "entryPoint": ".",
+        "options": {}
+      }
+    },
+    "errors": [
+      "rpc error: code = Unimplemented desc = unknown method GetRequiredPackages for service pulumirpc.LanguageRuntime"
+    ],
+    "metadata": {
+      "kind": "language",
+      "mode": "client",
+      "runtime": "go"
+    }
+  },
+  {
     "method": "/pulumirpc.LanguageRuntime/GetRequiredPlugins",
     "request": {
       "project": "deprecated",
@@ -247,7 +266,7 @@
       "customTimeouts": {},
       "acceptResources": true,
       "sourcePosition": {
-        "uri": "project://%2FUsers%2Fvvm%2Fgo%2Fpkg%2Fmod%2Fgithub.com%2Fpulumi%2Fpulumi%2Fsdk%2Fv3@v3.137.0%2Fgo%2Fpulumi%2Frun.go",
+        "uri": "project://%2FUsers%2Fvvm%2Fgo%2Fpkg%2Fmod%2Fgithub.com%2Fpulumi%2Fpulumi%2Fsdk%2Fv3@v3.143.0%2Fgo%2Fpulumi%2Frun.go",
         "line": 98
       },
       "supportsResultReporting": true
@@ -282,7 +301,7 @@
         "genradom:min": "0"
       },
       "parallel": 48,
-      "monitorAddress": "127.0.0.1:52744",
+      "monitorAddress": "127.0.0.1:57582",
       "organization": "pulumi",
       "configPropertyMap": {
         "genradom:min": 0
@@ -293,7 +312,7 @@
         "entryPoint": ".",
         "options": {}
       },
-      "loaderTarget": "127.0.0.1:52745"
+      "loaderTarget": "127.0.0.1:57583"
     },
     "response": {},
     "metadata": {

--- a/pkg/pf/tests/testdata/genrandom/random-empty-preview.json
+++ b/pkg/pf/tests/testdata/genrandom/random-empty-preview.json
@@ -24,6 +24,25 @@
     }
   },
   {
+    "method": "/pulumirpc.LanguageRuntime/GetRequiredPackages",
+    "request": {
+      "info": {
+        "rootDirectory": "/Users/vvm/code/pulumi-terraform-bridge/pkg/pf/tests/testdatagen/genrandom",
+        "programDirectory": "/Users/vvm/code/pulumi-terraform-bridge/pkg/pf/tests/testdatagen/genrandom",
+        "entryPoint": ".",
+        "options": {}
+      }
+    },
+    "errors": [
+      "rpc error: code = Unimplemented desc = unknown method GetRequiredPackages for service pulumirpc.LanguageRuntime"
+    ],
+    "metadata": {
+      "kind": "language",
+      "mode": "client",
+      "runtime": "go"
+    }
+  },
+  {
     "method": "/pulumirpc.LanguageRuntime/GetRequiredPlugins",
     "request": {
       "project": "deprecated",
@@ -247,7 +266,7 @@
       "customTimeouts": {},
       "acceptResources": true,
       "sourcePosition": {
-        "uri": "project://%2FUsers%2Fvvm%2Fgo%2Fpkg%2Fmod%2Fgithub.com%2Fpulumi%2Fpulumi%2Fsdk%2Fv3@v3.137.0%2Fgo%2Fpulumi%2Frun.go",
+        "uri": "project://%2FUsers%2Fvvm%2Fgo%2Fpkg%2Fmod%2Fgithub.com%2Fpulumi%2Fpulumi%2Fsdk%2Fv3@v3.143.0%2Fgo%2Fpulumi%2Frun.go",
         "line": 98
       },
       "supportsResultReporting": true
@@ -396,7 +415,7 @@
         "min": 1,
         "seed": "pseudo-random-seed"
       },
-      "randomSeed": "TTFN3t/Mt9UdllJ73HJN44pK94jKpkwHULmgCtfHZQM=",
+      "randomSeed": "p2/k+Gvri3k4HuN3GlKQ5yQCm3gfvAjXRGF95Xd/n1s=",
       "name": "r1",
       "type": "random:index/randomInteger:RandomInteger"
     },
@@ -573,7 +592,7 @@
       },
       "dryRun": true,
       "parallel": 48,
-      "monitorAddress": "127.0.0.1:52631",
+      "monitorAddress": "127.0.0.1:57492",
       "organization": "pulumi",
       "configPropertyMap": {
         "genradom:min": 1
@@ -584,7 +603,7 @@
         "entryPoint": ".",
         "options": {}
       },
-      "loaderTarget": "127.0.0.1:52632"
+      "loaderTarget": "127.0.0.1:57493"
     },
     "response": {},
     "metadata": {
@@ -597,28 +616,6 @@
     "method": "/pulumirpc.Analyzer/AnalyzeStack",
     "request": {
       "resources": [
-        {
-          "type": "pulumi:pulumi:Stack",
-          "properties": {
-            "r.result": 15
-          },
-          "urn": "urn:pulumi:generate::genradom::pulumi:pulumi:Stack::genradom-generate",
-          "name": "genradom-generate",
-          "options": {
-            "customTimeouts": {}
-          }
-        },
-        {
-          "type": "pulumi:providers:random",
-          "properties": {
-            "version": "4.8.2"
-          },
-          "urn": "urn:pulumi:generate::genradom::pulumi:providers:random::default_4_8_2",
-          "name": "default_4_8_2",
-          "options": {
-            "customTimeouts": {}
-          }
-        },
         {
           "type": "random:index/randomInteger:RandomInteger",
           "properties": {
@@ -642,6 +639,28 @@
             "name": "default_4_8_2"
           },
           "parent": "urn:pulumi:generate::genradom::pulumi:pulumi:Stack::genradom-generate"
+        },
+        {
+          "type": "pulumi:pulumi:Stack",
+          "properties": {
+            "r.result": 15
+          },
+          "urn": "urn:pulumi:generate::genradom::pulumi:pulumi:Stack::genradom-generate",
+          "name": "genradom-generate",
+          "options": {
+            "customTimeouts": {}
+          }
+        },
+        {
+          "type": "pulumi:providers:random",
+          "properties": {
+            "version": "4.8.2"
+          },
+          "urn": "urn:pulumi:generate::genradom::pulumi:providers:random::default_4_8_2",
+          "name": "default_4_8_2",
+          "options": {
+            "customTimeouts": {}
+          }
         }
       ]
     },

--- a/pkg/pf/tests/testdata/genrandom/random-empty-update.json
+++ b/pkg/pf/tests/testdata/genrandom/random-empty-update.json
@@ -24,6 +24,25 @@
     }
   },
   {
+    "method": "/pulumirpc.LanguageRuntime/GetRequiredPackages",
+    "request": {
+      "info": {
+        "rootDirectory": "/Users/vvm/code/pulumi-terraform-bridge/pkg/pf/tests/testdatagen/genrandom",
+        "programDirectory": "/Users/vvm/code/pulumi-terraform-bridge/pkg/pf/tests/testdatagen/genrandom",
+        "entryPoint": ".",
+        "options": {}
+      }
+    },
+    "errors": [
+      "rpc error: code = Unimplemented desc = unknown method GetRequiredPackages for service pulumirpc.LanguageRuntime"
+    ],
+    "metadata": {
+      "kind": "language",
+      "mode": "client",
+      "runtime": "go"
+    }
+  },
+  {
     "method": "/pulumirpc.LanguageRuntime/GetRequiredPlugins",
     "request": {
       "project": "deprecated",
@@ -247,7 +266,7 @@
       "customTimeouts": {},
       "acceptResources": true,
       "sourcePosition": {
-        "uri": "project://%2FUsers%2Fvvm%2Fgo%2Fpkg%2Fmod%2Fgithub.com%2Fpulumi%2Fpulumi%2Fsdk%2Fv3@v3.137.0%2Fgo%2Fpulumi%2Frun.go",
+        "uri": "project://%2FUsers%2Fvvm%2Fgo%2Fpkg%2Fmod%2Fgithub.com%2Fpulumi%2Fpulumi%2Fsdk%2Fv3@v3.143.0%2Fgo%2Fpulumi%2Frun.go",
         "line": 98
       },
       "supportsResultReporting": true
@@ -396,7 +415,7 @@
         "min": 1,
         "seed": "pseudo-random-seed"
       },
-      "randomSeed": "9IdHtuq2lGUrsjl/wGar4hFadqNNUBpn0lGRT9SFDV0=",
+      "randomSeed": "O7VL8WSRNg2La9FtX6WE1S53FeMBqTFYwBB+bVQXyMc=",
       "name": "r1",
       "type": "random:index/randomInteger:RandomInteger"
     },
@@ -572,7 +591,7 @@
         "genradom:min": "1"
       },
       "parallel": 48,
-      "monitorAddress": "127.0.0.1:52651",
+      "monitorAddress": "127.0.0.1:57508",
       "organization": "pulumi",
       "configPropertyMap": {
         "genradom:min": 1
@@ -583,7 +602,7 @@
         "entryPoint": ".",
         "options": {}
       },
-      "loaderTarget": "127.0.0.1:52652"
+      "loaderTarget": "127.0.0.1:57509"
     },
     "response": {},
     "metadata": {

--- a/pkg/pf/tests/testdata/genrandom/random-initial-preview.json
+++ b/pkg/pf/tests/testdata/genrandom/random-initial-preview.json
@@ -24,6 +24,25 @@
     }
   },
   {
+    "method": "/pulumirpc.LanguageRuntime/GetRequiredPackages",
+    "request": {
+      "info": {
+        "rootDirectory": "/Users/vvm/code/pulumi-terraform-bridge/pkg/pf/tests/testdatagen/genrandom",
+        "programDirectory": "/Users/vvm/code/pulumi-terraform-bridge/pkg/pf/tests/testdatagen/genrandom",
+        "entryPoint": ".",
+        "options": {}
+      }
+    },
+    "errors": [
+      "rpc error: code = Unimplemented desc = unknown method GetRequiredPackages for service pulumirpc.LanguageRuntime"
+    ],
+    "metadata": {
+      "kind": "language",
+      "mode": "client",
+      "runtime": "go"
+    }
+  },
+  {
     "method": "/pulumirpc.LanguageRuntime/GetRequiredPlugins",
     "request": {
       "project": "deprecated",
@@ -247,7 +266,7 @@
       "customTimeouts": {},
       "acceptResources": true,
       "sourcePosition": {
-        "uri": "project://%2FUsers%2Fvvm%2Fgo%2Fpkg%2Fmod%2Fgithub.com%2Fpulumi%2Fpulumi%2Fsdk%2Fv3@v3.137.0%2Fgo%2Fpulumi%2Frun.go",
+        "uri": "project://%2FUsers%2Fvvm%2Fgo%2Fpkg%2Fmod%2Fgithub.com%2Fpulumi%2Fpulumi%2Fsdk%2Fv3@v3.143.0%2Fgo%2Fpulumi%2Frun.go",
         "line": 98
       },
       "supportsResultReporting": true
@@ -367,7 +386,7 @@
         "min": 1,
         "seed": "pseudo-random-seed"
       },
-      "randomSeed": "8O+08h/HblqXuLbXS7VWRJdSeU09rKyP59mu0g6raeI=",
+      "randomSeed": "xOFNJ2P+FsUBRcUd8YmyAJ3GieooZwlPnDEVmrXDJEw=",
       "name": "r1",
       "type": "random:index/randomInteger:RandomInteger"
     },
@@ -535,7 +554,7 @@
       },
       "dryRun": true,
       "parallel": 48,
-      "monitorAddress": "127.0.0.1:52582",
+      "monitorAddress": "127.0.0.1:57457",
       "organization": "pulumi",
       "configPropertyMap": {
         "genradom:min": 1
@@ -546,7 +565,7 @@
         "entryPoint": ".",
         "options": {}
       },
-      "loaderTarget": "127.0.0.1:52583"
+      "loaderTarget": "127.0.0.1:57458"
     },
     "response": {},
     "metadata": {
@@ -559,28 +578,6 @@
     "method": "/pulumirpc.Analyzer/AnalyzeStack",
     "request": {
       "resources": [
-        {
-          "type": "pulumi:pulumi:Stack",
-          "properties": {
-            "r.result": "04da6b54-80e4-46f7-96ec-b56ff0331ba9"
-          },
-          "urn": "urn:pulumi:generate::genradom::pulumi:pulumi:Stack::genradom-generate",
-          "name": "genradom-generate",
-          "options": {
-            "customTimeouts": {}
-          }
-        },
-        {
-          "type": "pulumi:providers:random",
-          "properties": {
-            "version": "4.8.2"
-          },
-          "urn": "urn:pulumi:generate::genradom::pulumi:providers:random::default_4_8_2",
-          "name": "default_4_8_2",
-          "options": {
-            "customTimeouts": {}
-          }
-        },
         {
           "type": "random:index/randomInteger:RandomInteger",
           "properties": {
@@ -604,6 +601,28 @@
             "name": "default_4_8_2"
           },
           "parent": "urn:pulumi:generate::genradom::pulumi:pulumi:Stack::genradom-generate"
+        },
+        {
+          "type": "pulumi:pulumi:Stack",
+          "properties": {
+            "r.result": "04da6b54-80e4-46f7-96ec-b56ff0331ba9"
+          },
+          "urn": "urn:pulumi:generate::genradom::pulumi:pulumi:Stack::genradom-generate",
+          "name": "genradom-generate",
+          "options": {
+            "customTimeouts": {}
+          }
+        },
+        {
+          "type": "pulumi:providers:random",
+          "properties": {
+            "version": "4.8.2"
+          },
+          "urn": "urn:pulumi:generate::genradom::pulumi:providers:random::default_4_8_2",
+          "name": "default_4_8_2",
+          "options": {
+            "customTimeouts": {}
+          }
         }
       ]
     },

--- a/pkg/pf/tests/testdata/genrandom/random-initial-update.json
+++ b/pkg/pf/tests/testdata/genrandom/random-initial-update.json
@@ -24,6 +24,25 @@
     }
   },
   {
+    "method": "/pulumirpc.LanguageRuntime/GetRequiredPackages",
+    "request": {
+      "info": {
+        "rootDirectory": "/Users/vvm/code/pulumi-terraform-bridge/pkg/pf/tests/testdatagen/genrandom",
+        "programDirectory": "/Users/vvm/code/pulumi-terraform-bridge/pkg/pf/tests/testdatagen/genrandom",
+        "entryPoint": ".",
+        "options": {}
+      }
+    },
+    "errors": [
+      "rpc error: code = Unimplemented desc = unknown method GetRequiredPackages for service pulumirpc.LanguageRuntime"
+    ],
+    "metadata": {
+      "kind": "language",
+      "mode": "client",
+      "runtime": "go"
+    }
+  },
+  {
     "method": "/pulumirpc.LanguageRuntime/GetRequiredPlugins",
     "request": {
       "project": "deprecated",
@@ -247,7 +266,7 @@
       "customTimeouts": {},
       "acceptResources": true,
       "sourcePosition": {
-        "uri": "project://%2FUsers%2Fvvm%2Fgo%2Fpkg%2Fmod%2Fgithub.com%2Fpulumi%2Fpulumi%2Fsdk%2Fv3@v3.137.0%2Fgo%2Fpulumi%2Frun.go",
+        "uri": "project://%2FUsers%2Fvvm%2Fgo%2Fpkg%2Fmod%2Fgithub.com%2Fpulumi%2Fpulumi%2Fsdk%2Fv3@v3.143.0%2Fgo%2Fpulumi%2Frun.go",
         "line": 98
       },
       "supportsResultReporting": true
@@ -367,7 +386,7 @@
         "min": 1,
         "seed": "pseudo-random-seed"
       },
-      "randomSeed": "Y3YgsM0ynlrgQKkpO3yGyIWDI/Gb5ctYvGD+eRnwgEo=",
+      "randomSeed": "a7hyfYf8aiNP1kPJIKpWmcUBasGehqAy5+ZrFirIFOk=",
       "name": "r1",
       "type": "random:index/randomInteger:RandomInteger"
     },
@@ -537,7 +556,7 @@
         "genradom:min": "1"
       },
       "parallel": 48,
-      "monitorAddress": "127.0.0.1:52603",
+      "monitorAddress": "127.0.0.1:57473",
       "organization": "pulumi",
       "configPropertyMap": {
         "genradom:min": 1
@@ -548,7 +567,7 @@
         "entryPoint": ".",
         "options": {}
       },
-      "loaderTarget": "127.0.0.1:52604"
+      "loaderTarget": "127.0.0.1:57474"
     },
     "response": {},
     "metadata": {
@@ -561,28 +580,6 @@
     "method": "/pulumirpc.Analyzer/AnalyzeStack",
     "request": {
       "resources": [
-        {
-          "type": "pulumi:pulumi:Stack",
-          "properties": {
-            "r.result": 15
-          },
-          "urn": "urn:pulumi:generate::genradom::pulumi:pulumi:Stack::genradom-generate",
-          "name": "genradom-generate",
-          "options": {
-            "customTimeouts": {}
-          }
-        },
-        {
-          "type": "pulumi:providers:random",
-          "properties": {
-            "version": "4.8.2"
-          },
-          "urn": "urn:pulumi:generate::genradom::pulumi:providers:random::default_4_8_2",
-          "name": "default_4_8_2",
-          "options": {
-            "customTimeouts": {}
-          }
-        },
         {
           "type": "random:index/randomInteger:RandomInteger",
           "properties": {
@@ -606,6 +603,28 @@
             "name": "default_4_8_2"
           },
           "parent": "urn:pulumi:generate::genradom::pulumi:pulumi:Stack::genradom-generate"
+        },
+        {
+          "type": "pulumi:pulumi:Stack",
+          "properties": {
+            "r.result": 15
+          },
+          "urn": "urn:pulumi:generate::genradom::pulumi:pulumi:Stack::genradom-generate",
+          "name": "genradom-generate",
+          "options": {
+            "customTimeouts": {}
+          }
+        },
+        {
+          "type": "pulumi:providers:random",
+          "properties": {
+            "version": "4.8.2"
+          },
+          "urn": "urn:pulumi:generate::genradom::pulumi:providers:random::default_4_8_2",
+          "name": "default_4_8_2",
+          "options": {
+            "customTimeouts": {}
+          }
         }
       ]
     },

--- a/pkg/pf/tests/testdata/genrandom/random-replace-preview.json
+++ b/pkg/pf/tests/testdata/genrandom/random-replace-preview.json
@@ -24,6 +24,25 @@
     }
   },
   {
+    "method": "/pulumirpc.LanguageRuntime/GetRequiredPackages",
+    "request": {
+      "info": {
+        "rootDirectory": "/Users/vvm/code/pulumi-terraform-bridge/pkg/pf/tests/testdatagen/genrandom",
+        "programDirectory": "/Users/vvm/code/pulumi-terraform-bridge/pkg/pf/tests/testdatagen/genrandom",
+        "entryPoint": ".",
+        "options": {}
+      }
+    },
+    "errors": [
+      "rpc error: code = Unimplemented desc = unknown method GetRequiredPackages for service pulumirpc.LanguageRuntime"
+    ],
+    "metadata": {
+      "kind": "language",
+      "mode": "client",
+      "runtime": "go"
+    }
+  },
+  {
     "method": "/pulumirpc.LanguageRuntime/GetRequiredPlugins",
     "request": {
       "project": "deprecated",
@@ -247,7 +266,7 @@
       "customTimeouts": {},
       "acceptResources": true,
       "sourcePosition": {
-        "uri": "project://%2FUsers%2Fvvm%2Fgo%2Fpkg%2Fmod%2Fgithub.com%2Fpulumi%2Fpulumi%2Fsdk%2Fv3@v3.137.0%2Fgo%2Fpulumi%2Frun.go",
+        "uri": "project://%2FUsers%2Fvvm%2Fgo%2Fpkg%2Fmod%2Fgithub.com%2Fpulumi%2Fpulumi%2Fsdk%2Fv3@v3.143.0%2Fgo%2Fpulumi%2Frun.go",
         "line": 98
       },
       "supportsResultReporting": true
@@ -396,7 +415,7 @@
         "min": 2,
         "seed": "pseudo-random-seed"
       },
-      "randomSeed": "zGv1rNLN+wuFLvpvDhB4/dmBhXy62m4AaQrYmJQFWWg=",
+      "randomSeed": "UGmurPZCkajsI6lzkDsxEGgacHubhlcthqFbQzWPr3U=",
       "name": "r1",
       "type": "random:index/randomInteger:RandomInteger"
     },
@@ -505,13 +524,7 @@
       "changes": "DIFF_SOME",
       "diffs": [
         "min"
-      ],
-      "detailedDiff": {
-        "min": {
-          "kind": "UPDATE"
-        }
-      },
-      "hasDetailedDiff": true
+      ]
     },
     "metadata": {
       "kind": "resource",
@@ -529,7 +542,7 @@
         "min": 2,
         "seed": "pseudo-random-seed"
       },
-      "randomSeed": "zGv1rNLN+wuFLvpvDhB4/dmBhXy62m4AaQrYmJQFWWg=",
+      "randomSeed": "UGmurPZCkajsI6lzkDsxEGgacHubhlcthqFbQzWPr3U=",
       "name": "r1",
       "type": "random:index/randomInteger:RandomInteger"
     },
@@ -637,7 +650,7 @@
       },
       "dryRun": true,
       "parallel": 48,
-      "monitorAddress": "127.0.0.1:52673",
+      "monitorAddress": "127.0.0.1:57525",
       "organization": "pulumi",
       "configPropertyMap": {
         "genradom:min": 2
@@ -648,7 +661,7 @@
         "entryPoint": ".",
         "options": {}
       },
-      "loaderTarget": "127.0.0.1:52674"
+      "loaderTarget": "127.0.0.1:57526"
     },
     "response": {},
     "metadata": {
@@ -661,28 +674,6 @@
     "method": "/pulumirpc.Analyzer/AnalyzeStack",
     "request": {
       "resources": [
-        {
-          "type": "pulumi:pulumi:Stack",
-          "properties": {
-            "r.result": "04da6b54-80e4-46f7-96ec-b56ff0331ba9"
-          },
-          "urn": "urn:pulumi:generate::genradom::pulumi:pulumi:Stack::genradom-generate",
-          "name": "genradom-generate",
-          "options": {
-            "customTimeouts": {}
-          }
-        },
-        {
-          "type": "pulumi:providers:random",
-          "properties": {
-            "version": "4.8.2"
-          },
-          "urn": "urn:pulumi:generate::genradom::pulumi:providers:random::default_4_8_2",
-          "name": "default_4_8_2",
-          "options": {
-            "customTimeouts": {}
-          }
-        },
         {
           "type": "random:index/randomInteger:RandomInteger",
           "properties": {
@@ -706,6 +697,28 @@
             "name": "default_4_8_2"
           },
           "parent": "urn:pulumi:generate::genradom::pulumi:pulumi:Stack::genradom-generate"
+        },
+        {
+          "type": "pulumi:pulumi:Stack",
+          "properties": {
+            "r.result": "04da6b54-80e4-46f7-96ec-b56ff0331ba9"
+          },
+          "urn": "urn:pulumi:generate::genradom::pulumi:pulumi:Stack::genradom-generate",
+          "name": "genradom-generate",
+          "options": {
+            "customTimeouts": {}
+          }
+        },
+        {
+          "type": "pulumi:providers:random",
+          "properties": {
+            "version": "4.8.2"
+          },
+          "urn": "urn:pulumi:generate::genradom::pulumi:providers:random::default_4_8_2",
+          "name": "default_4_8_2",
+          "options": {
+            "customTimeouts": {}
+          }
         }
       ]
     },

--- a/pkg/pf/tests/testdata/genrandom/random-replace-update.json
+++ b/pkg/pf/tests/testdata/genrandom/random-replace-update.json
@@ -24,6 +24,25 @@
     }
   },
   {
+    "method": "/pulumirpc.LanguageRuntime/GetRequiredPackages",
+    "request": {
+      "info": {
+        "rootDirectory": "/Users/vvm/code/pulumi-terraform-bridge/pkg/pf/tests/testdatagen/genrandom",
+        "programDirectory": "/Users/vvm/code/pulumi-terraform-bridge/pkg/pf/tests/testdatagen/genrandom",
+        "entryPoint": ".",
+        "options": {}
+      }
+    },
+    "errors": [
+      "rpc error: code = Unimplemented desc = unknown method GetRequiredPackages for service pulumirpc.LanguageRuntime"
+    ],
+    "metadata": {
+      "kind": "language",
+      "mode": "client",
+      "runtime": "go"
+    }
+  },
+  {
     "method": "/pulumirpc.LanguageRuntime/GetRequiredPlugins",
     "request": {
       "project": "deprecated",
@@ -247,7 +266,7 @@
       "customTimeouts": {},
       "acceptResources": true,
       "sourcePosition": {
-        "uri": "project://%2FUsers%2Fvvm%2Fgo%2Fpkg%2Fmod%2Fgithub.com%2Fpulumi%2Fpulumi%2Fsdk%2Fv3@v3.137.0%2Fgo%2Fpulumi%2Frun.go",
+        "uri": "project://%2FUsers%2Fvvm%2Fgo%2Fpkg%2Fmod%2Fgithub.com%2Fpulumi%2Fpulumi%2Fsdk%2Fv3@v3.143.0%2Fgo%2Fpulumi%2Frun.go",
         "line": 98
       },
       "supportsResultReporting": true
@@ -396,7 +415,7 @@
         "min": 2,
         "seed": "pseudo-random-seed"
       },
-      "randomSeed": "K/7vIhrCI+kchV7s1Ny5HY+OsrK5r8lZvMNuSYeOK2o=",
+      "randomSeed": "NGFwjkx0vJvJ7FLryzb3zNG9hvU9U7L2KcImawEIvjE=",
       "name": "r1",
       "type": "random:index/randomInteger:RandomInteger"
     },
@@ -505,13 +524,7 @@
       "changes": "DIFF_SOME",
       "diffs": [
         "min"
-      ],
-      "detailedDiff": {
-        "min": {
-          "kind": "UPDATE"
-        }
-      },
-      "hasDetailedDiff": true
+      ]
     },
     "metadata": {
       "kind": "resource",
@@ -529,7 +542,7 @@
         "min": 2,
         "seed": "pseudo-random-seed"
       },
-      "randomSeed": "K/7vIhrCI+kchV7s1Ny5HY+OsrK5r8lZvMNuSYeOK2o=",
+      "randomSeed": "NGFwjkx0vJvJ7FLryzb3zNG9hvU9U7L2KcImawEIvjE=",
       "name": "r1",
       "type": "random:index/randomInteger:RandomInteger"
     },
@@ -639,7 +652,7 @@
         "genradom:min": "2"
       },
       "parallel": 48,
-      "monitorAddress": "127.0.0.1:52693",
+      "monitorAddress": "127.0.0.1:57545",
       "organization": "pulumi",
       "configPropertyMap": {
         "genradom:min": 2
@@ -650,7 +663,7 @@
         "entryPoint": ".",
         "options": {}
       },
-      "loaderTarget": "127.0.0.1:52694"
+      "loaderTarget": "127.0.0.1:57546"
     },
     "response": {},
     "metadata": {

--- a/pkg/pf/tests/testdata/updateprogram.json
+++ b/pkg/pf/tests/testdata/updateprogram.json
@@ -1366,16 +1366,7 @@
       "diffs": [
         "optionalInputString",
         "requiredInputString"
-      ],
-      "hasDetailedDiff": true,
-      "detailedDiff": {
-        "optionalInputString": {
-          "kind": "UPDATE"
-        },
-        "requiredInputString": {
-          "kind": "UPDATE"
-        }
-      }
+      ]
     },
     "metadata": {
       "kind": "resource",
@@ -1703,16 +1694,7 @@
       "diffs": [
         "optionalInputString",
         "requiredInputString"
-      ],
-      "hasDetailedDiff": true,
-      "detailedDiff": {
-        "optionalInputString": {
-          "kind": "UPDATE"
-        },
-        "requiredInputString": {
-          "kind": "UPDATE"
-        }
-      }
+      ]
     },
     "metadata": {
       "kind": "resource",

--- a/pkg/pf/tfbridge/provider.go
+++ b/pkg/pf/tfbridge/provider.go
@@ -17,7 +17,6 @@ package tfbridge
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/blang/semver"
 	pfprovider "github.com/hashicorp/terraform-plugin-framework/provider"
@@ -28,7 +27,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
@@ -177,7 +175,7 @@ func newProviderWithContext(ctx context.Context, info tfbridge.ProviderInfo,
 	}
 
 	opts := []providerOption{}
-	if info.EnableAccurateBridgePreview || cmdutil.IsTruthy(os.Getenv("PULUMI_TF_BRIDGE_ACCURATE_BRIDGE_PREVIEW")) {
+	if info.EnableAccurateBridgePreview {
 		opts = append(opts, withAccurateBridgePreview())
 	}
 


### PR DESCRIPTION
This change disables accurate previews for the PF tests as accurate preview rollout for PF is blocked on https://github.com/pulumi/pulumi-terraform-bridge/issues/2660

The first commit here are the code changes and the second one is test recordings.