### PR TITLE
Add setup terraform step to bridge CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -27,6 +27,10 @@ jobs:
         uses: pulumi/actions@v5
         with:
           pulumi-version: dev
+      - name: Install terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
       - name: Check out source code
         uses: actions/checkout@master
       - name: Install Go


### PR DESCRIPTION
The CI started failing because of missing terraform CLI. This is likely the result of a change in default github runner configurations.

This PR adds an explicit setup terraform step to the bridge CI.

fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/2824