### PR TITLE
Use the upstream provider's org as Publisher

### DIFF
--- a/dynamic/info.go
+++ b/dynamic/info.go
@@ -39,7 +39,6 @@ func providerInfo(ctx context.Context, p run.Provider, value parameterize.Value)
 		Name:           p.Name(),
 		Version:        p.Version(),
 		Description:    "A Pulumi provider dynamically bridged from " + p.Name() + ".",
-		Publisher:      "Pulumi",
 		ResourcePrefix: inferResourcePrefix(provider),
 
 		MetadataInfo: &tfbridge.MetadataInfo{
@@ -97,6 +96,7 @@ func providerInfo(ctx context.Context, p run.Provider, value parameterize.Value)
 		ghOrg := urlFields[len(urlFields)-2]
 		name := urlFields[len(urlFields)-1]
 		prov.GitHubOrg = ghOrg
+		prov.Publisher = ghOrg
 		prov.Repository = "https://github.com/" + ghOrg + "/terraform-provider-" + name
 	}
 

--- a/dynamic/testdata/TestSchemaGeneration/Backblaze/b2-0.8.9.golden
+++ b/dynamic/testdata/TestSchemaGeneration/Backblaze/b2-0.8.9.golden
@@ -4,7 +4,7 @@
     "description": "A Pulumi provider dynamically bridged from b2.",
     "attribution": "This Pulumi package is based on the [`b2` Terraform Provider](https://github.com/backblaze/terraform-provider-b2).",
     "repository": "https://github.com/backblaze/terraform-provider-b2",
-    "publisher": "Pulumi",
+    "publisher": "backblaze",
     "meta": {
         "moduleFormat": "(.*)(?:/[^/]*)"
     },

--- a/dynamic/testdata/TestSchemaGeneration/databricks/databricks-1.50.0.golden
+++ b/dynamic/testdata/TestSchemaGeneration/databricks/databricks-1.50.0.golden
@@ -4,7 +4,7 @@
     "description": "A Pulumi provider dynamically bridged from databricks.",
     "attribution": "This Pulumi package is based on the [`databricks` Terraform Provider](https://github.com/databricks/terraform-provider-databricks).",
     "repository": "https://github.com/databricks/terraform-provider-databricks",
-    "publisher": "Pulumi",
+    "publisher": "databricks",
     "meta": {
         "moduleFormat": "(.*)(?:/[^/]*)"
     },

--- a/dynamic/testdata/TestSchemaGeneration/hashicorp/random-3.3.0.golden
+++ b/dynamic/testdata/TestSchemaGeneration/hashicorp/random-3.3.0.golden
@@ -4,7 +4,7 @@
     "description": "A Pulumi provider dynamically bridged from random.",
     "attribution": "This Pulumi package is based on the [`random` Terraform Provider](https://github.com/hashicorp/terraform-provider-random).",
     "repository": "https://github.com/hashicorp/terraform-provider-random",
-    "publisher": "Pulumi",
+    "publisher": "hashicorp",
     "meta": {
         "moduleFormat": "(.*)(?:/[^/]*)"
     },

--- a/dynamic/testdata/TestSchemaGenerationFullDocs/hashicorp/random-3.6.3.golden
+++ b/dynamic/testdata/TestSchemaGenerationFullDocs/hashicorp/random-3.6.3.golden
@@ -4,7 +4,7 @@
     "description": "A Pulumi provider dynamically bridged from random.",
     "attribution": "This Pulumi package is based on the [`random` Terraform Provider](https://github.com/hashicorp/terraform-provider-random).",
     "repository": "https://github.com/hashicorp/terraform-provider-random",
-    "publisher": "Pulumi",
+    "publisher": "hashicorp",
     "meta": {
         "moduleFormat": "(.*)(?:/[^/]*)"
     },


### PR DESCRIPTION
Use the upstream GH org as the publisher for remote providers.