### PR TITLE
Remove bridgedProvider test utilities in favour of ToProviderInfo

### DIFF
--- a/pkg/pf/tests/autonaming_test.go
+++ b/pkg/pf/tests/autonaming_test.go
@@ -27,7 +27,7 @@ func TestAutonaming(t *testing.T) {
 			},
 		})
 
-	prov := bridgedProvider(provBuilder)
+	prov := provBuilder.ToProviderInfo()
 	prov.Resources["testprovider_test"] = &tfbridge.ResourceInfo{
 		Tok: "testprovider:index:Test",
 		Fields: map[string]*tfbridge.SchemaInfo{

--- a/pkg/pf/tests/config_test.go
+++ b/pkg/pf/tests/config_test.go
@@ -475,7 +475,7 @@ func TestAccProviderConfigureSecretsPluginFramework(t *testing.T) {
 				},
 			})
 
-			bp := bridgedProvider(tfp)
+			bp := tfp.ToProviderInfo()
 			bp.Config = map[string]*info.Schema{
 				"basic_strlist_config": {
 					// Prevent basicStrlistConfigs pluralization

--- a/pkg/pf/tests/diff_list_test.go
+++ b/pkg/pf/tests/diff_list_test.go
@@ -237,7 +237,6 @@ func TestDetailedDiffList(t *testing.T) {
 
 					diff := crosstests.Diff(
 						t, res, map[string]cty.Value{"key": initialValue}, map[string]cty.Value{"key": changeValue},
-						crosstests.DisableAccurateBridgePreview(),
 					)
 
 					autogold.ExpectFile(t, testOutput{

--- a/pkg/pf/tests/diff_map_test.go
+++ b/pkg/pf/tests/diff_map_test.go
@@ -187,7 +187,6 @@ func TestDetailedDiffMap(t *testing.T) {
 
 					diff := crosstests.Diff(
 						t, schemaValueMakerPair.res, map[string]cty.Value{"key": initialValue}, map[string]cty.Value{"key": changeValue},
-						crosstests.DisableAccurateBridgePreview(),
 					)
 
 					autogold.ExpectFile(t, testOutput{

--- a/pkg/pf/tests/diff_object_test.go
+++ b/pkg/pf/tests/diff_object_test.go
@@ -337,10 +337,7 @@ func TestDetailedDiffObject(t *testing.T) {
 					res := pb.NewResource(pb.NewResourceArgs{
 						ResourceSchema: schema.schema,
 					})
-					diff := crosstests.Diff(
-						t, res, initialValue, changeValue,
-						crosstests.DisableAccurateBridgePreview(),
-					)
+					diff := crosstests.Diff(t, res, initialValue, changeValue)
 					autogold.ExpectFile(t, testOutput{
 						initialValue: scenario.initialValue,
 						changeValue:  scenario.changeValue,
@@ -360,10 +357,7 @@ func TestDetailedDiffObject(t *testing.T) {
 						res := pb.NewResource(pb.NewResourceArgs{
 							ResourceSchema: schema.schema,
 						})
-						diff := crosstests.Diff(
-							t, res, initialValue, changeValue,
-							crosstests.DisableAccurateBridgePreview(),
-						)
+						diff := crosstests.Diff(t, res, initialValue, changeValue)
 						autogold.ExpectFile(t, testOutput{
 							initialValue: scenario.initialValue,
 							changeValue:  scenario.changeValue,

--- a/pkg/pf/tests/diff_secret_test.go
+++ b/pkg/pf/tests/diff_secret_test.go
@@ -32,7 +32,7 @@ func TestSecretBasic(t *testing.T) {
 			},
 		})
 
-	prov := bridgedProvider(provBuilder)
+	prov := provBuilder.ToProviderInfo()
 
 	program := `
 name: test
@@ -82,7 +82,7 @@ func TestSecretSet(t *testing.T) {
 		},
 	})
 
-	prov := bridgedProvider(provBuilder)
+	prov := provBuilder.ToProviderInfo()
 
 	program := `
 name: test
@@ -177,7 +177,7 @@ func TestSecretObjectBlock(t *testing.T) {
 		},
 	})
 
-	prov := bridgedProvider(provBuilder)
+	prov := provBuilder.ToProviderInfo()
 
 	program := `
 name: test
@@ -273,7 +273,7 @@ func TestSecretPulumiSchema(t *testing.T) {
 		},
 	})
 
-	prov := bridgedProvider(provBuilder)
+	prov := provBuilder.ToProviderInfo()
 
 	prov.Resources["testprovider_test"].Fields = map[string]*info.Schema{
 		"s": {Secret: tfbridge0.True()},

--- a/pkg/pf/tests/diff_set_test.go
+++ b/pkg/pf/tests/diff_set_test.go
@@ -597,7 +597,6 @@ func TestDetailedDiffSet(t *testing.T) {
 
 					diff := crosstests.Diff(
 						t, schemaValueMakerPair.res, map[string]cty.Value{"key": initialValue}, map[string]cty.Value{"key": changeValue},
-						crosstests.DisableAccurateBridgePreview(),
 					)
 
 					autogold.ExpectFile(t, testOutput{

--- a/pkg/pf/tests/diff_test.go
+++ b/pkg/pf/tests/diff_test.go
@@ -197,7 +197,6 @@ func TestDetailedDiffStringAttribute(t *testing.T) {
 					})
 					diff := crosstests.Diff(
 						t, res, map[string]cty.Value{"key": initialValue}, map[string]cty.Value{"key": changeValue},
-						crosstests.DisableAccurateBridgePreview(),
 					)
 
 					autogold.ExpectFile(t, testOutput{

--- a/pkg/pf/tests/internal/cross-tests/diff.go
+++ b/pkg/pf/tests/internal/cross-tests/diff.go
@@ -109,8 +109,7 @@ func Diff(t T, res pb.Resource, tfConfig1, tfConfig2 map[string]cty.Value, optio
 	require.NoError(t, err)
 	t.Logf("Pulumi.yaml:\n%s", string(bytes))
 
-	pt, err := pulcheck.PulCheck(
-		t, bridgedProvider(prov, bridgedProviderOpts{enableAccurateBridgePreview: !opts.disableAccurateBridgePreview}), string(bytes))
+	pt, err := pulcheck.PulCheck(t, prov.ToProviderInfo(), string(bytes))
 	require.NoError(t, err)
 	pt.Up(t)
 
@@ -134,8 +133,7 @@ func Diff(t T, res pb.Resource, tfConfig1, tfConfig2 map[string]cty.Value, optio
 }
 
 type diffOpts struct {
-	resourceInfo                 map[string]*info.Schema
-	disableAccurateBridgePreview bool
+	resourceInfo map[string]*info.Schema
 }
 
 type DiffOption func(*diffOpts)
@@ -143,9 +141,4 @@ type DiffOption func(*diffOpts)
 // DiffProviderInfo specifies a map of [info.Schema] to apply to the provider under test.
 func DiffProviderInfo(info map[string]*info.Schema) DiffOption {
 	return func(o *diffOpts) { o.resourceInfo = info }
-}
-
-// DisableAccurateBridgePreview disables the accurate bridge preview feature.
-func DisableAccurateBridgePreview() DiffOption {
-	return func(o *diffOpts) { o.disableAccurateBridgePreview = true }
 }

--- a/pkg/pf/tests/internal/cross-tests/util.go
+++ b/pkg/pf/tests/internal/cross-tests/util.go
@@ -24,11 +24,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 
 	crosstestsimpl "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/tests/cross-tests/impl"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/providerbuilder"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
-	tfbridge0 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/tokens"
 )
 
 type T = crosstestsimpl.T
@@ -56,24 +51,4 @@ func skipUnlessLinux(t T) {
 	if ci, ok := os.LookupEnv("CI"); ok && ci == "true" && !strings.Contains(strings.ToLower(runtime.GOOS), "linux") {
 		t.Skip("Skipping on non-Linux platforms as our CI does not yet install Terraform CLI required for these tests")
 	}
-}
-
-type bridgedProviderOpts struct {
-	enableAccurateBridgePreview bool
-}
-
-func bridgedProvider(prov *providerbuilder.Provider, opts bridgedProviderOpts) info.Provider {
-	shimProvider := tfbridge.ShimProvider(prov)
-
-	provider := tfbridge0.ProviderInfo{
-		P:                           shimProvider,
-		Name:                        prov.TypeName,
-		Version:                     prov.Version,
-		MetadataInfo:                &tfbridge0.MetadataInfo{},
-		EnableAccurateBridgePreview: opts.enableAccurateBridgePreview,
-	}
-
-	provider.MustComputeTokens(tokens.SingleModule(prov.TypeName, "index", tokens.MakeStandard(prov.TypeName)))
-
-	return provider
 }

--- a/pkg/pf/tests/provider_checkconfig_test.go
+++ b/pkg/pf/tests/provider_checkconfig_test.go
@@ -829,7 +829,7 @@ func TestExtraConfig(t *testing.T) {
 			},
 		})
 
-	prov := bridgedProvider(provBuilder)
+	prov := provBuilder.ToProviderInfo()
 
 	prov.ExtraConfig = map[string]*info.Config{
 		"extraConf": {

--- a/pkg/pf/tests/schema_and_program_test.go
+++ b/pkg/pf/tests/schema_and_program_test.go
@@ -44,7 +44,7 @@ func TestBasic(t *testing.T) {
 			},
 		})
 
-	prov := bridgedProvider(provBuilder)
+	prov := provBuilder.ToProviderInfo()
 
 	program := `
 name: test
@@ -102,7 +102,7 @@ func TestComputedSetNoDiffWhenElementRemoved(t *testing.T) {
 		},
 	})
 
-	prov := bridgedProvider(provBuilder)
+	prov := provBuilder.ToProviderInfo()
 
 	program1 := `
 name: test
@@ -262,7 +262,7 @@ func TestIDAttribute(t *testing.T) {
 			if tc.computeIDField != "" {
 				computeIDField = tfbridge.DelegateIDField(presource.PropertyKey(tc.computeIDField), "prov", "")
 			}
-			prov := bridgedProvider(&provBuilder)
+			prov := provBuilder.ToProviderInfo()
 			prov.Resources = map[string]*info.Resource{
 				"prov_test": {
 					Tok:       "prov:index/test:Test",
@@ -329,7 +329,7 @@ func TestDefaults(t *testing.T) {
 		},
 	})
 
-	prov := bridgedProvider(provBuilder)
+	prov := provBuilder.ToProviderInfo()
 
 	program := `
 name: test
@@ -391,7 +391,7 @@ func TestPlanModifiers(t *testing.T) {
 		},
 	})
 
-	prov := bridgedProvider(provBuilder)
+	prov := provBuilder.ToProviderInfo()
 
 	program := `
 name: test

--- a/pkg/pf/tests/util.go
+++ b/pkg/pf/tests/util.go
@@ -21,11 +21,8 @@ import (
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/require"
 
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/providerbuilder"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
 	tfbridge0 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/tokens"
 )
 
 func newProviderServer(t *testing.T, info tfbridge0.ProviderInfo) (pulumirpc.ResourceProviderServer, error) {
@@ -45,20 +42,4 @@ func newMuxedProviderServer(t *testing.T, info tfbridge0.ProviderInfo) pulumirpc
 	p, err := tfbridge.MakeMuxedServer(ctx, info.Name, info, meta)(nil)
 	require.NoError(t, err)
 	return p
-}
-
-func bridgedProvider(prov *providerbuilder.Provider) info.Provider {
-	shimProvider := tfbridge.ShimProvider(prov)
-
-	provider := tfbridge0.ProviderInfo{
-		P:                           shimProvider,
-		Name:                        prov.TypeName,
-		Version:                     "0.0.1",
-		MetadataInfo:                &tfbridge0.MetadataInfo{},
-		EnableAccurateBridgePreview: true,
-	}
-
-	provider.MustComputeTokens(tokens.SingleModule(prov.TypeName, "index", tokens.MakeStandard(prov.TypeName)))
-
-	return provider
 }


### PR DESCRIPTION
This PR is refactors the PF tests to remove the `bridgedProvider` utilities in favour of the new `ToProviderInfo` method on the `providerbuilder` class. Gets rid of some duplicated code.