### PR TITLE
SDKv2 Diff tests for secret set type

### DIFF
--- a/pkg/tests/diff_test/detailed_diff_set_test.go
+++ b/pkg/tests/diff_test/detailed_diff_set_test.go
@@ -575,3 +575,57 @@ func TestSDKv2DetailedDiffSetNestedComputedBlock(t *testing.T) {
 		})
 	}
 }
+
+func TestSDKv2DetailedDiffSetBlockSensitive(t *testing.T) {
+	t.Parallel()
+
+	blockSchemaSensitive := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"test": {
+				Type:      schema.TypeSet,
+				Optional:  true,
+				Sensitive: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"nested": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	blockSchemaNestedSensitive := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"test": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"nested": {
+							Type:      schema.TypeString,
+							Optional:  true,
+							Sensitive: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	setSchemaValueMakerPairs := []setSchemaValueMakerPair{
+		{"block sensitive", blockSchemaSensitive, nestedListValueMaker},
+		{"block nested sensitive", blockSchemaNestedSensitive, nestedListValueMaker},
+	}
+
+	for _, schemaValueMakerPair := range setSchemaValueMakerPairs {
+		t.Run(schemaValueMakerPair.name, func(t *testing.T) {
+			t.Parallel()
+			for _, scenario := range setScenarios() {
+				t.Run(scenario.name, runSetTest(schemaValueMakerPair.res, schemaValueMakerPair.valueMaker, scenario.initialValue, scenario.changeValue, false))
+			}
+		})
+	}
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/added.golden
@@ -1,0 +1,36 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{"value"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + tests: [secret]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/added_end.golden
@@ -1,0 +1,47 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [2]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/added_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/added_end_unordered.golden
@@ -1,0 +1,47 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [2]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/added_front.golden
@@ -1,0 +1,47 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [0]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/added_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/added_front_unordered.golden
@@ -1,0 +1,47 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [0]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/added_middle.golden
@@ -1,0 +1,47 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [1]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/added_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/added_middle_unordered.golden
@@ -1,0 +1,47 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [1]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/changed_empty_to_null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/changed_empty_to_null.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  nil,
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/changed_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/changed_non-null.golden
@@ -1,0 +1,46 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+      + test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested: [secret] => [secret]
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0].nested": map[string]interface{}{"kind": "UPDATE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/changed_non-null_to_null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/changed_non-null_to_null.golden
@@ -1,0 +1,38 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: nil,
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      - tests: [secret]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/changed_null_to_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/changed_null_to_empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: nil, changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/changed_null_to_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/changed_null_to_non-null.golden
@@ -1,0 +1,37 @@
+tests.testOutput{
+	initialValue: nil, changeValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + tests: [secret]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/removed.golden
@@ -1,0 +1,38 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      - tests: [secret]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/removed_end.golden
@@ -1,0 +1,47 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [2]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/removed_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/removed_end_unordered.golden
@@ -1,0 +1,47 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [0]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/removed_front.golden
@@ -1,0 +1,47 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [0]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/removed_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/removed_front_unordered.golden
@@ -1,0 +1,47 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/removed_middle.golden
@@ -1,0 +1,47 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/removed_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/removed_middle_unordered.golden
@@ -1,0 +1,47 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/same_element_updated.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/same_element_updated.golden
@@ -1,0 +1,54 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val4",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+      + test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [1]: {
+                  ~ nested: [secret] => [secret]
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1].nested": map[string]interface{}{"kind": "UPDATE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/same_element_updated_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/same_element_updated_unordered.golden
@@ -1,0 +1,56 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val4",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+      + test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [1]: [secret]
+          - [2]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[1]": map[string]interface{}{},
+		"tests[2]": map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/shuffled.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/shuffled.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/shuffled_added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/shuffled_added_end.golden
@@ -1,0 +1,47 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [2]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/shuffled_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/shuffled_added_front.golden
@@ -1,0 +1,47 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [0]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/shuffled_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/shuffled_added_middle.golden
@@ -1,0 +1,47 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [1]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/shuffled_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/shuffled_removed_end.golden
@@ -1,0 +1,47 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [2]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/shuffled_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/shuffled_removed_front.golden
@@ -1,0 +1,47 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [0]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/shuffled_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/shuffled_removed_middle.golden
@@ -1,0 +1,47 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/shuffled_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/shuffled_unordered.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/shuffled_with_duplicates.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/shuffled_with_duplicates.golden
@@ -1,0 +1,25 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/shuffled_with_duplicates_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/shuffled_with_duplicates_unordered.golden
@@ -1,0 +1,25 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/two_added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/two_added.golden
@@ -1,0 +1,56 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+      + test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [2]: [secret]
+          + [3]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2]": map[string]interface{}{},
+		"tests[3]": map[string]interface{}{},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/two_added_and_two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/two_added_and_two_removed.golden
@@ -1,0 +1,70 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val5",
+		"val6",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+      - test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+      + test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+      + test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [2]: {
+                  ~ nested: [secret] => [secret]
+                }
+          ~ [3]: {
+                  ~ nested: [secret] => [secret]
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested": map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -1,0 +1,70 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val5",
+		"val6",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+      - test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+      + test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+      + test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [0]: [secret]
+          + [1]: [secret]
+          - [2]: [secret]
+          - [3]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0]": map[string]interface{}{},
+		"tests[1]": map[string]interface{}{},
+		"tests[2]": map[string]interface{}{"kind": "DELETE"},
+		"tests[3]": map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -1,0 +1,70 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val5",
+		"val6",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+      - test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+      + test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+      + test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [1]: [secret]
+          ~ [2]: {
+                  ~ nested: [secret] => [secret]
+                }
+          - [3]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[1]":        map[string]interface{}{},
+		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3]":        map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -1,0 +1,72 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val5",
+		"val6",
+		"val2",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+      - test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+      + test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+      + test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [1]: [secret]
+          ~ [2]: {
+                  ~ nested: [secret] => [secret]
+                }
+          - [3]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[1]":        map[string]interface{}{},
+		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3]":        map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/two_removed.golden
@@ -1,0 +1,56 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+      - test {
+          # At least one attribute in this block is (or was) sensitive,
+          # so its contents will not be displayed.
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [2]: [secret]
+          - [3]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2]": map[string]interface{}{"kind": "DELETE"},
+		"tests[3]": map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/unchanged_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/unchanged_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/unchanged_null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/unchanged_null.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: nil, changeValue: nil,
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/added.golden
@@ -1,0 +1,35 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{"value"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + test {
+          + nested = "value"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + tests: [secret]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/added_end.golden
@@ -1,0 +1,46 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + test {
+          + nested = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [2]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/added_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/added_end_unordered.golden
@@ -1,0 +1,46 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + test {
+          + nested = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [2]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/added_front.golden
@@ -1,0 +1,46 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + test {
+          + nested = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [0]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/added_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/added_front_unordered.golden
@@ -1,0 +1,46 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + test {
+          + nested = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [0]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/added_middle.golden
@@ -1,0 +1,46 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + test {
+          + nested = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [1]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/added_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/added_middle_unordered.golden
@@ -1,0 +1,46 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + test {
+          + nested = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [1]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/changed_empty_to_null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/changed_empty_to_null.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  nil,
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/changed_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/changed_non-null.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - test {
+          - nested = "value" -> null
+        }
+      + test {
+          + nested = "value1"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [0]: {
+                  ~ nested: [secret] => [secret]
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0].nested": map[string]interface{}{"kind": "UPDATE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/changed_non-null_to_null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/changed_non-null_to_null.golden
@@ -1,0 +1,37 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: nil,
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - test {
+          - nested = "value" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      - tests: [secret]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/changed_null_to_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/changed_null_to_empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: nil, changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/changed_null_to_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/changed_null_to_non-null.golden
@@ -1,0 +1,36 @@
+tests.testOutput{
+	initialValue: nil, changeValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + test {
+          + nested = "value"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + tests: [secret]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/removed.golden
@@ -1,0 +1,37 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - test {
+          - nested = "value" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      - tests: [secret]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/removed_end.golden
@@ -1,0 +1,46 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - test {
+          - nested = "val3" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [2]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/removed_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/removed_end_unordered.golden
@@ -1,0 +1,46 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - test {
+          - nested = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [0]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/removed_front.golden
@@ -1,0 +1,46 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - test {
+          - nested = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [0]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/removed_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/removed_front_unordered.golden
@@ -1,0 +1,46 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - test {
+          - nested = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/removed_middle.golden
@@ -1,0 +1,46 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - test {
+          - nested = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/removed_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/removed_middle_unordered.golden
@@ -1,0 +1,46 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - test {
+          - nested = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/same_element_updated.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/same_element_updated.golden
@@ -1,0 +1,52 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val4",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - test {
+          - nested = "val2" -> null
+        }
+      + test {
+          + nested = "val4"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [1]: {
+                  ~ nested: [secret] => [secret]
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1].nested": map[string]interface{}{"kind": "UPDATE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/same_element_updated_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/same_element_updated_unordered.golden
@@ -1,0 +1,54 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val4",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - test {
+          - nested = "val3" -> null
+        }
+      + test {
+          + nested = "val4"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [1]: [secret]
+          - [2]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[1]": map[string]interface{}{},
+		"tests[2]": map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/shuffled.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/shuffled.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/shuffled_added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/shuffled_added_end.golden
@@ -1,0 +1,46 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + test {
+          + nested = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [2]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/shuffled_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/shuffled_added_front.golden
@@ -1,0 +1,46 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + test {
+          + nested = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [0]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/shuffled_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/shuffled_added_middle.golden
@@ -1,0 +1,46 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + test {
+          + nested = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [1]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/shuffled_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/shuffled_removed_end.golden
@@ -1,0 +1,46 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - test {
+          - nested = "val3" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [2]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/shuffled_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/shuffled_removed_front.golden
@@ -1,0 +1,46 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - test {
+          - nested = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [0]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/shuffled_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/shuffled_removed_middle.golden
@@ -1,0 +1,46 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - test {
+          - nested = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [1]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/shuffled_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/shuffled_unordered.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/shuffled_with_duplicates.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/shuffled_with_duplicates.golden
@@ -1,0 +1,25 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/shuffled_with_duplicates_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/shuffled_with_duplicates_unordered.golden
@@ -1,0 +1,25 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/two_added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/two_added.golden
@@ -1,0 +1,54 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + test {
+          + nested = "val3"
+        }
+      + test {
+          + nested = "val4"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [2]: [secret]
+          + [3]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2]": map[string]interface{}{},
+		"tests[3]": map[string]interface{}{},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/two_added_and_two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/two_added_and_two_removed.golden
@@ -1,0 +1,66 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val5",
+		"val6",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - test {
+          - nested = "val3" -> null
+        }
+      - test {
+          - nested = "val4" -> null
+        }
+      + test {
+          + nested = "val5"
+        }
+      + test {
+          + nested = "val6"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          ~ [2]: {
+                  ~ nested: [secret] => [secret]
+                }
+          ~ [3]: {
+                  ~ nested: [secret] => [secret]
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3].nested": map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -1,0 +1,66 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val5",
+		"val6",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - test {
+          - nested = "val3" -> null
+        }
+      - test {
+          - nested = "val4" -> null
+        }
+      + test {
+          + nested = "val5"
+        }
+      + test {
+          + nested = "val6"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [0]: [secret]
+          + [1]: [secret]
+          - [2]: [secret]
+          - [3]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[0]": map[string]interface{}{},
+		"tests[1]": map[string]interface{}{},
+		"tests[2]": map[string]interface{}{"kind": "DELETE"},
+		"tests[3]": map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -1,0 +1,66 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val5",
+		"val6",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - test {
+          - nested = "val3" -> null
+        }
+      - test {
+          - nested = "val4" -> null
+        }
+      + test {
+          + nested = "val5"
+        }
+      + test {
+          + nested = "val6"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [1]: [secret]
+          ~ [2]: {
+                  ~ nested: [secret] => [secret]
+                }
+          - [3]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[1]":        map[string]interface{}{},
+		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3]":        map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -1,0 +1,68 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val5",
+		"val6",
+		"val2",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - test {
+          - nested = "val3" -> null
+        }
+      - test {
+          - nested = "val4" -> null
+        }
+      + test {
+          + nested = "val5"
+        }
+      + test {
+          + nested = "val6"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          + [1]: [secret]
+          ~ [2]: {
+                  ~ nested: [secret] => [secret]
+                }
+          - [3]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[1]":        map[string]interface{}{},
+		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
+		"tests[3]":        map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/two_removed.golden
@@ -1,0 +1,54 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - test {
+          - nested = "val3" -> null
+        }
+      - test {
+          - nested = "val4" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ tests: [
+          - [2]: [secret]
+          - [3]: [secret]
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"tests[2]": map[string]interface{}{"kind": "DELETE"},
+		"tests[3]": map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/unchanged_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/unchanged_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/unchanged_null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/unchanged_null.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: nil, changeValue: nil,
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}


### PR DESCRIPTION
This adds Diff tests for the SDKv2 bridge for secrets in set types.

Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/2791