### PR TITLE
Do not render empty code choosers on generated index page

### DIFF
--- a/pkg/tfgen/convert_cli.go
+++ b/pkg/tfgen/convert_cli.go
@@ -45,6 +45,10 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen/internal/autofill"
 )
 
+const (
+	exampleUnavailable = "Example currently unavailable in this language\n"
+)
+
 func cliConverterEnabled() bool {
 	return cmdutil.IsTruthy(os.Getenv("PULUMI_CONVERT"))
 }
@@ -645,13 +649,14 @@ func (cc *cliConverter) singleExampleFromHCLToPCL(path, hclCode string) (transla
 func (cc *cliConverter) singleExampleFromPCLToLanguage(example translatedExample, lang string) (string, error) {
 	var err error
 
-	if example.PCL == "" {
-		return "", nil
-	}
 	source, diags, _ := cc.convertPCL(example.PCL, lang)
 	diags = cc.postProcessDiagnostics(diags.Extend(example.Diagnostics))
 	if diags.HasErrors() {
 		err = fmt.Errorf("conversion errors: %s", diags.Error())
+	}
+
+	if source == "" {
+		source = exampleUnavailable
 	}
 	source = "```" + lang + "\n" + source + "```"
 	return source, err

--- a/pkg/tfgen/convert_cli.go
+++ b/pkg/tfgen/convert_cli.go
@@ -651,8 +651,7 @@ func (cc *cliConverter) singleExampleFromPCLToLanguage(example translatedExample
 	source, diags, _ := cc.convertPCL(example.PCL, lang)
 	diags = cc.postProcessDiagnostics(diags.Extend(example.Diagnostics))
 	if diags.HasErrors() {
-		source = "Example currently unavailable in this language\n"
-		err = fmt.Errorf("failed to convert an example: %s", diags.Error())
+		err = fmt.Errorf("conversion errors: %s", diags.Error())
 	}
 	source = "```" + lang + "\n" + source + "```"
 	return source, err

--- a/pkg/tfgen/installation_docs.go
+++ b/pkg/tfgen/installation_docs.go
@@ -260,6 +260,7 @@ func convertExample(g *Generator, code string, exampleNumber int) (string, error
 		choosableEnd = "\n{{% /choosable %}}\n"
 	)
 	exampleContent := chooserStart
+	successfulConversion := false
 
 	// Generate each language in turn and mark up the output with the correct Hugo shortcodes.
 	for _, lang := range langs {
@@ -273,10 +274,17 @@ func convertExample(g *Generator, code string, exampleNumber int) (string, error
 		if err != nil {
 			g.warn(err.Error())
 		}
+		if convertedLang != "" {
+			successfulConversion = true
+		}
+
 		exampleContent += choosableStart + pulumiYAML + convertedLang + choosableEnd
 	}
-	exampleContent += chooserEnd
-	return exampleContent, nil
+
+	if successfulConversion {
+		return exampleContent + chooserEnd, nil
+	}
+	return "", nil
 }
 
 type titleRemover struct{}

--- a/pkg/tfgen/installation_docs.go
+++ b/pkg/tfgen/installation_docs.go
@@ -259,6 +259,10 @@ func convertExample(g *Generator, code string, exampleNumber int) (string, error
 		return "", err
 	}
 
+	if pclExample.PCL == "" {
+		return "", nil
+	}
+
 	langs := genLanguageToSlice(g.language)
 	const (
 		chooserStart = `{{< chooser language "typescript,python,go,csharp,java,yaml" >}}` + "\n"
@@ -280,10 +284,9 @@ func convertExample(g *Generator, code string, exampleNumber int) (string, error
 		if err != nil {
 			g.warn(err.Error())
 		}
-		if convertedLang != "" {
+		if convertedLang != exampleUnavailable {
 			successfulConversion = true
 		}
-
 		exampleContent += choosableStart + pulumiYAML + convertedLang + choosableEnd
 	}
 

--- a/pkg/tfgen/installation_docs.go
+++ b/pkg/tfgen/installation_docs.go
@@ -521,12 +521,14 @@ func isMarkdownSectionEmpty(title string, contentBytes []byte) bool {
 
 	err := ast.Walk(astNode, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
 		if section, ok := n.(*section.Section); ok && entering {
-			sectionText := section.Text(contentBytes)
-			// A little confusingly, we check if the section text _only_ contains the title, "Example Usage".
-			// Non-empty sections contain the title + content, so if we see only the title, the section is empty.
-			if string(sectionText) == title {
-				isEmpty = true
-				return ast.WalkStop, nil
+			if section.HasChildren() {
+				// A titled section is empty if it has only one child - the title.
+				// If the child's text matches the title, the section is empty.
+				sectionText := string(section.FirstChild().Text(contentBytes))
+				if section.FirstChild() == section.LastChild() && sectionText == title {
+					isEmpty = true
+					return ast.WalkStop, nil
+				}
 			}
 		}
 		return ast.WalkContinue, nil

--- a/pkg/tfgen/installation_docs_test.go
+++ b/pkg/tfgen/installation_docs_test.go
@@ -645,6 +645,28 @@ func TestSkipDefaultSectionHeaders(t *testing.T) {
 	}
 }
 
+func TestRemoveEmptyExamples(t *testing.T) {
+	t.Parallel()
+	type testCase struct {
+		name     string
+		input    string
+		expected string
+	}
+
+	tc := testCase{
+		name:     "An empty Example Usage section is skipped",
+		input:    readTestFile(t, "skip-empty-examples/input.md"),
+		expected: readTestFile(t, "skip-empty-examples/expected.md"),
+	}
+
+	t.Run(tc.name, func(t *testing.T) {
+		t.Parallel()
+		actual, err := removeEmptySection("Example Usage", []byte(tc.input))
+		require.NoError(t, err)
+		assertEqualHTML(t, tc.expected, string(actual))
+	})
+}
+
 // Helper func to determine if the HTML rendering is equal.
 // This helps in cases where the processed Markdown is slightly different from the expected Markdown
 // due to goldmark making some (insignificant to the final HTML) changes when parsing and rendering.
@@ -662,26 +684,4 @@ func assertEqualHTML(t *testing.T, expected, actual string) bool {
 		panic(err)
 	}
 	return assert.Equal(t, expectedBuf.String(), outputBuf.String())
-}
-
-func TestRemoveEmptyExamples(t *testing.T) {
-	t.Parallel()
-	type testCase struct {
-		name     string
-		input    string
-		expected string
-	}
-
-	tc := testCase{
-		name:     "An empty Example Usage section is skipped",
-		input:    readTestFile(t, "skip-empty-examples/input.md"),
-		expected: readTestFile(t, "skip-empty-examples/expected.md"),
-	}
-
-	t.Run(tc.name, func(t *testing.T) {
-		t.Parallel()
-		actual, err := removeEmptyExamples(tc.input)
-		require.NoError(t, err)
-		assertEqualHTML(t, tc.expected, actual)
-	})
 }

--- a/pkg/tfgen/installation_docs_test.go
+++ b/pkg/tfgen/installation_docs_test.go
@@ -476,6 +476,32 @@ func TestTranslateCodeBlocks(t *testing.T) {
 				language: RegistryDocs,
 			},
 		},
+		{
+			name:       "Translates standalone provider config into Pulumi config YAML",
+			contentStr: readfile(t, "test_data/installation-docs/provider-config-only.md"),
+			expected:   readfile(t, "test_data/installation-docs/provider-config-only-expected.md"),
+			g: &Generator{
+				sink: mockSink{},
+				cliConverterState: &cliConverter{
+					info: p,
+					pcls: pclsMap,
+				},
+				language: RegistryDocs,
+			},
+		},
+		{
+			name:       "Translates standalone example into languages",
+			contentStr: readfile(t, "test_data/installation-docs/example-only.md"),
+			expected:   readfile(t, "test_data/installation-docs/example-only-expected.md"),
+			g: &Generator{
+				sink: mockSink{},
+				cliConverterState: &cliConverter{
+					info: p,
+					pcls: pclsMap,
+				},
+				language: RegistryDocs,
+			},
+		},
 	}
 
 	for _, tt := range testCases {

--- a/pkg/tfgen/installation_docs_test.go
+++ b/pkg/tfgen/installation_docs_test.go
@@ -491,9 +491,6 @@ func TestTranslateCodeBlocks(t *testing.T) {
 			}
 			t.Setenv("PULUMI_CONVERT", "1")
 			actual, err := translateCodeBlocks(tt.contentStr, tt.g)
-			if tt.name == "Does not translate an invalid example and leaves example block blank" {
-				writefile(t, "test_data/installation-docs/invalid-example-actual", []byte(actual))
-			}
 			require.NoError(t, err)
 			require.Equal(t, tt.expected, actual)
 		})
@@ -639,4 +636,26 @@ func assertEqualHTML(t *testing.T, expected, actual string) bool {
 		panic(err)
 	}
 	return assert.Equal(t, expectedBuf.String(), outputBuf.String())
+}
+
+func TestRemoveEmptyExamples(t *testing.T) {
+	t.Parallel()
+	type testCase struct {
+		name     string
+		input    string
+		expected string
+	}
+
+	tc := testCase{
+		name:     "An empty Example Usage section is skipped",
+		input:    readTestFile(t, "skip-empty-examples/input.md"),
+		expected: readTestFile(t, "skip-empty-examples/expected.md"),
+	}
+
+	t.Run(tc.name, func(t *testing.T) {
+		t.Parallel()
+		actual, err := removeEmptyExamples(tc.input)
+		require.NoError(t, err)
+		assertEqualHTML(t, tc.expected, actual)
+	})
 }

--- a/pkg/tfgen/test_data/installation-docs/example-only-expected.md
+++ b/pkg/tfgen/test_data/installation-docs/example-only-expected.md
@@ -1,0 +1,132 @@
+This example is invalid and should not be translated for this test to pass
+
+## Example Usage
+
+{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
+{{% choosable language typescript %}}
+```typescript
+import * as pulumi from "@pulumi/pulumi";
+import * as simple from "@pulumi/simple";
+
+//# Define a resource
+const aResource = new simple.index.Resource("a_resource", {
+    renamedInput1: "hello",
+    inputTwo: true,
+});
+export const someOutput = aResource.result;
+```
+{{% /choosable %}}
+{{% choosable language python %}}
+```python
+import pulumi
+import pulumi_simple as simple
+
+## Define a resource
+a_resource = simple.index.Resource("a_resource",
+    renamed_input1=hello,
+    input_two=True)
+pulumi.export("someOutput", a_resource["result"])
+```
+{{% /choosable %}}
+{{% choosable language csharp %}}
+```csharp
+using System.Collections.Generic;
+using System.Linq;
+using Pulumi;
+using Simple = Pulumi.Simple;
+
+return await Deployment.RunAsync(() => 
+{
+    //# Define a resource
+    var aResource = new Simple.Index.Resource("a_resource", new()
+    {
+        RenamedInput1 = "hello",
+        InputTwo = true,
+    });
+
+    return new Dictionary<string, object?>
+    {
+        ["someOutput"] = aResource.Result,
+    };
+});
+
+```
+{{% /choosable %}}
+{{% choosable language go %}}
+```go
+package main
+
+import (
+	"github.com/pulumi/pulumi-simple/sdk/go/simple"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		// # Define a resource
+		aResource, err := simple.NewResource(ctx, "a_resource", &simple.ResourceArgs{
+			RenamedInput1: "hello",
+			InputTwo:      true,
+		})
+		if err != nil {
+			return err
+		}
+		ctx.Export("someOutput", aResource.Result)
+		return nil
+	})
+}
+```
+{{% /choosable %}}
+{{% choosable language yaml %}}
+```yaml
+resources:
+  ## Define a resource
+  aResource:
+    type: simple:resource
+    name: a_resource
+    properties:
+      renamedInput1: hello
+      inputTwo: true
+outputs:
+  someOutput: ${aResource.result}
+```
+{{% /choosable %}}
+{{% choosable language java %}}
+```java
+package generated_program;
+
+import com.pulumi.Context;
+import com.pulumi.Pulumi;
+import com.pulumi.core.Output;
+import com.pulumi.simple.resource;
+import com.pulumi.simple.ResourceArgs;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Map;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+public class App {
+    public static void main(String[] args) {
+        Pulumi.run(App::stack);
+    }
+
+    public static void stack(Context ctx) {
+        //# Define a resource
+        var aResource = new Resource("aResource", ResourceArgs.builder()
+            .renamedInput1("hello")
+            .inputTwo(true)
+            .build());
+
+        ctx.export("someOutput", aResource.result());
+    }
+}
+```
+{{% /choosable %}}
+{{< /chooser >}}
+
+
+## Configuration Reference
+
+The following configuration inputs are supported:

--- a/pkg/tfgen/test_data/installation-docs/example-only-expected.md
+++ b/pkg/tfgen/test_data/installation-docs/example-only-expected.md
@@ -1,4 +1,4 @@
-This example is invalid and should not be translated for this test to pass
+This example will only translate the resource code. It has no configuration file.
 
 ## Example Usage
 

--- a/pkg/tfgen/test_data/installation-docs/example-only.md
+++ b/pkg/tfgen/test_data/installation-docs/example-only.md
@@ -1,4 +1,4 @@
-This example is invalid and should not be translated for this test to pass
+This example will only translate the resource code. It has no configuration file.
 
 ## Example Usage
 

--- a/pkg/tfgen/test_data/installation-docs/example-only.md
+++ b/pkg/tfgen/test_data/installation-docs/example-only.md
@@ -3,14 +3,6 @@ This example is invalid and should not be translated for this test to pass
 ## Example Usage
 
 ```hcl
-# Configure the OpenStack Provider
-misspelledprovider "simple-provider" {
-  user_name   = "admin"
-  tenant_name = "admin"
-  password    = "pwd"
-  auth_url    = "http://myauthurl:5000/v3"
-  region      = "RegionOne"
-}
 ## Define a resource
 resource "simple_resource" "a_resource" {
   input_one = "hello"

--- a/pkg/tfgen/test_data/installation-docs/invalid-example-expected.md
+++ b/pkg/tfgen/test_data/installation-docs/invalid-example-expected.md
@@ -1,0 +1,9 @@
+This example is invalid and should not be translated for this test to pass
+
+## Example Usage
+
+
+
+## Configuration Reference
+
+The following configuration inputs are supported:

--- a/pkg/tfgen/test_data/installation-docs/invalid-example.md
+++ b/pkg/tfgen/test_data/installation-docs/invalid-example.md
@@ -1,0 +1,27 @@
+This example is invalid and should not be translated for this test to pass
+
+## Example Usage
+
+```hcl
+# Configure the OpenStack Provider
+proider "simple-provider" {
+  user_name   = "admin"
+  tenant_name = "admin"
+  password    = "pwd"
+  auth_url    = "http://myauthurl:5000/v3"
+  region      = "RegionOne"
+}
+## Define a resource
+resource "simple_resource" "a_resource" {
+  input_one = "hello"
+  input_two = true
+}
+
+output "some_output" {
+  value = simple_resource.a_resource.result
+}
+```
+
+## Configuration Reference
+
+The following configuration inputs are supported:

--- a/pkg/tfgen/test_data/installation-docs/provider-config-only-expected.md
+++ b/pkg/tfgen/test_data/installation-docs/provider-config-only-expected.md
@@ -1,0 +1,26 @@
+This example should translate at least the Pulumi config
+
+## Example Usage
+
+```yaml
+# Pulumi.yaml provider configuration file
+name: configuration-example
+runtime: 
+config:
+    simple-provider:authUrl:
+        value: http://myauthurl:5000/v3
+    simple-provider:password:
+        value: pwd
+    simple-provider:region:
+        value: RegionOne
+    simple-provider:tenantName:
+        value: admin
+    simple-provider:userName:
+        value: admin
+
+```
+
+
+## Configuration Reference
+
+The following configuration inputs are supported:

--- a/pkg/tfgen/test_data/installation-docs/provider-config-only.md
+++ b/pkg/tfgen/test_data/installation-docs/provider-config-only.md
@@ -1,0 +1,18 @@
+This example should translate at least the Pulumi config
+
+## Example Usage
+
+```hcl
+# Configure the OpenStack Provider
+provider "simple-provider" {
+  user_name   = "admin"
+  tenant_name = "admin"
+  password    = "pwd"
+  auth_url    = "http://myauthurl:5000/v3"
+  region      = "RegionOne"
+}
+```
+
+## Configuration Reference
+
+The following configuration inputs are supported:

--- a/pkg/tfgen/test_data/skip-empty-examples/expected.md
+++ b/pkg/tfgen/test_data/skip-empty-examples/expected.md
@@ -1,0 +1,9 @@
+# PagerDuty Provider
+
+[PagerDuty](https://www.pagerduty.com/) is an incident management platform that provides reliable notifications, automatic escalations, on-call scheduling, and other functionality to help teams detect and address unplanned work in real-time.
+
+Use the navigation to the left to read about the available resources.
+
+## Perfectly allowed header for a helpful section
+
+This section should not be skipped

--- a/pkg/tfgen/test_data/skip-empty-examples/input.md
+++ b/pkg/tfgen/test_data/skip-empty-examples/input.md
@@ -1,0 +1,13 @@
+# PagerDuty Provider
+
+[PagerDuty](https://www.pagerduty.com/) is an incident management platform that provides reliable notifications, automatic escalations, on-call scheduling, and other functionality to help teams detect and address unplanned work in real-time.
+
+Use the navigation to the left to read about the available resources.
+
+## Example Usage
+
+
+
+## Perfectly allowed header for a helpful section
+
+This section should not be skipped


### PR DESCRIPTION
This pull request does the following:

1. Prevents the generation of code choosers with empty content
1. Writes a YAML config file with no code choosers if the example is config-only
1. Checks the `pclExample` object for empty pulumi YAML or PCL explicitly and before attempting to convert, removing the empty string check from the converter functions
1. Adds tests to illustrate all four situations: 
    - valid provider config + example
    - invalid code
    - valid provider config but no example
    - valid example but no provider config
 1. Adds `exampleUnavailable` placeholder constant for use when conversion fails on an individual language
 1. Adds a `successfulConversion` flag that flips to True as soon as any one language registers as having content other than the `exampleUnavailable` message. The idea is that if even only one pulumi language converted, we want to display the code chooser.
 
 Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/2819