### PR TITLE
SDKv2 Diff tests for secret primitive types

### DIFF
--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffBool/sensitive/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffBool/sensitive/added.golden
@@ -1,0 +1,31 @@
+tests.testOutput{
+	initialValue: valast.Ptr(false), changeValue: valast.Ptr(true),
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "newid"
+      ~ prop = (sensitive value)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: [secret] => [secret]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{"kind": "UPDATE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffBool/sensitive/changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffBool/sensitive/changed.golden
@@ -1,0 +1,31 @@
+tests.testOutput{
+	initialValue: valast.Ptr(true), changeValue: valast.Ptr(false),
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "newid"
+      ~ prop = (sensitive value)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: [secret] => [secret]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{"kind": "UPDATE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffBool/sensitive/removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffBool/sensitive/removed.golden
@@ -1,0 +1,31 @@
+tests.testOutput{
+	initialValue: valast.Ptr(true), changeValue: valast.Ptr(false),
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "newid"
+      ~ prop = (sensitive value)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: [secret] => [secret]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{"kind": "UPDATE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffBool/sensitive/unchanged_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffBool/sensitive/unchanged_empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: valast.Ptr(false), changeValue: valast.Ptr(false),
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffBool/sensitive/unchanged_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffBool/sensitive/unchanged_non-empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: valast.Ptr(true), changeValue: valast.Ptr(true),
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffBool/sensitiveForceNew/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffBool/sensitiveForceNew/added.golden
@@ -1,0 +1,31 @@
+tests.testOutput{
+	initialValue: valast.Ptr(false), changeValue: valast.Ptr(true),
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "newid" -> (known after apply)
+      ~ prop = (sensitive value) # forces replacement
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: [secret] => [secret]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffBool/sensitiveForceNew/changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffBool/sensitiveForceNew/changed.golden
@@ -1,0 +1,31 @@
+tests.testOutput{
+	initialValue: valast.Ptr(true), changeValue: valast.Ptr(false),
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "newid" -> (known after apply)
+      ~ prop = (sensitive value) # forces replacement
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: [secret] => [secret]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffBool/sensitiveForceNew/removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffBool/sensitiveForceNew/removed.golden
@@ -1,0 +1,31 @@
+tests.testOutput{
+	initialValue: valast.Ptr(true), changeValue: valast.Ptr(false),
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "newid" -> (known after apply)
+      ~ prop = (sensitive value) # forces replacement
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: [secret] => [secret]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffBool/sensitiveForceNew/unchanged_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffBool/sensitiveForceNew/unchanged_empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: valast.Ptr(false), changeValue: valast.Ptr(false),
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffBool/sensitiveForceNew/unchanged_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffBool/sensitiveForceNew/unchanged_non-empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: valast.Ptr(true), changeValue: valast.Ptr(true),
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffFloat/sensitive/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffFloat/sensitive/added.golden
@@ -1,0 +1,32 @@
+tests.testOutput{
+	initialValue: valast.Ptr(float64(0)),
+	changeValue:  valast.Ptr(float64(1)),
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "newid"
+      ~ prop = (sensitive value)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: [secret] => [secret]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{"kind": "UPDATE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffFloat/sensitive/changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffFloat/sensitive/changed.golden
@@ -1,0 +1,32 @@
+tests.testOutput{
+	initialValue: valast.Ptr(float64(1)),
+	changeValue:  valast.Ptr(float64(2)),
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "newid"
+      ~ prop = (sensitive value)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: [secret] => [secret]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{"kind": "UPDATE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffFloat/sensitive/removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffFloat/sensitive/removed.golden
@@ -1,0 +1,32 @@
+tests.testOutput{
+	initialValue: valast.Ptr(float64(1)),
+	changeValue:  valast.Ptr(float64(0)),
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "newid"
+      ~ prop = (sensitive value)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: [secret] => [secret]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{"kind": "UPDATE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffFloat/sensitive/unchanged_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffFloat/sensitive/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: valast.Ptr(float64(0)),
+	changeValue:  valast.Ptr(float64(0)),
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffFloat/sensitive/unchanged_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffFloat/sensitive/unchanged_non-empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: valast.Ptr(float64(1)),
+	changeValue:  valast.Ptr(float64(1)),
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffFloat/sensitiveForceNew/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffFloat/sensitiveForceNew/added.golden
@@ -1,0 +1,32 @@
+tests.testOutput{
+	initialValue: valast.Ptr(float64(0)),
+	changeValue:  valast.Ptr(float64(1)),
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "newid" -> (known after apply)
+      ~ prop = (sensitive value) # forces replacement
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: [secret] => [secret]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffFloat/sensitiveForceNew/changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffFloat/sensitiveForceNew/changed.golden
@@ -1,0 +1,32 @@
+tests.testOutput{
+	initialValue: valast.Ptr(float64(1)),
+	changeValue:  valast.Ptr(float64(2)),
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "newid" -> (known after apply)
+      ~ prop = (sensitive value) # forces replacement
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: [secret] => [secret]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffFloat/sensitiveForceNew/removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffFloat/sensitiveForceNew/removed.golden
@@ -1,0 +1,32 @@
+tests.testOutput{
+	initialValue: valast.Ptr(float64(1)),
+	changeValue:  valast.Ptr(float64(0)),
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "newid" -> (known after apply)
+      ~ prop = (sensitive value) # forces replacement
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: [secret] => [secret]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffFloat/sensitiveForceNew/unchanged_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffFloat/sensitiveForceNew/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: valast.Ptr(float64(0)),
+	changeValue:  valast.Ptr(float64(0)),
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffFloat/sensitiveForceNew/unchanged_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffFloat/sensitiveForceNew/unchanged_non-empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: valast.Ptr(float64(1)),
+	changeValue:  valast.Ptr(float64(1)),
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffInt/sensitive/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffInt/sensitive/added.golden
@@ -1,0 +1,32 @@
+tests.testOutput{
+	initialValue: valast.Ptr(int64(0)),
+	changeValue:  valast.Ptr(int64(1)),
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "newid"
+      ~ prop = (sensitive value)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: [secret] => [secret]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{"kind": "UPDATE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffInt/sensitive/changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffInt/sensitive/changed.golden
@@ -1,0 +1,32 @@
+tests.testOutput{
+	initialValue: valast.Ptr(int64(1)),
+	changeValue:  valast.Ptr(int64(2)),
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "newid"
+      ~ prop = (sensitive value)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: [secret] => [secret]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{"kind": "UPDATE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffInt/sensitive/removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffInt/sensitive/removed.golden
@@ -1,0 +1,32 @@
+tests.testOutput{
+	initialValue: valast.Ptr(int64(1)),
+	changeValue:  valast.Ptr(int64(0)),
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "newid"
+      ~ prop = (sensitive value)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: [secret] => [secret]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{"kind": "UPDATE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffInt/sensitive/unchanged_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffInt/sensitive/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: valast.Ptr(int64(0)),
+	changeValue:  valast.Ptr(int64(0)),
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffInt/sensitive/unchanged_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffInt/sensitive/unchanged_non-empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: valast.Ptr(int64(1)),
+	changeValue:  valast.Ptr(int64(1)),
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffInt/sensitiveForceNew/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffInt/sensitiveForceNew/added.golden
@@ -1,0 +1,32 @@
+tests.testOutput{
+	initialValue: valast.Ptr(int64(0)),
+	changeValue:  valast.Ptr(int64(1)),
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "newid" -> (known after apply)
+      ~ prop = (sensitive value) # forces replacement
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: [secret] => [secret]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffInt/sensitiveForceNew/changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffInt/sensitiveForceNew/changed.golden
@@ -1,0 +1,32 @@
+tests.testOutput{
+	initialValue: valast.Ptr(int64(1)),
+	changeValue:  valast.Ptr(int64(2)),
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "newid" -> (known after apply)
+      ~ prop = (sensitive value) # forces replacement
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: [secret] => [secret]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffInt/sensitiveForceNew/removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffInt/sensitiveForceNew/removed.golden
@@ -1,0 +1,32 @@
+tests.testOutput{
+	initialValue: valast.Ptr(int64(1)),
+	changeValue:  valast.Ptr(int64(0)),
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "newid" -> (known after apply)
+      ~ prop = (sensitive value) # forces replacement
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: [secret] => [secret]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffInt/sensitiveForceNew/unchanged_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffInt/sensitiveForceNew/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: valast.Ptr(int64(0)),
+	changeValue:  valast.Ptr(int64(0)),
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffInt/sensitiveForceNew/unchanged_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffInt/sensitiveForceNew/unchanged_non-empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: valast.Ptr(int64(1)),
+	changeValue:  valast.Ptr(int64(1)),
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/sensitive/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/sensitive/added.golden
@@ -1,0 +1,32 @@
+tests.testOutput{
+	initialValue: &map[string]string{},
+	changeValue:  &map[string]string{"key": "val1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "newid"
+      + prop = (sensitive value)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + prop: [secret]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/sensitive/changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/sensitive/changed.golden
@@ -1,0 +1,36 @@
+tests.testOutput{
+	initialValue: &map[string]string{
+		"key": "val1",
+	},
+	changeValue: &map[string]string{"key": "val2"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "newid"
+      ~ prop = (sensitive value)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: {
+          ~ key: [secret] => [secret]
+        }
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop.key": map[string]interface{}{"kind": "UPDATE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/sensitive/key_changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/sensitive/key_changed.golden
@@ -1,0 +1,40 @@
+tests.testOutput{
+	initialValue: &map[string]string{
+		"key": "val1",
+	},
+	changeValue: &map[string]string{"key2": "val1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "newid"
+      ~ prop = (sensitive value)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: {
+          - key : [secret]
+          + key2: [secret]
+        }
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"prop.key":  map[string]interface{}{"kind": "DELETE"},
+		"prop.key2": map[string]interface{}{},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/sensitive/removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/sensitive/removed.golden
@@ -1,0 +1,36 @@
+tests.testOutput{
+	initialValue: &map[string]string{
+		"key": "val1",
+	},
+	changeValue: &map[string]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "newid"
+      ~ prop = (sensitive value)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: {
+          - key: [secret]
+        }
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop.key": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/sensitive/unchanged_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/sensitive/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &map[string]string{},
+	changeValue:  &map[string]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/sensitive/unchanged_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/sensitive/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &map[string]string{
+		"key": "val1",
+	},
+	changeValue: &map[string]string{"key": "val1"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/sensitiveForceNew/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/sensitiveForceNew/added.golden
@@ -1,0 +1,32 @@
+tests.testOutput{
+	initialValue: &map[string]string{},
+	changeValue:  &map[string]string{"key": "val1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "newid" -> (known after apply)
+      + prop = (sensitive value) # forces replacement
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + prop: [secret]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{"kind": "ADD_REPLACE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/sensitiveForceNew/changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/sensitiveForceNew/changed.golden
@@ -1,0 +1,36 @@
+tests.testOutput{
+	initialValue: &map[string]string{
+		"key": "val1",
+	},
+	changeValue: &map[string]string{"key": "val2"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "newid" -> (known after apply)
+      ~ prop = (sensitive value) # forces replacement
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: {
+          ~ key: [secret] => [secret]
+        }
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop.key": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/sensitiveForceNew/key_changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/sensitiveForceNew/key_changed.golden
@@ -1,0 +1,40 @@
+tests.testOutput{
+	initialValue: &map[string]string{
+		"key": "val1",
+	},
+	changeValue: &map[string]string{"key2": "val1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "newid" -> (known after apply)
+      ~ prop = (sensitive value) # forces replacement
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: {
+          - key : [secret]
+          + key2: [secret]
+        }
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"prop.key":  map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"prop.key2": map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/sensitiveForceNew/removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/sensitiveForceNew/removed.golden
@@ -1,0 +1,36 @@
+tests.testOutput{
+	initialValue: &map[string]string{
+		"key": "val1",
+	},
+	changeValue: &map[string]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "newid" -> (known after apply)
+      - prop = (sensitive value) -> null # forces replacement
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: {
+          - key: [secret]
+        }
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop.key": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/sensitiveForceNew/unchanged_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/sensitiveForceNew/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &map[string]string{},
+	changeValue:  &map[string]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/sensitiveForceNew/unchanged_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffMap/sensitiveForceNew/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &map[string]string{
+		"key": "val1",
+	},
+	changeValue: &map[string]string{"key": "val1"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffString/sensitive/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffString/sensitive/added.golden
@@ -1,0 +1,31 @@
+tests.testOutput{
+	initialValue: valast.Ptr(""), changeValue: valast.Ptr("val1"),
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "newid"
+      + prop = (sensitive value)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: [secret] => [secret]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{"kind": "UPDATE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffString/sensitive/changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffString/sensitive/changed.golden
@@ -1,0 +1,31 @@
+tests.testOutput{
+	initialValue: valast.Ptr("val1"), changeValue: valast.Ptr("val2"),
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "newid"
+      ~ prop = (sensitive value)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: [secret] => [secret]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{"kind": "UPDATE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffString/sensitive/removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffString/sensitive/removed.golden
@@ -1,0 +1,31 @@
+tests.testOutput{
+	initialValue: valast.Ptr("val1"), changeValue: valast.Ptr(""),
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "newid"
+      - prop = (sensitive value) -> null
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: [secret] => [secret]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{"kind": "UPDATE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffString/sensitive/unchanged_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffString/sensitive/unchanged_empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: valast.Ptr(""), changeValue: valast.Ptr(""),
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffString/sensitive/unchanged_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffString/sensitive/unchanged_non-empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: valast.Ptr("val1"), changeValue: valast.Ptr("val1"),
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffString/sensitiveForceNew/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffString/sensitiveForceNew/added.golden
@@ -1,0 +1,31 @@
+tests.testOutput{
+	initialValue: valast.Ptr(""), changeValue: valast.Ptr("val1"),
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "newid" -> (known after apply)
+      + prop = (sensitive value) # forces replacement
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: [secret] => [secret]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffString/sensitiveForceNew/changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffString/sensitiveForceNew/changed.golden
@@ -1,0 +1,31 @@
+tests.testOutput{
+	initialValue: valast.Ptr("val1"), changeValue: valast.Ptr("val2"),
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "newid" -> (known after apply)
+      ~ prop = (sensitive value) # forces replacement
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: [secret] => [secret]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffString/sensitiveForceNew/removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffString/sensitiveForceNew/removed.golden
@@ -1,0 +1,31 @@
+tests.testOutput{
+	initialValue: valast.Ptr("val1"), changeValue: valast.Ptr(""),
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id   = "newid" -> (known after apply)
+      - prop = (sensitive value) -> null # forces replacement
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ prop: [secret] => [secret]
+Resources:
+    +-1 to replace
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffString/sensitiveForceNew/unchanged_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffString/sensitiveForceNew/unchanged_empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: valast.Ptr(""), changeValue: valast.Ptr(""),
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffString/sensitiveForceNew/unchanged_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffString/sensitiveForceNew/unchanged_non-empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: valast.Ptr("val1"), changeValue: valast.Ptr("val1"),
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/value_makers.go
+++ b/pkg/tests/diff_test/value_makers.go
@@ -182,6 +182,29 @@ func generateBaseTests[T any](
 		},
 	}
 
+	sensitiveSchema := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"prop": {
+				Type:      typ,
+				Elem:      elem,
+				Optional:  true,
+				Sensitive: true,
+			},
+		},
+	}
+
+	sensitiveForceNewSchema := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"prop": {
+				Type:      typ,
+				Elem:      elem,
+				Optional:  true,
+				Sensitive: true,
+				ForceNew:  true,
+			},
+		},
+	}
+
 	return []diffSchemaValueMakerPair[T]{
 			{"optional", optionalSchema, ctyVal},
 			{"optionalForceNew", optionalForceNewSchema, ctyVal},
@@ -191,6 +214,8 @@ func generateBaseTests[T any](
 			{"optionalComputedForceNew", optionalComputedForceNewSchema, ctyVal},
 			{"optionalDefault", optionalDefaultSchema, ctyVal},
 			{"optionalDefaultForceNew", optionalDefaultForceNewSchema, ctyVal},
+			{"sensitive", sensitiveSchema, ctyVal},
+			{"sensitiveForceNew", sensitiveForceNewSchema, ctyVal},
 		}, []diffScenario[T]{
 			{"unchanged empty", noValue, noValue},
 			{"unchanged non-empty", valueOne, valueOne},


### PR DESCRIPTION
This adds Diff tests for the SDKv2 bridge for secrets in primitive types.

Part of https://github.com/pulumi/pulumi-terraform-bridge/issues/2791