### PR TITLE
chore: remove redundant test line from CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -47,8 +47,6 @@ jobs:
         run: cd pkg/pf && make build
       - name: Test
         run: make test
-      - name: Test Dynamic
-        run: cd dynamic && make test
       - name: Upload coverage reports to Codecov
         # If we have a CODECOV_TOKEN secret, then we upload it to get a coverage report.
         #


### PR DESCRIPTION
Since a special dynamic/go.mod got removed, `make test` already is running tests from the `dynamic` Go package and this line is redundant.