### PR TITLE
Disable accurate previews for remainder of pf detailed diff tests

### DIFF
--- a/pkg/pf/tests/diff_test.go
+++ b/pkg/pf/tests/diff_test.go
@@ -195,7 +195,10 @@ func TestDetailedDiffStringAttribute(t *testing.T) {
 					res := pb.NewResource(pb.NewResourceArgs{
 						ResourceSchema: schema.schema,
 					})
-					diff := crosstests.Diff(t, res, map[string]cty.Value{"key": initialValue}, map[string]cty.Value{"key": changeValue})
+					diff := crosstests.Diff(
+						t, res, map[string]cty.Value{"key": initialValue}, map[string]cty.Value{"key": changeValue},
+						crosstests.DisableAccurateBridgePreview(),
+					)
 
 					autogold.ExpectFile(t, testOutput{
 						initialValue: scenario.initialValue,

--- a/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/default/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/default/added.golden
@@ -22,10 +22,9 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ testprovider:index/test:Test: (update)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
-      ~ key: "default" => "value"
+      + key: "value"
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/default/changed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/default/changed.golden
@@ -28,5 +28,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/default/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/default/removed.golden
@@ -27,5 +27,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/default_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/default_replace/added.golden
@@ -22,10 +22,10 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       ~ key: "default" => "value"
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/default_replace/changed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/default_replace/changed.golden
@@ -23,10 +23,10 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       ~ key: "value" => "value1"
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/default_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/default_replace/removed.golden
@@ -22,10 +22,10 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
-      - key: "value"
+      ~ id : "test-id" => output<string>
+      ~ key: "value" => "default"
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/no_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/no_replace/added.golden
@@ -27,5 +27,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/no_replace/changed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/no_replace/changed.golden
@@ -28,5 +28,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/no_replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/no_replace/removed.golden
@@ -27,5 +27,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/plan_modifier_default/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/plan_modifier_default/added.golden
@@ -22,10 +22,9 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ testprovider:index/test:Test: (update)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
-      ~ key: "default" => "value"
+      + key: "value"
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/plan_modifier_default/changed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/plan_modifier_default/changed.golden
@@ -28,5 +28,4 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/plan_modifier_default_replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/plan_modifier_default_replace/added.golden
@@ -22,10 +22,10 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       ~ key: "default" => "value"
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/plan_modifier_default_replace/changed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/plan_modifier_default_replace/changed.golden
@@ -23,10 +23,10 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       ~ key: "value" => "value1"
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/replace/added.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/replace/added.golden
@@ -22,10 +22,10 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       + key: "value"
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/replace/changed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/replace/changed.golden
@@ -23,10 +23,10 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       ~ key: "value" => "value1"
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/replace/removed.golden
+++ b/pkg/pf/tests/testdata/TestDetailedDiffStringAttribute/replace/removed.golden
@@ -22,10 +22,10 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-testprovider:index/test:Test: (replace)
         [id=test-id]
         [urn=urn:pulumi:test::project::testprovider:index/test:Test::p]
+      ~ id : "test-id" => output<string>
       - key: "value"
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"key": map[string]interface{}{"kind": "DELETE"}},
 }


### PR DESCRIPTION
Disabled accurate previews for the rest of the PF detailed diff tests. These were missed in https://github.com/pulumi/pulumi-terraform-bridge/pull/2752