### PR TITLE
Fix varname in debugging instructions

### DIFF
--- a/dynamic/README.md
+++ b/dynamic/README.md
@@ -302,7 +302,7 @@ Moving the release process into [github.com/pulumi/pulumi-terraform-bridge](http
 
 Dynamically bridged providers allow the Terraform provider interactions to be recorded in order to allow maintainers who do not have access to the Terraform provider to debug them. To do that:
 
-1. Users should run their `pulumi-terraform-provider` repro locally with `PULUMI_DEBUG_GRPC_LOGS=pulumi-logs.json PULUMI_TF_DEBUG_GRPC=tf-logs.json` set.
+1. Users should run their `pulumi-terraform-provider` repro locally with `PULUMI_DEBUG_GRPC=pulumi-logs.json PULUMI_TF_DEBUG_GRPC=tf-logs.json` set.
 1. They should attach both logs to the issue they filed, as well as the program they used.
 1. To reproduce the behaviour, maintainers should use the `tf-logs.json` like in `dynamic/log_replay_provider.go:TestLogReplayProviderWithProgram`:
    1. Dump the sanitized log file under `testadata`.


### PR DESCRIPTION
In https://github.com/pulumi/pulumi-terraform-provider/issues/55 I gave a customer the wrong varname following these instructions a bit too closely.

This change uses the correct env var name, `PULUMI_DEBUG_GRPC`
