### PR TITLE
SDKv2 Diff tests for secret list type

### DIFF
--- a/pkg/tests/diff_test/detailed_diff_list_test.go
+++ b/pkg/tests/diff_test/detailed_diff_list_test.go
@@ -110,7 +110,6 @@ func TestSDKv2DetailedDiffList(t *testing.T) {
 			},
 		},
 	}
-	_ = listBlockSchemaNestedForceNew
 
 	maxItemsOneBlockSchema := schema.Resource{
 		Schema: map[string]*schema.Schema{
@@ -148,7 +147,6 @@ func TestSDKv2DetailedDiffList(t *testing.T) {
 			},
 		},
 	}
-	_ = maxItemsOneBlockSchemaForceNew
 
 	maxItemsOneBlockSchemaNestedForceNew := schema.Resource{
 		Schema: map[string]*schema.Schema{
@@ -168,7 +166,42 @@ func TestSDKv2DetailedDiffList(t *testing.T) {
 			},
 		},
 	}
-	_ = maxItemsOneBlockSchemaNestedForceNew
+
+	listBlockSchemaSensitive := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"list_block": {
+				Type:      schema.TypeList,
+				Optional:  true,
+				Sensitive: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"nested_prop": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	listBlockSchemaNestedSensitive := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"list_block": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"nested_prop": {
+							Type:      schema.TypeString,
+							Optional:  true,
+							Sensitive: true,
+						},
+					},
+				},
+			},
+		},
+	}
 
 	attrList := func(arr *[]string) map[string]cty.Value {
 		if arr == nil {
@@ -240,6 +273,8 @@ func TestSDKv2DetailedDiffList(t *testing.T) {
 		{"list block", listBlockSchema, blockList},
 		{"list block force new", listBlockSchemaForceNew, blockList},
 		{"list block nested force new", listBlockSchemaNestedForceNew, blockList},
+		{"list block sensitive", listBlockSchemaSensitive, blockList},
+		{"list block nested sensitive", listBlockSchemaNestedSensitive, nestedBlockList},
 	}
 
 	maxItemsOnePairs := []struct {

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/added_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/added_empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: nil, changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/added_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/added_non-empty.golden
@@ -1,0 +1,36 @@
+tests.testOutput{
+	initialValue: nil, changeValue: &[]string{
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + list_block {
+          + nested_prop = (sensitive value)
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + listBlocks: [secret]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"listBlocks": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/changed.golden
@@ -1,0 +1,41 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+	},
+	changeValue: &[]string{"val2"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ listBlocks: [
+          ~ [0]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"listBlocks[0].nestedProp": map[string]interface{}{"kind": "UPDATE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/list_element_added_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/list_element_added_back.golden
@@ -1,0 +1,46 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + list_block {
+          + nested_prop = (sensitive value)
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ listBlocks: [
+          + [2]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"listBlocks[2]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/list_element_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/list_element_added_front.golden
@@ -1,0 +1,60 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      + list_block {
+          + nested_prop = (sensitive value)
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ listBlocks: [
+          ~ [0]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [1]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          + [2]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"listBlocks[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[2]":            map[string]interface{}{},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/list_element_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/list_element_added_middle.golden
@@ -1,0 +1,55 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      + list_block {
+          + nested_prop = (sensitive value)
+        }
+
+        # (1 unchanged block hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ listBlocks: [
+          ~ [1]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          + [2]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"listBlocks[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[2]":            map[string]interface{}{},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/list_element_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/list_element_removed_end.golden
@@ -1,0 +1,60 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      - list_block {
+          - nested_prop = (sensitive value) -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ listBlocks: [
+          ~ [0]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [1]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          - [2]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"listBlocks[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[2]":            map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/list_element_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/list_element_removed_front.golden
@@ -1,0 +1,55 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      - list_block {
+          - nested_prop = (sensitive value) -> null
+        }
+
+        # (1 unchanged block hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ listBlocks: [
+          ~ [0]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          - [2]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"listBlocks[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[2]":            map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/list_element_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/list_element_removed_middle.golden
@@ -1,0 +1,60 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      - list_block {
+          - nested_prop = (sensitive value) -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ listBlocks: [
+          ~ [0]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [1]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          - [2]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"listBlocks[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[2]":            map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/long_list_added_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/long_list_added_back.golden
@@ -1,0 +1,82 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+		"value20",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + list_block {
+          + nested_prop = (sensitive value)
+        }
+
+        # (20 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ listBlocks: [
+          + [20]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"listBlocks[20]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/long_list_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/long_list_added_front.golden
@@ -1,0 +1,222 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value20",
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      + list_block {
+          + nested_prop = (sensitive value)
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ listBlocks: [
+          ~ [0]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [1]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [2]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [3]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [4]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [5]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [6]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [7]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [8]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [9]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [10]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [11]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [12]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [13]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [14]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [15]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [16]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [17]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [18]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [19]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          + [20]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"listBlocks[0].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[10].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[11].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[12].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[13].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[14].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[15].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[16].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[17].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[18].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[19].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[1].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[20]":            map[string]interface{}{},
+		"listBlocks[2].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[3].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[4].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[5].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[6].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[7].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[8].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[9].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/long_list_removed_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/long_list_removed_back.golden
@@ -1,0 +1,82 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+		"value20",
+	},
+	changeValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - list_block {
+          - nested_prop = (sensitive value) -> null
+        }
+
+        # (20 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ listBlocks: [
+          - [20]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"listBlocks[20]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/long_list_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/long_list_removed_front.golden
@@ -1,0 +1,222 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value20",
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      - list_block {
+          - nested_prop = (sensitive value) -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ listBlocks: [
+          ~ [0]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [1]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [2]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [3]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [4]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [5]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [6]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [7]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [8]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [9]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [10]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [11]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [12]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [13]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [14]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [15]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [16]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [17]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [18]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [19]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          - [20]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"listBlocks[0].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[10].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[11].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[12].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[13].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[14].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[15].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[16].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[17].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[18].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[19].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[1].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[20]":            map[string]interface{}{"kind": "DELETE"},
+		"listBlocks[2].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[3].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[4].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[5].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[6].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[7].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[8].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[9].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/one_added,_one_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/one_added,_one_removed.golden
@@ -1,0 +1,63 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val4",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+      ~ list_block {
+          ~ nested_prop = (sensitive value)
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ listBlocks: [
+          ~ [0]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [1]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [2]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"listBlocks[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"listBlocks[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/removed_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/removed_empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  nil,
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/removed_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/removed_non-empty.golden
@@ -1,0 +1,37 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+	},
+	changeValue: nil,
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - list_block {
+          - nested_prop = (sensitive value) -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      - listBlocks: [secret]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"listBlocks": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/unchanged_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/unchanged_empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: nil, changeValue: nil,
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/unchanged_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+	},
+	changeValue: &[]string{"val1"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/added_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/added_empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: nil, changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/added_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/added_non-empty.golden
@@ -1,0 +1,34 @@
+tests.testOutput{
+	initialValue: nil, changeValue: &[]string{
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + list_block {}
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + listBlocks: [secret]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"listBlocks": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/changed.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+	},
+	changeValue: &[]string{"val2"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/list_element_added_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/list_element_added_back.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + list_block {}
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ listBlocks: [
+          + [2]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"listBlocks[2]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/list_element_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/list_element_added_front.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + list_block {}
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ listBlocks: [
+          + [2]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"listBlocks[2]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/list_element_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/list_element_added_middle.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + list_block {}
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ listBlocks: [
+          + [2]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"listBlocks[2]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/list_element_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/list_element_removed_end.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - list_block {}
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ listBlocks: [
+          - [2]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"listBlocks[2]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/list_element_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/list_element_removed_front.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - list_block {}
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ listBlocks: [
+          - [2]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"listBlocks[2]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/list_element_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/list_element_removed_middle.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - list_block {}
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ listBlocks: [
+          - [2]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"listBlocks[2]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/long_list_added_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/long_list_added_back.golden
@@ -1,0 +1,80 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+		"value20",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + list_block {}
+
+        # (20 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ listBlocks: [
+          + [20]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"listBlocks[20]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/long_list_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/long_list_added_front.golden
@@ -1,0 +1,80 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value20",
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + list_block {}
+
+        # (20 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ listBlocks: [
+          + [20]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"listBlocks[20]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/long_list_removed_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/long_list_removed_back.golden
@@ -1,0 +1,80 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+		"value20",
+	},
+	changeValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - list_block {}
+
+        # (20 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ listBlocks: [
+          - [20]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"listBlocks[20]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/long_list_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/long_list_removed_front.golden
@@ -1,0 +1,80 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value20",
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - list_block {}
+
+        # (20 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ listBlocks: [
+          - [20]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"listBlocks[20]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/one_added,_one_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/one_added,_one_removed.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val4",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/removed_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/removed_empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  nil,
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/removed_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/removed_non-empty.golden
@@ -1,0 +1,35 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+	},
+	changeValue: nil,
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - list_block {}
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      - listBlocks: [secret]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"listBlocks": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/unchanged_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/unchanged_empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: nil, changeValue: nil,
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/unchanged_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+	},
+	changeValue: &[]string{"val1"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}


### PR DESCRIPTION
This adds Diff tests for the SDKv2 bridge for secrets in list types.

Part of https://github.com/pulumi/pulumi-terraform-bridge/issues/2791