### PR TITLE
Add a separate PF accurate previews feature flag

### DIFF
--- a/pkg/pf/tests/diff_secret_test.go
+++ b/pkg/pf/tests/diff_secret_test.go
@@ -57,7 +57,7 @@ resources:
     ~ testprovider:index/test:Test: (update)
         [id=test-id]
         [urn=urn:pulumi:test::test::testprovider:index/test:Test::mainRes]
-      ~ s: [secret] => [secret]
+        s: [secret]
 Resources:
     ~ 1 to update
     1 unchanged
@@ -202,9 +202,7 @@ resources:
     ~ testprovider:index/test:Test: (update)
         [id=test-id]
         [urn=urn:pulumi:test::test::testprovider:index/test:Test::mainRes]
-      ~ key: {
-          ~ prop1: [secret] => [secret]
-        }
+        key: [secret]
 Resources:
     ~ 1 to update
     1 unchanged
@@ -225,8 +223,9 @@ Resources:
     ~ testprovider:index/test:Test: (update)
         [id=test-id]
         [urn=urn:pulumi:test::test::testprovider:index/test:Test::mainRes]
-      ~ key: {
-          ~ prop1: [secret] => [secret]
+        key: {
+            prop1: [secret]
+            prop2: "value2"
         }
 Resources:
     ~ 1 to update
@@ -249,6 +248,7 @@ Resources:
         [id=test-id]
         [urn=urn:pulumi:test::test::testprovider:index/test:Test::mainRes]
       ~ key: {
+            prop1: [secret]
           ~ prop2: "value2" => "value3"
         }
 Resources:
@@ -302,7 +302,7 @@ resources:
     ~ testprovider:index/test:Test: (update)
         [id=test-id]
         [urn=urn:pulumi:test::test::testprovider:index/test:Test::mainRes]
-      ~ s: [secret] => [secret]
+        s: [secret]
 Resources:
     ~ 1 to update
     1 unchanged

--- a/pkg/pf/tfbridge/provider.go
+++ b/pkg/pf/tfbridge/provider.go
@@ -17,6 +17,7 @@ package tfbridge
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/blang/semver"
 	pfprovider "github.com/hashicorp/terraform-plugin-framework/provider"
@@ -27,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
@@ -43,14 +45,14 @@ import (
 )
 
 type providerOptions struct {
-	enableAccurateBridgePreview bool
+	enableAccuratePFBridgePreview bool
 }
 
 type providerOption func(providerOptions) (providerOptions, error)
 
-func withAccurateBridgePreview() providerOption {
+func withAccuratePFBridgePreview() providerOption {
 	return func(opts providerOptions) (providerOptions, error) {
-		opts.enableAccurateBridgePreview = true
+		opts.enableAccuratePFBridgePreview = true
 		return opts, nil
 	}
 }
@@ -175,8 +177,8 @@ func newProviderWithContext(ctx context.Context, info tfbridge.ProviderInfo,
 	}
 
 	opts := []providerOption{}
-	if info.EnableAccurateBridgePreview {
-		opts = append(opts, withAccurateBridgePreview())
+	if info.EnableAccuratePFBridgePreview || cmdutil.IsTruthy(os.Getenv("PULUMI_TF_BRIDGE_ACCURATE_PF_BRIDGE_PREVIEW")) {
+		opts = append(opts, withAccuratePFBridgePreview())
 	}
 
 	p := &provider{

--- a/pkg/pf/tfbridge/provider_diff.go
+++ b/pkg/pf/tfbridge/provider_diff.go
@@ -134,7 +134,7 @@ func (p *provider) DiffWithContext(
 		return plugin.DiffResult{}, err
 	}
 
-	if providerOpts.enableAccurateBridgePreview {
+	if providerOpts.enableAccuratePFBridgePreview {
 		replaceOverride := len(replaceKeys) > 0
 		pluginDetailedDiff, err := calculateDetailedDiff(
 			ctx, &rh, priorState, plannedStateValue, checkedInputs, &replaceOverride)

--- a/pkg/tfbridge/info/info.go
+++ b/pkg/tfbridge/info/info.go
@@ -170,9 +170,12 @@ type Provider struct {
 	// EnableZeroDefaultSchemaVersion makes the provider default
 	// to version 0 when no version is specified in the state of a resource.
 	EnableZeroDefaultSchemaVersion bool
-	// EnableAccurateBridgePreview makes the bridge use an experimental feature
+	// EnableAccurateBridgePreview makes the SDKv2 bridge use an experimental feature
 	// to generate more accurate diffs and previews for resources
 	EnableAccurateBridgePreview bool
+	// EnableAccuratePFBridgePreview makes the Plugin Framework bridge use an experimental feature
+	// to generate more accurate diffs and previews for resources
+	EnableAccuratePFBridgePreview bool
 }
 
 // HclExampler represents a supplemental HCL example for a given resource or function.


### PR DESCRIPTION
We've decided to postpone rolling out PF accurate previews, so the SDKv2 bridge and the PF bridge need separate feature flags. This change adds a new feature flag for PF and keeps the old one for the SDKv2.

related to https://github.com/pulumi/pulumi-terraform-bridge/issues/2598
