### PR TITLE
SDKv2 Diff tests for Map

### DIFF
--- a/pkg/tests/diff_test/detailed_diff_map_test.go
+++ b/pkg/tests/diff_test/detailed_diff_map_test.go
@@ -1,14 +1,10 @@
 package tests
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hexops/autogold/v2"
 	"github.com/zclconf/go-cty/cty"
-
-	crosstests "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/tests/cross-tests"
 )
 
 func TestSDKv2DetailedDiffMap(t *testing.T) {
@@ -26,7 +22,7 @@ func TestSDKv2DetailedDiffMap(t *testing.T) {
 	}
 
 	var nilVal map[string]string
-	schemaValueMakerPairs, scenarios := generatePrimitiveSchemaValueMakerPairs(
+	schemaValueMakerPairs, scenarios := generateBaseTests(
 		schema.TypeMap, &schema.Schema{Type: schema.TypeString}, ctyMaker,
 		map[string]string{"key": "val1"}, map[string]string{"key": "val2"},
 		map[string]string{"key": "computedVal"}, map[string]string{"key": "defaultVal"}, nilVal)
@@ -37,26 +33,5 @@ func TestSDKv2DetailedDiffMap(t *testing.T) {
 		changeValue:  ref(map[string]string{"key2": "val1"}),
 	})
 
-	for _, schemaValueMakerPair := range schemaValueMakerPairs {
-		t.Run(schemaValueMakerPair.name, func(t *testing.T) {
-			t.Parallel()
-			for _, scenario := range scenarios {
-				t.Run(scenario.name, func(t *testing.T) {
-					if strings.Contains(schemaValueMakerPair.name, "required") &&
-						(scenario.initialValue == nil || scenario.changeValue == nil) {
-						t.Skip("Required fields cannot be unset")
-					}
-					t.Parallel()
-					diff := crosstests.Diff(t, &schemaValueMakerPair.schema, schemaValueMakerPair.valueMaker(scenario.initialValue), schemaValueMakerPair.valueMaker(scenario.changeValue))
-					autogold.ExpectFile(t, testOutput{
-						initialValue: scenario.initialValue,
-						changeValue:  scenario.changeValue,
-						tfOut:        diff.TFOut,
-						pulumiOut:    diff.PulumiOut,
-						detailedDiff: diff.PulumiDiff.DetailedDiff,
-					})
-				})
-			}
-		})
-	}
+	runSDKv2TestMatrix(t, schemaValueMakerPairs, scenarios)
 }

--- a/pkg/tests/diff_test/detailed_diff_primitive_test.go
+++ b/pkg/tests/diff_test/detailed_diff_primitive_test.go
@@ -12,7 +12,7 @@ func TestSDKv2DetailedDiffString(t *testing.T) {
 
 	var nilVal string
 	schemaValueMakerPairs, scenarios := generateBaseTests(
-		schema.TypeString, cty.StringVal, "val1", "val2", "computed", "default", nilVal)
+		schema.TypeString, nil, cty.StringVal, "val1", "val2", "computed", "default", nilVal)
 
 	runSDKv2TestMatrix(t, schemaValueMakerPairs, scenarios)
 }
@@ -22,7 +22,7 @@ func TestSDKv2DetailedDiffBool(t *testing.T) {
 
 	var nilVal bool
 	schemaValueMakerPairs, scenarios := generateBaseTests(
-		schema.TypeBool, cty.BoolVal, true, false, true, false, nilVal)
+		schema.TypeBool, nil, cty.BoolVal, true, false, true, false, nilVal)
 
 	runSDKv2TestMatrix(t, schemaValueMakerPairs, scenarios)
 }
@@ -32,7 +32,7 @@ func TestSDKv2DetailedDiffInt(t *testing.T) {
 
 	var nilVal int64
 	schemaValueMakerPairs, scenarios := generateBaseTests(
-		schema.TypeInt, cty.NumberIntVal, 1, 2, 3, 4, nilVal)
+		schema.TypeInt, nil, cty.NumberIntVal, 1, 2, 3, 4, nilVal)
 
 	runSDKv2TestMatrix(t, schemaValueMakerPairs, scenarios)
 }
@@ -42,7 +42,7 @@ func TestSDKv2DetailedDiffFloat(t *testing.T) {
 
 	var nilVal float64
 	schemaValueMakerPairs, scenarios := generateBaseTests(
-		schema.TypeFloat, cty.NumberFloatVal, 1.0, 2.0, 3.0, 4.0, nilVal)
+		schema.TypeFloat, nil, cty.NumberFloatVal, 1.0, 2.0, 3.0, 4.0, nilVal)
 
 	runSDKv2TestMatrix(t, schemaValueMakerPairs, scenarios)
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optional/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optional/added.golden
@@ -1,0 +1,36 @@
+tests.testOutput{
+	initialValue: &map[string]string{},
+	changeValue:  &map[string]string{"key": "val1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "newid"
+      + prop = {
+          + "key" = "val1"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + prop: {
+          + key: "val1"
+        }
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optional/changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optional/changed.golden
@@ -1,0 +1,38 @@
+tests.testOutput{
+	initialValue: &map[string]string{
+		"key": "val1",
+	},
+	changeValue: &map[string]string{"key": "val2"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "newid"
+      ~ prop = {
+          ~ "key" = "val1" -> "val2"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: {
+          ~ key: "val1" => "val2"
+        }
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop.key": map[string]interface{}{"kind": "UPDATE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optional/key_changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optional/key_changed.golden
@@ -1,6 +1,8 @@
 tests.testOutput{
-	initialValue: map[string]string{},
-	changeValue:  map[string]string{"key": "val"},
+	initialValue: &map[string]string{
+		"key": "val1",
+	},
+	changeValue: &map[string]string{"key2": "val1"},
 	tfOut: `
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
@@ -10,9 +12,10 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
-        id       = "newid"
-      + map_prop = {
-          + "key" = "val"
+        id   = "newid"
+      ~ prop = {
+          - "key"  = "val1" -> null
+          + "key2" = "val1"
         }
     }
 
@@ -25,12 +28,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + mapProp: {
-          + key: "val"
+      ~ prop: {
+          - key : "val1"
+          + key2: "val1"
         }
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"mapProp": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"prop.key":  map[string]interface{}{"kind": "DELETE"},
+		"prop.key2": map[string]interface{}{},
+	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optional/removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optional/removed.golden
@@ -1,0 +1,38 @@
+tests.testOutput{
+	initialValue: &map[string]string{
+		"key": "val1",
+	},
+	changeValue: &map[string]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "newid"
+      ~ prop = {
+          - "key" = "val1" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: {
+          - key: "val1"
+        }
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop.key": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optional/unchanged_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optional/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &map[string]string{},
+	changeValue:  &map[string]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optional/unchanged_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optional/unchanged_non-empty.golden
@@ -1,6 +1,8 @@
 tests.testOutput{
-	initialValue: map[string]string{},
-	changeValue:  map[string]string{},
+	initialValue: &map[string]string{
+		"key": "val1",
+	},
+	changeValue: &map[string]string{"key": "val1"},
 	tfOut: `
 No changes. Your infrastructure matches the configuration.
 

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalComputed/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalComputed/added.golden
@@ -1,0 +1,36 @@
+tests.testOutput{
+	initialValue: &map[string]string{},
+	changeValue:  &map[string]string{"key": "val1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ prop = {
+          ~ "key" = "computedVal" -> "val1"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: {
+          ~ key: "computedVal" => "val1"
+        }
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop.key": map[string]interface{}{"kind": "UPDATE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalComputed/changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalComputed/changed.golden
@@ -1,8 +1,8 @@
 tests.testOutput{
-	initialValue: map[string]string{
-		"key": "val",
+	initialValue: &map[string]string{
+		"key": "val1",
 	},
-	changeValue: map[string]string{"key": "val2"},
+	changeValue: &map[string]string{"key": "val2"},
 	tfOut: `
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
@@ -12,9 +12,9 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
-        id       = "newid"
-      ~ map_prop = {
-          ~ "key" = "val" -> "val2"
+        id   = "id"
+      ~ prop = {
+          ~ "key" = "val1" -> "val2"
         }
     }
 
@@ -25,14 +25,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
     ~ crossprovider:index/testRes:TestRes: (update)
-        [id=newid]
+        [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ mapProp: {
-          ~ key: "val" => "val2"
+      ~ prop: {
+          ~ key: "val1" => "val2"
         }
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"mapProp.key": map[string]interface{}{"kind": "UPDATE"}},
+	detailedDiff: map[string]interface{}{"prop.key": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalComputed/key_changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalComputed/key_changed.golden
@@ -1,8 +1,8 @@
 tests.testOutput{
-	initialValue: map[string]string{
-		"key": "val",
+	initialValue: &map[string]string{
+		"key": "val1",
 	},
-	changeValue: map[string]string{},
+	changeValue: &map[string]string{"key2": "val1"},
 	tfOut: `
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
@@ -12,9 +12,10 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
-        id       = "newid"
-      ~ map_prop = {
-          - "key" = "val" -> null
+        id   = "id"
+      ~ prop = {
+          - "key"  = "val1" -> null
+          + "key2" = "val1"
         }
     }
 
@@ -25,14 +26,18 @@ Plan: 0 to add, 1 to change, 0 to destroy.
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
     ~ crossprovider:index/testRes:TestRes: (update)
-        [id=newid]
+        [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ mapProp: {
-          - key: "val"
+      ~ prop: {
+          - key : "val1"
+          + key2: "val1"
         }
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"mapProp.key": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{
+		"prop.key":  map[string]interface{}{"kind": "DELETE"},
+		"prop.key2": map[string]interface{}{},
+	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalComputed/removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalComputed/removed.golden
@@ -1,0 +1,38 @@
+tests.testOutput{
+	initialValue: &map[string]string{
+		"key": "val1",
+	},
+	changeValue: &map[string]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ prop = {
+          - "key" = "val1" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: {
+          - key: "val1"
+        }
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop.key": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalComputed/unchanged_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalComputed/unchanged_empty.golden
@@ -1,8 +1,6 @@
 tests.testOutput{
-	initialValue: map[string]string{
-		"key": "val",
-	},
-	changeValue: map[string]string{"key2": "val"},
+	initialValue: &map[string]string{},
+	changeValue:  &map[string]string{},
 	tfOut: `
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
@@ -12,10 +10,9 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
-        id       = "newid"
-      ~ map_prop = {
-          - "key"  = "val" -> null
-          + "key2" = "val"
+        id   = "id"
+      ~ prop = {
+          - "key" = "computedVal" -> null
         }
     }
 
@@ -26,18 +23,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
     ~ crossprovider:index/testRes:TestRes: (update)
-        [id=newid]
+        [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ mapProp: {
-          - key : "val"
-          + key2: "val"
+      ~ prop: {
+          - key: "computedVal"
         }
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"mapProp.key":  map[string]interface{}{"kind": "DELETE"},
-		"mapProp.key2": map[string]interface{}{},
-	},
+	detailedDiff: map[string]interface{}{"prop.key": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalComputed/unchanged_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalComputed/unchanged_non-empty.golden
@@ -1,8 +1,8 @@
 tests.testOutput{
-	initialValue: map[string]string{
-		"key": "val",
+	initialValue: &map[string]string{
+		"key": "val1",
 	},
-	changeValue: map[string]string{"key": "val"},
+	changeValue: &map[string]string{"key": "val1"},
 	tfOut: `
 No changes. Your infrastructure matches the configuration.
 

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalComputedForceNew/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalComputedForceNew/added.golden
@@ -1,0 +1,36 @@
+tests.testOutput{
+	initialValue: &map[string]string{},
+	changeValue:  &map[string]string{"key": "val1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "id" -> (known after apply)
+      ~ prop = { # forces replacement
+          ~ "key" = "computedVal" -> "val1"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: {
+          ~ key: "computedVal" => "val1"
+        }
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop.key": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalComputedForceNew/changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalComputedForceNew/changed.golden
@@ -1,0 +1,38 @@
+tests.testOutput{
+	initialValue: &map[string]string{
+		"key": "val1",
+	},
+	changeValue: &map[string]string{"key": "val2"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "id" -> (known after apply)
+      ~ prop = { # forces replacement
+          ~ "key" = "val1" -> "val2"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: {
+          ~ key: "val1" => "val2"
+        }
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop.key": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalComputedForceNew/key_changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalComputedForceNew/key_changed.golden
@@ -1,0 +1,43 @@
+tests.testOutput{
+	initialValue: &map[string]string{
+		"key": "val1",
+	},
+	changeValue: &map[string]string{"key2": "val1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "id" -> (known after apply)
+      ~ prop = { # forces replacement
+          - "key"  = "val1" -> null
+          + "key2" = "val1"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: {
+          - key : "val1"
+          + key2: "val1"
+        }
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"prop.key":  map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"prop.key2": map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalComputedForceNew/removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalComputedForceNew/removed.golden
@@ -1,0 +1,38 @@
+tests.testOutput{
+	initialValue: &map[string]string{
+		"key": "val1",
+	},
+	changeValue: &map[string]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "id" -> (known after apply)
+      ~ prop = {
+          - "key" = "val1"
+        } -> (known after apply) # forces replacement
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: {
+          - key: "val1"
+        }
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop.key": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalComputedForceNew/unchanged_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalComputedForceNew/unchanged_empty.golden
@@ -1,0 +1,36 @@
+tests.testOutput{
+	initialValue: &map[string]string{},
+	changeValue:  &map[string]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "id" -> (known after apply)
+      ~ prop = {
+          - "key" = "computedVal"
+        } -> (known after apply) # forces replacement
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: {
+          - key: "computedVal"
+        }
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop.key": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalComputedForceNew/unchanged_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalComputedForceNew/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &map[string]string{
+		"key": "val1",
+	},
+	changeValue: &map[string]string{"key": "val1"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalDefault/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalDefault/added.golden
@@ -1,0 +1,36 @@
+tests.testOutput{
+	initialValue: &map[string]string{},
+	changeValue:  &map[string]string{"key": "val1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "newid"
+      + prop = {
+          + "key" = "val1"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + prop: {
+          + key: "val1"
+        }
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalDefault/changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalDefault/changed.golden
@@ -1,0 +1,38 @@
+tests.testOutput{
+	initialValue: &map[string]string{
+		"key": "val1",
+	},
+	changeValue: &map[string]string{"key": "val2"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "newid"
+      ~ prop = {
+          ~ "key" = "val1" -> "val2"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: {
+          ~ key: "val1" => "val2"
+        }
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop.key": map[string]interface{}{"kind": "UPDATE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalDefault/key_changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalDefault/key_changed.golden
@@ -1,0 +1,43 @@
+tests.testOutput{
+	initialValue: &map[string]string{
+		"key": "val1",
+	},
+	changeValue: &map[string]string{"key2": "val1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "newid"
+      ~ prop = {
+          - "key"  = "val1" -> null
+          + "key2" = "val1"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: {
+          - key : "val1"
+          + key2: "val1"
+        }
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"prop.key":  map[string]interface{}{"kind": "DELETE"},
+		"prop.key2": map[string]interface{}{},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalDefault/removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalDefault/removed.golden
@@ -1,0 +1,38 @@
+tests.testOutput{
+	initialValue: &map[string]string{
+		"key": "val1",
+	},
+	changeValue: &map[string]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "newid"
+      ~ prop = {
+          - "key" = "val1" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: {
+          - key: "val1"
+        }
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop.key": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalDefault/unchanged_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalDefault/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &map[string]string{},
+	changeValue:  &map[string]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalDefault/unchanged_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalDefault/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &map[string]string{
+		"key": "val1",
+	},
+	changeValue: &map[string]string{"key": "val1"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalDefaultForceNew/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalDefaultForceNew/added.golden
@@ -1,0 +1,36 @@
+tests.testOutput{
+	initialValue: &map[string]string{},
+	changeValue:  &map[string]string{"key": "val1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "newid" -> (known after apply)
+      + prop = { # forces replacement
+          + "key" = "val1"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + prop: {
+          + key: "val1"
+        }
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalDefaultForceNew/changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalDefaultForceNew/changed.golden
@@ -1,0 +1,38 @@
+tests.testOutput{
+	initialValue: &map[string]string{
+		"key": "val1",
+	},
+	changeValue: &map[string]string{"key": "val2"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "newid" -> (known after apply)
+      ~ prop = { # forces replacement
+          ~ "key" = "val1" -> "val2"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: {
+          ~ key: "val1" => "val2"
+        }
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop.key": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalDefaultForceNew/key_changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalDefaultForceNew/key_changed.golden
@@ -1,0 +1,43 @@
+tests.testOutput{
+	initialValue: &map[string]string{
+		"key": "val1",
+	},
+	changeValue: &map[string]string{"key2": "val1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "newid" -> (known after apply)
+      ~ prop = { # forces replacement
+          - "key"  = "val1" -> null
+          + "key2" = "val1"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: {
+          - key : "val1"
+          + key2: "val1"
+        }
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"prop.key":  map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"prop.key2": map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalDefaultForceNew/removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalDefaultForceNew/removed.golden
@@ -1,0 +1,38 @@
+tests.testOutput{
+	initialValue: &map[string]string{
+		"key": "val1",
+	},
+	changeValue: &map[string]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "newid" -> (known after apply)
+      - prop = { # forces replacement
+          - "key" = "val1"
+        } -> null
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: {
+          - key: "val1"
+        }
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop.key": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalDefaultForceNew/unchanged_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalDefaultForceNew/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &map[string]string{},
+	changeValue:  &map[string]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalDefaultForceNew/unchanged_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalDefaultForceNew/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &map[string]string{
+		"key": "val1",
+	},
+	changeValue: &map[string]string{"key": "val1"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalForceNew/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalForceNew/added.golden
@@ -1,0 +1,36 @@
+tests.testOutput{
+	initialValue: &map[string]string{},
+	changeValue:  &map[string]string{"key": "val1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "newid" -> (known after apply)
+      + prop = { # forces replacement
+          + "key" = "val1"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + prop: {
+          + key: "val1"
+        }
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalForceNew/changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalForceNew/changed.golden
@@ -1,0 +1,38 @@
+tests.testOutput{
+	initialValue: &map[string]string{
+		"key": "val1",
+	},
+	changeValue: &map[string]string{"key": "val2"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "newid" -> (known after apply)
+      ~ prop = { # forces replacement
+          ~ "key" = "val1" -> "val2"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: {
+          ~ key: "val1" => "val2"
+        }
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop.key": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalForceNew/key_changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalForceNew/key_changed.golden
@@ -1,0 +1,43 @@
+tests.testOutput{
+	initialValue: &map[string]string{
+		"key": "val1",
+	},
+	changeValue: &map[string]string{"key2": "val1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "newid" -> (known after apply)
+      ~ prop = { # forces replacement
+          - "key"  = "val1" -> null
+          + "key2" = "val1"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: {
+          - key : "val1"
+          + key2: "val1"
+        }
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"prop.key":  map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"prop.key2": map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalForceNew/removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalForceNew/removed.golden
@@ -1,0 +1,38 @@
+tests.testOutput{
+	initialValue: &map[string]string{
+		"key": "val1",
+	},
+	changeValue: &map[string]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "newid" -> (known after apply)
+      - prop = { # forces replacement
+          - "key" = "val1"
+        } -> null
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: {
+          - key: "val1"
+        }
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop.key": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalForceNew/unchanged_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalForceNew/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &map[string]string{},
+	changeValue:  &map[string]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalForceNew/unchanged_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/optionalForceNew/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &map[string]string{
+		"key": "val1",
+	},
+	changeValue: &map[string]string{"key": "val1"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/required/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/required/added.golden
@@ -1,0 +1,36 @@
+tests.testOutput{
+	initialValue: &map[string]string{},
+	changeValue:  &map[string]string{"key": "val1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "newid"
+      + prop = {
+          + "key" = "val1"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + prop: {
+          + key: "val1"
+        }
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/required/changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/required/changed.golden
@@ -1,0 +1,38 @@
+tests.testOutput{
+	initialValue: &map[string]string{
+		"key": "val1",
+	},
+	changeValue: &map[string]string{"key": "val2"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "newid"
+      ~ prop = {
+          ~ "key" = "val1" -> "val2"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: {
+          ~ key: "val1" => "val2"
+        }
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop.key": map[string]interface{}{"kind": "UPDATE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/required/key_changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/required/key_changed.golden
@@ -1,0 +1,43 @@
+tests.testOutput{
+	initialValue: &map[string]string{
+		"key": "val1",
+	},
+	changeValue: &map[string]string{"key2": "val1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "newid"
+      ~ prop = {
+          - "key"  = "val1" -> null
+          + "key2" = "val1"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: {
+          - key : "val1"
+          + key2: "val1"
+        }
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"prop.key":  map[string]interface{}{"kind": "DELETE"},
+		"prop.key2": map[string]interface{}{},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/required/removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/required/removed.golden
@@ -1,0 +1,38 @@
+tests.testOutput{
+	initialValue: &map[string]string{
+		"key": "val1",
+	},
+	changeValue: &map[string]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "newid"
+      ~ prop = {
+          - "key" = "val1" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: {
+          - key: "val1"
+        }
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop.key": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/required/unchanged_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/required/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &map[string]string{},
+	changeValue:  &map[string]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/required/unchanged_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/required/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &map[string]string{
+		"key": "val1",
+	},
+	changeValue: &map[string]string{"key": "val1"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/requiredForceNew/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/requiredForceNew/added.golden
@@ -1,0 +1,36 @@
+tests.testOutput{
+	initialValue: &map[string]string{},
+	changeValue:  &map[string]string{"key": "val1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "newid" -> (known after apply)
+      + prop = { # forces replacement
+          + "key" = "val1"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + prop: {
+          + key: "val1"
+        }
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/requiredForceNew/changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/requiredForceNew/changed.golden
@@ -1,0 +1,38 @@
+tests.testOutput{
+	initialValue: &map[string]string{
+		"key": "val1",
+	},
+	changeValue: &map[string]string{"key": "val2"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "newid" -> (known after apply)
+      ~ prop = { # forces replacement
+          ~ "key" = "val1" -> "val2"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: {
+          ~ key: "val1" => "val2"
+        }
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop.key": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/requiredForceNew/key_changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/requiredForceNew/key_changed.golden
@@ -1,0 +1,43 @@
+tests.testOutput{
+	initialValue: &map[string]string{
+		"key": "val1",
+	},
+	changeValue: &map[string]string{"key2": "val1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "newid" -> (known after apply)
+      ~ prop = { # forces replacement
+          - "key"  = "val1" -> null
+          + "key2" = "val1"
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: {
+          - key : "val1"
+          + key2: "val1"
+        }
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"prop.key":  map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"prop.key2": map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/requiredForceNew/removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/requiredForceNew/removed.golden
@@ -1,0 +1,38 @@
+tests.testOutput{
+	initialValue: &map[string]string{
+		"key": "val1",
+	},
+	changeValue: &map[string]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "newid" -> (known after apply)
+      - prop = { # forces replacement
+          - "key" = "val1"
+        } -> null
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: {
+          - key: "val1"
+        }
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop.key": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/requiredForceNew/unchanged_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/requiredForceNew/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &map[string]string{},
+	changeValue:  &map[string]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/requiredForceNew/unchanged_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/requiredForceNew/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &map[string]string{
+		"key": "val1",
+	},
+	changeValue: &map[string]string{"key": "val1"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/value_makers.go
+++ b/pkg/tests/diff_test/value_makers.go
@@ -78,7 +78,7 @@ func generateBaseTests[T any](
 		Schema: map[string]*schema.Schema{
 			"prop": {
 				Type:     typ,
-				Elem:     elem,	
+				Elem:     elem,
 				Optional: true,
 			},
 		},

--- a/pkg/tests/diff_test/value_makers.go
+++ b/pkg/tests/diff_test/value_makers.go
@@ -59,7 +59,7 @@ func runSDKv2TestMatrix[T any](
 }
 
 func generateBaseTests[T any](
-	typ schema.ValueType, ctyMaker func(v T) cty.Value, val1, val2, computedVal, defaultVal, nilVal T,
+	typ schema.ValueType, elem any, ctyMaker func(v T) cty.Value, val1, val2, computedVal, defaultVal, nilVal T,
 ) ([]diffSchemaValueMakerPair[T], []diffScenario[T]) {
 	valueOne := ref(val1)
 	valueTwo := ref(val2)
@@ -78,6 +78,7 @@ func generateBaseTests[T any](
 		Schema: map[string]*schema.Schema{
 			"prop": {
 				Type:     typ,
+				Elem:     elem,	
 				Optional: true,
 			},
 		},
@@ -87,6 +88,7 @@ func generateBaseTests[T any](
 		Schema: map[string]*schema.Schema{
 			"prop": {
 				Type:     typ,
+				Elem:     elem,
 				Optional: true,
 				ForceNew: true,
 			},
@@ -97,6 +99,7 @@ func generateBaseTests[T any](
 		Schema: map[string]*schema.Schema{
 			"prop": {
 				Type:     typ,
+				Elem:     elem,
 				Required: true,
 			},
 		},
@@ -106,6 +109,7 @@ func generateBaseTests[T any](
 		Schema: map[string]*schema.Schema{
 			"prop": {
 				Type:     typ,
+				Elem:     elem,
 				ForceNew: true,
 				Required: true,
 			},
@@ -126,6 +130,7 @@ func generateBaseTests[T any](
 		Schema: map[string]*schema.Schema{
 			"prop": {
 				Type:     typ,
+				Elem:     elem,
 				Optional: true,
 				Computed: true,
 			},
@@ -141,6 +146,7 @@ func generateBaseTests[T any](
 		Schema: map[string]*schema.Schema{
 			"prop": {
 				Type:     typ,
+				Elem:     elem,
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
@@ -157,6 +163,7 @@ func generateBaseTests[T any](
 		Schema: map[string]*schema.Schema{
 			"prop": {
 				Type:     typ,
+				Elem:     elem,
 				Optional: true,
 				Default:  defaultVal,
 			},
@@ -167,6 +174,7 @@ func generateBaseTests[T any](
 		Schema: map[string]*schema.Schema{
 			"prop": {
 				Type:     typ,
+				Elem:     elem,
 				Optional: true,
 				Default:  defaultVal,
 				ForceNew: true,


### PR DESCRIPTION
This PR finishes the coverage of the SDKv2 bridge for Diff for Map types.

[f2a0c1c](https://github.com/pulumi/pulumi-terraform-bridge/pull/2830/commits/f2a0c1c07fdb4d6795448cccc8b8d45bcfee0eff) contains the test recordings

fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/2787