### PR TITLE
Document versioning practices for dynamic package

### DIFF
--- a/dynamic/version/version.go
+++ b/dynamic/version/version.go
@@ -15,6 +15,11 @@
 package version
 
 // version is initialized by the Go linker to contain the semver of this build.
+
+// This is the same mechanism that Pulumi uses to embed versions in all of our binaries.
+// When updating the module version of this library, ensure to update the correct module path in
+// the Goreleaser for https://github.com/pulumi/pulumi-terraform-provider.
+// See also https://github.com/pulumi/pulumi-terraform-provider/pull/56.
 var version string
 
 // The Version of the provider.

--- a/dynamic/version/version.go
+++ b/dynamic/version/version.go
@@ -15,7 +15,7 @@
 package version
 
 // version is initialized by the Go linker to contain the semver of this build.
-
+//
 // This is the same mechanism that Pulumi uses to embed versions in all of our binaries.
 // When updating the module version of this library, ensure to update the correct module path in
 // the Goreleaser for https://github.com/pulumi/pulumi-terraform-provider.


### PR DESCRIPTION
Followup for https://github.com/pulumi/pulumi-terraform-provider/issues/54.

Clarifies where and how we're linking in the version to the dynamic binary.
