### PR TITLE
Disable the `make lint test` part of weekly-pulumi-update

### DIFF
--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Bridge Pulumi Upgrade
       if: steps.gomod.outputs.changes != 0
       run: >-
-        make build && make lint && make test
+        make build
 
         git add .
 


### PR DESCRIPTION
We don't need to run `make lint test` as part of creating the update PR, since these steps are already run as part of CI on the PR itself.