### PR TITLE
Ensure logging from dynamic schema generation is structured

### DIFF
--- a/pkg/pf/tfbridge/provider.go
+++ b/pkg/pf/tfbridge/provider.go
@@ -255,7 +255,10 @@ func (p *provider) ParameterizeWithContext(
 			if err != nil {
 				return err
 			}
+			pp.Unwrap().logSink = p.logSink // Preserve the log sink from p
+
 			*p = *pp.Unwrap()
+
 			return nil
 		})
 


### PR DESCRIPTION
For logging to show by default, it needs to be in structured form. This PR correctly preserves the log sink after calls to Parameterize, and uses that log sink as the `Sink` in tfgen generator calls.