### PR TITLE
Add walkTwoPropertyValues walker for recursing into two property values simultaneously

### DIFF
--- a/pkg/tfbridge/property_path.go
+++ b/pkg/tfbridge/property_path.go
@@ -1,6 +1,7 @@
 package tfbridge
 
 import (
+	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 
@@ -37,6 +38,10 @@ func (k propertyPath) Subpath(subkey string) propertyPath {
 	return k.append(subkey)
 }
 
+func (k propertyPath) Subkey(subkey resource.PropertyKey) propertyPath {
+	return k.append(string(subkey))
+}
+
 func (k propertyPath) Index(i int) propertyPath {
 	return k.append(i)
 }
@@ -56,6 +61,119 @@ func lookupSchemas(
 ) (shim.Schema, *info.Schema, error) {
 	schemaPath := PropertyPathToSchemaPath(resource.PropertyPath(path), tfs, ps)
 	return LookupSchemas(schemaPath, tfs, ps)
+}
+
+func combinePropertyMapKeys(
+	object1, object2 resource.PropertyMap,
+) map[resource.PropertyKey]struct{} {
+	combined := make(map[resource.PropertyKey]struct{})
+	for k := range object1 {
+		combined[k] = struct{}{}
+	}
+	for k := range object2 {
+		combined[k] = struct{}{}
+	}
+	return combined
+}
+
+// SkipChildrenError is an error that can be returned by the visitor to skip the children of the current step.
+type SkipChildrenError struct{}
+
+func (SkipChildrenError) Error() string {
+	return "skip children"
+}
+
+type twoPropertyValueVisitor func(path propertyPath, val1, val2 resource.PropertyValue) error
+
+// walkTwoPropertyValues walks the two property values and calls the visitor for each step.
+// It returns an error if the visitor returns an error other than SkipChildrenError.
+//
+// The visitor can return SkipChildrenError to skip the children of the current step.
+// In case the two values have different types, we walk both values, starting with val1.
+func walkTwoPropertyValues(
+	path propertyPath,
+	val1, val2 resource.PropertyValue,
+	visitor twoPropertyValueVisitor,
+) error {
+	err := visitor(path, val1, val2)
+	if err != nil {
+		if errors.Is(err, SkipChildrenError{}) {
+			return nil
+		}
+		return err
+	}
+
+	if val1.IsArray() && val2.IsArray() {
+		arr1 := val1.ArrayValue()
+		arr2 := val2.ArrayValue()
+		for i := range max(len(arr1), len(arr2)) {
+			childPath := path.Index(i)
+			var childVal1, childVal2 resource.PropertyValue
+			if i >= len(arr1) {
+				childVal1 = resource.NewNullProperty()
+			} else {
+				childVal1 = arr1[i]
+			}
+			if i >= len(arr2) {
+				childVal2 = resource.NewNullProperty()
+			} else {
+				childVal2 = arr2[i]
+			}
+			err := walkTwoPropertyValues(childPath, childVal1, childVal2, visitor)
+			if err != nil {
+				return err
+			}
+		}
+	} else if val1.IsObject() && val2.IsObject() {
+		obj1 := val1.ObjectValue()
+		obj2 := val2.ObjectValue()
+		combined := combinePropertyMapKeys(obj1, obj2)
+		for k := range combined {
+			err := walkTwoPropertyValues(path.Subkey(k), obj1[k], obj2[k], visitor)
+			if err != nil {
+				return err
+			}
+		}
+	} else {
+		if val1.IsArray() {
+			arr1 := val1.ArrayValue()
+			for i, v := range arr1 {
+				childPath := path.Index(i)
+				err := walkTwoPropertyValues(childPath, v, resource.NewNullProperty(), visitor)
+				if err != nil {
+					return err
+				}
+			}
+		} else if val1.IsObject() {
+			obj1 := val1.ObjectValue()
+			for k, v := range obj1 {
+				err := walkTwoPropertyValues(path.Subkey(k), v, resource.NewNullProperty(), visitor)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		if val2.IsArray() {
+			arr2 := val2.ArrayValue()
+			for i, v := range arr2 {
+				childPath := path.Index(i)
+				err := walkTwoPropertyValues(childPath, resource.NewNullProperty(), v, visitor)
+				if err != nil {
+					return err
+				}
+			}
+		} else if val2.IsObject() {
+			obj2 := val2.ObjectValue()
+			for k, v := range obj2 {
+				err := walkTwoPropertyValues(path.Subkey(k), resource.NewNullProperty(), v, visitor)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
 }
 
 func propertyPathTriggersReplacement(

--- a/pkg/tfbridge/property_path_test.go
+++ b/pkg/tfbridge/property_path_test.go
@@ -3,6 +3,7 @@ package tfbridge
 import (
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/require"
 )
@@ -158,5 +159,143 @@ func TestWalkTwoPropertyValues(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, []string{"", "a", "a[0]", "a.b"}, visited)
+	})
+
+	t.Run("both arrays error", func(t *testing.T) {
+		val1 := resource.NewArrayProperty([]resource.PropertyValue{
+			resource.NewStringProperty("a"),
+		})
+
+		val2 := resource.NewArrayProperty([]resource.PropertyValue{
+			resource.NewStringProperty("b"),
+		})
+
+		err := walkTwoPropertyValues(
+			propertyPath{},
+			val1,
+			val2,
+			func(path propertyPath, v1, v2 resource.PropertyValue) error {
+				if v1.IsString() || v2.IsString() {
+					return errors.New("error")
+				}
+				return nil
+			})
+
+		require.Error(t, err)
+	})
+
+	t.Run("both objects error", func(t *testing.T) {
+		val1 := resource.NewObjectProperty(resource.PropertyMap{
+			"a": resource.NewStringProperty("a"),
+		})
+
+		val2 := resource.NewObjectProperty(resource.PropertyMap{
+			"b": resource.NewStringProperty("b"),
+		})
+
+		err := walkTwoPropertyValues(
+			propertyPath{},
+			val1,
+			val2,
+			func(path propertyPath, v1, v2 resource.PropertyValue) error {
+				if v1.IsString() || v2.IsString() {
+					return errors.New("error")
+				}
+				return nil
+			})
+
+		require.Error(t, err)
+	})
+
+	t.Run("mismatched types first array error", func(t *testing.T) {
+		val1 := resource.NewArrayProperty([]resource.PropertyValue{
+			resource.NewStringProperty("a"),
+		})
+
+		val2 := resource.NewObjectProperty(resource.PropertyMap{
+			"b": resource.NewStringProperty("b"),
+		})
+
+		err := walkTwoPropertyValues(
+			propertyPath{},
+			val1,
+			val2,
+			func(path propertyPath, v1, v2 resource.PropertyValue) error {
+				if v1.IsString() {
+					return errors.New("error")
+				}
+				return nil
+			})
+
+		require.Error(t, err)
+	})
+
+	t.Run("mismatched types first object error", func(t *testing.T) {
+		val1 := resource.NewObjectProperty(resource.PropertyMap{
+			"a": resource.NewStringProperty("a"),
+		})
+
+		val2 := resource.NewArrayProperty([]resource.PropertyValue{
+			resource.NewStringProperty("b"),
+		})
+
+		err := walkTwoPropertyValues(
+			propertyPath{},
+			val1,
+			val2,
+			func(path propertyPath, v1, v2 resource.PropertyValue) error {
+				if v1.IsString() {
+					return errors.New("error")
+				}
+				return nil
+			})
+
+		require.Error(t, err)
+	})
+
+	t.Run("mismatched types second array error", func(t *testing.T) {
+		val1 := resource.NewObjectProperty(resource.PropertyMap{
+			"a": resource.NewStringProperty("a"),
+		})
+
+		val2 := resource.NewArrayProperty([]resource.PropertyValue{
+			resource.NewStringProperty("b"),
+		})
+
+		err := walkTwoPropertyValues(
+			propertyPath{},
+			val1,
+			val2,
+			func(path propertyPath, v1, v2 resource.PropertyValue) error {
+				if v2.IsString() {
+					return errors.New("error")
+				}
+				return nil
+			})
+
+		require.Error(t, err)
+	})
+
+	t.Run("mismatched types second object error", func(t *testing.T) {
+		val1 := resource.NewArrayProperty([]resource.PropertyValue{
+			resource.NewStringProperty("a"),
+		})
+
+		val2 := resource.NewObjectProperty(resource.PropertyMap{
+			"b": resource.NewStringProperty("b"),
+		})
+
+		err := walkTwoPropertyValues(
+			propertyPath{},
+			val1,
+			val2,
+			func(path propertyPath, v1, v2 resource.PropertyValue) error {
+				if v2.IsString() {
+					return errors.New("error")
+				}
+				return nil
+			})
+
+		require.Error(t, err)
 	})
 }

--- a/pkg/tfbridge/property_path_test.go
+++ b/pkg/tfbridge/property_path_test.go
@@ -157,8 +157,8 @@ func TestWalkTwoPropertyValues(t *testing.T) {
 				return nil
 			})
 
-		require.NoError(t, err)
-		require.Equal(t, []string{"", "a", "a[0]", "a.b"}, visited)
+		require.Error(t, err)
+		require.IsType(t, TypeMismatchError{}, err)
 	})
 
 	t.Run("both arrays error", func(t *testing.T) {
@@ -228,6 +228,7 @@ func TestWalkTwoPropertyValues(t *testing.T) {
 			})
 
 		require.Error(t, err)
+		require.IsType(t, TypeMismatchError{}, err)
 	})
 
 	t.Run("mismatched types first object error", func(t *testing.T) {
@@ -251,6 +252,7 @@ func TestWalkTwoPropertyValues(t *testing.T) {
 			})
 
 		require.Error(t, err)
+		require.IsType(t, TypeMismatchError{}, err)
 	})
 
 	t.Run("mismatched types second array error", func(t *testing.T) {
@@ -274,6 +276,7 @@ func TestWalkTwoPropertyValues(t *testing.T) {
 			})
 
 		require.Error(t, err)
+		require.IsType(t, TypeMismatchError{}, err)
 	})
 
 	t.Run("mismatched types second object error", func(t *testing.T) {
@@ -297,5 +300,6 @@ func TestWalkTwoPropertyValues(t *testing.T) {
 			})
 
 		require.Error(t, err)
+		require.IsType(t, TypeMismatchError{}, err)
 	})
 }

--- a/pkg/tfbridge/property_path_test.go
+++ b/pkg/tfbridge/property_path_test.go
@@ -1,0 +1,162 @@
+package tfbridge
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWalkTwoPropertyValues(t *testing.T) {
+	t.Parallel()
+	t.Run("simple values", func(t *testing.T) {
+		val1 := resource.NewStringProperty("hello")
+		val2 := resource.NewStringProperty("world")
+		visited := make(map[string]bool)
+
+		err := walkTwoPropertyValues(
+			propertyPath{},
+			val1,
+			val2,
+			func(path propertyPath, v1, v2 resource.PropertyValue) error {
+				visited[path.String()] = true
+				require.Equal(t, "hello", v1.StringValue())
+				require.Equal(t, "world", v2.StringValue())
+				return nil
+			})
+
+		require.NoError(t, err)
+		require.True(t, visited[""])
+	})
+
+	t.Run("arrays", func(t *testing.T) {
+		val1 := resource.NewArrayProperty([]resource.PropertyValue{
+			resource.NewStringProperty("a"),
+			resource.NewStringProperty("b"),
+		})
+		val2 := resource.NewArrayProperty([]resource.PropertyValue{
+			resource.NewStringProperty("x"),
+			resource.NewStringProperty("y"),
+			resource.NewStringProperty("z"),
+		})
+		visited := make([]string, 0)
+
+		err := walkTwoPropertyValues(
+			propertyPath{},
+			val1,
+			val2,
+			func(path propertyPath, v1, v2 resource.PropertyValue) error {
+				visited = append(visited, path.String())
+				return nil
+			})
+
+		require.NoError(t, err)
+		require.Equal(t, []string{"", "[0]", "[1]", "[2]"}, visited)
+	})
+
+	t.Run("objects", func(t *testing.T) {
+		val1 := resource.NewObjectProperty(resource.PropertyMap{
+			"a": resource.NewStringProperty("value1"),
+		})
+		val2 := resource.NewObjectProperty(resource.PropertyMap{
+			"b": resource.NewStringProperty("value2"),
+		})
+		visited := make([]string, 0)
+
+		err := walkTwoPropertyValues(
+			propertyPath{},
+			val1,
+			val2,
+			func(path propertyPath, v1, v2 resource.PropertyValue) error {
+				visited = append(visited, path.String())
+				return nil
+			})
+
+		require.NoError(t, err)
+		require.Len(t, visited, 3)
+		require.Contains(t, visited, "")
+		require.Contains(t, visited, "a")
+		require.Contains(t, visited, "b")
+	})
+
+	t.Run("skip children", func(t *testing.T) {
+		val1 := resource.NewArrayProperty([]resource.PropertyValue{
+			resource.NewStringProperty("a"),
+			resource.NewStringProperty("b"),
+		})
+		val2 := resource.NewArrayProperty([]resource.PropertyValue{
+			resource.NewStringProperty("x"),
+			resource.NewStringProperty("y"),
+		})
+		visited := make([]string, 0)
+
+		err := walkTwoPropertyValues(
+			propertyPath{},
+			val1,
+			val2,
+			func(path propertyPath, v1, v2 resource.PropertyValue) error {
+				visited = append(visited, path.String())
+				return SkipChildrenError{}
+			})
+
+		require.NoError(t, err)
+		require.Equal(t, []string{""}, visited)
+	})
+
+	t.Run("nested structure", func(t *testing.T) {
+		val1 := resource.NewObjectProperty(resource.PropertyMap{
+			"array": resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewObjectProperty(resource.PropertyMap{
+					"key": resource.NewStringProperty("value1"),
+				}),
+			}),
+		})
+		val2 := resource.NewObjectProperty(resource.PropertyMap{
+			"array": resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewObjectProperty(resource.PropertyMap{
+					"key": resource.NewStringProperty("value2"),
+				}),
+			}),
+		})
+		visited := make([]string, 0)
+
+		err := walkTwoPropertyValues(
+			propertyPath{},
+			val1,
+			val2,
+			func(path propertyPath, v1, v2 resource.PropertyValue) error {
+				visited = append(visited, path.String())
+				return nil
+			})
+
+		require.NoError(t, err)
+		require.Equal(t, []string{"", "array", "array[0]", "array[0].key"}, visited)
+	})
+
+	t.Run("mismatched types", func(t *testing.T) {
+		val1 := resource.NewObjectProperty(resource.PropertyMap{
+			"a": resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("hello"),
+			}),
+		})
+		val2 := resource.NewObjectProperty(resource.PropertyMap{
+			"a": resource.NewObjectProperty(resource.PropertyMap{
+				"b": resource.NewStringProperty("world"),
+			}),
+		})
+
+		visited := make([]string, 0)
+
+		err := walkTwoPropertyValues(
+			propertyPath{},
+			val1,
+			val2,
+			func(path propertyPath, v1, v2 resource.PropertyValue) error {
+				visited = append(visited, path.String())
+				return nil
+			})
+
+		require.NoError(t, err)
+		require.Equal(t, []string{"", "a", "a[0]", "a.b"}, visited)
+	})
+}


### PR DESCRIPTION
This PR adds a `walkTwoPropertyValues` property value walker which can recurse over two property values simultaneously.

This is necessary for checking which input elements match a given plan element in https://github.com/pulumi/pulumi-terraform-bridge/pull/2761