### PR TITLE
Refactor Set and List Diff tests to use generic utilities

### DIFF
--- a/pkg/tests/diff_test/detailed_diff_list_test.go
+++ b/pkg/tests/diff_test/detailed_diff_list_test.go
@@ -5,10 +5,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hexops/autogold/v2"
-	"github.com/zclconf/go-cty/cty"
-
-	crosstests "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/tests/cross-tests"
 )
 
 func TestSDKv2DetailedDiffList(t *testing.T) {
@@ -16,7 +12,7 @@ func TestSDKv2DetailedDiffList(t *testing.T) {
 
 	listAttrSchema := schema.Resource{
 		Schema: map[string]*schema.Schema{
-			"list_attr": {
+			"prop": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
@@ -26,7 +22,7 @@ func TestSDKv2DetailedDiffList(t *testing.T) {
 
 	listAttrSchemaForceNew := schema.Resource{
 		Schema: map[string]*schema.Schema{
-			"list_attr": {
+			"prop": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
@@ -37,7 +33,7 @@ func TestSDKv2DetailedDiffList(t *testing.T) {
 
 	maxItemsOneAttrSchema := schema.Resource{
 		Schema: map[string]*schema.Schema{
-			"list_attr": {
+			"prop": {
 				Type:     schema.TypeList,
 				Optional: true,
 				MaxItems: 1,
@@ -48,7 +44,7 @@ func TestSDKv2DetailedDiffList(t *testing.T) {
 
 	maxItemsOneAttrSchemaForceNew := schema.Resource{
 		Schema: map[string]*schema.Schema{
-			"list_attr": {
+			"prop": {
 				Type:     schema.TypeList,
 				Optional: true,
 				MaxItems: 1,
@@ -60,12 +56,12 @@ func TestSDKv2DetailedDiffList(t *testing.T) {
 
 	listBlockSchema := schema.Resource{
 		Schema: map[string]*schema.Schema{
-			"list_block": {
+			"prop": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"prop": {
+						"nested_prop": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
@@ -77,13 +73,13 @@ func TestSDKv2DetailedDiffList(t *testing.T) {
 
 	listBlockSchemaForceNew := schema.Resource{
 		Schema: map[string]*schema.Schema{
-			"list_block": {
+			"prop": {
 				Type:     schema.TypeList,
 				Optional: true,
 				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"prop": {
+						"nested_prop": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
@@ -95,7 +91,7 @@ func TestSDKv2DetailedDiffList(t *testing.T) {
 
 	listBlockSchemaNestedForceNew := schema.Resource{
 		Schema: map[string]*schema.Schema{
-			"list_block": {
+			"prop": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Resource{
@@ -113,7 +109,7 @@ func TestSDKv2DetailedDiffList(t *testing.T) {
 
 	maxItemsOneBlockSchema := schema.Resource{
 		Schema: map[string]*schema.Schema{
-			"list_block": {
+			"prop": {
 				Type:     schema.TypeList,
 				Optional: true,
 				MaxItems: 1,
@@ -131,7 +127,7 @@ func TestSDKv2DetailedDiffList(t *testing.T) {
 
 	maxItemsOneBlockSchemaForceNew := schema.Resource{
 		Schema: map[string]*schema.Schema{
-			"list_block": {
+			"prop": {
 				Type:     schema.TypeList,
 				Optional: true,
 				MaxItems: 1,
@@ -150,7 +146,7 @@ func TestSDKv2DetailedDiffList(t *testing.T) {
 
 	maxItemsOneBlockSchemaNestedForceNew := schema.Resource{
 		Schema: map[string]*schema.Schema{
-			"list_block": {
+			"prop": {
 				Type:     schema.TypeList,
 				Optional: true,
 				MaxItems: 1,
@@ -169,7 +165,7 @@ func TestSDKv2DetailedDiffList(t *testing.T) {
 
 	listBlockSchemaSensitive := schema.Resource{
 		Schema: map[string]*schema.Schema{
-			"list_block": {
+			"prop": {
 				Type:      schema.TypeList,
 				Optional:  true,
 				Sensitive: true,
@@ -187,7 +183,7 @@ func TestSDKv2DetailedDiffList(t *testing.T) {
 
 	listBlockSchemaNestedSensitive := schema.Resource{
 		Schema: map[string]*schema.Schema{
-			"list_block": {
+			"prop": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Resource{
@@ -203,97 +199,25 @@ func TestSDKv2DetailedDiffList(t *testing.T) {
 		},
 	}
 
-	attrList := func(arr *[]string) map[string]cty.Value {
-		if arr == nil {
-			return map[string]cty.Value{}
-		}
-
-		if len(*arr) == 0 {
-			return map[string]cty.Value{
-				"list_attr": cty.ListValEmpty(cty.String),
-			}
-		}
-
-		slice := make([]cty.Value, len(*arr))
-		for i, v := range *arr {
-			slice[i] = cty.StringVal(v)
-		}
-		return map[string]cty.Value{
-			"list_attr": cty.ListVal(slice),
-		}
+	listPairs := []diffSchemaValueMakerPair[[]string]{
+		{"list attribute", listAttrSchema, listValueMaker},
+		{"list attribute force new", listAttrSchemaForceNew, listValueMaker},
+		{"list block", listBlockSchema, nestedListValueMaker},
+		{"list block force new", listBlockSchemaForceNew, nestedListValueMaker},
+		{"list block nested force new", listBlockSchemaNestedForceNew, nestedListValueMaker},
+		{"list block sensitive", listBlockSchemaSensitive, nestedListValueMaker},
+		{"list block nested sensitive", listBlockSchemaNestedSensitive, nestedListValueMaker},
 	}
 
-	blockList := func(arr *[]string) map[string]cty.Value {
-		if arr == nil {
-			return map[string]cty.Value{}
-		}
-
-		if len(*arr) == 0 {
-			return map[string]cty.Value{
-				"list_block": cty.ListValEmpty(cty.DynamicPseudoType),
-			}
-		}
-
-		slice := make([]cty.Value, len(*arr))
-		for i, v := range *arr {
-			slice[i] = cty.ObjectVal(map[string]cty.Value{"prop": cty.StringVal(v)})
-		}
-		return map[string]cty.Value{
-			"list_block": cty.ListVal(slice),
-		}
+	maxItemsOnePairs := []diffSchemaValueMakerPair[[]string]{
+		{"max items one attribute", maxItemsOneAttrSchema, listValueMaker},
+		{"max items one attribute force new", maxItemsOneAttrSchemaForceNew, listValueMaker},
+		{"max items one block", maxItemsOneBlockSchema, nestedListValueMaker},
+		{"max items one block force new", maxItemsOneBlockSchemaForceNew, nestedListValueMaker},
+		{"max items one block nested force new", maxItemsOneBlockSchemaNestedForceNew, nestedListValueMaker},
 	}
 
-	nestedBlockList := func(arr *[]string) map[string]cty.Value {
-		if arr == nil {
-			return map[string]cty.Value{}
-		}
-
-		if len(*arr) == 0 {
-			return map[string]cty.Value{
-				"list_block": cty.ListValEmpty(cty.DynamicPseudoType),
-			}
-		}
-
-		slice := make([]cty.Value, len(*arr))
-		for i, v := range *arr {
-			slice[i] = cty.ObjectVal(map[string]cty.Value{"nested_prop": cty.StringVal(v)})
-		}
-		return map[string]cty.Value{
-			"list_block": cty.ListVal(slice),
-		}
-	}
-
-	listPairs := []struct {
-		name       string
-		schema     schema.Resource
-		valueMaker func(*[]string) map[string]cty.Value
-	}{
-		{"list attribute", listAttrSchema, attrList},
-		{"list attribute force new", listAttrSchemaForceNew, attrList},
-		{"list block", listBlockSchema, blockList},
-		{"list block force new", listBlockSchemaForceNew, blockList},
-		{"list block nested force new", listBlockSchemaNestedForceNew, blockList},
-		{"list block sensitive", listBlockSchemaSensitive, blockList},
-		{"list block nested sensitive", listBlockSchemaNestedSensitive, nestedBlockList},
-	}
-
-	maxItemsOnePairs := []struct {
-		name       string
-		schema     schema.Resource
-		valueMaker func(*[]string) map[string]cty.Value
-	}{
-		{"max items one attribute", maxItemsOneAttrSchema, attrList},
-		{"max items one attribute force new", maxItemsOneAttrSchemaForceNew, attrList},
-		{"max items one block", maxItemsOneBlockSchema, nestedBlockList},
-		{"max items one block force new", maxItemsOneBlockSchemaForceNew, nestedBlockList},
-		{"max items one block nested force new", maxItemsOneBlockSchemaNestedForceNew, nestedBlockList},
-	}
-
-	oneElementScenarios := []struct {
-		name         string
-		initialValue *[]string
-		changeValue  *[]string
-	}{
+	oneElementScenarios := []diffScenario[[]string]{
 		{"unchanged empty", nil, nil},
 		{"unchanged non-empty", ref([]string{"val1"}), ref([]string{"val1"})},
 		{"added non-empty", nil, ref([]string{"val1"})},
@@ -311,17 +235,13 @@ func TestSDKv2DetailedDiffList(t *testing.T) {
 	longListAddedBack = append(longListAddedBack, "value20")
 	longListAddedFront := append([]string{"value20"}, *longList...)
 
-	multiElementScenarios := []struct {
-		name         string
-		initialValue *[]string
-		changeValue  *[]string
-	}{
+	multiElementScenarios := []diffScenario[[]string]{
 		{"list element added front", ref([]string{"val2", "val3"}), ref([]string{"val1", "val2", "val3"})},
 		{"list element added back", ref([]string{"val1", "val2"}), ref([]string{"val1", "val2", "val3"})},
 		{"list element added middle", ref([]string{"val1", "val3"}), ref([]string{"val1", "val2", "val3"})},
-		{"list element removed front", ref([]string{"val1", "val2", "val3"}), ref([]string{"val3", "val2"})},
-		{"list element removed middle", ref([]string{"val1", "val2", "val3"}), ref([]string{"val3", "val1"})},
-		{"list element removed end", ref([]string{"val1", "val2", "val3"}), ref([]string{"val2", "val1"})},
+		{"list element removed front", ref([]string{"val1", "val2", "val3"}), ref([]string{"val2", "val3"})},
+		{"list element removed middle", ref([]string{"val1", "val2", "val3"}), ref([]string{"val1", "val3"})},
+		{"list element removed end", ref([]string{"val1", "val2", "val3"}), ref([]string{"val1", "val2"})},
 		{"one added, one removed", ref([]string{"val1", "val2", "val3"}), ref([]string{"val2", "val3", "val4"})},
 		{"long list added back", longList, &longListAddedBack},
 		// TODO[pulumi/pulumi-terraform-bridge#2239]: These cases present as multiple changes instead of just one
@@ -332,38 +252,6 @@ func TestSDKv2DetailedDiffList(t *testing.T) {
 
 	scenarios := append(oneElementScenarios, multiElementScenarios...)
 
-	runTest := func(t *testing.T, schema schema.Resource, valueMaker func(*[]string) map[string]cty.Value, initialValue *[]string, changeValue *[]string) {
-		diff := crosstests.Diff(t, &schema, valueMaker(initialValue), valueMaker(changeValue))
-		autogold.ExpectFile(t, testOutput{
-			initialValue: initialValue,
-			changeValue:  changeValue,
-			tfOut:        diff.TFOut,
-			pulumiOut:    diff.PulumiOut,
-			detailedDiff: diff.PulumiDiff.DetailedDiff,
-		})
-	}
-
-	for _, schemaValueMakerPair := range listPairs {
-		t.Run(schemaValueMakerPair.name, func(t *testing.T) {
-			t.Parallel()
-			for _, scenario := range scenarios {
-				t.Run(scenario.name, func(t *testing.T) {
-					t.Parallel()
-					runTest(t, schemaValueMakerPair.schema, schemaValueMakerPair.valueMaker, scenario.initialValue, scenario.changeValue)
-				})
-			}
-		})
-	}
-
-	for _, schemaValueMakerPair := range maxItemsOnePairs {
-		t.Run(schemaValueMakerPair.name, func(t *testing.T) {
-			t.Parallel()
-			for _, scenario := range oneElementScenarios {
-				t.Run(scenario.name, func(t *testing.T) {
-					t.Parallel()
-					runTest(t, schemaValueMakerPair.schema, schemaValueMakerPair.valueMaker, scenario.initialValue, scenario.changeValue)
-				})
-			}
-		})
-	}
+	runSDKv2TestMatrix(t, listPairs, scenarios)
+	runSDKv2TestMatrix(t, maxItemsOnePairs, oneElementScenarios)
 }

--- a/pkg/tests/diff_test/detailed_diff_set_test.go
+++ b/pkg/tests/diff_test/detailed_diff_set_test.go
@@ -6,11 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hexops/autogold/v2"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/zclconf/go-cty/cty"
-
-	crosstests "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/tests/cross-tests"
 )
 
 func setScenarios() []diffScenario[[]string] {
@@ -64,31 +60,6 @@ func setScenarios() []diffScenario[[]string] {
 		{"two added and two removed shuffled, one overlaps", &[]string{"val1", "val2", "val3", "val4"}, &[]string{"val1", "val5", "val6", "val2"}},
 		{"two added and two removed shuffled, no overlaps", &[]string{"val1", "val2", "val3", "val4"}, &[]string{"val5", "val6", "val1", "val2"}},
 		{"two added and two removed shuffled, with duplicates", &[]string{"val1", "val2", "val3", "val4"}, &[]string{"val1", "val5", "val6", "val2", "val1", "val2"}},
-	}
-}
-
-func runSetTest(
-	schema schema.Resource, valueMaker func(*[]string) map[string]cty.Value, val1 *[]string, val2 *[]string,
-	disableAccurateBridgePreviews bool,
-) func(t *testing.T) {
-	return func(t *testing.T) {
-		t.Parallel()
-		initialValue := valueMaker(val1)
-		changeValue := valueMaker(val2)
-
-		opts := []crosstests.DiffOption{}
-		if disableAccurateBridgePreviews {
-			opts = append(opts, crosstests.DiffDisableAccurateBridgePreviews())
-		}
-		diff := crosstests.Diff(t, &schema, initialValue, changeValue, opts...)
-
-		autogold.ExpectFile(t, testOutput{
-			initialValue: val1,
-			changeValue:  val2,
-			tfOut:        diff.TFOut,
-			pulumiOut:    diff.PulumiOut,
-			detailedDiff: diff.PulumiDiff.DetailedDiff,
-		})
 	}
 }
 

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/added_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/added_non-empty.golden
@@ -11,8 +11,8 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
-        id        = "newid"
-      + list_attr = [
+        id   = "newid"
+      + prop = [
           + "val1",
         ]
     }
@@ -26,12 +26,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + listAttrs: [
+      + props: [
       +     [0]: "val1"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listAttrs": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/changed.golden
@@ -12,8 +12,8 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
-        id        = "newid"
-      ~ list_attr = [
+        id   = "newid"
+      ~ prop = [
           ~ "val1" -> "val2",
         ]
     }
@@ -27,12 +27,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listAttrs: [
+      ~ props: [
           ~ [0]: "val1" => "val2"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listAttrs[0]": map[string]interface{}{"kind": "UPDATE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/list_element_added_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/list_element_added_back.golden
@@ -17,8 +17,8 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
-        id        = "newid"
-      ~ list_attr = [
+        id   = "newid"
+      ~ prop = [
             # (1 unchanged element hidden)
             "val2",
           + "val3",
@@ -34,12 +34,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listAttrs: [
+      ~ props: [
           + [2]: "val3"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listAttrs[2]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/list_element_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/list_element_added_front.golden
@@ -17,8 +17,8 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
-        id        = "newid"
-      ~ list_attr = [
+        id   = "newid"
+      ~ prop = [
           + "val1",
             "val2",
             # (1 unchanged element hidden)
@@ -34,7 +34,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listAttrs: [
+      ~ props: [
           ~ [0]: "val2" => "val1"
           ~ [1]: "val3" => "val2"
           + [2]: "val3"
@@ -44,8 +44,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"listAttrs[0]": map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[1]": map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[2]": map[string]interface{}{},
+		"props[0]": map[string]interface{}{"kind": "UPDATE"},
+		"props[1]": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]": map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/list_element_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/list_element_added_middle.golden
@@ -17,8 +17,8 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
-        id        = "newid"
-      ~ list_attr = [
+        id   = "newid"
+      ~ prop = [
             "val1",
           + "val2",
             "val3",
@@ -34,7 +34,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listAttrs: [
+      ~ props: [
           ~ [1]: "val3" => "val2"
           + [2]: "val3"
         ]
@@ -43,7 +43,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"listAttrs[1]": map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[2]": map[string]interface{}{},
+		"props[1]": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]": map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/list_element_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/list_element_removed_end.golden
@@ -5,8 +5,8 @@ tests.testOutput{
 		"val3",
 	},
 	changeValue: &[]string{
-		"val2",
 		"val1",
+		"val2",
 	},
 	tfOut: `
 Terraform used the selected providers to generate the following execution
@@ -17,12 +17,11 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
-        id        = "newid"
-      ~ list_attr = [
-          - "val1",
+        id   = "newid"
+      ~ prop = [
+            # (1 unchanged element hidden)
             "val2",
           - "val3",
-          + "val1",
         ]
     }
 
@@ -35,18 +34,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listAttrs: [
-          ~ [0]: "val1" => "val2"
-          ~ [1]: "val2" => "val1"
+      ~ props: [
           - [2]: "val3"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"listAttrs[0]": map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[1]": map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[2]": map[string]interface{}{"kind": "DELETE"},
-	},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/list_element_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/list_element_removed_front.golden
@@ -5,8 +5,8 @@ tests.testOutput{
 		"val3",
 	},
 	changeValue: &[]string{
-		"val3",
 		"val2",
+		"val3",
 	},
 	tfOut: `
 Terraform used the selected providers to generate the following execution
@@ -17,12 +17,11 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
-        id        = "newid"
-      ~ list_attr = [
+        id   = "newid"
+      ~ prop = [
           - "val1",
-          - "val2",
-            "val3",
-          + "val2",
+            "val2",
+            # (1 unchanged element hidden)
         ]
     }
 
@@ -35,8 +34,9 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listAttrs: [
-          ~ [0]: "val1" => "val3"
+      ~ props: [
+          ~ [0]: "val1" => "val2"
+          ~ [1]: "val2" => "val3"
           - [2]: "val3"
         ]
 Resources:
@@ -44,7 +44,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"listAttrs[0]": map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[0]": map[string]interface{}{"kind": "UPDATE"},
+		"props[1]": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/list_element_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/list_element_removed_middle.golden
@@ -5,8 +5,8 @@ tests.testOutput{
 		"val3",
 	},
 	changeValue: &[]string{
-		"val3",
 		"val1",
+		"val3",
 	},
 	tfOut: `
 Terraform used the selected providers to generate the following execution
@@ -17,12 +17,11 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
-        id        = "newid"
-      ~ list_attr = [
-          - "val1",
+        id   = "newid"
+      ~ prop = [
+            "val1",
           - "val2",
             "val3",
-          + "val1",
         ]
     }
 
@@ -35,9 +34,8 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listAttrs: [
-          ~ [0]: "val1" => "val3"
-          ~ [1]: "val2" => "val1"
+      ~ props: [
+          ~ [1]: "val2" => "val3"
           - [2]: "val3"
         ]
 Resources:
@@ -45,8 +43,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"listAttrs[0]": map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[1]": map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[1]": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/long_list_added_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/long_list_added_back.golden
@@ -53,8 +53,8 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
-        id        = "newid"
-      ~ list_attr = [
+        id   = "newid"
+      ~ prop = [
             # (19 unchanged elements hidden)
             "value19",
           + "value20",
@@ -70,12 +70,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listAttrs: [
+      ~ props: [
           + [20]: "value20"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listAttrs[20]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[20]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/long_list_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/long_list_added_front.golden
@@ -53,8 +53,8 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
-        id        = "newid"
-      ~ list_attr = [
+        id   = "newid"
+      ~ prop = [
           + "value20",
             "value0",
             # (19 unchanged elements hidden)
@@ -70,7 +70,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listAttrs: [
+      ~ props: [
           ~ [0]: "value0" => "value20"
           ~ [1]: "value1" => "value0"
           ~ [2]: "value2" => "value1"
@@ -98,26 +98,26 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"listAttrs[0]":  map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[10]": map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[11]": map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[12]": map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[13]": map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[14]": map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[15]": map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[16]": map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[17]": map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[18]": map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[19]": map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[1]":  map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[20]": map[string]interface{}{},
-		"listAttrs[2]":  map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[3]":  map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[4]":  map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[5]":  map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[6]":  map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[7]":  map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[8]":  map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[9]":  map[string]interface{}{"kind": "UPDATE"},
+		"props[0]":  map[string]interface{}{"kind": "UPDATE"},
+		"props[10]": map[string]interface{}{"kind": "UPDATE"},
+		"props[11]": map[string]interface{}{"kind": "UPDATE"},
+		"props[12]": map[string]interface{}{"kind": "UPDATE"},
+		"props[13]": map[string]interface{}{"kind": "UPDATE"},
+		"props[14]": map[string]interface{}{"kind": "UPDATE"},
+		"props[15]": map[string]interface{}{"kind": "UPDATE"},
+		"props[16]": map[string]interface{}{"kind": "UPDATE"},
+		"props[17]": map[string]interface{}{"kind": "UPDATE"},
+		"props[18]": map[string]interface{}{"kind": "UPDATE"},
+		"props[19]": map[string]interface{}{"kind": "UPDATE"},
+		"props[1]":  map[string]interface{}{"kind": "UPDATE"},
+		"props[20]": map[string]interface{}{},
+		"props[2]":  map[string]interface{}{"kind": "UPDATE"},
+		"props[3]":  map[string]interface{}{"kind": "UPDATE"},
+		"props[4]":  map[string]interface{}{"kind": "UPDATE"},
+		"props[5]":  map[string]interface{}{"kind": "UPDATE"},
+		"props[6]":  map[string]interface{}{"kind": "UPDATE"},
+		"props[7]":  map[string]interface{}{"kind": "UPDATE"},
+		"props[8]":  map[string]interface{}{"kind": "UPDATE"},
+		"props[9]":  map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/long_list_removed_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/long_list_removed_back.golden
@@ -53,8 +53,8 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
-        id        = "newid"
-      ~ list_attr = [
+        id   = "newid"
+      ~ prop = [
             # (19 unchanged elements hidden)
             "value19",
           - "value20",
@@ -70,12 +70,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listAttrs: [
+      ~ props: [
           - [20]: "value20"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listAttrs[20]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[20]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/long_list_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/long_list_removed_front.golden
@@ -53,8 +53,8 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
-        id        = "newid"
-      ~ list_attr = [
+        id   = "newid"
+      ~ prop = [
           - "value20",
             "value0",
             # (19 unchanged elements hidden)
@@ -70,7 +70,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listAttrs: [
+      ~ props: [
           ~ [0]: "value20" => "value0"
           ~ [1]: "value0" => "value1"
           ~ [2]: "value1" => "value2"
@@ -98,26 +98,26 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"listAttrs[0]":  map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[10]": map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[11]": map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[12]": map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[13]": map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[14]": map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[15]": map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[16]": map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[17]": map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[18]": map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[19]": map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[1]":  map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[20]": map[string]interface{}{"kind": "DELETE"},
-		"listAttrs[2]":  map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[3]":  map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[4]":  map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[5]":  map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[6]":  map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[7]":  map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[8]":  map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[9]":  map[string]interface{}{"kind": "UPDATE"},
+		"props[0]":  map[string]interface{}{"kind": "UPDATE"},
+		"props[10]": map[string]interface{}{"kind": "UPDATE"},
+		"props[11]": map[string]interface{}{"kind": "UPDATE"},
+		"props[12]": map[string]interface{}{"kind": "UPDATE"},
+		"props[13]": map[string]interface{}{"kind": "UPDATE"},
+		"props[14]": map[string]interface{}{"kind": "UPDATE"},
+		"props[15]": map[string]interface{}{"kind": "UPDATE"},
+		"props[16]": map[string]interface{}{"kind": "UPDATE"},
+		"props[17]": map[string]interface{}{"kind": "UPDATE"},
+		"props[18]": map[string]interface{}{"kind": "UPDATE"},
+		"props[19]": map[string]interface{}{"kind": "UPDATE"},
+		"props[1]":  map[string]interface{}{"kind": "UPDATE"},
+		"props[20]": map[string]interface{}{"kind": "DELETE"},
+		"props[2]":  map[string]interface{}{"kind": "UPDATE"},
+		"props[3]":  map[string]interface{}{"kind": "UPDATE"},
+		"props[4]":  map[string]interface{}{"kind": "UPDATE"},
+		"props[5]":  map[string]interface{}{"kind": "UPDATE"},
+		"props[6]":  map[string]interface{}{"kind": "UPDATE"},
+		"props[7]":  map[string]interface{}{"kind": "UPDATE"},
+		"props[8]":  map[string]interface{}{"kind": "UPDATE"},
+		"props[9]":  map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/one_added,_one_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/one_added,_one_removed.golden
@@ -18,8 +18,8 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
-        id        = "newid"
-      ~ list_attr = [
+        id   = "newid"
+      ~ prop = [
           ~ "val1" -> "val2",
           ~ "val2" -> "val3",
           ~ "val3" -> "val4",
@@ -35,7 +35,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listAttrs: [
+      ~ props: [
           ~ [0]: "val1" => "val2"
           ~ [1]: "val2" => "val3"
           ~ [2]: "val3" => "val4"
@@ -45,8 +45,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"listAttrs[0]": map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[1]": map[string]interface{}{"kind": "UPDATE"},
-		"listAttrs[2]": map[string]interface{}{"kind": "UPDATE"},
+		"props[0]": map[string]interface{}{"kind": "UPDATE"},
+		"props[1]": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/removed_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/removed_non-empty.golden
@@ -12,8 +12,8 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
-        id        = "newid"
-      ~ list_attr = [
+        id   = "newid"
+      ~ prop = [
           - "val1",
         ]
     }
@@ -27,12 +27,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - listAttrs: [
+      - props: [
       -     [0]: "val1"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listAttrs": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/added_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/added_non-empty.golden
@@ -11,8 +11,8 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
-      ~ id        = "newid" -> (known after apply)
-      + list_attr = [ # forces replacement
+      ~ id   = "newid" -> (known after apply)
+      + prop = [ # forces replacement
           + "val1",
         ]
     }
@@ -26,12 +26,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + listAttrs: [
+      + props: [
       +     [0]: "val1"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listAttrs": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/changed.golden
@@ -12,8 +12,8 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
-      ~ id        = "newid" -> (known after apply)
-      ~ list_attr = [ # forces replacement
+      ~ id   = "newid" -> (known after apply)
+      ~ prop = [ # forces replacement
           ~ "val1" -> "val2",
         ]
     }
@@ -27,12 +27,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listAttrs: [
+      ~ props: [
           ~ [0]: "val1" => "val2"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listAttrs[0]": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_added_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_added_back.golden
@@ -17,8 +17,8 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
-      ~ id        = "newid" -> (known after apply)
-      ~ list_attr = [ # forces replacement
+      ~ id   = "newid" -> (known after apply)
+      ~ prop = [ # forces replacement
             # (1 unchanged element hidden)
             "val2",
           + "val3",
@@ -34,12 +34,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listAttrs: [
+      ~ props: [
           + [2]: "val3"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listAttrs[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_added_front.golden
@@ -17,8 +17,8 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
-      ~ id        = "newid" -> (known after apply)
-      ~ list_attr = [ # forces replacement
+      ~ id   = "newid" -> (known after apply)
+      ~ prop = [ # forces replacement
           + "val1",
             "val2",
             # (1 unchanged element hidden)
@@ -34,7 +34,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listAttrs: [
+      ~ props: [
           ~ [0]: "val2" => "val1"
           ~ [1]: "val3" => "val2"
           + [2]: "val3"
@@ -44,8 +44,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"listAttrs[0]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[1]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_added_middle.golden
@@ -17,8 +17,8 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
-      ~ id        = "newid" -> (known after apply)
-      ~ list_attr = [ # forces replacement
+      ~ id   = "newid" -> (known after apply)
+      ~ prop = [ # forces replacement
             "val1",
           + "val2",
             "val3",
@@ -34,7 +34,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listAttrs: [
+      ~ props: [
           ~ [1]: "val3" => "val2"
           + [2]: "val3"
         ]
@@ -43,7 +43,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"listAttrs[1]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[1]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_removed_end.golden
@@ -5,8 +5,8 @@ tests.testOutput{
 		"val3",
 	},
 	changeValue: &[]string{
-		"val2",
 		"val1",
+		"val2",
 	},
 	tfOut: `
 Terraform used the selected providers to generate the following execution
@@ -17,12 +17,11 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
-      ~ id        = "newid" -> (known after apply)
-      ~ list_attr = [ # forces replacement
-          - "val1",
+      ~ id   = "newid" -> (known after apply)
+      ~ prop = [ # forces replacement
+            # (1 unchanged element hidden)
             "val2",
           - "val3",
-          + "val1",
         ]
     }
 
@@ -35,18 +34,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listAttrs: [
-          ~ [0]: "val1" => "val2"
-          ~ [1]: "val2" => "val1"
+      ~ props: [
           - [2]: "val3"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"listAttrs[0]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[1]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_removed_front.golden
@@ -5,8 +5,8 @@ tests.testOutput{
 		"val3",
 	},
 	changeValue: &[]string{
-		"val3",
 		"val2",
+		"val3",
 	},
 	tfOut: `
 Terraform used the selected providers to generate the following execution
@@ -17,12 +17,11 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
-      ~ id        = "newid" -> (known after apply)
-      ~ list_attr = [ # forces replacement
+      ~ id   = "newid" -> (known after apply)
+      ~ prop = [ # forces replacement
           - "val1",
-          - "val2",
-            "val3",
-          + "val2",
+            "val2",
+            # (1 unchanged element hidden)
         ]
     }
 
@@ -35,8 +34,9 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listAttrs: [
-          ~ [0]: "val1" => "val3"
+      ~ props: [
+          ~ [0]: "val1" => "val2"
+          ~ [1]: "val2" => "val3"
           - [2]: "val3"
         ]
 Resources:
@@ -44,7 +44,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"listAttrs[0]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_removed_middle.golden
@@ -5,8 +5,8 @@ tests.testOutput{
 		"val3",
 	},
 	changeValue: &[]string{
-		"val3",
 		"val1",
+		"val3",
 	},
 	tfOut: `
 Terraform used the selected providers to generate the following execution
@@ -17,12 +17,11 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
-      ~ id        = "newid" -> (known after apply)
-      ~ list_attr = [ # forces replacement
-          - "val1",
+      ~ id   = "newid" -> (known after apply)
+      ~ prop = [ # forces replacement
+            "val1",
           - "val2",
             "val3",
-          + "val1",
         ]
     }
 
@@ -35,9 +34,8 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listAttrs: [
-          ~ [0]: "val1" => "val3"
-          ~ [1]: "val2" => "val1"
+      ~ props: [
+          ~ [1]: "val2" => "val3"
           - [2]: "val3"
         ]
 Resources:
@@ -45,8 +43,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"listAttrs[0]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[1]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[1]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/long_list_added_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/long_list_added_back.golden
@@ -53,8 +53,8 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
-      ~ id        = "newid" -> (known after apply)
-      ~ list_attr = [ # forces replacement
+      ~ id   = "newid" -> (known after apply)
+      ~ prop = [ # forces replacement
             # (19 unchanged elements hidden)
             "value19",
           + "value20",
@@ -70,12 +70,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listAttrs: [
+      ~ props: [
           + [20]: "value20"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listAttrs[20]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[20]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/long_list_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/long_list_added_front.golden
@@ -53,8 +53,8 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
-      ~ id        = "newid" -> (known after apply)
-      ~ list_attr = [ # forces replacement
+      ~ id   = "newid" -> (known after apply)
+      ~ prop = [ # forces replacement
           + "value20",
             "value0",
             # (19 unchanged elements hidden)
@@ -70,7 +70,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listAttrs: [
+      ~ props: [
           ~ [0]: "value0" => "value20"
           ~ [1]: "value1" => "value0"
           ~ [2]: "value2" => "value1"
@@ -98,26 +98,26 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"listAttrs[0]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[10]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[11]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[12]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[13]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[14]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[15]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[16]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[17]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[18]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[19]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[1]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[20]": map[string]interface{}{"kind": "ADD_REPLACE"},
-		"listAttrs[2]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[3]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[4]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[5]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[6]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[7]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[8]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[9]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[0]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[10]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[11]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[12]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[13]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[14]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[15]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[16]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[17]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[18]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[19]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[20]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[2]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[3]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[4]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[5]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[6]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[7]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[8]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[9]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/long_list_removed_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/long_list_removed_back.golden
@@ -53,8 +53,8 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
-      ~ id        = "newid" -> (known after apply)
-      ~ list_attr = [ # forces replacement
+      ~ id   = "newid" -> (known after apply)
+      ~ prop = [ # forces replacement
             # (19 unchanged elements hidden)
             "value19",
           - "value20",
@@ -70,12 +70,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listAttrs: [
+      ~ props: [
           - [20]: "value20"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listAttrs[20]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[20]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/long_list_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/long_list_removed_front.golden
@@ -53,8 +53,8 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
-      ~ id        = "newid" -> (known after apply)
-      ~ list_attr = [ # forces replacement
+      ~ id   = "newid" -> (known after apply)
+      ~ prop = [ # forces replacement
           - "value20",
             "value0",
             # (19 unchanged elements hidden)
@@ -70,7 +70,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listAttrs: [
+      ~ props: [
           ~ [0]: "value20" => "value0"
           ~ [1]: "value0" => "value1"
           ~ [2]: "value1" => "value2"
@@ -98,26 +98,26 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"listAttrs[0]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[10]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[11]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[12]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[13]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[14]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[15]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[16]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[17]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[18]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[19]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[1]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[20]": map[string]interface{}{"kind": "DELETE_REPLACE"},
-		"listAttrs[2]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[3]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[4]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[5]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[6]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[7]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[8]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[9]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[0]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[10]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[11]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[12]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[13]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[14]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[15]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[16]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[17]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[18]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[19]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[20]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[2]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[3]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[4]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[5]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[6]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[7]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[8]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[9]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/one_added,_one_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/one_added,_one_removed.golden
@@ -18,8 +18,8 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
-      ~ id        = "newid" -> (known after apply)
-      ~ list_attr = [ # forces replacement
+      ~ id   = "newid" -> (known after apply)
+      ~ prop = [ # forces replacement
           ~ "val1" -> "val2",
           ~ "val2" -> "val3",
           ~ "val3" -> "val4",
@@ -35,7 +35,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listAttrs: [
+      ~ props: [
           ~ [0]: "val1" => "val2"
           ~ [1]: "val2" => "val3"
           ~ [2]: "val3" => "val4"
@@ -45,8 +45,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"listAttrs[0]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[1]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"listAttrs[2]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[0]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/removed_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/removed_non-empty.golden
@@ -12,8 +12,8 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
-      ~ id        = "newid" -> (known after apply)
-      - list_attr = [ # forces replacement
+      ~ id   = "newid" -> (known after apply)
+      - prop = [ # forces replacement
           - "val1",
         ] -> null
     }
@@ -27,12 +27,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - listAttrs: [
+      - props: [
       -     [0]: "val1"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listAttrs": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block/added_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block/added_non-empty.golden
@@ -13,8 +13,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + list_block {
-          + prop = "val1"
+      + prop {
+          + nested_prop = "val1"
         }
     }
 
@@ -27,14 +27,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + listBlocks: [
+      + props: [
       +     [0]: {
-              + prop      : "val1"
+              + nestedProp: "val1"
             }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block/changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block/changed.golden
@@ -14,8 +14,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      ~ list_block {
-          ~ prop = "val1" -> "val2"
+      ~ prop {
+          ~ nested_prop = "val1" -> "val2"
         }
     }
 
@@ -28,14 +28,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
           ~ [0]: {
-                  ~ prop: "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks[0].prop": map[string]interface{}{"kind": "UPDATE"}},
+	detailedDiff: map[string]interface{}{"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block/list_element_added_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block/list_element_added_back.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + list_block {
-          + prop = "val3"
+      + prop {
+          + nested_prop = "val3"
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
           + [2]: {
-                  + prop      : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks[2]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block/list_element_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block/list_element_added_front.golden
@@ -19,14 +19,14 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      ~ list_block {
-          ~ prop = "val2" -> "val1"
+      ~ prop {
+          ~ nested_prop = "val2" -> "val1"
         }
-      ~ list_block {
-          ~ prop = "val3" -> "val2"
+      ~ prop {
+          ~ nested_prop = "val3" -> "val2"
         }
-      + list_block {
-          + prop = "val3"
+      + prop {
+          + nested_prop = "val3"
         }
     }
 
@@ -39,15 +39,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
           ~ [0]: {
-                  ~ prop: "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           ~ [1]: {
-                  ~ prop: "val3" => "val2"
+                  ~ nestedProp: "val3" => "val2"
                 }
           + [2]: {
-                  + prop      : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
@@ -55,8 +55,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"listBlocks[0].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[1].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[2]":      map[string]interface{}{},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block/list_element_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block/list_element_added_middle.golden
@@ -19,11 +19,11 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      ~ list_block {
-          ~ prop = "val3" -> "val2"
+      ~ prop {
+          ~ nested_prop = "val3" -> "val2"
         }
-      + list_block {
-          + prop = "val3"
+      + prop {
+          + nested_prop = "val3"
         }
 
         # (1 unchanged block hidden)
@@ -38,12 +38,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
           ~ [1]: {
-                  ~ prop: "val3" => "val2"
+                  ~ nestedProp: "val3" => "val2"
                 }
           + [2]: {
-                  + prop      : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
@@ -51,7 +51,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"listBlocks[1].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[2]":      map[string]interface{}{},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block/list_element_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block/list_element_removed_end.golden
@@ -5,8 +5,8 @@ tests.testOutput{
 		"val3",
 	},
 	changeValue: &[]string{
-		"val2",
 		"val1",
+		"val2",
 	},
 	tfOut: `
 Terraform used the selected providers to generate the following execution
@@ -19,15 +19,11 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      ~ list_block {
-          ~ prop = "val1" -> "val2"
+      - prop {
+          - nested_prop = "val3" -> null
         }
-      ~ list_block {
-          ~ prop = "val2" -> "val1"
-        }
-      - list_block {
-          - prop = "val3" -> null
-        }
+
+        # (2 unchanged blocks hidden)
     }
 
 Plan: 0 to add, 1 to change, 0 to destroy.
@@ -39,24 +35,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
-          ~ [0]: {
-                  ~ prop: "val1" => "val2"
-                }
-          ~ [1]: {
-                  ~ prop: "val2" => "val1"
-                }
+      ~ props: [
           - [2]: {
-                  - prop: "val3"
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"listBlocks[0].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[1].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[2]":      map[string]interface{}{"kind": "DELETE"},
-	},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block/list_element_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block/list_element_removed_front.golden
@@ -5,8 +5,8 @@ tests.testOutput{
 		"val3",
 	},
 	changeValue: &[]string{
-		"val3",
 		"val2",
+		"val3",
 	},
 	tfOut: `
 Terraform used the selected providers to generate the following execution
@@ -19,14 +19,15 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      ~ list_block {
-          ~ prop = "val1" -> "val3"
+      ~ prop {
+          ~ nested_prop = "val1" -> "val2"
         }
-      - list_block {
-          - prop = "val3" -> null
+      ~ prop {
+          ~ nested_prop = "val2" -> "val3"
         }
-
-        # (1 unchanged block hidden)
+      - prop {
+          - nested_prop = "val3" -> null
+        }
     }
 
 Plan: 0 to add, 1 to change, 0 to destroy.
@@ -38,12 +39,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
           ~ [0]: {
-                  ~ prop: "val1" => "val3"
+                  ~ nestedProp: "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ nestedProp: "val2" => "val3"
                 }
           - [2]: {
-                  - prop: "val3"
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -51,7 +55,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"listBlocks[0].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[2]":      map[string]interface{}{"kind": "DELETE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block/list_element_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block/list_element_removed_middle.golden
@@ -5,8 +5,8 @@ tests.testOutput{
 		"val3",
 	},
 	changeValue: &[]string{
-		"val3",
 		"val1",
+		"val3",
 	},
 	tfOut: `
 Terraform used the selected providers to generate the following execution
@@ -19,15 +19,14 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      ~ list_block {
-          ~ prop = "val1" -> "val3"
+      ~ prop {
+          ~ nested_prop = "val2" -> "val3"
         }
-      ~ list_block {
-          ~ prop = "val2" -> "val1"
+      - prop {
+          - nested_prop = "val3" -> null
         }
-      - list_block {
-          - prop = "val3" -> null
-        }
+
+        # (1 unchanged block hidden)
     }
 
 Plan: 0 to add, 1 to change, 0 to destroy.
@@ -39,15 +38,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
-          ~ [0]: {
-                  ~ prop: "val1" => "val3"
-                }
+      ~ props: [
           ~ [1]: {
-                  ~ prop: "val2" => "val1"
+                  ~ nestedProp: "val2" => "val3"
                 }
           - [2]: {
-                  - prop: "val3"
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -55,8 +51,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"listBlocks[0].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[1].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[2]":      map[string]interface{}{"kind": "DELETE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block/long_list_added_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block/long_list_added_back.golden
@@ -55,8 +55,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + list_block {
-          + prop = "value20"
+      + prop {
+          + nested_prop = "value20"
         }
 
         # (20 unchanged blocks hidden)
@@ -71,14 +71,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
           + [20]: {
-                  + prop      : "value20"
+                  + nestedProp: "value20"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks[20]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[20]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block/long_list_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block/long_list_added_front.golden
@@ -55,68 +55,68 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      ~ list_block {
-          ~ prop = "value0" -> "value20"
+      ~ prop {
+          ~ nested_prop = "value0" -> "value20"
         }
-      ~ list_block {
-          ~ prop = "value1" -> "value0"
+      ~ prop {
+          ~ nested_prop = "value1" -> "value0"
         }
-      ~ list_block {
-          ~ prop = "value2" -> "value1"
+      ~ prop {
+          ~ nested_prop = "value2" -> "value1"
         }
-      ~ list_block {
-          ~ prop = "value3" -> "value2"
+      ~ prop {
+          ~ nested_prop = "value3" -> "value2"
         }
-      ~ list_block {
-          ~ prop = "value4" -> "value3"
+      ~ prop {
+          ~ nested_prop = "value4" -> "value3"
         }
-      ~ list_block {
-          ~ prop = "value5" -> "value4"
+      ~ prop {
+          ~ nested_prop = "value5" -> "value4"
         }
-      ~ list_block {
-          ~ prop = "value6" -> "value5"
+      ~ prop {
+          ~ nested_prop = "value6" -> "value5"
         }
-      ~ list_block {
-          ~ prop = "value7" -> "value6"
+      ~ prop {
+          ~ nested_prop = "value7" -> "value6"
         }
-      ~ list_block {
-          ~ prop = "value8" -> "value7"
+      ~ prop {
+          ~ nested_prop = "value8" -> "value7"
         }
-      ~ list_block {
-          ~ prop = "value9" -> "value8"
+      ~ prop {
+          ~ nested_prop = "value9" -> "value8"
         }
-      ~ list_block {
-          ~ prop = "value10" -> "value9"
+      ~ prop {
+          ~ nested_prop = "value10" -> "value9"
         }
-      ~ list_block {
-          ~ prop = "value11" -> "value10"
+      ~ prop {
+          ~ nested_prop = "value11" -> "value10"
         }
-      ~ list_block {
-          ~ prop = "value12" -> "value11"
+      ~ prop {
+          ~ nested_prop = "value12" -> "value11"
         }
-      ~ list_block {
-          ~ prop = "value13" -> "value12"
+      ~ prop {
+          ~ nested_prop = "value13" -> "value12"
         }
-      ~ list_block {
-          ~ prop = "value14" -> "value13"
+      ~ prop {
+          ~ nested_prop = "value14" -> "value13"
         }
-      ~ list_block {
-          ~ prop = "value15" -> "value14"
+      ~ prop {
+          ~ nested_prop = "value15" -> "value14"
         }
-      ~ list_block {
-          ~ prop = "value16" -> "value15"
+      ~ prop {
+          ~ nested_prop = "value16" -> "value15"
         }
-      ~ list_block {
-          ~ prop = "value17" -> "value16"
+      ~ prop {
+          ~ nested_prop = "value17" -> "value16"
         }
-      ~ list_block {
-          ~ prop = "value18" -> "value17"
+      ~ prop {
+          ~ nested_prop = "value18" -> "value17"
         }
-      ~ list_block {
-          ~ prop = "value19" -> "value18"
+      ~ prop {
+          ~ nested_prop = "value19" -> "value18"
         }
-      + list_block {
-          + prop = "value19"
+      + prop {
+          + nested_prop = "value19"
         }
     }
 
@@ -129,69 +129,69 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
           ~ [0]: {
-                  ~ prop: "value0" => "value20"
+                  ~ nestedProp: "value0" => "value20"
                 }
           ~ [1]: {
-                  ~ prop: "value1" => "value0"
+                  ~ nestedProp: "value1" => "value0"
                 }
           ~ [2]: {
-                  ~ prop: "value2" => "value1"
+                  ~ nestedProp: "value2" => "value1"
                 }
           ~ [3]: {
-                  ~ prop: "value3" => "value2"
+                  ~ nestedProp: "value3" => "value2"
                 }
           ~ [4]: {
-                  ~ prop: "value4" => "value3"
+                  ~ nestedProp: "value4" => "value3"
                 }
           ~ [5]: {
-                  ~ prop: "value5" => "value4"
+                  ~ nestedProp: "value5" => "value4"
                 }
           ~ [6]: {
-                  ~ prop: "value6" => "value5"
+                  ~ nestedProp: "value6" => "value5"
                 }
           ~ [7]: {
-                  ~ prop: "value7" => "value6"
+                  ~ nestedProp: "value7" => "value6"
                 }
           ~ [8]: {
-                  ~ prop: "value8" => "value7"
+                  ~ nestedProp: "value8" => "value7"
                 }
           ~ [9]: {
-                  ~ prop: "value9" => "value8"
+                  ~ nestedProp: "value9" => "value8"
                 }
           ~ [10]: {
-                  ~ prop: "value10" => "value9"
+                  ~ nestedProp: "value10" => "value9"
                 }
           ~ [11]: {
-                  ~ prop: "value11" => "value10"
+                  ~ nestedProp: "value11" => "value10"
                 }
           ~ [12]: {
-                  ~ prop: "value12" => "value11"
+                  ~ nestedProp: "value12" => "value11"
                 }
           ~ [13]: {
-                  ~ prop: "value13" => "value12"
+                  ~ nestedProp: "value13" => "value12"
                 }
           ~ [14]: {
-                  ~ prop: "value14" => "value13"
+                  ~ nestedProp: "value14" => "value13"
                 }
           ~ [15]: {
-                  ~ prop: "value15" => "value14"
+                  ~ nestedProp: "value15" => "value14"
                 }
           ~ [16]: {
-                  ~ prop: "value16" => "value15"
+                  ~ nestedProp: "value16" => "value15"
                 }
           ~ [17]: {
-                  ~ prop: "value17" => "value16"
+                  ~ nestedProp: "value17" => "value16"
                 }
           ~ [18]: {
-                  ~ prop: "value18" => "value17"
+                  ~ nestedProp: "value18" => "value17"
                 }
           ~ [19]: {
-                  ~ prop: "value19" => "value18"
+                  ~ nestedProp: "value19" => "value18"
                 }
           + [20]: {
-                  + prop      : "value19"
+                  + nestedProp: "value19"
                 }
         ]
 Resources:
@@ -199,26 +199,26 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"listBlocks[0].prop":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[10].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[11].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[12].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[13].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[14].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[15].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[16].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[17].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[18].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[19].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[1].prop":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[20]":      map[string]interface{}{},
-		"listBlocks[2].prop":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[3].prop":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[4].prop":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[5].prop":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[6].prop":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[7].prop":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[8].prop":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[9].prop":  map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[10].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[11].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[12].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[13].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[14].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[15].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[16].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[17].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[18].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[19].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[20]":            map[string]interface{}{},
+		"props[2].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[4].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[5].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[6].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[7].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[8].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[9].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block/long_list_removed_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block/long_list_removed_back.golden
@@ -55,8 +55,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - list_block {
-          - prop = "value20" -> null
+      - prop {
+          - nested_prop = "value20" -> null
         }
 
         # (20 unchanged blocks hidden)
@@ -71,14 +71,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
           - [20]: {
-                  - prop: "value20"
+                  - nestedProp: "value20"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks[20]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[20]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block/long_list_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block/long_list_removed_front.golden
@@ -55,68 +55,68 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      ~ list_block {
-          ~ prop = "value20" -> "value0"
+      ~ prop {
+          ~ nested_prop = "value20" -> "value0"
         }
-      ~ list_block {
-          ~ prop = "value0" -> "value1"
+      ~ prop {
+          ~ nested_prop = "value0" -> "value1"
         }
-      ~ list_block {
-          ~ prop = "value1" -> "value2"
+      ~ prop {
+          ~ nested_prop = "value1" -> "value2"
         }
-      ~ list_block {
-          ~ prop = "value2" -> "value3"
+      ~ prop {
+          ~ nested_prop = "value2" -> "value3"
         }
-      ~ list_block {
-          ~ prop = "value3" -> "value4"
+      ~ prop {
+          ~ nested_prop = "value3" -> "value4"
         }
-      ~ list_block {
-          ~ prop = "value4" -> "value5"
+      ~ prop {
+          ~ nested_prop = "value4" -> "value5"
         }
-      ~ list_block {
-          ~ prop = "value5" -> "value6"
+      ~ prop {
+          ~ nested_prop = "value5" -> "value6"
         }
-      ~ list_block {
-          ~ prop = "value6" -> "value7"
+      ~ prop {
+          ~ nested_prop = "value6" -> "value7"
         }
-      ~ list_block {
-          ~ prop = "value7" -> "value8"
+      ~ prop {
+          ~ nested_prop = "value7" -> "value8"
         }
-      ~ list_block {
-          ~ prop = "value8" -> "value9"
+      ~ prop {
+          ~ nested_prop = "value8" -> "value9"
         }
-      ~ list_block {
-          ~ prop = "value9" -> "value10"
+      ~ prop {
+          ~ nested_prop = "value9" -> "value10"
         }
-      ~ list_block {
-          ~ prop = "value10" -> "value11"
+      ~ prop {
+          ~ nested_prop = "value10" -> "value11"
         }
-      ~ list_block {
-          ~ prop = "value11" -> "value12"
+      ~ prop {
+          ~ nested_prop = "value11" -> "value12"
         }
-      ~ list_block {
-          ~ prop = "value12" -> "value13"
+      ~ prop {
+          ~ nested_prop = "value12" -> "value13"
         }
-      ~ list_block {
-          ~ prop = "value13" -> "value14"
+      ~ prop {
+          ~ nested_prop = "value13" -> "value14"
         }
-      ~ list_block {
-          ~ prop = "value14" -> "value15"
+      ~ prop {
+          ~ nested_prop = "value14" -> "value15"
         }
-      ~ list_block {
-          ~ prop = "value15" -> "value16"
+      ~ prop {
+          ~ nested_prop = "value15" -> "value16"
         }
-      ~ list_block {
-          ~ prop = "value16" -> "value17"
+      ~ prop {
+          ~ nested_prop = "value16" -> "value17"
         }
-      ~ list_block {
-          ~ prop = "value17" -> "value18"
+      ~ prop {
+          ~ nested_prop = "value17" -> "value18"
         }
-      ~ list_block {
-          ~ prop = "value18" -> "value19"
+      ~ prop {
+          ~ nested_prop = "value18" -> "value19"
         }
-      - list_block {
-          - prop = "value19" -> null
+      - prop {
+          - nested_prop = "value19" -> null
         }
     }
 
@@ -129,69 +129,69 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
           ~ [0]: {
-                  ~ prop: "value20" => "value0"
+                  ~ nestedProp: "value20" => "value0"
                 }
           ~ [1]: {
-                  ~ prop: "value0" => "value1"
+                  ~ nestedProp: "value0" => "value1"
                 }
           ~ [2]: {
-                  ~ prop: "value1" => "value2"
+                  ~ nestedProp: "value1" => "value2"
                 }
           ~ [3]: {
-                  ~ prop: "value2" => "value3"
+                  ~ nestedProp: "value2" => "value3"
                 }
           ~ [4]: {
-                  ~ prop: "value3" => "value4"
+                  ~ nestedProp: "value3" => "value4"
                 }
           ~ [5]: {
-                  ~ prop: "value4" => "value5"
+                  ~ nestedProp: "value4" => "value5"
                 }
           ~ [6]: {
-                  ~ prop: "value5" => "value6"
+                  ~ nestedProp: "value5" => "value6"
                 }
           ~ [7]: {
-                  ~ prop: "value6" => "value7"
+                  ~ nestedProp: "value6" => "value7"
                 }
           ~ [8]: {
-                  ~ prop: "value7" => "value8"
+                  ~ nestedProp: "value7" => "value8"
                 }
           ~ [9]: {
-                  ~ prop: "value8" => "value9"
+                  ~ nestedProp: "value8" => "value9"
                 }
           ~ [10]: {
-                  ~ prop: "value9" => "value10"
+                  ~ nestedProp: "value9" => "value10"
                 }
           ~ [11]: {
-                  ~ prop: "value10" => "value11"
+                  ~ nestedProp: "value10" => "value11"
                 }
           ~ [12]: {
-                  ~ prop: "value11" => "value12"
+                  ~ nestedProp: "value11" => "value12"
                 }
           ~ [13]: {
-                  ~ prop: "value12" => "value13"
+                  ~ nestedProp: "value12" => "value13"
                 }
           ~ [14]: {
-                  ~ prop: "value13" => "value14"
+                  ~ nestedProp: "value13" => "value14"
                 }
           ~ [15]: {
-                  ~ prop: "value14" => "value15"
+                  ~ nestedProp: "value14" => "value15"
                 }
           ~ [16]: {
-                  ~ prop: "value15" => "value16"
+                  ~ nestedProp: "value15" => "value16"
                 }
           ~ [17]: {
-                  ~ prop: "value16" => "value17"
+                  ~ nestedProp: "value16" => "value17"
                 }
           ~ [18]: {
-                  ~ prop: "value17" => "value18"
+                  ~ nestedProp: "value17" => "value18"
                 }
           ~ [19]: {
-                  ~ prop: "value18" => "value19"
+                  ~ nestedProp: "value18" => "value19"
                 }
           - [20]: {
-                  - prop: "value19"
+                  - nestedProp: "value19"
                 }
         ]
 Resources:
@@ -199,26 +199,26 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"listBlocks[0].prop":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[10].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[11].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[12].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[13].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[14].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[15].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[16].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[17].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[18].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[19].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[1].prop":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[20]":      map[string]interface{}{"kind": "DELETE"},
-		"listBlocks[2].prop":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[3].prop":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[4].prop":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[5].prop":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[6].prop":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[7].prop":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[8].prop":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[9].prop":  map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[10].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[11].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[12].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[13].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[14].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[15].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[16].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[17].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[18].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[19].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[20]":            map[string]interface{}{"kind": "DELETE"},
+		"props[2].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[4].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[5].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[6].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[7].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[8].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[9].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block/one_added,_one_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block/one_added,_one_removed.golden
@@ -20,14 +20,14 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      ~ list_block {
-          ~ prop = "val1" -> "val2"
+      ~ prop {
+          ~ nested_prop = "val1" -> "val2"
         }
-      ~ list_block {
-          ~ prop = "val2" -> "val3"
+      ~ prop {
+          ~ nested_prop = "val2" -> "val3"
         }
-      ~ list_block {
-          ~ prop = "val3" -> "val4"
+      ~ prop {
+          ~ nested_prop = "val3" -> "val4"
         }
     }
 
@@ -40,15 +40,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
           ~ [0]: {
-                  ~ prop: "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ prop: "val2" => "val3"
+                  ~ nestedProp: "val2" => "val3"
                 }
           ~ [2]: {
-                  ~ prop: "val3" => "val4"
+                  ~ nestedProp: "val3" => "val4"
                 }
         ]
 Resources:
@@ -56,8 +56,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"listBlocks[0].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[1].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[2].prop": map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block/removed_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block/removed_non-empty.golden
@@ -14,8 +14,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - list_block {
-          - prop = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
         }
     }
 
@@ -28,14 +28,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - listBlocks: [
+      - props: [
       -     [0]: {
-              - prop: "val1"
+              - nestedProp: "val1"
             }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_force_new/added_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_force_new/added_non-empty.golden
@@ -13,8 +13,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      + list_block { # forces replacement
-          + prop = "val1"
+      + prop { # forces replacement
+          + nested_prop = "val1"
         }
     }
 
@@ -27,14 +27,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + listBlocks: [
+      + props: [
       +     [0]: {
-              + prop      : "val1"
+              + nestedProp: "val1"
             }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_force_new/changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_force_new/changed.golden
@@ -14,8 +14,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      ~ list_block {
-          ~ prop = "val1" -> "val2"
+      ~ prop {
+          ~ nested_prop = "val1" -> "val2"
         }
     }
 
@@ -28,14 +28,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
           ~ [0]: {
-                  ~ prop: "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks[0].prop": map[string]interface{}{"kind": "UPDATE"}},
+	detailedDiff: map[string]interface{}{"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_force_new/list_element_added_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_force_new/list_element_added_back.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      + list_block { # forces replacement
-          + prop = "val3"
+      + prop { # forces replacement
+          + nested_prop = "val3"
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
           + [2]: {
-                  + prop      : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_force_new/list_element_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_force_new/list_element_added_front.golden
@@ -19,14 +19,14 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      ~ list_block { # forces replacement
-          ~ prop = "val2" -> "val1"
+      ~ prop { # forces replacement
+          ~ nested_prop = "val2" -> "val1"
         }
-      ~ list_block { # forces replacement
-          ~ prop = "val3" -> "val2"
+      ~ prop { # forces replacement
+          ~ nested_prop = "val3" -> "val2"
         }
-      + list_block { # forces replacement
-          + prop = "val3"
+      + prop { # forces replacement
+          + nested_prop = "val3"
         }
     }
 
@@ -39,15 +39,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
           ~ [0]: {
-                  ~ prop: "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           ~ [1]: {
-                  ~ prop: "val3" => "val2"
+                  ~ nestedProp: "val3" => "val2"
                 }
           + [2]: {
-                  + prop      : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
@@ -55,8 +55,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"listBlocks[0].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[1].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[2]":      map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_force_new/list_element_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_force_new/list_element_added_middle.golden
@@ -19,11 +19,11 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      ~ list_block { # forces replacement
-          ~ prop = "val3" -> "val2"
+      ~ prop { # forces replacement
+          ~ nested_prop = "val3" -> "val2"
         }
-      + list_block { # forces replacement
-          + prop = "val3"
+      + prop { # forces replacement
+          + nested_prop = "val3"
         }
 
         # (1 unchanged block hidden)
@@ -38,12 +38,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
           ~ [1]: {
-                  ~ prop: "val3" => "val2"
+                  ~ nestedProp: "val3" => "val2"
                 }
           + [2]: {
-                  + prop      : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
@@ -51,7 +51,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"listBlocks[1].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[2]":      map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_force_new/list_element_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_force_new/list_element_removed_end.golden
@@ -5,8 +5,8 @@ tests.testOutput{
 		"val3",
 	},
 	changeValue: &[]string{
-		"val2",
 		"val1",
+		"val2",
 	},
 	tfOut: `
 Terraform used the selected providers to generate the following execution
@@ -19,15 +19,11 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      ~ list_block { # forces replacement
-          ~ prop = "val1" -> "val2"
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
         }
-      ~ list_block { # forces replacement
-          ~ prop = "val2" -> "val1"
-        }
-      - list_block { # forces replacement
-          - prop = "val3" -> null
-        }
+
+        # (2 unchanged blocks hidden)
     }
 
 Plan: 1 to add, 0 to change, 1 to destroy.
@@ -39,24 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
-          ~ [0]: {
-                  ~ prop: "val1" => "val2"
-                }
-          ~ [1]: {
-                  ~ prop: "val2" => "val1"
-                }
+      ~ props: [
           - [2]: {
-                  - prop: "val3"
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"listBlocks[0].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[1].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[2]":      map[string]interface{}{"kind": "DELETE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_force_new/list_element_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_force_new/list_element_removed_front.golden
@@ -5,8 +5,8 @@ tests.testOutput{
 		"val3",
 	},
 	changeValue: &[]string{
-		"val3",
 		"val2",
+		"val3",
 	},
 	tfOut: `
 Terraform used the selected providers to generate the following execution
@@ -19,14 +19,15 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      ~ list_block { # forces replacement
-          ~ prop = "val1" -> "val3"
+      ~ prop { # forces replacement
+          ~ nested_prop = "val1" -> "val2"
         }
-      - list_block { # forces replacement
-          - prop = "val3" -> null
+      ~ prop { # forces replacement
+          ~ nested_prop = "val2" -> "val3"
         }
-
-        # (1 unchanged block hidden)
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
+        }
     }
 
 Plan: 1 to add, 0 to change, 1 to destroy.
@@ -38,12 +39,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
           ~ [0]: {
-                  ~ prop: "val1" => "val3"
+                  ~ nestedProp: "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ nestedProp: "val2" => "val3"
                 }
           - [2]: {
-                  - prop: "val3"
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -51,7 +55,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"listBlocks[0].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[2]":      map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_force_new/list_element_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_force_new/list_element_removed_middle.golden
@@ -5,8 +5,8 @@ tests.testOutput{
 		"val3",
 	},
 	changeValue: &[]string{
-		"val3",
 		"val1",
+		"val3",
 	},
 	tfOut: `
 Terraform used the selected providers to generate the following execution
@@ -19,15 +19,14 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      ~ list_block { # forces replacement
-          ~ prop = "val1" -> "val3"
+      ~ prop { # forces replacement
+          ~ nested_prop = "val2" -> "val3"
         }
-      ~ list_block { # forces replacement
-          ~ prop = "val2" -> "val1"
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
         }
-      - list_block { # forces replacement
-          - prop = "val3" -> null
-        }
+
+        # (1 unchanged block hidden)
     }
 
 Plan: 1 to add, 0 to change, 1 to destroy.
@@ -39,15 +38,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
-          ~ [0]: {
-                  ~ prop: "val1" => "val3"
-                }
+      ~ props: [
           ~ [1]: {
-                  ~ prop: "val2" => "val1"
+                  ~ nestedProp: "val2" => "val3"
                 }
           - [2]: {
-                  - prop: "val3"
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -55,8 +51,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"listBlocks[0].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[1].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[2]":      map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_force_new/long_list_added_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_force_new/long_list_added_back.golden
@@ -55,8 +55,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      + list_block { # forces replacement
-          + prop = "value20"
+      + prop { # forces replacement
+          + nested_prop = "value20"
         }
 
         # (20 unchanged blocks hidden)
@@ -71,14 +71,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
           + [20]: {
-                  + prop      : "value20"
+                  + nestedProp: "value20"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks[20]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[20]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_force_new/long_list_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_force_new/long_list_added_front.golden
@@ -55,68 +55,68 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      ~ list_block { # forces replacement
-          ~ prop = "value0" -> "value20"
+      ~ prop { # forces replacement
+          ~ nested_prop = "value0" -> "value20"
         }
-      ~ list_block { # forces replacement
-          ~ prop = "value1" -> "value0"
+      ~ prop { # forces replacement
+          ~ nested_prop = "value1" -> "value0"
         }
-      ~ list_block { # forces replacement
-          ~ prop = "value2" -> "value1"
+      ~ prop { # forces replacement
+          ~ nested_prop = "value2" -> "value1"
         }
-      ~ list_block { # forces replacement
-          ~ prop = "value3" -> "value2"
+      ~ prop { # forces replacement
+          ~ nested_prop = "value3" -> "value2"
         }
-      ~ list_block { # forces replacement
-          ~ prop = "value4" -> "value3"
+      ~ prop { # forces replacement
+          ~ nested_prop = "value4" -> "value3"
         }
-      ~ list_block { # forces replacement
-          ~ prop = "value5" -> "value4"
+      ~ prop { # forces replacement
+          ~ nested_prop = "value5" -> "value4"
         }
-      ~ list_block { # forces replacement
-          ~ prop = "value6" -> "value5"
+      ~ prop { # forces replacement
+          ~ nested_prop = "value6" -> "value5"
         }
-      ~ list_block { # forces replacement
-          ~ prop = "value7" -> "value6"
+      ~ prop { # forces replacement
+          ~ nested_prop = "value7" -> "value6"
         }
-      ~ list_block { # forces replacement
-          ~ prop = "value8" -> "value7"
+      ~ prop { # forces replacement
+          ~ nested_prop = "value8" -> "value7"
         }
-      ~ list_block { # forces replacement
-          ~ prop = "value9" -> "value8"
+      ~ prop { # forces replacement
+          ~ nested_prop = "value9" -> "value8"
         }
-      ~ list_block { # forces replacement
-          ~ prop = "value10" -> "value9"
+      ~ prop { # forces replacement
+          ~ nested_prop = "value10" -> "value9"
         }
-      ~ list_block { # forces replacement
-          ~ prop = "value11" -> "value10"
+      ~ prop { # forces replacement
+          ~ nested_prop = "value11" -> "value10"
         }
-      ~ list_block { # forces replacement
-          ~ prop = "value12" -> "value11"
+      ~ prop { # forces replacement
+          ~ nested_prop = "value12" -> "value11"
         }
-      ~ list_block { # forces replacement
-          ~ prop = "value13" -> "value12"
+      ~ prop { # forces replacement
+          ~ nested_prop = "value13" -> "value12"
         }
-      ~ list_block { # forces replacement
-          ~ prop = "value14" -> "value13"
+      ~ prop { # forces replacement
+          ~ nested_prop = "value14" -> "value13"
         }
-      ~ list_block { # forces replacement
-          ~ prop = "value15" -> "value14"
+      ~ prop { # forces replacement
+          ~ nested_prop = "value15" -> "value14"
         }
-      ~ list_block { # forces replacement
-          ~ prop = "value16" -> "value15"
+      ~ prop { # forces replacement
+          ~ nested_prop = "value16" -> "value15"
         }
-      ~ list_block { # forces replacement
-          ~ prop = "value17" -> "value16"
+      ~ prop { # forces replacement
+          ~ nested_prop = "value17" -> "value16"
         }
-      ~ list_block { # forces replacement
-          ~ prop = "value18" -> "value17"
+      ~ prop { # forces replacement
+          ~ nested_prop = "value18" -> "value17"
         }
-      ~ list_block { # forces replacement
-          ~ prop = "value19" -> "value18"
+      ~ prop { # forces replacement
+          ~ nested_prop = "value19" -> "value18"
         }
-      + list_block { # forces replacement
-          + prop = "value19"
+      + prop { # forces replacement
+          + nested_prop = "value19"
         }
     }
 
@@ -129,69 +129,69 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
           ~ [0]: {
-                  ~ prop: "value0" => "value20"
+                  ~ nestedProp: "value0" => "value20"
                 }
           ~ [1]: {
-                  ~ prop: "value1" => "value0"
+                  ~ nestedProp: "value1" => "value0"
                 }
           ~ [2]: {
-                  ~ prop: "value2" => "value1"
+                  ~ nestedProp: "value2" => "value1"
                 }
           ~ [3]: {
-                  ~ prop: "value3" => "value2"
+                  ~ nestedProp: "value3" => "value2"
                 }
           ~ [4]: {
-                  ~ prop: "value4" => "value3"
+                  ~ nestedProp: "value4" => "value3"
                 }
           ~ [5]: {
-                  ~ prop: "value5" => "value4"
+                  ~ nestedProp: "value5" => "value4"
                 }
           ~ [6]: {
-                  ~ prop: "value6" => "value5"
+                  ~ nestedProp: "value6" => "value5"
                 }
           ~ [7]: {
-                  ~ prop: "value7" => "value6"
+                  ~ nestedProp: "value7" => "value6"
                 }
           ~ [8]: {
-                  ~ prop: "value8" => "value7"
+                  ~ nestedProp: "value8" => "value7"
                 }
           ~ [9]: {
-                  ~ prop: "value9" => "value8"
+                  ~ nestedProp: "value9" => "value8"
                 }
           ~ [10]: {
-                  ~ prop: "value10" => "value9"
+                  ~ nestedProp: "value10" => "value9"
                 }
           ~ [11]: {
-                  ~ prop: "value11" => "value10"
+                  ~ nestedProp: "value11" => "value10"
                 }
           ~ [12]: {
-                  ~ prop: "value12" => "value11"
+                  ~ nestedProp: "value12" => "value11"
                 }
           ~ [13]: {
-                  ~ prop: "value13" => "value12"
+                  ~ nestedProp: "value13" => "value12"
                 }
           ~ [14]: {
-                  ~ prop: "value14" => "value13"
+                  ~ nestedProp: "value14" => "value13"
                 }
           ~ [15]: {
-                  ~ prop: "value15" => "value14"
+                  ~ nestedProp: "value15" => "value14"
                 }
           ~ [16]: {
-                  ~ prop: "value16" => "value15"
+                  ~ nestedProp: "value16" => "value15"
                 }
           ~ [17]: {
-                  ~ prop: "value17" => "value16"
+                  ~ nestedProp: "value17" => "value16"
                 }
           ~ [18]: {
-                  ~ prop: "value18" => "value17"
+                  ~ nestedProp: "value18" => "value17"
                 }
           ~ [19]: {
-                  ~ prop: "value19" => "value18"
+                  ~ nestedProp: "value19" => "value18"
                 }
           + [20]: {
-                  + prop      : "value19"
+                  + nestedProp: "value19"
                 }
         ]
 Resources:
@@ -199,26 +199,26 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"listBlocks[0].prop":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[10].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[11].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[12].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[13].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[14].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[15].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[16].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[17].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[18].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[19].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[1].prop":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[20]":      map[string]interface{}{"kind": "ADD_REPLACE"},
-		"listBlocks[2].prop":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[3].prop":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[4].prop":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[5].prop":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[6].prop":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[7].prop":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[8].prop":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[9].prop":  map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[10].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[11].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[12].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[13].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[14].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[15].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[16].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[17].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[18].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[19].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[20]":            map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[2].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[4].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[5].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[6].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[7].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[8].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[9].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_force_new/long_list_removed_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_force_new/long_list_removed_back.golden
@@ -55,8 +55,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      - list_block { # forces replacement
-          - prop = "value20" -> null
+      - prop { # forces replacement
+          - nested_prop = "value20" -> null
         }
 
         # (20 unchanged blocks hidden)
@@ -71,14 +71,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
           - [20]: {
-                  - prop: "value20"
+                  - nestedProp: "value20"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks[20]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[20]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_force_new/long_list_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_force_new/long_list_removed_front.golden
@@ -55,68 +55,68 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      ~ list_block { # forces replacement
-          ~ prop = "value20" -> "value0"
+      ~ prop { # forces replacement
+          ~ nested_prop = "value20" -> "value0"
         }
-      ~ list_block { # forces replacement
-          ~ prop = "value0" -> "value1"
+      ~ prop { # forces replacement
+          ~ nested_prop = "value0" -> "value1"
         }
-      ~ list_block { # forces replacement
-          ~ prop = "value1" -> "value2"
+      ~ prop { # forces replacement
+          ~ nested_prop = "value1" -> "value2"
         }
-      ~ list_block { # forces replacement
-          ~ prop = "value2" -> "value3"
+      ~ prop { # forces replacement
+          ~ nested_prop = "value2" -> "value3"
         }
-      ~ list_block { # forces replacement
-          ~ prop = "value3" -> "value4"
+      ~ prop { # forces replacement
+          ~ nested_prop = "value3" -> "value4"
         }
-      ~ list_block { # forces replacement
-          ~ prop = "value4" -> "value5"
+      ~ prop { # forces replacement
+          ~ nested_prop = "value4" -> "value5"
         }
-      ~ list_block { # forces replacement
-          ~ prop = "value5" -> "value6"
+      ~ prop { # forces replacement
+          ~ nested_prop = "value5" -> "value6"
         }
-      ~ list_block { # forces replacement
-          ~ prop = "value6" -> "value7"
+      ~ prop { # forces replacement
+          ~ nested_prop = "value6" -> "value7"
         }
-      ~ list_block { # forces replacement
-          ~ prop = "value7" -> "value8"
+      ~ prop { # forces replacement
+          ~ nested_prop = "value7" -> "value8"
         }
-      ~ list_block { # forces replacement
-          ~ prop = "value8" -> "value9"
+      ~ prop { # forces replacement
+          ~ nested_prop = "value8" -> "value9"
         }
-      ~ list_block { # forces replacement
-          ~ prop = "value9" -> "value10"
+      ~ prop { # forces replacement
+          ~ nested_prop = "value9" -> "value10"
         }
-      ~ list_block { # forces replacement
-          ~ prop = "value10" -> "value11"
+      ~ prop { # forces replacement
+          ~ nested_prop = "value10" -> "value11"
         }
-      ~ list_block { # forces replacement
-          ~ prop = "value11" -> "value12"
+      ~ prop { # forces replacement
+          ~ nested_prop = "value11" -> "value12"
         }
-      ~ list_block { # forces replacement
-          ~ prop = "value12" -> "value13"
+      ~ prop { # forces replacement
+          ~ nested_prop = "value12" -> "value13"
         }
-      ~ list_block { # forces replacement
-          ~ prop = "value13" -> "value14"
+      ~ prop { # forces replacement
+          ~ nested_prop = "value13" -> "value14"
         }
-      ~ list_block { # forces replacement
-          ~ prop = "value14" -> "value15"
+      ~ prop { # forces replacement
+          ~ nested_prop = "value14" -> "value15"
         }
-      ~ list_block { # forces replacement
-          ~ prop = "value15" -> "value16"
+      ~ prop { # forces replacement
+          ~ nested_prop = "value15" -> "value16"
         }
-      ~ list_block { # forces replacement
-          ~ prop = "value16" -> "value17"
+      ~ prop { # forces replacement
+          ~ nested_prop = "value16" -> "value17"
         }
-      ~ list_block { # forces replacement
-          ~ prop = "value17" -> "value18"
+      ~ prop { # forces replacement
+          ~ nested_prop = "value17" -> "value18"
         }
-      ~ list_block { # forces replacement
-          ~ prop = "value18" -> "value19"
+      ~ prop { # forces replacement
+          ~ nested_prop = "value18" -> "value19"
         }
-      - list_block { # forces replacement
-          - prop = "value19" -> null
+      - prop { # forces replacement
+          - nested_prop = "value19" -> null
         }
     }
 
@@ -129,69 +129,69 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
           ~ [0]: {
-                  ~ prop: "value20" => "value0"
+                  ~ nestedProp: "value20" => "value0"
                 }
           ~ [1]: {
-                  ~ prop: "value0" => "value1"
+                  ~ nestedProp: "value0" => "value1"
                 }
           ~ [2]: {
-                  ~ prop: "value1" => "value2"
+                  ~ nestedProp: "value1" => "value2"
                 }
           ~ [3]: {
-                  ~ prop: "value2" => "value3"
+                  ~ nestedProp: "value2" => "value3"
                 }
           ~ [4]: {
-                  ~ prop: "value3" => "value4"
+                  ~ nestedProp: "value3" => "value4"
                 }
           ~ [5]: {
-                  ~ prop: "value4" => "value5"
+                  ~ nestedProp: "value4" => "value5"
                 }
           ~ [6]: {
-                  ~ prop: "value5" => "value6"
+                  ~ nestedProp: "value5" => "value6"
                 }
           ~ [7]: {
-                  ~ prop: "value6" => "value7"
+                  ~ nestedProp: "value6" => "value7"
                 }
           ~ [8]: {
-                  ~ prop: "value7" => "value8"
+                  ~ nestedProp: "value7" => "value8"
                 }
           ~ [9]: {
-                  ~ prop: "value8" => "value9"
+                  ~ nestedProp: "value8" => "value9"
                 }
           ~ [10]: {
-                  ~ prop: "value9" => "value10"
+                  ~ nestedProp: "value9" => "value10"
                 }
           ~ [11]: {
-                  ~ prop: "value10" => "value11"
+                  ~ nestedProp: "value10" => "value11"
                 }
           ~ [12]: {
-                  ~ prop: "value11" => "value12"
+                  ~ nestedProp: "value11" => "value12"
                 }
           ~ [13]: {
-                  ~ prop: "value12" => "value13"
+                  ~ nestedProp: "value12" => "value13"
                 }
           ~ [14]: {
-                  ~ prop: "value13" => "value14"
+                  ~ nestedProp: "value13" => "value14"
                 }
           ~ [15]: {
-                  ~ prop: "value14" => "value15"
+                  ~ nestedProp: "value14" => "value15"
                 }
           ~ [16]: {
-                  ~ prop: "value15" => "value16"
+                  ~ nestedProp: "value15" => "value16"
                 }
           ~ [17]: {
-                  ~ prop: "value16" => "value17"
+                  ~ nestedProp: "value16" => "value17"
                 }
           ~ [18]: {
-                  ~ prop: "value17" => "value18"
+                  ~ nestedProp: "value17" => "value18"
                 }
           ~ [19]: {
-                  ~ prop: "value18" => "value19"
+                  ~ nestedProp: "value18" => "value19"
                 }
           - [20]: {
-                  - prop: "value19"
+                  - nestedProp: "value19"
                 }
         ]
 Resources:
@@ -199,26 +199,26 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"listBlocks[0].prop":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[10].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[11].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[12].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[13].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[14].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[15].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[16].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[17].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[18].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[19].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[1].prop":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[20]":      map[string]interface{}{"kind": "DELETE_REPLACE"},
-		"listBlocks[2].prop":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[3].prop":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[4].prop":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[5].prop":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[6].prop":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[7].prop":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[8].prop":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[9].prop":  map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[10].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[11].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[12].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[13].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[14].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[15].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[16].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[17].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[18].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[19].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[20]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[2].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[4].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[5].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[6].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[7].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[8].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[9].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_force_new/one_added,_one_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_force_new/one_added,_one_removed.golden
@@ -20,14 +20,14 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      ~ list_block {
-          ~ prop = "val1" -> "val2"
+      ~ prop {
+          ~ nested_prop = "val1" -> "val2"
         }
-      ~ list_block {
-          ~ prop = "val2" -> "val3"
+      ~ prop {
+          ~ nested_prop = "val2" -> "val3"
         }
-      ~ list_block {
-          ~ prop = "val3" -> "val4"
+      ~ prop {
+          ~ nested_prop = "val3" -> "val4"
         }
     }
 
@@ -40,15 +40,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
           ~ [0]: {
-                  ~ prop: "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ prop: "val2" => "val3"
+                  ~ nestedProp: "val2" => "val3"
                 }
           ~ [2]: {
-                  ~ prop: "val3" => "val4"
+                  ~ nestedProp: "val3" => "val4"
                 }
         ]
 Resources:
@@ -56,8 +56,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"listBlocks[0].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[1].prop": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[2].prop": map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_force_new/removed_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_force_new/removed_non-empty.golden
@@ -14,8 +14,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      - list_block { # forces replacement
-          - prop = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
         }
     }
 
@@ -28,14 +28,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - listBlocks: [
+      - props: [
       -     [0]: {
-              - prop: "val1"
+              - nestedProp: "val1"
             }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_force_new/added_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_force_new/added_non-empty.golden
@@ -5,33 +5,36 @@ tests.testOutput{
 	tfOut: `
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-  ~ update in-place
++/- create replacement and then destroy
 
 Terraform will perform the following actions:
 
-  # crossprovider_test_res.example will be updated in-place
-  ~ resource "crossprovider_test_res" "example" {
-        id = "newid"
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "newid" -> (known after apply)
 
-      + list_block {}
+      + prop {
+          + nested_prop = "val1" # forces replacement
+        }
     }
 
-Plan: 0 to add, 1 to change, 0 to destroy.
+Plan: 1 to add, 0 to change, 1 to destroy.
 
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
-    ~ crossprovider:index/testRes:TestRes: (update)
+    +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + listBlocks: [
+      + props: [
       +     [0]: {
+              + nestedProp: "val1"
             }
         ]
 Resources:
-    ~ 1 to update
+    +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_force_new/changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_force_new/changed.golden
@@ -4,15 +4,38 @@ tests.testOutput{
 	},
 	changeValue: &[]string{"val2"},
 	tfOut: `
-No changes. Your infrastructure matches the configuration.
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
 
-Terraform has compared your real infrastructure against your configuration
-and found no differences, so no changes are needed.
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "newid" -> (known after apply)
+
+      ~ prop {
+          ~ nested_prop = "val1" -> "val2" # forces replacement
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProp: "val1" => "val2"
+                }
+        ]
 Resources:
-    2 unchanged
+    +-1 to replace
+    1 unchanged
 `,
+	detailedDiff: map[string]interface{}{"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_force_new/list_element_added_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_force_new/list_element_added_back.golden
@@ -11,35 +11,38 @@ tests.testOutput{
 	tfOut: `
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-  ~ update in-place
++/- create replacement and then destroy
 
 Terraform will perform the following actions:
 
-  # crossprovider_test_res.example will be updated in-place
-  ~ resource "crossprovider_test_res" "example" {
-        id = "newid"
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "newid" -> (known after apply)
 
-      + list_block {}
+      + prop {
+          + nested_prop = "val3" # forces replacement
+        }
 
         # (2 unchanged blocks hidden)
     }
 
-Plan: 0 to add, 1 to change, 0 to destroy.
+Plan: 1 to add, 0 to change, 1 to destroy.
 
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
-    ~ crossprovider:index/testRes:TestRes: (update)
+    +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
           + [2]: {
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
-    ~ 1 to update
+    +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks[2]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_force_new/list_element_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_force_new/list_element_added_front.golden
@@ -11,35 +11,52 @@ tests.testOutput{
 	tfOut: `
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-  ~ update in-place
++/- create replacement and then destroy
 
 Terraform will perform the following actions:
 
-  # crossprovider_test_res.example will be updated in-place
-  ~ resource "crossprovider_test_res" "example" {
-        id = "newid"
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "newid" -> (known after apply)
 
-      + list_block {}
-
-        # (2 unchanged blocks hidden)
+      ~ prop {
+          ~ nested_prop = "val2" -> "val1" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "val3" -> "val2" # forces replacement
+        }
+      + prop {
+          + nested_prop = "val3" # forces replacement
+        }
     }
 
-Plan: 0 to add, 1 to change, 0 to destroy.
+Plan: 1 to add, 0 to change, 1 to destroy.
 
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
-    ~ crossprovider:index/testRes:TestRes: (update)
+    +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProp: "val2" => "val1"
+                }
+          ~ [1]: {
+                  ~ nestedProp: "val3" => "val2"
+                }
           + [2]: {
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
-    ~ 1 to update
+    +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks[2]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_force_new/list_element_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_force_new/list_element_added_middle.golden
@@ -11,35 +11,47 @@ tests.testOutput{
 	tfOut: `
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-  ~ update in-place
++/- create replacement and then destroy
 
 Terraform will perform the following actions:
 
-  # crossprovider_test_res.example will be updated in-place
-  ~ resource "crossprovider_test_res" "example" {
-        id = "newid"
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "newid" -> (known after apply)
 
-      + list_block {}
+      ~ prop {
+          ~ nested_prop = "val3" -> "val2" # forces replacement
+        }
+      + prop {
+          + nested_prop = "val3" # forces replacement
+        }
 
-        # (2 unchanged blocks hidden)
+        # (1 unchanged block hidden)
     }
 
-Plan: 0 to add, 1 to change, 0 to destroy.
+Plan: 1 to add, 0 to change, 1 to destroy.
 
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
-    ~ crossprovider:index/testRes:TestRes: (update)
+    +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
+          ~ [1]: {
+                  ~ nestedProp: "val3" => "val2"
+                }
           + [2]: {
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
-    ~ 1 to update
+    +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks[2]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
+	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_force_new/list_element_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_force_new/list_element_removed_end.golden
@@ -5,42 +5,44 @@ tests.testOutput{
 		"val3",
 	},
 	changeValue: &[]string{
-		"val2",
 		"val1",
+		"val2",
 	},
 	tfOut: `
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-  ~ update in-place
++/- create replacement and then destroy
 
 Terraform will perform the following actions:
 
-  # crossprovider_test_res.example will be updated in-place
-  ~ resource "crossprovider_test_res" "example" {
-        id = "newid"
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "newid" -> (known after apply)
 
-      - list_block {}
+      - prop {
+          - nested_prop = "val3" -> null # forces replacement
+        }
 
         # (2 unchanged blocks hidden)
     }
 
-Plan: 0 to add, 1 to change, 0 to destroy.
+Plan: 1 to add, 0 to change, 1 to destroy.
 
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
-    ~ crossprovider:index/testRes:TestRes: (update)
+    +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
           - [2]: {
-                  - nestedProp: <null>
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
-    ~ 1 to update
+    +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks[2]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_force_new/list_element_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_force_new/list_element_removed_front.golden
@@ -5,42 +5,58 @@ tests.testOutput{
 		"val3",
 	},
 	changeValue: &[]string{
-		"val3",
 		"val2",
+		"val3",
 	},
 	tfOut: `
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-  ~ update in-place
++/- create replacement and then destroy
 
 Terraform will perform the following actions:
 
-  # crossprovider_test_res.example will be updated in-place
-  ~ resource "crossprovider_test_res" "example" {
-        id = "newid"
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "newid" -> (known after apply)
 
-      - list_block {}
-
-        # (2 unchanged blocks hidden)
+      ~ prop {
+          ~ nested_prop = "val1" -> "val2" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "val2" -> "val3" # forces replacement
+        }
+      - prop {
+          - nested_prop = "val3" -> null # forces replacement
+        }
     }
 
-Plan: 0 to add, 1 to change, 0 to destroy.
+Plan: 1 to add, 0 to change, 1 to destroy.
 
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
-    ~ crossprovider:index/testRes:TestRes: (update)
+    +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProp: "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ nestedProp: "val2" => "val3"
+                }
           - [2]: {
-                  - nestedProp: <null>
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
-    ~ 1 to update
+    +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks[2]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_force_new/list_element_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_force_new/list_element_removed_middle.golden
@@ -5,42 +5,53 @@ tests.testOutput{
 		"val3",
 	},
 	changeValue: &[]string{
-		"val3",
 		"val1",
+		"val3",
 	},
 	tfOut: `
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-  ~ update in-place
++/- create replacement and then destroy
 
 Terraform will perform the following actions:
 
-  # crossprovider_test_res.example will be updated in-place
-  ~ resource "crossprovider_test_res" "example" {
-        id = "newid"
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "newid" -> (known after apply)
 
-      - list_block {}
+      ~ prop {
+          ~ nested_prop = "val2" -> "val3" # forces replacement
+        }
+      - prop {
+          - nested_prop = "val3" -> null # forces replacement
+        }
 
-        # (2 unchanged blocks hidden)
+        # (1 unchanged block hidden)
     }
 
-Plan: 0 to add, 1 to change, 0 to destroy.
+Plan: 1 to add, 0 to change, 1 to destroy.
 
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
-    ~ crossprovider:index/testRes:TestRes: (update)
+    +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
+          ~ [1]: {
+                  ~ nestedProp: "val2" => "val3"
+                }
           - [2]: {
-                  - nestedProp: <null>
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
-    ~ 1 to update
+    +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks[2]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
+	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_force_new/long_list_added_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_force_new/long_list_added_back.golden
@@ -47,35 +47,38 @@ tests.testOutput{
 	tfOut: `
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-  ~ update in-place
++/- create replacement and then destroy
 
 Terraform will perform the following actions:
 
-  # crossprovider_test_res.example will be updated in-place
-  ~ resource "crossprovider_test_res" "example" {
-        id = "newid"
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "newid" -> (known after apply)
 
-      + list_block {}
+      + prop {
+          + nested_prop = "value20" # forces replacement
+        }
 
         # (20 unchanged blocks hidden)
     }
 
-Plan: 0 to add, 1 to change, 0 to destroy.
+Plan: 1 to add, 0 to change, 1 to destroy.
 
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
-    ~ crossprovider:index/testRes:TestRes: (update)
+    +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
           + [20]: {
+                  + nestedProp: "value20"
                 }
         ]
 Resources:
-    ~ 1 to update
+    +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks[20]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[20]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_force_new/long_list_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_force_new/long_list_added_front.golden
@@ -47,35 +47,178 @@ tests.testOutput{
 	tfOut: `
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-  ~ update in-place
++/- create replacement and then destroy
 
 Terraform will perform the following actions:
 
-  # crossprovider_test_res.example will be updated in-place
-  ~ resource "crossprovider_test_res" "example" {
-        id = "newid"
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "newid" -> (known after apply)
 
-      + list_block {}
-
-        # (20 unchanged blocks hidden)
+      ~ prop {
+          ~ nested_prop = "value0" -> "value20" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "value1" -> "value0" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "value2" -> "value1" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "value3" -> "value2" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "value4" -> "value3" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "value5" -> "value4" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "value6" -> "value5" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "value7" -> "value6" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "value8" -> "value7" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "value9" -> "value8" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "value10" -> "value9" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "value11" -> "value10" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "value12" -> "value11" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "value13" -> "value12" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "value14" -> "value13" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "value15" -> "value14" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "value16" -> "value15" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "value17" -> "value16" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "value18" -> "value17" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "value19" -> "value18" # forces replacement
+        }
+      + prop {
+          + nested_prop = "value19" # forces replacement
+        }
     }
 
-Plan: 0 to add, 1 to change, 0 to destroy.
+Plan: 1 to add, 0 to change, 1 to destroy.
 
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
-    ~ crossprovider:index/testRes:TestRes: (update)
+    +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProp: "value0" => "value20"
+                }
+          ~ [1]: {
+                  ~ nestedProp: "value1" => "value0"
+                }
+          ~ [2]: {
+                  ~ nestedProp: "value2" => "value1"
+                }
+          ~ [3]: {
+                  ~ nestedProp: "value3" => "value2"
+                }
+          ~ [4]: {
+                  ~ nestedProp: "value4" => "value3"
+                }
+          ~ [5]: {
+                  ~ nestedProp: "value5" => "value4"
+                }
+          ~ [6]: {
+                  ~ nestedProp: "value6" => "value5"
+                }
+          ~ [7]: {
+                  ~ nestedProp: "value7" => "value6"
+                }
+          ~ [8]: {
+                  ~ nestedProp: "value8" => "value7"
+                }
+          ~ [9]: {
+                  ~ nestedProp: "value9" => "value8"
+                }
+          ~ [10]: {
+                  ~ nestedProp: "value10" => "value9"
+                }
+          ~ [11]: {
+                  ~ nestedProp: "value11" => "value10"
+                }
+          ~ [12]: {
+                  ~ nestedProp: "value12" => "value11"
+                }
+          ~ [13]: {
+                  ~ nestedProp: "value13" => "value12"
+                }
+          ~ [14]: {
+                  ~ nestedProp: "value14" => "value13"
+                }
+          ~ [15]: {
+                  ~ nestedProp: "value15" => "value14"
+                }
+          ~ [16]: {
+                  ~ nestedProp: "value16" => "value15"
+                }
+          ~ [17]: {
+                  ~ nestedProp: "value17" => "value16"
+                }
+          ~ [18]: {
+                  ~ nestedProp: "value18" => "value17"
+                }
+          ~ [19]: {
+                  ~ nestedProp: "value19" => "value18"
+                }
           + [20]: {
+                  + nestedProp: "value19"
                 }
         ]
 Resources:
-    ~ 1 to update
+    +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks[20]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"props[0].nestedProp":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[10].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[11].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[12].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[13].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[14].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[15].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[16].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[17].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[18].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[19].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1].nestedProp":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[20]":            map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[2].nestedProp":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[3].nestedProp":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[4].nestedProp":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[5].nestedProp":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[6].nestedProp":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[7].nestedProp":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[8].nestedProp":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[9].nestedProp":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_force_new/long_list_removed_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_force_new/long_list_removed_back.golden
@@ -47,36 +47,38 @@ tests.testOutput{
 	tfOut: `
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-  ~ update in-place
++/- create replacement and then destroy
 
 Terraform will perform the following actions:
 
-  # crossprovider_test_res.example will be updated in-place
-  ~ resource "crossprovider_test_res" "example" {
-        id = "newid"
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "newid" -> (known after apply)
 
-      - list_block {}
+      - prop {
+          - nested_prop = "value20" -> null # forces replacement
+        }
 
         # (20 unchanged blocks hidden)
     }
 
-Plan: 0 to add, 1 to change, 0 to destroy.
+Plan: 1 to add, 0 to change, 1 to destroy.
 
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
-    ~ crossprovider:index/testRes:TestRes: (update)
+    +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
           - [20]: {
-                  - nestedProp: <null>
+                  - nestedProp: "value20"
                 }
         ]
 Resources:
-    ~ 1 to update
+    +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks[20]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[20]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_force_new/long_list_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_force_new/long_list_removed_front.golden
@@ -47,36 +47,178 @@ tests.testOutput{
 	tfOut: `
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-  ~ update in-place
++/- create replacement and then destroy
 
 Terraform will perform the following actions:
 
-  # crossprovider_test_res.example will be updated in-place
-  ~ resource "crossprovider_test_res" "example" {
-        id = "newid"
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "newid" -> (known after apply)
 
-      - list_block {}
-
-        # (20 unchanged blocks hidden)
+      ~ prop {
+          ~ nested_prop = "value20" -> "value0" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "value0" -> "value1" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "value1" -> "value2" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "value2" -> "value3" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "value3" -> "value4" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "value4" -> "value5" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "value5" -> "value6" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "value6" -> "value7" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "value7" -> "value8" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "value8" -> "value9" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "value9" -> "value10" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "value10" -> "value11" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "value11" -> "value12" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "value12" -> "value13" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "value13" -> "value14" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "value14" -> "value15" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "value15" -> "value16" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "value16" -> "value17" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "value17" -> "value18" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "value18" -> "value19" # forces replacement
+        }
+      - prop {
+          - nested_prop = "value19" -> null # forces replacement
+        }
     }
 
-Plan: 0 to add, 1 to change, 0 to destroy.
+Plan: 1 to add, 0 to change, 1 to destroy.
 
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
-    ~ crossprovider:index/testRes:TestRes: (update)
+    +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProp: "value20" => "value0"
+                }
+          ~ [1]: {
+                  ~ nestedProp: "value0" => "value1"
+                }
+          ~ [2]: {
+                  ~ nestedProp: "value1" => "value2"
+                }
+          ~ [3]: {
+                  ~ nestedProp: "value2" => "value3"
+                }
+          ~ [4]: {
+                  ~ nestedProp: "value3" => "value4"
+                }
+          ~ [5]: {
+                  ~ nestedProp: "value4" => "value5"
+                }
+          ~ [6]: {
+                  ~ nestedProp: "value5" => "value6"
+                }
+          ~ [7]: {
+                  ~ nestedProp: "value6" => "value7"
+                }
+          ~ [8]: {
+                  ~ nestedProp: "value7" => "value8"
+                }
+          ~ [9]: {
+                  ~ nestedProp: "value8" => "value9"
+                }
+          ~ [10]: {
+                  ~ nestedProp: "value9" => "value10"
+                }
+          ~ [11]: {
+                  ~ nestedProp: "value10" => "value11"
+                }
+          ~ [12]: {
+                  ~ nestedProp: "value11" => "value12"
+                }
+          ~ [13]: {
+                  ~ nestedProp: "value12" => "value13"
+                }
+          ~ [14]: {
+                  ~ nestedProp: "value13" => "value14"
+                }
+          ~ [15]: {
+                  ~ nestedProp: "value14" => "value15"
+                }
+          ~ [16]: {
+                  ~ nestedProp: "value15" => "value16"
+                }
+          ~ [17]: {
+                  ~ nestedProp: "value16" => "value17"
+                }
+          ~ [18]: {
+                  ~ nestedProp: "value17" => "value18"
+                }
+          ~ [19]: {
+                  ~ nestedProp: "value18" => "value19"
+                }
           - [20]: {
-                  - nestedProp: <null>
+                  - nestedProp: "value19"
                 }
         ]
 Resources:
-    ~ 1 to update
+    +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks[20]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{
+		"props[0].nestedProp":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[10].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[11].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[12].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[13].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[14].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[15].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[16].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[17].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[18].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[19].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1].nestedProp":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[20]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[2].nestedProp":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[3].nestedProp":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[4].nestedProp":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[5].nestedProp":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[6].nestedProp":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[7].nestedProp":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[8].nestedProp":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[9].nestedProp":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_force_new/one_added,_one_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_force_new/one_added,_one_removed.golden
@@ -10,15 +10,54 @@ tests.testOutput{
 		"val4",
 	},
 	tfOut: `
-No changes. Your infrastructure matches the configuration.
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
++/- create replacement and then destroy
 
-Terraform has compared your real infrastructure against your configuration
-and found no differences, so no changes are needed.
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "newid" -> (known after apply)
+
+      ~ prop {
+          ~ nested_prop = "val1" -> "val2" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "val2" -> "val3" # forces replacement
+        }
+      ~ prop {
+          ~ nested_prop = "val3" -> "val4" # forces replacement
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.
+
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    +-crossprovider:index/testRes:TestRes: (replace)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProp: "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ nestedProp: "val2" => "val3"
+                }
+          ~ [2]: {
+                  ~ nestedProp: "val3" => "val4"
+                }
+        ]
 Resources:
-    2 unchanged
+    +-1 to replace
+    1 unchanged
 `,
+	detailedDiff: map[string]interface{}{
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_force_new/removed_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_force_new/removed_non-empty.golden
@@ -6,34 +6,36 @@ tests.testOutput{
 	tfOut: `
 Terraform used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-  ~ update in-place
++/- create replacement and then destroy
 
 Terraform will perform the following actions:
 
-  # crossprovider_test_res.example will be updated in-place
-  ~ resource "crossprovider_test_res" "example" {
-        id = "newid"
+  # crossprovider_test_res.example must be replaced
++/- resource "crossprovider_test_res" "example" {
+      ~ id = "newid" -> (known after apply)
 
-      - list_block {}
+      - prop {
+          - nested_prop = "val1" -> null # forces replacement
+        }
     }
 
-Plan: 0 to add, 1 to change, 0 to destroy.
+Plan: 1 to add, 0 to change, 1 to destroy.
 
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
-    ~ crossprovider:index/testRes:TestRes: (update)
+    +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - listBlocks: [
+      - props: [
       -     [0]: {
-              - nestedProp: <null>
+              - nestedProp: "val1"
             }
         ]
 Resources:
-    ~ 1 to update
+    +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/added_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/added_non-empty.golden
@@ -13,7 +13,7 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + list_block {
+      + prop {
           + nested_prop = (sensitive value)
         }
     }
@@ -27,10 +27,10 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + listBlocks: [secret]
+      + props: [secret]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/changed.golden
@@ -14,7 +14,7 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
     }
@@ -28,7 +28,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
           ~ [0]: {
                   ~ nestedProp: [secret] => [secret]
                 }
@@ -37,5 +37,5 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks[0].nestedProp": map[string]interface{}{"kind": "UPDATE"}},
+	detailedDiff: map[string]interface{}{"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/list_element_added_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/list_element_added_back.golden
@@ -19,7 +19,7 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + list_block {
+      + prop {
           + nested_prop = (sensitive value)
         }
 
@@ -35,12 +35,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
           + [2]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks[2]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/list_element_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/list_element_added_front.golden
@@ -19,13 +19,13 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      + list_block {
+      + prop {
           + nested_prop = (sensitive value)
         }
     }
@@ -39,7 +39,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
           ~ [0]: {
                   ~ nestedProp: [secret] => [secret]
                 }
@@ -53,8 +53,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"listBlocks[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[2]":            map[string]interface{}{},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/list_element_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/list_element_added_middle.golden
@@ -19,10 +19,10 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      + list_block {
+      + prop {
           + nested_prop = (sensitive value)
         }
 
@@ -38,7 +38,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
           ~ [1]: {
                   ~ nestedProp: [secret] => [secret]
                 }
@@ -49,7 +49,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"listBlocks[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[2]":            map[string]interface{}{},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/list_element_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/list_element_removed_end.golden
@@ -5,8 +5,8 @@ tests.testOutput{
 		"val3",
 	},
 	changeValue: &[]string{
-		"val2",
 		"val1",
+		"val2",
 	},
 	tfOut: `
 Terraform used the selected providers to generate the following execution
@@ -19,15 +19,11 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      ~ list_block {
-          ~ nested_prop = (sensitive value)
-        }
-      ~ list_block {
-          ~ nested_prop = (sensitive value)
-        }
-      - list_block {
+      - prop {
           - nested_prop = (sensitive value) -> null
         }
+
+        # (2 unchanged blocks hidden)
     }
 
 Plan: 0 to add, 1 to change, 0 to destroy.
@@ -39,22 +35,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
-          ~ [0]: {
-                  ~ nestedProp: [secret] => [secret]
-                }
-          ~ [1]: {
-                  ~ nestedProp: [secret] => [secret]
-                }
+      ~ props: [
           - [2]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"listBlocks[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[2]":            map[string]interface{}{"kind": "DELETE"},
-	},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/list_element_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/list_element_removed_front.golden
@@ -5,8 +5,8 @@ tests.testOutput{
 		"val3",
 	},
 	changeValue: &[]string{
-		"val3",
 		"val2",
+		"val3",
 	},
 	tfOut: `
 Terraform used the selected providers to generate the following execution
@@ -19,14 +19,15 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      - list_block {
+      ~ prop {
+          ~ nested_prop = (sensitive value)
+        }
+      - prop {
           - nested_prop = (sensitive value) -> null
         }
-
-        # (1 unchanged block hidden)
     }
 
 Plan: 0 to add, 1 to change, 0 to destroy.
@@ -38,8 +39,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
           ~ [0]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [1]: {
                   ~ nestedProp: [secret] => [secret]
                 }
           - [2]: [secret]
@@ -49,7 +53,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"listBlocks[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[2]":            map[string]interface{}{"kind": "DELETE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/list_element_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/list_element_removed_middle.golden
@@ -5,8 +5,8 @@ tests.testOutput{
 		"val3",
 	},
 	changeValue: &[]string{
-		"val3",
 		"val1",
+		"val3",
 	},
 	tfOut: `
 Terraform used the selected providers to generate the following execution
@@ -19,15 +19,14 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
-          ~ nested_prop = (sensitive value)
-        }
-      - list_block {
+      - prop {
           - nested_prop = (sensitive value) -> null
         }
+
+        # (1 unchanged block hidden)
     }
 
 Plan: 0 to add, 1 to change, 0 to destroy.
@@ -39,10 +38,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
-          ~ [0]: {
-                  ~ nestedProp: [secret] => [secret]
-                }
+      ~ props: [
           ~ [1]: {
                   ~ nestedProp: [secret] => [secret]
                 }
@@ -53,8 +49,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"listBlocks[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[2]":            map[string]interface{}{"kind": "DELETE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/long_list_added_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/long_list_added_back.golden
@@ -55,7 +55,7 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + list_block {
+      + prop {
           + nested_prop = (sensitive value)
         }
 
@@ -71,12 +71,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
           + [20]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks[20]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[20]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/long_list_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/long_list_added_front.golden
@@ -55,67 +55,67 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      + list_block {
+      + prop {
           + nested_prop = (sensitive value)
         }
     }
@@ -129,7 +129,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
           ~ [0]: {
                   ~ nestedProp: [secret] => [secret]
                 }
@@ -197,26 +197,26 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"listBlocks[0].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[10].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[11].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[12].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[13].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[14].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[15].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[16].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[17].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[18].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[19].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[1].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[20]":            map[string]interface{}{},
-		"listBlocks[2].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[3].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[4].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[5].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[6].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[7].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[8].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[9].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[10].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[11].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[12].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[13].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[14].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[15].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[16].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[17].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[18].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[19].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[20]":            map[string]interface{}{},
+		"props[2].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[4].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[5].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[6].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[7].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[8].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[9].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/long_list_removed_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/long_list_removed_back.golden
@@ -55,7 +55,7 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - list_block {
+      - prop {
           - nested_prop = (sensitive value) -> null
         }
 
@@ -71,12 +71,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
           - [20]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks[20]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[20]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/long_list_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/long_list_removed_front.golden
@@ -55,67 +55,67 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      - list_block {
+      - prop {
           - nested_prop = (sensitive value) -> null
         }
     }
@@ -129,7 +129,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
           ~ [0]: {
                   ~ nestedProp: [secret] => [secret]
                 }
@@ -197,26 +197,26 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"listBlocks[0].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[10].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[11].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[12].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[13].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[14].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[15].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[16].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[17].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[18].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[19].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[1].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[20]":            map[string]interface{}{"kind": "DELETE"},
-		"listBlocks[2].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[3].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[4].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[5].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[6].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[7].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[8].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[9].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[10].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[11].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[12].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[13].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[14].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[15].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[16].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[17].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[18].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[19].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[20]":            map[string]interface{}{"kind": "DELETE"},
+		"props[2].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[4].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[5].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[6].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[7].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[8].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[9].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/one_added,_one_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/one_added,_one_removed.golden
@@ -20,13 +20,13 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = (sensitive value)
         }
     }
@@ -40,7 +40,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
           ~ [0]: {
                   ~ nestedProp: [secret] => [secret]
                 }
@@ -56,8 +56,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"listBlocks[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"listBlocks[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/removed_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_sensitive/removed_non-empty.golden
@@ -14,7 +14,7 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - list_block {
+      - prop {
           - nested_prop = (sensitive value) -> null
         }
     }
@@ -28,10 +28,10 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - listBlocks: [secret]
+      - props: [secret]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/added_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/added_non-empty.golden
@@ -13,7 +13,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + list_block {}
+      + prop {
+          + nested_prop = "val1"
+        }
     }
 
 Plan: 0 to add, 1 to change, 0 to destroy.
@@ -25,10 +27,10 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + listBlocks: [secret]
+      + props: [secret]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/changed.golden
@@ -4,15 +4,38 @@ tests.testOutput{
 	},
 	changeValue: &[]string{"val2"},
 	tfOut: `
-No changes. Your infrastructure matches the configuration.
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
 
-Terraform has compared your real infrastructure against your configuration
-and found no differences, so no changes are needed.
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      ~ prop {
+          ~ nested_prop = "val1" -> "val2"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+        ]
 Resources:
-    2 unchanged
+    ~ 1 to update
+    1 unchanged
 `,
+	detailedDiff: map[string]interface{}{"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/list_element_added_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/list_element_added_back.golden
@@ -19,7 +19,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + list_block {}
+      + prop {
+          + nested_prop = "val3"
+        }
 
         # (2 unchanged blocks hidden)
     }
@@ -33,12 +35,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
           + [2]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks[2]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/list_element_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/list_element_added_front.golden
@@ -19,9 +19,15 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + list_block {}
-
-        # (2 unchanged blocks hidden)
+      ~ prop {
+          ~ nested_prop = "val2" -> "val1"
+        }
+      ~ prop {
+          ~ nested_prop = "val3" -> "val2"
+        }
+      + prop {
+          + nested_prop = "val3"
+        }
     }
 
 Plan: 0 to add, 1 to change, 0 to destroy.
@@ -33,12 +39,22 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [1]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
           + [2]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks[2]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{},
+	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/list_element_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/list_element_added_middle.golden
@@ -19,9 +19,14 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + list_block {}
+      ~ prop {
+          ~ nested_prop = "val3" -> "val2"
+        }
+      + prop {
+          + nested_prop = "val3"
+        }
 
-        # (2 unchanged blocks hidden)
+        # (1 unchanged block hidden)
     }
 
 Plan: 0 to add, 1 to change, 0 to destroy.
@@ -33,12 +38,18 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
+          ~ [1]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
           + [2]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks[2]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{},
+	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/list_element_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/list_element_removed_end.golden
@@ -5,8 +5,8 @@ tests.testOutput{
 		"val3",
 	},
 	changeValue: &[]string{
-		"val2",
 		"val1",
+		"val2",
 	},
 	tfOut: `
 Terraform used the selected providers to generate the following execution
@@ -19,7 +19,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - list_block {}
+      - prop {
+          - nested_prop = "val3" -> null
+        }
 
         # (2 unchanged blocks hidden)
     }
@@ -33,12 +35,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
           - [2]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks[2]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/list_element_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/list_element_removed_front.golden
@@ -5,8 +5,8 @@ tests.testOutput{
 		"val3",
 	},
 	changeValue: &[]string{
-		"val3",
 		"val2",
+		"val3",
 	},
 	tfOut: `
 Terraform used the selected providers to generate the following execution
@@ -19,9 +19,15 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - list_block {}
-
-        # (2 unchanged blocks hidden)
+      ~ prop {
+          ~ nested_prop = "val1" -> "val2"
+        }
+      ~ prop {
+          ~ nested_prop = "val2" -> "val3"
+        }
+      - prop {
+          - nested_prop = "val3" -> null
+        }
     }
 
 Plan: 0 to add, 1 to change, 0 to destroy.
@@ -33,12 +39,22 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [1]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
           - [2]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks[2]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/list_element_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/list_element_removed_middle.golden
@@ -5,8 +5,8 @@ tests.testOutput{
 		"val3",
 	},
 	changeValue: &[]string{
-		"val3",
 		"val1",
+		"val3",
 	},
 	tfOut: `
 Terraform used the selected providers to generate the following execution
@@ -19,9 +19,14 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - list_block {}
+      ~ prop {
+          ~ nested_prop = "val2" -> "val3"
+        }
+      - prop {
+          - nested_prop = "val3" -> null
+        }
 
-        # (2 unchanged blocks hidden)
+        # (1 unchanged block hidden)
     }
 
 Plan: 0 to add, 1 to change, 0 to destroy.
@@ -33,12 +38,18 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
+          ~ [1]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
           - [2]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks[2]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/long_list_added_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/long_list_added_back.golden
@@ -55,7 +55,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + list_block {}
+      + prop {
+          + nested_prop = "value20"
+        }
 
         # (20 unchanged blocks hidden)
     }
@@ -69,12 +71,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
           + [20]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks[20]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[20]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/long_list_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/long_list_added_front.golden
@@ -55,9 +55,69 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + list_block {}
-
-        # (20 unchanged blocks hidden)
+      ~ prop {
+          ~ nested_prop = "value0" -> "value20"
+        }
+      ~ prop {
+          ~ nested_prop = "value1" -> "value0"
+        }
+      ~ prop {
+          ~ nested_prop = "value2" -> "value1"
+        }
+      ~ prop {
+          ~ nested_prop = "value3" -> "value2"
+        }
+      ~ prop {
+          ~ nested_prop = "value4" -> "value3"
+        }
+      ~ prop {
+          ~ nested_prop = "value5" -> "value4"
+        }
+      ~ prop {
+          ~ nested_prop = "value6" -> "value5"
+        }
+      ~ prop {
+          ~ nested_prop = "value7" -> "value6"
+        }
+      ~ prop {
+          ~ nested_prop = "value8" -> "value7"
+        }
+      ~ prop {
+          ~ nested_prop = "value9" -> "value8"
+        }
+      ~ prop {
+          ~ nested_prop = "value10" -> "value9"
+        }
+      ~ prop {
+          ~ nested_prop = "value11" -> "value10"
+        }
+      ~ prop {
+          ~ nested_prop = "value12" -> "value11"
+        }
+      ~ prop {
+          ~ nested_prop = "value13" -> "value12"
+        }
+      ~ prop {
+          ~ nested_prop = "value14" -> "value13"
+        }
+      ~ prop {
+          ~ nested_prop = "value15" -> "value14"
+        }
+      ~ prop {
+          ~ nested_prop = "value16" -> "value15"
+        }
+      ~ prop {
+          ~ nested_prop = "value17" -> "value16"
+        }
+      ~ prop {
+          ~ nested_prop = "value18" -> "value17"
+        }
+      ~ prop {
+          ~ nested_prop = "value19" -> "value18"
+        }
+      + prop {
+          + nested_prop = "value19"
+        }
     }
 
 Plan: 0 to add, 1 to change, 0 to destroy.
@@ -69,12 +129,94 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [1]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [2]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [3]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [4]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [5]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [6]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [7]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [8]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [9]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [10]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [11]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [12]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [13]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [14]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [15]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [16]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [17]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [18]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [19]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
           + [20]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks[20]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{
+		"props[0].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[10].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[11].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[12].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[13].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[14].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[15].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[16].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[17].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[18].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[19].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[20]":            map[string]interface{}{},
+		"props[2].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[4].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[5].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[6].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[7].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[8].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[9].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/long_list_removed_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/long_list_removed_back.golden
@@ -55,7 +55,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - list_block {}
+      - prop {
+          - nested_prop = "value20" -> null
+        }
 
         # (20 unchanged blocks hidden)
     }
@@ -69,12 +71,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
           - [20]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks[20]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[20]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/long_list_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/long_list_removed_front.golden
@@ -55,9 +55,69 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - list_block {}
-
-        # (20 unchanged blocks hidden)
+      ~ prop {
+          ~ nested_prop = "value20" -> "value0"
+        }
+      ~ prop {
+          ~ nested_prop = "value0" -> "value1"
+        }
+      ~ prop {
+          ~ nested_prop = "value1" -> "value2"
+        }
+      ~ prop {
+          ~ nested_prop = "value2" -> "value3"
+        }
+      ~ prop {
+          ~ nested_prop = "value3" -> "value4"
+        }
+      ~ prop {
+          ~ nested_prop = "value4" -> "value5"
+        }
+      ~ prop {
+          ~ nested_prop = "value5" -> "value6"
+        }
+      ~ prop {
+          ~ nested_prop = "value6" -> "value7"
+        }
+      ~ prop {
+          ~ nested_prop = "value7" -> "value8"
+        }
+      ~ prop {
+          ~ nested_prop = "value8" -> "value9"
+        }
+      ~ prop {
+          ~ nested_prop = "value9" -> "value10"
+        }
+      ~ prop {
+          ~ nested_prop = "value10" -> "value11"
+        }
+      ~ prop {
+          ~ nested_prop = "value11" -> "value12"
+        }
+      ~ prop {
+          ~ nested_prop = "value12" -> "value13"
+        }
+      ~ prop {
+          ~ nested_prop = "value13" -> "value14"
+        }
+      ~ prop {
+          ~ nested_prop = "value14" -> "value15"
+        }
+      ~ prop {
+          ~ nested_prop = "value15" -> "value16"
+        }
+      ~ prop {
+          ~ nested_prop = "value16" -> "value17"
+        }
+      ~ prop {
+          ~ nested_prop = "value17" -> "value18"
+        }
+      ~ prop {
+          ~ nested_prop = "value18" -> "value19"
+        }
+      - prop {
+          - nested_prop = "value19" -> null
+        }
     }
 
 Plan: 0 to add, 1 to change, 0 to destroy.
@@ -69,12 +129,94 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlocks: [
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [1]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [2]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [3]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [4]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [5]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [6]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [7]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [8]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [9]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [10]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [11]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [12]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [13]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [14]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [15]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [16]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [17]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [18]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [19]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
           - [20]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks[20]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{
+		"props[0].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[10].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[11].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[12].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[13].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[14].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[15].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[16].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[17].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[18].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[19].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[20]":            map[string]interface{}{"kind": "DELETE"},
+		"props[2].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[4].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[5].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[6].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[7].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[8].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[9].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/one_added,_one_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/one_added,_one_removed.golden
@@ -10,15 +10,54 @@ tests.testOutput{
 		"val4",
 	},
 	tfOut: `
-No changes. Your infrastructure matches the configuration.
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
 
-Terraform has compared your real infrastructure against your configuration
-and found no differences, so no changes are needed.
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      ~ prop {
+          ~ nested_prop = "val1" -> "val2"
+        }
+      ~ prop {
+          ~ nested_prop = "val2" -> "val3"
+        }
+      ~ prop {
+          ~ nested_prop = "val3" -> "val4"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [1]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+          ~ [2]: {
+                  ~ nestedProp: [secret] => [secret]
+                }
+        ]
 Resources:
-    2 unchanged
+    ~ 1 to update
+    1 unchanged
 `,
+	detailedDiff: map[string]interface{}{
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/removed_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_sensitive/removed_non-empty.golden
@@ -14,7 +14,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - list_block {}
+      - prop {
+          - nested_prop = "val1" -> null
+        }
     }
 
 Plan: 0 to add, 1 to change, 0 to destroy.
@@ -26,10 +28,10 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - listBlocks: [secret]
+      - props: [secret]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlocks": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/max_items_one_attribute/added_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/max_items_one_attribute/added_non-empty.golden
@@ -11,8 +11,8 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
-        id        = "newid"
-      + list_attr = [
+        id   = "newid"
+      + prop = [
           + "val1",
         ]
     }
@@ -26,10 +26,10 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + listAttr: "val1"
+      + prop: "val1"
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listAttr": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/max_items_one_attribute/changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/max_items_one_attribute/changed.golden
@@ -12,8 +12,8 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
-        id        = "newid"
-      ~ list_attr = [
+        id   = "newid"
+      ~ prop = [
           ~ "val1" -> "val2",
         ]
     }
@@ -27,10 +27,10 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listAttr: "val1" => "val2"
+      ~ prop: "val1" => "val2"
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listAttr": map[string]interface{}{"kind": "UPDATE"}},
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/max_items_one_attribute/removed_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/max_items_one_attribute/removed_non-empty.golden
@@ -12,8 +12,8 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
-        id        = "newid"
-      ~ list_attr = [
+        id   = "newid"
+      ~ prop = [
           - "val1",
         ]
     }
@@ -27,10 +27,10 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - listAttr: "val1"
+      - prop: "val1"
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listAttr": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/max_items_one_attribute_force_new/added_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/max_items_one_attribute_force_new/added_non-empty.golden
@@ -11,8 +11,8 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
-      ~ id        = "newid" -> (known after apply)
-      + list_attr = [ # forces replacement
+      ~ id   = "newid" -> (known after apply)
+      + prop = [ # forces replacement
           + "val1",
         ]
     }
@@ -26,10 +26,10 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + listAttr: "val1"
+      + prop: "val1"
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listAttr": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/max_items_one_attribute_force_new/changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/max_items_one_attribute_force_new/changed.golden
@@ -12,8 +12,8 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
-      ~ id        = "newid" -> (known after apply)
-      ~ list_attr = [ # forces replacement
+      ~ id   = "newid" -> (known after apply)
+      ~ prop = [ # forces replacement
           ~ "val1" -> "val2",
         ]
     }
@@ -27,10 +27,10 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listAttr: "val1" => "val2"
+      ~ prop: "val1" => "val2"
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listAttr": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/max_items_one_attribute_force_new/removed_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/max_items_one_attribute_force_new/removed_non-empty.golden
@@ -12,8 +12,8 @@ Terraform will perform the following actions:
 
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
-      ~ id        = "newid" -> (known after apply)
-      - list_attr = [ # forces replacement
+      ~ id   = "newid" -> (known after apply)
+      - prop = [ # forces replacement
           - "val1",
         ] -> null
     }
@@ -27,10 +27,10 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - listAttr: "val1"
+      - prop: "val1"
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listAttr": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/max_items_one_block/added_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/max_items_one_block/added_non-empty.golden
@@ -13,7 +13,7 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + list_block {
+      + prop {
           + nested_prop = "val1"
         }
     }
@@ -27,12 +27,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + listBlock: {
+      + prop: {
           + nestedProp: "val1"
         }
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlock": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/max_items_one_block/changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/max_items_one_block/changed.golden
@@ -14,7 +14,7 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = "val1" -> "val2"
         }
     }
@@ -28,12 +28,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlock: {
+      ~ prop: {
           ~ nestedProp: "val1" => "val2"
         }
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlock.nestedProp": map[string]interface{}{"kind": "UPDATE"}},
+	detailedDiff: map[string]interface{}{"prop.nestedProp": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/max_items_one_block/removed_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/max_items_one_block/removed_non-empty.golden
@@ -14,7 +14,7 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - list_block {
+      - prop {
           - nested_prop = "val1" -> null
         }
     }
@@ -28,12 +28,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - listBlock: {
+      - prop: {
           - nestedProp: "val1"
         }
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlock": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/max_items_one_block_force_new/added_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/max_items_one_block_force_new/added_non-empty.golden
@@ -13,7 +13,7 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      + list_block { # forces replacement
+      + prop { # forces replacement
           + nested_prop = "val1"
         }
     }
@@ -27,12 +27,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + listBlock: {
+      + prop: {
           + nestedProp: "val1"
         }
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlock": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/max_items_one_block_force_new/changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/max_items_one_block_force_new/changed.golden
@@ -14,7 +14,7 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = "val1" -> "val2"
         }
     }
@@ -28,12 +28,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlock: {
+      ~ prop: {
           ~ nestedProp: "val1" => "val2"
         }
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlock.nestedProp": map[string]interface{}{"kind": "UPDATE"}},
+	detailedDiff: map[string]interface{}{"prop.nestedProp": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/max_items_one_block_force_new/removed_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/max_items_one_block_force_new/removed_non-empty.golden
@@ -14,7 +14,7 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      - list_block { # forces replacement
+      - prop { # forces replacement
           - nested_prop = "val1" -> null
         }
     }
@@ -28,12 +28,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - listBlock: {
+      - prop: {
           - nestedProp: "val1"
         }
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlock": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/max_items_one_block_nested_force_new/added_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/max_items_one_block_nested_force_new/added_non-empty.golden
@@ -13,7 +13,7 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      + list_block {
+      + prop {
           + nested_prop = "val1" # forces replacement
         }
     }
@@ -27,12 +27,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + listBlock: {
+      + prop: {
           + nestedProp: "val1"
         }
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlock": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/max_items_one_block_nested_force_new/changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/max_items_one_block_nested_force_new/changed.golden
@@ -14,7 +14,7 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      ~ list_block {
+      ~ prop {
           ~ nested_prop = "val1" -> "val2" # forces replacement
         }
     }
@@ -28,12 +28,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ listBlock: {
+      ~ prop: {
           ~ nestedProp: "val1" => "val2"
         }
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlock.nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"prop.nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/max_items_one_block_nested_force_new/removed_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/max_items_one_block_nested_force_new/removed_non-empty.golden
@@ -14,7 +14,7 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      - list_block {
+      - prop {
           - nested_prop = "val1" -> null # forces replacement
         }
     }
@@ -28,12 +28,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - listBlock: {
+      - prop: {
           - nestedProp: "val1"
         }
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"listBlock": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"prop": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/added.golden
@@ -11,7 +11,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "newid" -> (known after apply)
-      + test = [ # forces replacement
+      + prop = [ # forces replacement
           + "value",
         ]
     }
@@ -25,12 +25,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
+      + props: [
       +     [0]: "value"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/added_end.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "newid" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           + "val3",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: "val3"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/added_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/added_end_unordered.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "newid" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           + "val1",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: "val1"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/added_front.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "newid" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           + "val1",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: "val1"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/added_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/added_front_unordered.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "newid" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           + "val2",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: "val2"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/added_middle.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "newid" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           + "val2",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: "val2"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/added_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/added_middle_unordered.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "newid" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           + "val3",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: "val3"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/changed_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/changed_non-null.golden
@@ -13,7 +13,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "newid" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           - "value",
           + "value1",
         ]
@@ -28,12 +28,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: "value" => "value1"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/changed_non-null_to_null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/changed_non-null_to_null.golden
@@ -13,7 +13,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "newid" -> (known after apply)
-      - test = [ # forces replacement
+      - prop = [ # forces replacement
           - "value",
         ] -> null
     }
@@ -27,12 +27,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - tests: [
+      - props: [
       -     [0]: "value"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/changed_null_to_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/changed_null_to_non-null.golden
@@ -12,7 +12,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "newid" -> (known after apply)
-      + test = [ # forces replacement
+      + prop = [ # forces replacement
           + "value",
         ]
     }
@@ -26,12 +26,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
+      + props: [
       +     [0]: "value"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/removed.golden
@@ -13,7 +13,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "newid" -> (known after apply)
-      - test = [ # forces replacement
+      - prop = [ # forces replacement
           - "value",
         ] -> null
     }
@@ -27,12 +27,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - tests: [
+      - props: [
       -     [0]: "value"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/removed_end.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "newid" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           - "val3",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: "val3"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/removed_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/removed_end_unordered.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "newid" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           - "val1",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: "val1"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/removed_front.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "newid" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           - "val1",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: "val1"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/removed_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/removed_front_unordered.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "newid" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           - "val2",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: "val2"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/removed_middle.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "newid" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           - "val2",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: "val2"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/removed_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/removed_middle_unordered.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "newid" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           - "val2",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: "val2"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/same_element_updated.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/same_element_updated.golden
@@ -19,7 +19,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "newid" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           - "val2",
           + "val4",
             # (2 unchanged elements hidden)
@@ -35,12 +35,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [1]: "val2" => "val4"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/same_element_updated_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/same_element_updated_unordered.golden
@@ -19,7 +19,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "newid" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           - "val3",
           + "val4",
             # (2 unchanged elements hidden)
@@ -35,7 +35,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: "val4"
           - [2]: "val3"
         ]
@@ -44,7 +44,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/shuffled_added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/shuffled_added_end.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "newid" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           + "val3",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: "val3"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/shuffled_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/shuffled_added_front.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "newid" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           + "val1",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: "val1"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/shuffled_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/shuffled_added_middle.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "newid" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           + "val2",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: "val2"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/shuffled_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/shuffled_removed_end.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "newid" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           - "val3",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: "val3"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/shuffled_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/shuffled_removed_front.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "newid" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           - "val1",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: "val1"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/shuffled_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/shuffled_removed_middle.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "newid" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           - "val2",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: "val2"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/two_added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/two_added.golden
@@ -19,7 +19,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "newid" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           + "val3",
           + "val4",
             # (2 unchanged elements hidden)
@@ -35,7 +35,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: "val3"
           + [3]: "val4"
         ]
@@ -44,7 +44,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[3]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[3]": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/two_added_and_two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/two_added_and_two_removed.golden
@@ -21,7 +21,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "newid" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           - "val3",
           - "val4",
           + "val5",
@@ -39,7 +39,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [2]: "val3" => "val5"
           ~ [3]: "val4" => "val6"
         ]
@@ -48,7 +48,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[3]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -21,7 +21,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "newid" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           - "val3",
           - "val4",
           + "val5",
@@ -39,7 +39,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: "val5"
           + [1]: "val6"
           - [2]: "val3"
@@ -50,9 +50,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -21,7 +21,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "newid" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           - "val3",
           - "val4",
           + "val5",
@@ -39,7 +39,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: "val5"
           ~ [2]: "val3" => "val6"
           - [3]: "val4"
@@ -49,8 +49,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[2]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -23,7 +23,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "newid" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           - "val3",
           - "val4",
           + "val5",
@@ -41,7 +41,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: "val5"
           ~ [2]: "val3" => "val6"
           - [3]: "val4"
@@ -51,8 +51,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[2]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_force_new/two_removed.golden
@@ -19,7 +19,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "newid" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           - "val3",
           - "val4",
             # (2 unchanged elements hidden)
@@ -35,7 +35,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: "val3"
           - [3]: "val4"
         ]
@@ -44,7 +44,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/added.golden
@@ -11,7 +11,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "newid"
-      + test = [
+      + prop = [
           + "value",
         ]
     }
@@ -25,12 +25,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
+      + props: [
       +     [0]: "value"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/added_end.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "newid"
-      ~ test = [
+      ~ prop = [
           + "val3",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: "val3"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/added_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/added_end_unordered.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "newid"
-      ~ test = [
+      ~ prop = [
           + "val1",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: "val1"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/added_front.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "newid"
-      ~ test = [
+      ~ prop = [
           + "val1",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: "val1"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/added_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/added_front_unordered.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "newid"
-      ~ test = [
+      ~ prop = [
           + "val2",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: "val2"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/added_middle.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "newid"
-      ~ test = [
+      ~ prop = [
           + "val2",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: "val2"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/added_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/added_middle_unordered.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "newid"
-      ~ test = [
+      ~ prop = [
           + "val3",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: "val3"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/changed_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/changed_non-null.golden
@@ -13,7 +13,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "newid"
-      ~ test = [
+      ~ prop = [
           - "value",
           + "value1",
         ]
@@ -28,12 +28,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: "value" => "value1"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "UPDATE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/changed_non-null_to_null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/changed_non-null_to_null.golden
@@ -13,7 +13,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "newid"
-      ~ test = [
+      ~ prop = [
           - "value",
         ]
     }
@@ -27,12 +27,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - tests: [
+      - props: [
       -     [0]: "value"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/changed_null_to_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/changed_null_to_non-null.golden
@@ -12,7 +12,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "newid"
-      + test = [
+      + prop = [
           + "value",
         ]
     }
@@ -26,12 +26,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
+      + props: [
       +     [0]: "value"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/removed.golden
@@ -13,7 +13,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "newid"
-      ~ test = [
+      ~ prop = [
           - "value",
         ]
     }
@@ -27,12 +27,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - tests: [
+      - props: [
       -     [0]: "value"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/removed_end.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "newid"
-      ~ test = [
+      ~ prop = [
           - "val3",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: "val3"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/removed_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/removed_end_unordered.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "newid"
-      ~ test = [
+      ~ prop = [
           - "val1",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: "val1"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/removed_front.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "newid"
-      ~ test = [
+      ~ prop = [
           - "val1",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: "val1"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/removed_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/removed_front_unordered.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "newid"
-      ~ test = [
+      ~ prop = [
           - "val2",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: "val2"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/removed_middle.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "newid"
-      ~ test = [
+      ~ prop = [
           - "val2",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: "val2"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/removed_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/removed_middle_unordered.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "newid"
-      ~ test = [
+      ~ prop = [
           - "val2",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: "val2"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/same_element_updated.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/same_element_updated.golden
@@ -19,7 +19,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "newid"
-      ~ test = [
+      ~ prop = [
           - "val2",
           + "val4",
             # (2 unchanged elements hidden)
@@ -35,12 +35,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [1]: "val2" => "val4"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "UPDATE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/same_element_updated_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/same_element_updated_unordered.golden
@@ -19,7 +19,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "newid"
-      ~ test = [
+      ~ prop = [
           - "val3",
           + "val4",
             # (2 unchanged elements hidden)
@@ -35,7 +35,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: "val4"
           - [2]: "val3"
         ]
@@ -44,7 +44,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]": map[string]interface{}{},
-		"tests[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[1]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/shuffled_added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/shuffled_added_end.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "newid"
-      ~ test = [
+      ~ prop = [
           + "val3",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: "val3"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/shuffled_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/shuffled_added_front.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "newid"
-      ~ test = [
+      ~ prop = [
           + "val1",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: "val1"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/shuffled_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/shuffled_added_middle.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "newid"
-      ~ test = [
+      ~ prop = [
           + "val2",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: "val2"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/shuffled_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/shuffled_removed_end.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "newid"
-      ~ test = [
+      ~ prop = [
           - "val3",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: "val3"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/shuffled_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/shuffled_removed_front.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "newid"
-      ~ test = [
+      ~ prop = [
           - "val1",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: "val1"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/shuffled_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/shuffled_removed_middle.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "newid"
-      ~ test = [
+      ~ prop = [
           - "val2",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: "val2"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/two_added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/two_added.golden
@@ -19,7 +19,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "newid"
-      ~ test = [
+      ~ prop = [
           + "val3",
           + "val4",
             # (2 unchanged elements hidden)
@@ -35,7 +35,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: "val3"
           + [3]: "val4"
         ]
@@ -44,7 +44,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{},
-		"tests[3]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{},
+		"props[3]": map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/two_added_and_two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/two_added_and_two_removed.golden
@@ -21,7 +21,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "newid"
-      ~ test = [
+      ~ prop = [
           - "val3",
           - "val4",
           + "val5",
@@ -39,7 +39,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [2]: "val3" => "val5"
           ~ [3]: "val4" => "val6"
         ]
@@ -48,7 +48,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]": map[string]interface{}{"kind": "UPDATE"},
+		"props[3]": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -21,7 +21,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "newid"
-      ~ test = [
+      ~ prop = [
           - "val3",
           - "val4",
           + "val5",
@@ -39,7 +39,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: "val5"
           + [1]: "val6"
           - [2]: "val3"
@@ -50,9 +50,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0]": map[string]interface{}{},
-		"tests[1]": map[string]interface{}{},
-		"tests[2]": map[string]interface{}{"kind": "DELETE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE"},
+		"props[0]": map[string]interface{}{},
+		"props[1]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -21,7 +21,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "newid"
-      ~ test = [
+      ~ prop = [
           - "val3",
           - "val4",
           + "val5",
@@ -39,7 +39,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: "val5"
           ~ [2]: "val3" => "val6"
           - [3]: "val4"
@@ -49,8 +49,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]": map[string]interface{}{},
-		"tests[2]": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE"},
+		"props[1]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{"kind": "UPDATE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -23,7 +23,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "newid"
-      ~ test = [
+      ~ prop = [
           - "val3",
           - "val4",
           + "val5",
@@ -41,7 +41,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: "val5"
           ~ [2]: "val3" => "val6"
           - [3]: "val4"
@@ -51,8 +51,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]": map[string]interface{}{},
-		"tests[2]": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE"},
+		"props[1]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{"kind": "UPDATE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetAttribute/attribute_no_force_new/two_removed.golden
@@ -19,7 +19,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "newid"
-      ~ test = [
+      ~ prop = [
           - "val3",
           - "val4",
             # (2 unchanged elements hidden)
@@ -35,7 +35,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: "val3"
           - [3]: "val4"
         ]
@@ -44,7 +44,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{"kind": "DELETE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/added.golden
@@ -12,8 +12,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      + test { # forces replacement
-          + nested = "value"
+      + prop { # forces replacement
+          + nested_prop = "value"
         }
     }
 
@@ -26,14 +26,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
+      + props: [
       +     [0]: {
-              + nested    : "value"
+              + nestedProp: "value"
             }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/added_end.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      + test { # forces replacement
-          + nested = "val3"
+      + prop { # forces replacement
+          + nested_prop = "val3"
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/added_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/added_end_unordered.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      + test { # forces replacement
-          + nested = "val1"
+      + prop { # forces replacement
+          + nested_prop = "val1"
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: {
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/added_front.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      + test { # forces replacement
-          + nested = "val1"
+      + prop { # forces replacement
+          + nested_prop = "val1"
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: {
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/added_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/added_front_unordered.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      + test { # forces replacement
-          + nested = "val2"
+      + prop { # forces replacement
+          + nested_prop = "val2"
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: {
-                  + nested    : "val2"
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/added_middle.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      + test { # forces replacement
-          + nested = "val2"
+      + prop { # forces replacement
+          + nested_prop = "val2"
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
-                  + nested    : "val2"
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/added_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/added_middle_unordered.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      + test { # forces replacement
-          + nested = "val3"
+      + prop { # forces replacement
+          + nested_prop = "val3"
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/changed_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/changed_non-null.golden
@@ -14,11 +14,11 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      - test { # forces replacement
-          - nested = "value" -> null
+      - prop { # forces replacement
+          - nested_prop = "value" -> null
         }
-      + test { # forces replacement
-          + nested = "value1"
+      + prop { # forces replacement
+          + nested_prop = "value1"
         }
     }
 
@@ -31,14 +31,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested: "value" => "value1"
+                  ~ nestedProp: "value" => "value1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0].nested": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/changed_non-null_to_null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/changed_non-null_to_null.golden
@@ -14,8 +14,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      - test { # forces replacement
-          - nested = "value" -> null
+      - prop { # forces replacement
+          - nested_prop = "value" -> null
         }
     }
 
@@ -28,14 +28,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - tests: [
+      - props: [
       -     [0]: {
-              - nested: "value"
+              - nestedProp: "value"
             }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/changed_null_to_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/changed_null_to_non-null.golden
@@ -13,8 +13,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      + test { # forces replacement
-          + nested = "value"
+      + prop { # forces replacement
+          + nested_prop = "value"
         }
     }
 
@@ -27,14 +27,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
+      + props: [
       +     [0]: {
-              + nested    : "value"
+              + nestedProp: "value"
             }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/removed.golden
@@ -14,8 +14,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      - test { # forces replacement
-          - nested = "value" -> null
+      - prop { # forces replacement
+          - nested_prop = "value" -> null
         }
     }
 
@@ -28,14 +28,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - tests: [
+      - props: [
       -     [0]: {
-              - nested: "value"
+              - nestedProp: "value"
             }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/removed_end.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      - test { # forces replacement
-          - nested = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: {
-                  - nested: "val3"
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/removed_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/removed_end_unordered.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      - test { # forces replacement
-          - nested = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: {
-                  - nested: "val1"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/removed_front.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      - test { # forces replacement
-          - nested = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: {
-                  - nested: "val1"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/removed_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/removed_front_unordered.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      - test { # forces replacement
-          - nested = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: {
-                  - nested: "val2"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/removed_middle.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      - test { # forces replacement
-          - nested = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: {
-                  - nested: "val2"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/removed_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/removed_middle_unordered.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      - test { # forces replacement
-          - nested = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: {
-                  - nested: "val2"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/same_element_updated.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/same_element_updated.golden
@@ -20,11 +20,11 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      - test { # forces replacement
-          - nested = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
         }
-      + test { # forces replacement
-          + nested = "val4"
+      + prop { # forces replacement
+          + nested_prop = "val4"
         }
 
         # (2 unchanged blocks hidden)
@@ -39,14 +39,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [1]: {
-                  ~ nested: "val2" => "val4"
+                  ~ nestedProp: "val2" => "val4"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1].nested": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/same_element_updated_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/same_element_updated_unordered.golden
@@ -20,11 +20,11 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      - test { # forces replacement
-          - nested = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
         }
-      + test { # forces replacement
-          + nested = "val4"
+      + prop { # forces replacement
+          + nested_prop = "val4"
         }
 
         # (2 unchanged blocks hidden)
@@ -39,12 +39,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
-                  + nested    : "val4"
+                  + nestedProp: "val4"
                 }
           - [2]: {
-                  - nested: "val3"
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -52,7 +52,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/shuffled_added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/shuffled_added_end.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      + test { # forces replacement
-          + nested = "val3"
+      + prop { # forces replacement
+          + nested_prop = "val3"
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/shuffled_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/shuffled_added_front.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      + test { # forces replacement
-          + nested = "val1"
+      + prop { # forces replacement
+          + nested_prop = "val1"
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: {
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/shuffled_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/shuffled_added_middle.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      + test { # forces replacement
-          + nested = "val2"
+      + prop { # forces replacement
+          + nested_prop = "val2"
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
-                  + nested    : "val2"
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/shuffled_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/shuffled_removed_end.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      - test { # forces replacement
-          - nested = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: {
-                  - nested: "val3"
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/shuffled_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/shuffled_removed_front.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      - test { # forces replacement
-          - nested = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: {
-                  - nested: "val1"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/shuffled_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/shuffled_removed_middle.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      - test { # forces replacement
-          - nested = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: {
-                  - nested: "val2"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/two_added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/two_added.golden
@@ -20,11 +20,11 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      + test { # forces replacement
-          + nested = "val3"
+      + prop { # forces replacement
+          + nested_prop = "val3"
         }
-      + test { # forces replacement
-          + nested = "val4"
+      + prop { # forces replacement
+          + nested_prop = "val4"
         }
 
         # (2 unchanged blocks hidden)
@@ -39,12 +39,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
           + [3]: {
-                  + nested    : "val4"
+                  + nestedProp: "val4"
                 }
         ]
 Resources:
@@ -52,7 +52,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[3]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[3]": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/two_added_and_two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/two_added_and_two_removed.golden
@@ -22,17 +22,17 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      - test { # forces replacement
-          - nested = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
         }
-      - test { # forces replacement
-          - nested = "val4" -> null
+      - prop { # forces replacement
+          - nested_prop = "val4" -> null
         }
-      + test { # forces replacement
-          + nested = "val5"
+      + prop { # forces replacement
+          + nested_prop = "val5"
         }
-      + test { # forces replacement
-          + nested = "val6"
+      + prop { # forces replacement
+          + nested_prop = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -47,12 +47,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [2]: {
-                  ~ nested: "val3" => "val5"
+                  ~ nestedProp: "val3" => "val5"
                 }
           ~ [3]: {
-                  ~ nested: "val4" => "val6"
+                  ~ nestedProp: "val4" => "val6"
                 }
         ]
 Resources:
@@ -60,7 +60,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2].nested": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3].nested": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -22,17 +22,17 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      - test { # forces replacement
-          - nested = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
         }
-      - test { # forces replacement
-          - nested = "val4" -> null
+      - prop { # forces replacement
+          - nested_prop = "val4" -> null
         }
-      + test { # forces replacement
-          + nested = "val5"
+      + prop { # forces replacement
+          + nested_prop = "val5"
         }
-      + test { # forces replacement
-          + nested = "val6"
+      + prop { # forces replacement
+          + nested_prop = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -47,18 +47,18 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: {
-                  + nested    : "val5"
+                  + nestedProp: "val5"
                 }
           + [1]: {
-                  + nested    : "val6"
+                  + nestedProp: "val6"
                 }
           - [2]: {
-                  - nested: "val3"
+                  - nestedProp: "val3"
                 }
           - [3]: {
-                  - nested: "val4"
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -66,9 +66,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -22,17 +22,17 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      - test { # forces replacement
-          - nested = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
         }
-      - test { # forces replacement
-          - nested = "val4" -> null
+      - prop { # forces replacement
+          - nested_prop = "val4" -> null
         }
-      + test { # forces replacement
-          + nested = "val5"
+      + prop { # forces replacement
+          + nested_prop = "val5"
         }
-      + test { # forces replacement
-          + nested = "val6"
+      + prop { # forces replacement
+          + nested_prop = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -47,15 +47,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
-                  + nested    : "val5"
+                  + nestedProp: "val5"
                 }
           ~ [2]: {
-                  ~ nested: "val3" => "val6"
+                  ~ nestedProp: "val3" => "val6"
                 }
           - [3]: {
-                  - nested: "val4"
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -63,8 +63,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]":        map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[2].nested": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3]":        map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[1]":            map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[3]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -24,17 +24,17 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      - test { # forces replacement
-          - nested = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
         }
-      - test { # forces replacement
-          - nested = "val4" -> null
+      - prop { # forces replacement
+          - nested_prop = "val4" -> null
         }
-      + test { # forces replacement
-          + nested = "val5"
+      + prop { # forces replacement
+          + nested_prop = "val5"
         }
-      + test { # forces replacement
-          + nested = "val6"
+      + prop { # forces replacement
+          + nested_prop = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -49,15 +49,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
-                  + nested    : "val5"
+                  + nestedProp: "val5"
                 }
           ~ [2]: {
-                  ~ nested: "val3" => "val6"
+                  ~ nestedProp: "val3" => "val6"
                 }
           - [3]: {
-                  - nested: "val4"
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -65,8 +65,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]":        map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[2].nested": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3]":        map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[1]":            map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[3]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_nested_force_new/two_removed.golden
@@ -20,11 +20,11 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      - test { # forces replacement
-          - nested = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
         }
-      - test { # forces replacement
-          - nested = "val4" -> null
+      - prop { # forces replacement
+          - nested_prop = "val4" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -39,12 +39,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: {
-                  - nested: "val3"
+                  - nestedProp: "val3"
                 }
           - [3]: {
-                  - nested: "val4"
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -52,7 +52,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/added.golden
@@ -12,8 +12,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + test {
-          + nested = "value"
+      + prop {
+          + nested_prop = "value"
         }
     }
 
@@ -26,14 +26,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
+      + props: [
       +     [0]: {
-              + nested    : "value"
+              + nestedProp: "value"
             }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/added_end.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + test {
-          + nested = "val3"
+      + prop {
+          + nested_prop = "val3"
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/added_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/added_end_unordered.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + test {
-          + nested = "val1"
+      + prop {
+          + nested_prop = "val1"
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: {
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/added_front.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + test {
-          + nested = "val1"
+      + prop {
+          + nested_prop = "val1"
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: {
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/added_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/added_front_unordered.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + test {
-          + nested = "val2"
+      + prop {
+          + nested_prop = "val2"
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: {
-                  + nested    : "val2"
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/added_middle.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + test {
-          + nested = "val2"
+      + prop {
+          + nested_prop = "val2"
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
-                  + nested    : "val2"
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/added_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/added_middle_unordered.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + test {
-          + nested = "val3"
+      + prop {
+          + nested_prop = "val3"
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/changed_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/changed_non-null.golden
@@ -14,11 +14,11 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "value" -> null
+      - prop {
+          - nested_prop = "value" -> null
         }
-      + test {
-          + nested = "value1"
+      + prop {
+          + nested_prop = "value1"
         }
     }
 
@@ -31,14 +31,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested: "value" => "value1"
+                  ~ nestedProp: "value" => "value1"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0].nested": map[string]interface{}{"kind": "UPDATE"}},
+	detailedDiff: map[string]interface{}{"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/changed_non-null_to_null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/changed_non-null_to_null.golden
@@ -14,8 +14,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "value" -> null
+      - prop {
+          - nested_prop = "value" -> null
         }
     }
 
@@ -28,14 +28,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - tests: [
+      - props: [
       -     [0]: {
-              - nested: "value"
+              - nestedProp: "value"
             }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/changed_null_to_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/changed_null_to_non-null.golden
@@ -13,8 +13,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + test {
-          + nested = "value"
+      + prop {
+          + nested_prop = "value"
         }
     }
 
@@ -27,14 +27,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
+      + props: [
       +     [0]: {
-              + nested    : "value"
+              + nestedProp: "value"
             }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/removed.golden
@@ -14,8 +14,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "value" -> null
+      - prop {
+          - nested_prop = "value" -> null
         }
     }
 
@@ -28,14 +28,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - tests: [
+      - props: [
       -     [0]: {
-              - nested: "value"
+              - nestedProp: "value"
             }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/removed_end.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: {
-                  - nested: "val3"
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/removed_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/removed_end_unordered.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: {
-                  - nested: "val1"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/removed_front.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: {
-                  - nested: "val1"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/removed_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/removed_front_unordered.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: {
-                  - nested: "val2"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/removed_middle.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: {
-                  - nested: "val2"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/removed_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/removed_middle_unordered.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: {
-                  - nested: "val2"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/same_element_updated.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/same_element_updated.golden
@@ -20,11 +20,11 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
         }
-      + test {
-          + nested = "val4"
+      + prop {
+          + nested_prop = "val4"
         }
 
         # (2 unchanged blocks hidden)
@@ -39,14 +39,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [1]: {
-                  ~ nested: "val2" => "val4"
+                  ~ nestedProp: "val2" => "val4"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1].nested": map[string]interface{}{"kind": "UPDATE"}},
+	detailedDiff: map[string]interface{}{"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/same_element_updated_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/same_element_updated_unordered.golden
@@ -20,11 +20,11 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
         }
-      + test {
-          + nested = "val4"
+      + prop {
+          + nested_prop = "val4"
         }
 
         # (2 unchanged blocks hidden)
@@ -39,12 +39,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
-                  + nested    : "val4"
+                  + nestedProp: "val4"
                 }
           - [2]: {
-                  - nested: "val3"
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -52,7 +52,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]": map[string]interface{}{},
-		"tests[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[1]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/shuffled_added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/shuffled_added_end.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + test {
-          + nested = "val3"
+      + prop {
+          + nested_prop = "val3"
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/shuffled_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/shuffled_added_front.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + test {
-          + nested = "val1"
+      + prop {
+          + nested_prop = "val1"
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: {
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/shuffled_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/shuffled_added_middle.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + test {
-          + nested = "val2"
+      + prop {
+          + nested_prop = "val2"
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
-                  + nested    : "val2"
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/shuffled_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/shuffled_removed_end.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: {
-                  - nested: "val3"
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/shuffled_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/shuffled_removed_front.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: {
-                  - nested: "val1"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/shuffled_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/shuffled_removed_middle.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: {
-                  - nested: "val2"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/two_added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/two_added.golden
@@ -20,11 +20,11 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + test {
-          + nested = "val3"
+      + prop {
+          + nested_prop = "val3"
         }
-      + test {
-          + nested = "val4"
+      + prop {
+          + nested_prop = "val4"
         }
 
         # (2 unchanged blocks hidden)
@@ -39,12 +39,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
           + [3]: {
-                  + nested    : "val4"
+                  + nestedProp: "val4"
                 }
         ]
 Resources:
@@ -52,7 +52,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{},
-		"tests[3]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{},
+		"props[3]": map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/two_added_and_two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/two_added_and_two_removed.golden
@@ -22,17 +22,17 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
         }
-      - test {
-          - nested = "val4" -> null
+      - prop {
+          - nested_prop = "val4" -> null
         }
-      + test {
-          + nested = "val5"
+      + prop {
+          + nested_prop = "val5"
         }
-      + test {
-          + nested = "val6"
+      + prop {
+          + nested_prop = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -47,12 +47,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [2]: {
-                  ~ nested: "val3" => "val5"
+                  ~ nestedProp: "val3" => "val5"
                 }
           ~ [3]: {
-                  ~ nested: "val4" => "val6"
+                  ~ nestedProp: "val4" => "val6"
                 }
         ]
 Resources:
@@ -60,7 +60,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested": map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -22,17 +22,17 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
         }
-      - test {
-          - nested = "val4" -> null
+      - prop {
+          - nested_prop = "val4" -> null
         }
-      + test {
-          + nested = "val5"
+      + prop {
+          + nested_prop = "val5"
         }
-      + test {
-          + nested = "val6"
+      + prop {
+          + nested_prop = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -47,18 +47,18 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: {
-                  + nested    : "val5"
+                  + nestedProp: "val5"
                 }
           + [1]: {
-                  + nested    : "val6"
+                  + nestedProp: "val6"
                 }
           - [2]: {
-                  - nested: "val3"
+                  - nestedProp: "val3"
                 }
           - [3]: {
-                  - nested: "val4"
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -66,9 +66,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0]": map[string]interface{}{},
-		"tests[1]": map[string]interface{}{},
-		"tests[2]": map[string]interface{}{"kind": "DELETE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE"},
+		"props[0]": map[string]interface{}{},
+		"props[1]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -22,17 +22,17 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
         }
-      - test {
-          - nested = "val4" -> null
+      - prop {
+          - nested_prop = "val4" -> null
         }
-      + test {
-          + nested = "val5"
+      + prop {
+          + nested_prop = "val5"
         }
-      + test {
-          + nested = "val6"
+      + prop {
+          + nested_prop = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -47,15 +47,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
-                  + nested    : "val5"
+                  + nestedProp: "val5"
                 }
           ~ [2]: {
-                  ~ nested: "val3" => "val6"
+                  ~ nestedProp: "val3" => "val6"
                 }
           - [3]: {
-                  - nested: "val4"
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -63,8 +63,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]":        map[string]interface{}{},
-		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]":        map[string]interface{}{"kind": "DELETE"},
+		"props[1]":            map[string]interface{}{},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -24,17 +24,17 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
         }
-      - test {
-          - nested = "val4" -> null
+      - prop {
+          - nested_prop = "val4" -> null
         }
-      + test {
-          + nested = "val5"
+      + prop {
+          + nested_prop = "val5"
         }
-      + test {
-          + nested = "val6"
+      + prop {
+          + nested_prop = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -49,15 +49,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
-                  + nested    : "val5"
+                  + nestedProp: "val5"
                 }
           ~ [2]: {
-                  ~ nested: "val3" => "val6"
+                  ~ nestedProp: "val3" => "val6"
                 }
           - [3]: {
-                  - nested: "val4"
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -65,8 +65,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]":        map[string]interface{}{},
-		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]":        map[string]interface{}{"kind": "DELETE"},
+		"props[1]":            map[string]interface{}{},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_no_force_new/two_removed.golden
@@ -20,11 +20,11 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
         }
-      - test {
-          - nested = "val4" -> null
+      - prop {
+          - nested_prop = "val4" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -39,12 +39,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: {
-                  - nested: "val3"
+                  - nestedProp: "val3"
                 }
           - [3]: {
-                  - nested: "val4"
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -52,7 +52,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{"kind": "DELETE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/added.golden
@@ -12,8 +12,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      + test { # forces replacement
-          + nested = "value"
+      + prop { # forces replacement
+          + nested_prop = "value"
         }
     }
 
@@ -26,14 +26,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
+      + props: [
       +     [0]: {
-              + nested    : "value"
+              + nestedProp: "value"
             }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/added_end.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      + test { # forces replacement
-          + nested = "val3"
+      + prop { # forces replacement
+          + nested_prop = "val3"
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/added_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/added_end_unordered.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      + test { # forces replacement
-          + nested = "val1"
+      + prop { # forces replacement
+          + nested_prop = "val1"
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: {
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/added_front.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      + test { # forces replacement
-          + nested = "val1"
+      + prop { # forces replacement
+          + nested_prop = "val1"
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: {
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/added_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/added_front_unordered.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      + test { # forces replacement
-          + nested = "val2"
+      + prop { # forces replacement
+          + nested_prop = "val2"
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: {
-                  + nested    : "val2"
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/added_middle.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      + test { # forces replacement
-          + nested = "val2"
+      + prop { # forces replacement
+          + nested_prop = "val2"
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
-                  + nested    : "val2"
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/added_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/added_middle_unordered.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      + test { # forces replacement
-          + nested = "val3"
+      + prop { # forces replacement
+          + nested_prop = "val3"
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/changed_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/changed_non-null.golden
@@ -14,11 +14,11 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "value" -> null
+      - prop {
+          - nested_prop = "value" -> null
         }
-      + test {
-          + nested = "value1"
+      + prop {
+          + nested_prop = "value1"
         }
     }
 
@@ -31,14 +31,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested: "value" => "value1"
+                  ~ nestedProp: "value" => "value1"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0].nested": map[string]interface{}{"kind": "UPDATE"}},
+	detailedDiff: map[string]interface{}{"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/changed_non-null_to_null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/changed_non-null_to_null.golden
@@ -14,8 +14,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      - test { # forces replacement
-          - nested = "value" -> null
+      - prop { # forces replacement
+          - nested_prop = "value" -> null
         }
     }
 
@@ -28,14 +28,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - tests: [
+      - props: [
       -     [0]: {
-              - nested: "value"
+              - nestedProp: "value"
             }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/changed_null_to_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/changed_null_to_non-null.golden
@@ -13,8 +13,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      + test { # forces replacement
-          + nested = "value"
+      + prop { # forces replacement
+          + nested_prop = "value"
         }
     }
 
@@ -27,14 +27,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
+      + props: [
       +     [0]: {
-              + nested    : "value"
+              + nestedProp: "value"
             }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/removed.golden
@@ -14,8 +14,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      - test { # forces replacement
-          - nested = "value" -> null
+      - prop { # forces replacement
+          - nested_prop = "value" -> null
         }
     }
 
@@ -28,14 +28,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - tests: [
+      - props: [
       -     [0]: {
-              - nested: "value"
+              - nestedProp: "value"
             }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/removed_end.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      - test { # forces replacement
-          - nested = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: {
-                  - nested: "val3"
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/removed_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/removed_end_unordered.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      - test { # forces replacement
-          - nested = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: {
-                  - nested: "val1"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/removed_front.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      - test { # forces replacement
-          - nested = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: {
-                  - nested: "val1"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/removed_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/removed_front_unordered.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      - test { # forces replacement
-          - nested = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: {
-                  - nested: "val2"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/removed_middle.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      - test { # forces replacement
-          - nested = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: {
-                  - nested: "val2"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/removed_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/removed_middle_unordered.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      - test { # forces replacement
-          - nested = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: {
-                  - nested: "val2"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/same_element_updated.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/same_element_updated.golden
@@ -20,11 +20,11 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
         }
-      + test {
-          + nested = "val4"
+      + prop {
+          + nested_prop = "val4"
         }
 
         # (2 unchanged blocks hidden)
@@ -39,14 +39,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [1]: {
-                  ~ nested: "val2" => "val4"
+                  ~ nestedProp: "val2" => "val4"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1].nested": map[string]interface{}{"kind": "UPDATE"}},
+	detailedDiff: map[string]interface{}{"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/same_element_updated_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/same_element_updated_unordered.golden
@@ -20,11 +20,11 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
         }
-      + test {
-          + nested = "val4"
+      + prop {
+          + nested_prop = "val4"
         }
 
         # (2 unchanged blocks hidden)
@@ -39,12 +39,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
-                  + nested    : "val4"
+                  + nestedProp: "val4"
                 }
           - [2]: {
-                  - nested: "val3"
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -52,7 +52,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]": map[string]interface{}{},
-		"tests[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[1]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/shuffled_added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/shuffled_added_end.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      + test { # forces replacement
-          + nested = "val3"
+      + prop { # forces replacement
+          + nested_prop = "val3"
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/shuffled_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/shuffled_added_front.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      + test { # forces replacement
-          + nested = "val1"
+      + prop { # forces replacement
+          + nested_prop = "val1"
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: {
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/shuffled_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/shuffled_added_middle.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      + test { # forces replacement
-          + nested = "val2"
+      + prop { # forces replacement
+          + nested_prop = "val2"
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
-                  + nested    : "val2"
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/shuffled_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/shuffled_removed_end.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      - test { # forces replacement
-          - nested = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: {
-                  - nested: "val3"
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/shuffled_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/shuffled_removed_front.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      - test { # forces replacement
-          - nested = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: {
-                  - nested: "val1"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/shuffled_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/shuffled_removed_middle.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      - test { # forces replacement
-          - nested = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -35,14 +35,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: {
-                  - nested: "val2"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/two_added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/two_added.golden
@@ -20,11 +20,11 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      + test { # forces replacement
-          + nested = "val3"
+      + prop { # forces replacement
+          + nested_prop = "val3"
         }
-      + test { # forces replacement
-          + nested = "val4"
+      + prop { # forces replacement
+          + nested_prop = "val4"
         }
 
         # (2 unchanged blocks hidden)
@@ -39,12 +39,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
           + [3]: {
-                  + nested    : "val4"
+                  + nestedProp: "val4"
                 }
         ]
 Resources:
@@ -52,7 +52,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[3]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[3]": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/two_added_and_two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/two_added_and_two_removed.golden
@@ -22,17 +22,17 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
         }
-      - test {
-          - nested = "val4" -> null
+      - prop {
+          - nested_prop = "val4" -> null
         }
-      + test {
-          + nested = "val5"
+      + prop {
+          + nested_prop = "val5"
         }
-      + test {
-          + nested = "val6"
+      + prop {
+          + nested_prop = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -47,12 +47,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [2]: {
-                  ~ nested: "val3" => "val5"
+                  ~ nestedProp: "val3" => "val5"
                 }
           ~ [3]: {
-                  ~ nested: "val4" => "val6"
+                  ~ nestedProp: "val4" => "val6"
                 }
         ]
 Resources:
@@ -60,7 +60,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested": map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -22,17 +22,17 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
         }
-      - test {
-          - nested = "val4" -> null
+      - prop {
+          - nested_prop = "val4" -> null
         }
-      + test {
-          + nested = "val5"
+      + prop {
+          + nested_prop = "val5"
         }
-      + test {
-          + nested = "val6"
+      + prop {
+          + nested_prop = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -47,18 +47,18 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: {
-                  + nested    : "val5"
+                  + nestedProp: "val5"
                 }
           + [1]: {
-                  + nested    : "val6"
+                  + nestedProp: "val6"
                 }
           - [2]: {
-                  - nested: "val3"
+                  - nestedProp: "val3"
                 }
           - [3]: {
-                  - nested: "val4"
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -66,9 +66,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0]": map[string]interface{}{},
-		"tests[1]": map[string]interface{}{},
-		"tests[2]": map[string]interface{}{"kind": "DELETE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE"},
+		"props[0]": map[string]interface{}{},
+		"props[1]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -22,17 +22,17 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
         }
-      - test {
-          - nested = "val4" -> null
+      - prop {
+          - nested_prop = "val4" -> null
         }
-      + test {
-          + nested = "val5"
+      + prop {
+          + nested_prop = "val5"
         }
-      + test {
-          + nested = "val6"
+      + prop {
+          + nested_prop = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -47,15 +47,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
-                  + nested    : "val5"
+                  + nestedProp: "val5"
                 }
           ~ [2]: {
-                  ~ nested: "val3" => "val6"
+                  ~ nestedProp: "val3" => "val6"
                 }
           - [3]: {
-                  - nested: "val4"
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -63,8 +63,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]":        map[string]interface{}{},
-		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]":        map[string]interface{}{"kind": "DELETE"},
+		"props[1]":            map[string]interface{}{},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -24,17 +24,17 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
         }
-      - test {
-          - nested = "val4" -> null
+      - prop {
+          - nested_prop = "val4" -> null
         }
-      + test {
-          + nested = "val5"
+      + prop {
+          + nested_prop = "val5"
         }
-      + test {
-          + nested = "val6"
+      + prop {
+          + nested_prop = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -49,15 +49,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
-                  + nested    : "val5"
+                  + nestedProp: "val5"
                 }
           ~ [2]: {
-                  ~ nested: "val3" => "val6"
+                  ~ nestedProp: "val3" => "val6"
                 }
           - [3]: {
-                  - nested: "val4"
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -65,8 +65,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]":        map[string]interface{}{},
-		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]":        map[string]interface{}{"kind": "DELETE"},
+		"props[1]":            map[string]interface{}{},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlock/block_top_level_force_new/two_removed.golden
@@ -20,11 +20,11 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "newid" -> (known after apply)
 
-      - test { # forces replacement
-          - nested = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
         }
-      - test { # forces replacement
-          - nested = "val4" -> null
+      - prop { # forces replacement
+          - nested_prop = "val4" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -39,12 +39,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: {
-                  - nested: "val3"
+                  - nestedProp: "val3"
                 }
           - [3]: {
-                  - nested: "val4"
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -52,7 +52,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/added.golden
@@ -12,7 +12,7 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + test {
+      + prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
@@ -27,10 +27,10 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [secret]
+      + props: [secret]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/added_end.golden
@@ -19,7 +19,7 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + test {
+      + prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
@@ -36,12 +36,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/added_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/added_end_unordered.golden
@@ -19,7 +19,7 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + test {
+      + prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
@@ -36,12 +36,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/added_front.golden
@@ -19,7 +19,7 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + test {
+      + prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
@@ -36,12 +36,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/added_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/added_front_unordered.golden
@@ -19,7 +19,7 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + test {
+      + prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
@@ -36,12 +36,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/added_middle.golden
@@ -19,7 +19,7 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + test {
+      + prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
@@ -36,12 +36,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/added_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/added_middle_unordered.golden
@@ -19,7 +19,7 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + test {
+      + prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
@@ -36,12 +36,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/changed_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/changed_non-null.golden
@@ -14,11 +14,11 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
+      - prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
-      + test {
+      + prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
@@ -33,14 +33,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested: [secret] => [secret]
+                  ~ nestedProp: [secret] => [secret]
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0].nested": map[string]interface{}{"kind": "UPDATE"}},
+	detailedDiff: map[string]interface{}{"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/changed_non-null_to_null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/changed_non-null_to_null.golden
@@ -14,7 +14,7 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
+      - prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
@@ -29,10 +29,10 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - tests: [secret]
+      - props: [secret]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/changed_null_to_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/changed_null_to_non-null.golden
@@ -13,7 +13,7 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + test {
+      + prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
@@ -28,10 +28,10 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [secret]
+      + props: [secret]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/removed.golden
@@ -14,7 +14,7 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
+      - prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
@@ -29,10 +29,10 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - tests: [secret]
+      - props: [secret]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/removed_end.golden
@@ -19,7 +19,7 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
+      - prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
@@ -36,12 +36,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/removed_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/removed_end_unordered.golden
@@ -19,7 +19,7 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
+      - prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
@@ -36,12 +36,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/removed_front.golden
@@ -19,7 +19,7 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
+      - prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
@@ -36,12 +36,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/removed_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/removed_front_unordered.golden
@@ -19,7 +19,7 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
+      - prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
@@ -36,12 +36,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/removed_middle.golden
@@ -19,7 +19,7 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
+      - prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
@@ -36,12 +36,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/removed_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/removed_middle_unordered.golden
@@ -19,7 +19,7 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
+      - prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
@@ -36,12 +36,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/same_element_updated.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/same_element_updated.golden
@@ -20,11 +20,11 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
+      - prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
-      + test {
+      + prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
@@ -41,14 +41,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [1]: {
-                  ~ nested: [secret] => [secret]
+                  ~ nestedProp: [secret] => [secret]
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1].nested": map[string]interface{}{"kind": "UPDATE"}},
+	detailedDiff: map[string]interface{}{"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/same_element_updated_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/same_element_updated_unordered.golden
@@ -20,11 +20,11 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
+      - prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
-      + test {
+      + prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
@@ -41,7 +41,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: [secret]
           - [2]: [secret]
         ]
@@ -50,7 +50,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]": map[string]interface{}{},
-		"tests[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[1]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/shuffled_added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/shuffled_added_end.golden
@@ -19,7 +19,7 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + test {
+      + prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
@@ -36,12 +36,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/shuffled_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/shuffled_added_front.golden
@@ -19,7 +19,7 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + test {
+      + prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
@@ -36,12 +36,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/shuffled_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/shuffled_added_middle.golden
@@ -19,7 +19,7 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + test {
+      + prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
@@ -36,12 +36,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/shuffled_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/shuffled_removed_end.golden
@@ -19,7 +19,7 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
+      - prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
@@ -36,12 +36,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/shuffled_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/shuffled_removed_front.golden
@@ -19,7 +19,7 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
+      - prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
@@ -36,12 +36,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/shuffled_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/shuffled_removed_middle.golden
@@ -19,7 +19,7 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
+      - prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
@@ -36,12 +36,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/two_added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/two_added.golden
@@ -20,11 +20,11 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + test {
+      + prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
-      + test {
+      + prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
@@ -41,7 +41,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: [secret]
           + [3]: [secret]
         ]
@@ -50,7 +50,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{},
-		"tests[3]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{},
+		"props[3]": map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/two_added_and_two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/two_added_and_two_removed.golden
@@ -22,19 +22,19 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
+      - prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
-      - test {
+      - prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
-      + test {
+      + prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
-      + test {
+      + prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
@@ -51,12 +51,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [2]: {
-                  ~ nested: [secret] => [secret]
+                  ~ nestedProp: [secret] => [secret]
                 }
           ~ [3]: {
-                  ~ nested: [secret] => [secret]
+                  ~ nestedProp: [secret] => [secret]
                 }
         ]
 Resources:
@@ -64,7 +64,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested": map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -22,19 +22,19 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
+      - prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
-      - test {
+      - prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
-      + test {
+      + prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
-      + test {
+      + prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
@@ -51,7 +51,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: [secret]
           + [1]: [secret]
           - [2]: [secret]
@@ -62,9 +62,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0]": map[string]interface{}{},
-		"tests[1]": map[string]interface{}{},
-		"tests[2]": map[string]interface{}{"kind": "DELETE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE"},
+		"props[0]": map[string]interface{}{},
+		"props[1]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -22,19 +22,19 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
+      - prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
-      - test {
+      - prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
-      + test {
+      + prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
-      + test {
+      + prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
@@ -51,10 +51,10 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: [secret]
           ~ [2]: {
-                  ~ nested: [secret] => [secret]
+                  ~ nestedProp: [secret] => [secret]
                 }
           - [3]: [secret]
         ]
@@ -63,8 +63,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]":        map[string]interface{}{},
-		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]":        map[string]interface{}{"kind": "DELETE"},
+		"props[1]":            map[string]interface{}{},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -24,19 +24,19 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
+      - prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
-      - test {
+      - prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
-      + test {
+      + prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
-      + test {
+      + prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
@@ -53,10 +53,10 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: [secret]
           ~ [2]: {
-                  ~ nested: [secret] => [secret]
+                  ~ nestedProp: [secret] => [secret]
                 }
           - [3]: [secret]
         ]
@@ -65,8 +65,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]":        map[string]interface{}{},
-		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]":        map[string]interface{}{"kind": "DELETE"},
+		"props[1]":            map[string]interface{}{},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_nested_sensitive/two_removed.golden
@@ -20,11 +20,11 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
+      - prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
-      - test {
+      - prop {
           # At least one attribute in this block is (or was) sensitive,
           # so its contents will not be displayed.
         }
@@ -41,7 +41,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: [secret]
           - [3]: [secret]
         ]
@@ -50,7 +50,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{"kind": "DELETE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/added.golden
@@ -12,8 +12,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + test {
-          + nested = "value"
+      + prop {
+          + nested_prop = "value"
         }
     }
 
@@ -26,10 +26,10 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [secret]
+      + props: [secret]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/added_end.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + test {
-          + nested = "val3"
+      + prop {
+          + nested_prop = "val3"
         }
 
         # (2 unchanged blocks hidden)
@@ -35,12 +35,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/added_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/added_end_unordered.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + test {
-          + nested = "val1"
+      + prop {
+          + nested_prop = "val1"
         }
 
         # (2 unchanged blocks hidden)
@@ -35,12 +35,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/added_front.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + test {
-          + nested = "val1"
+      + prop {
+          + nested_prop = "val1"
         }
 
         # (2 unchanged blocks hidden)
@@ -35,12 +35,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/added_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/added_front_unordered.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + test {
-          + nested = "val2"
+      + prop {
+          + nested_prop = "val2"
         }
 
         # (2 unchanged blocks hidden)
@@ -35,12 +35,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/added_middle.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + test {
-          + nested = "val2"
+      + prop {
+          + nested_prop = "val2"
         }
 
         # (2 unchanged blocks hidden)
@@ -35,12 +35,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/added_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/added_middle_unordered.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + test {
-          + nested = "val3"
+      + prop {
+          + nested_prop = "val3"
         }
 
         # (2 unchanged blocks hidden)
@@ -35,12 +35,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/changed_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/changed_non-null.golden
@@ -14,11 +14,11 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "value" -> null
+      - prop {
+          - nested_prop = "value" -> null
         }
-      + test {
-          + nested = "value1"
+      + prop {
+          + nested_prop = "value1"
         }
     }
 
@@ -31,14 +31,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested: [secret] => [secret]
+                  ~ nestedProp: [secret] => [secret]
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0].nested": map[string]interface{}{"kind": "UPDATE"}},
+	detailedDiff: map[string]interface{}{"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/changed_non-null_to_null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/changed_non-null_to_null.golden
@@ -14,8 +14,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "value" -> null
+      - prop {
+          - nested_prop = "value" -> null
         }
     }
 
@@ -28,10 +28,10 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - tests: [secret]
+      - props: [secret]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/changed_null_to_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/changed_null_to_non-null.golden
@@ -13,8 +13,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + test {
-          + nested = "value"
+      + prop {
+          + nested_prop = "value"
         }
     }
 
@@ -27,10 +27,10 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [secret]
+      + props: [secret]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/removed.golden
@@ -14,8 +14,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "value" -> null
+      - prop {
+          - nested_prop = "value" -> null
         }
     }
 
@@ -28,10 +28,10 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - tests: [secret]
+      - props: [secret]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/removed_end.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -35,12 +35,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/removed_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/removed_end_unordered.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -35,12 +35,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/removed_front.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -35,12 +35,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/removed_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/removed_front_unordered.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -35,12 +35,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/removed_middle.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -35,12 +35,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/removed_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/removed_middle_unordered.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -35,12 +35,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/same_element_updated.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/same_element_updated.golden
@@ -20,11 +20,11 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
         }
-      + test {
-          + nested = "val4"
+      + prop {
+          + nested_prop = "val4"
         }
 
         # (2 unchanged blocks hidden)
@@ -39,14 +39,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [1]: {
-                  ~ nested: [secret] => [secret]
+                  ~ nestedProp: [secret] => [secret]
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1].nested": map[string]interface{}{"kind": "UPDATE"}},
+	detailedDiff: map[string]interface{}{"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/same_element_updated_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/same_element_updated_unordered.golden
@@ -20,11 +20,11 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
         }
-      + test {
-          + nested = "val4"
+      + prop {
+          + nested_prop = "val4"
         }
 
         # (2 unchanged blocks hidden)
@@ -39,7 +39,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: [secret]
           - [2]: [secret]
         ]
@@ -48,7 +48,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]": map[string]interface{}{},
-		"tests[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[1]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/shuffled_added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/shuffled_added_end.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + test {
-          + nested = "val3"
+      + prop {
+          + nested_prop = "val3"
         }
 
         # (2 unchanged blocks hidden)
@@ -35,12 +35,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/shuffled_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/shuffled_added_front.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + test {
-          + nested = "val1"
+      + prop {
+          + nested_prop = "val1"
         }
 
         # (2 unchanged blocks hidden)
@@ -35,12 +35,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/shuffled_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/shuffled_added_middle.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + test {
-          + nested = "val2"
+      + prop {
+          + nested_prop = "val2"
         }
 
         # (2 unchanged blocks hidden)
@@ -35,12 +35,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/shuffled_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/shuffled_removed_end.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -35,12 +35,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/shuffled_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/shuffled_removed_front.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -35,12 +35,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/shuffled_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/shuffled_removed_middle.golden
@@ -19,8 +19,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -35,12 +35,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: [secret]
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/two_added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/two_added.golden
@@ -20,11 +20,11 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      + test {
-          + nested = "val3"
+      + prop {
+          + nested_prop = "val3"
         }
-      + test {
-          + nested = "val4"
+      + prop {
+          + nested_prop = "val4"
         }
 
         # (2 unchanged blocks hidden)
@@ -39,7 +39,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: [secret]
           + [3]: [secret]
         ]
@@ -48,7 +48,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{},
-		"tests[3]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{},
+		"props[3]": map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/two_added_and_two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/two_added_and_two_removed.golden
@@ -22,17 +22,17 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
         }
-      - test {
-          - nested = "val4" -> null
+      - prop {
+          - nested_prop = "val4" -> null
         }
-      + test {
-          + nested = "val5"
+      + prop {
+          + nested_prop = "val5"
         }
-      + test {
-          + nested = "val6"
+      + prop {
+          + nested_prop = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -47,12 +47,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [2]: {
-                  ~ nested: [secret] => [secret]
+                  ~ nestedProp: [secret] => [secret]
                 }
           ~ [3]: {
-                  ~ nested: [secret] => [secret]
+                  ~ nestedProp: [secret] => [secret]
                 }
         ]
 Resources:
@@ -60,7 +60,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested": map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -22,17 +22,17 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
         }
-      - test {
-          - nested = "val4" -> null
+      - prop {
+          - nested_prop = "val4" -> null
         }
-      + test {
-          + nested = "val5"
+      + prop {
+          + nested_prop = "val5"
         }
-      + test {
-          + nested = "val6"
+      + prop {
+          + nested_prop = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -47,7 +47,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: [secret]
           + [1]: [secret]
           - [2]: [secret]
@@ -58,9 +58,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0]": map[string]interface{}{},
-		"tests[1]": map[string]interface{}{},
-		"tests[2]": map[string]interface{}{"kind": "DELETE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE"},
+		"props[0]": map[string]interface{}{},
+		"props[1]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -22,17 +22,17 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
         }
-      - test {
-          - nested = "val4" -> null
+      - prop {
+          - nested_prop = "val4" -> null
         }
-      + test {
-          + nested = "val5"
+      + prop {
+          + nested_prop = "val5"
         }
-      + test {
-          + nested = "val6"
+      + prop {
+          + nested_prop = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -47,10 +47,10 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: [secret]
           ~ [2]: {
-                  ~ nested: [secret] => [secret]
+                  ~ nestedProp: [secret] => [secret]
                 }
           - [3]: [secret]
         ]
@@ -59,8 +59,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]":        map[string]interface{}{},
-		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]":        map[string]interface{}{"kind": "DELETE"},
+		"props[1]":            map[string]interface{}{},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -24,17 +24,17 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
         }
-      - test {
-          - nested = "val4" -> null
+      - prop {
+          - nested_prop = "val4" -> null
         }
-      + test {
-          + nested = "val5"
+      + prop {
+          + nested_prop = "val5"
         }
-      + test {
-          + nested = "val6"
+      + prop {
+          + nested_prop = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -49,10 +49,10 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: [secret]
           ~ [2]: {
-                  ~ nested: [secret] => [secret]
+                  ~ nestedProp: [secret] => [secret]
                 }
           - [3]: [secret]
         ]
@@ -61,8 +61,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]":        map[string]interface{}{},
-		"tests[2].nested": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]":        map[string]interface{}{"kind": "DELETE"},
+		"props[1]":            map[string]interface{}{},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockSensitive/block_sensitive/two_removed.golden
@@ -20,11 +20,11 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "newid"
 
-      - test {
-          - nested = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
         }
-      - test {
-          - nested = "val4" -> null
+      - prop {
+          - nested_prop = "val4" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -39,7 +39,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: [secret]
           - [3]: [secret]
         ]
@@ -48,7 +48,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{"kind": "DELETE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/added.golden
@@ -11,7 +11,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "id" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           + "value",
         ]
     }
@@ -25,12 +25,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
+      + props: [
       +     [0]: "value"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/added_end.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "id" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           + "val3",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: "val3"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/added_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/added_end_unordered.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "id" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           + "val1",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: "val1"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/added_front.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "id" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           + "val1",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: "val1"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/added_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/added_front_unordered.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "id" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           + "val2",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: "val2"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/added_middle.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "id" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           + "val2",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: "val2"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/added_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/added_middle_unordered.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "id" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           + "val3",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: "val3"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/changed_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/changed_non-null.golden
@@ -13,7 +13,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "id" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           - "value",
           + "value1",
         ]
@@ -28,12 +28,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: "value" => "value1"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/changed_null_to_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/changed_null_to_non-null.golden
@@ -12,7 +12,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "id" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           + "value",
         ]
     }
@@ -26,12 +26,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
+      + props: [
       +     [0]: "value"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/removed.golden
@@ -13,7 +13,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "id" -> (known after apply)
-      ~ test = [
+      ~ prop = [
           - "value",
         ] -> (known after apply) # forces replacement
     }
@@ -27,12 +27,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - tests: [
+      - props: [
       -     [0]: "value"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/removed_end.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "id" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           - "val3",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: "val3"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/removed_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/removed_end_unordered.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "id" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           - "val1",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: "val1"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/removed_front.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "id" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           - "val1",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: "val1"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/removed_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/removed_front_unordered.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "id" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           - "val2",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: "val2"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/removed_middle.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "id" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           - "val2",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: "val2"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/removed_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/removed_middle_unordered.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "id" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           - "val2",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: "val2"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/same_element_updated.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/same_element_updated.golden
@@ -19,7 +19,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "id" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           - "val2",
           + "val4",
             # (2 unchanged elements hidden)
@@ -35,12 +35,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [1]: "val2" => "val4"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/same_element_updated_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/same_element_updated_unordered.golden
@@ -19,7 +19,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "id" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           - "val3",
           + "val4",
             # (2 unchanged elements hidden)
@@ -35,7 +35,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: "val4"
           - [2]: "val3"
         ]
@@ -44,7 +44,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/shuffled_added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/shuffled_added_end.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "id" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           + "val3",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: "val3"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/shuffled_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/shuffled_added_front.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "id" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           + "val1",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: "val1"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/shuffled_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/shuffled_added_middle.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "id" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           + "val2",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: "val2"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/shuffled_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/shuffled_removed_end.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "id" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           - "val3",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: "val3"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/shuffled_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/shuffled_removed_front.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "id" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           - "val1",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: "val1"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/shuffled_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/shuffled_removed_middle.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "id" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           - "val2",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: "val2"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/two_added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/two_added.golden
@@ -19,7 +19,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "id" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           + "val3",
           + "val4",
             # (2 unchanged elements hidden)
@@ -35,7 +35,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: "val3"
           + [3]: "val4"
         ]
@@ -44,7 +44,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[3]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[3]": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/two_added_and_two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/two_added_and_two_removed.golden
@@ -21,7 +21,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "id" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           - "val3",
           - "val4",
           + "val5",
@@ -39,7 +39,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [2]: "val3" => "val5"
           ~ [3]: "val4" => "val6"
         ]
@@ -48,7 +48,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[3]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -21,7 +21,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "id" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           - "val3",
           - "val4",
           + "val5",
@@ -39,7 +39,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: "val5"
           + [1]: "val6"
           - [2]: "val3"
@@ -50,9 +50,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -21,7 +21,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "id" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           - "val3",
           - "val4",
           + "val5",
@@ -39,7 +39,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: "val5"
           ~ [2]: "val3" => "val6"
           - [3]: "val4"
@@ -49,8 +49,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[2]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -23,7 +23,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "id" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           - "val3",
           - "val4",
           + "val5",
@@ -41,7 +41,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: "val5"
           ~ [2]: "val3" => "val6"
           - [3]: "val4"
@@ -51,8 +51,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[2]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_force_new/two_removed.golden
@@ -19,7 +19,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example must be replaced
 +/- resource "crossprovider_test_res" "example" {
       ~ id   = "id" -> (known after apply)
-      ~ test = [ # forces replacement
+      ~ prop = [ # forces replacement
           - "val3",
           - "val4",
             # (2 unchanged elements hidden)
@@ -35,7 +35,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: "val3"
           - [3]: "val4"
         ]
@@ -44,7 +44,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/added.golden
@@ -11,7 +11,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "id"
-      ~ test = [
+      ~ prop = [
           - "computed",
           + "value",
         ]
@@ -26,12 +26,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: "computed" => "value"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "UPDATE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/added_end.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "id"
-      ~ test = [
+      ~ prop = [
           + "val3",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: "val3"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/added_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/added_end_unordered.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "id"
-      ~ test = [
+      ~ prop = [
           + "val1",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: "val1"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/added_front.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "id"
-      ~ test = [
+      ~ prop = [
           + "val1",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: "val1"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/added_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/added_front_unordered.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "id"
-      ~ test = [
+      ~ prop = [
           + "val2",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: "val2"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/added_middle.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "id"
-      ~ test = [
+      ~ prop = [
           + "val2",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: "val2"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/added_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/added_middle_unordered.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "id"
-      ~ test = [
+      ~ prop = [
           + "val3",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: "val3"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/changed_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/changed_non-null.golden
@@ -13,7 +13,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "id"
-      ~ test = [
+      ~ prop = [
           - "value",
           + "value1",
         ]
@@ -28,12 +28,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: "value" => "value1"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "UPDATE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/changed_null_to_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/changed_null_to_empty.golden
@@ -10,7 +10,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "id"
-      ~ test = [
+      ~ prop = [
           - "computed",
         ]
     }
@@ -24,12 +24,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - tests: [
+      - props: [
       -     [0]: "computed"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/changed_null_to_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/changed_null_to_non-null.golden
@@ -12,7 +12,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "id"
-      ~ test = [
+      ~ prop = [
           - "computed",
           + "value",
         ]
@@ -27,12 +27,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: "computed" => "value"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "UPDATE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/removed.golden
@@ -13,7 +13,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "id"
-      ~ test = [
+      ~ prop = [
           - "value",
         ]
     }
@@ -27,12 +27,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - tests: [
+      - props: [
       -     [0]: "value"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/removed_end.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "id"
-      ~ test = [
+      ~ prop = [
           - "val3",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: "val3"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/removed_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/removed_end_unordered.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "id"
-      ~ test = [
+      ~ prop = [
           - "val1",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: "val1"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/removed_front.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "id"
-      ~ test = [
+      ~ prop = [
           - "val1",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: "val1"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/removed_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/removed_front_unordered.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "id"
-      ~ test = [
+      ~ prop = [
           - "val2",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: "val2"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/removed_middle.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "id"
-      ~ test = [
+      ~ prop = [
           - "val2",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: "val2"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/removed_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/removed_middle_unordered.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "id"
-      ~ test = [
+      ~ prop = [
           - "val2",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: "val2"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/same_element_updated.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/same_element_updated.golden
@@ -19,7 +19,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "id"
-      ~ test = [
+      ~ prop = [
           - "val2",
           + "val4",
             # (2 unchanged elements hidden)
@@ -35,12 +35,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [1]: "val2" => "val4"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "UPDATE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/same_element_updated_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/same_element_updated_unordered.golden
@@ -19,7 +19,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "id"
-      ~ test = [
+      ~ prop = [
           - "val3",
           + "val4",
             # (2 unchanged elements hidden)
@@ -35,7 +35,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: "val4"
           - [2]: "val3"
         ]
@@ -44,7 +44,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]": map[string]interface{}{},
-		"tests[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[1]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/shuffled_added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/shuffled_added_end.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "id"
-      ~ test = [
+      ~ prop = [
           + "val3",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: "val3"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/shuffled_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/shuffled_added_front.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "id"
-      ~ test = [
+      ~ prop = [
           + "val1",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: "val1"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/shuffled_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/shuffled_added_middle.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "id"
-      ~ test = [
+      ~ prop = [
           + "val2",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: "val2"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/shuffled_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/shuffled_removed_end.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "id"
-      ~ test = [
+      ~ prop = [
           - "val3",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: "val3"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/shuffled_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/shuffled_removed_front.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "id"
-      ~ test = [
+      ~ prop = [
           - "val1",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: "val1"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/shuffled_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/shuffled_removed_middle.golden
@@ -18,7 +18,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "id"
-      ~ test = [
+      ~ prop = [
           - "val2",
             # (2 unchanged elements hidden)
         ]
@@ -33,12 +33,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: "val2"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/two_added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/two_added.golden
@@ -19,7 +19,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "id"
-      ~ test = [
+      ~ prop = [
           + "val3",
           + "val4",
             # (2 unchanged elements hidden)
@@ -35,7 +35,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: "val3"
           + [3]: "val4"
         ]
@@ -44,7 +44,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{},
-		"tests[3]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{},
+		"props[3]": map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/two_added_and_two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/two_added_and_two_removed.golden
@@ -21,7 +21,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "id"
-      ~ test = [
+      ~ prop = [
           - "val3",
           - "val4",
           + "val5",
@@ -39,7 +39,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [2]: "val3" => "val5"
           ~ [3]: "val4" => "val6"
         ]
@@ -48,7 +48,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]": map[string]interface{}{"kind": "UPDATE"},
+		"props[3]": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -21,7 +21,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "id"
-      ~ test = [
+      ~ prop = [
           - "val3",
           - "val4",
           + "val5",
@@ -39,7 +39,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: "val5"
           + [1]: "val6"
           - [2]: "val3"
@@ -50,9 +50,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0]": map[string]interface{}{},
-		"tests[1]": map[string]interface{}{},
-		"tests[2]": map[string]interface{}{"kind": "DELETE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE"},
+		"props[0]": map[string]interface{}{},
+		"props[1]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -21,7 +21,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "id"
-      ~ test = [
+      ~ prop = [
           - "val3",
           - "val4",
           + "val5",
@@ -39,7 +39,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: "val5"
           ~ [2]: "val3" => "val6"
           - [3]: "val4"
@@ -49,8 +49,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]": map[string]interface{}{},
-		"tests[2]": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE"},
+		"props[1]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{"kind": "UPDATE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -23,7 +23,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "id"
-      ~ test = [
+      ~ prop = [
           - "val3",
           - "val4",
           + "val5",
@@ -41,7 +41,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: "val5"
           ~ [2]: "val3" => "val6"
           - [3]: "val4"
@@ -51,8 +51,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]": map[string]interface{}{},
-		"tests[2]": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE"},
+		"props[1]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{"kind": "UPDATE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/two_removed.golden
@@ -19,7 +19,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "id"
-      ~ test = [
+      ~ prop = [
           - "val3",
           - "val4",
             # (2 unchanged elements hidden)
@@ -35,7 +35,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: "val3"
           - [3]: "val4"
         ]
@@ -44,7 +44,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{"kind": "DELETE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/unchanged_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedAttribute/computed_attribute_no_force_new/unchanged_empty.golden
@@ -11,7 +11,7 @@ Terraform will perform the following actions:
   # crossprovider_test_res.example will be updated in-place
   ~ resource "crossprovider_test_res" "example" {
         id   = "id"
-      ~ test = [
+      ~ prop = [
           - "computed",
         ]
     }
@@ -25,12 +25,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - tests: [
+      - props: [
       -     [0]: "computed"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/added.golden
@@ -12,9 +12,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "value"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "value"
         }
     }
 
@@ -27,14 +27,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
+      + props: [
       +     [0]: {
-              + nested    : "value"
+              + nestedProp: "value"
             }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/added_end.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,13 +50,13 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
                 }
           + [2]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
@@ -64,8 +64,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/added_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/added_end_unordered.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,13 +50,13 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
                 }
           + [2]: {
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
@@ -64,8 +64,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/added_front.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,15 +50,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val2"
+                  ~ nestedProp: "val3" => "val2"
                 }
           + [2]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
@@ -66,10 +66,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/added_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/added_front_unordered.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,14 +50,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
                 }
           + [2]: {
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
@@ -65,9 +65,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/added_middle.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,14 +50,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val2"
+                  ~ nestedProp: "val3" => "val2"
                 }
           + [2]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
@@ -65,9 +65,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/added_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/added_middle_unordered.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,15 +50,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  ~ nestedProp: "val2" => "val3"
                 }
           + [2]: {
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
@@ -66,10 +66,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/changed_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/changed_non-null.golden
@@ -14,13 +14,13 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "value" -> null
+      - prop { # forces replacement
+          - nested_prop = "value" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "value1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "value1"
         }
     }
 
@@ -33,9 +33,9 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "value" => "value1"
+                  ~ nestedProp: "value" => "value1"
                 }
         ]
 Resources:
@@ -43,7 +43,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/changed_null_to_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/changed_null_to_non-null.golden
@@ -13,9 +13,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "value"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "value"
         }
     }
 
@@ -28,14 +28,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
+      + props: [
       +     [0]: {
-              + nested    : "value"
+              + nestedProp: "value"
             }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/removed_end.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
     }
 
@@ -50,14 +50,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -65,8 +65,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/removed_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/removed_end_unordered.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,16 +50,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  ~ nestedProp: "val2" => "val3"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -67,10 +67,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/removed_front.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,16 +50,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  ~ nestedProp: "val2" => "val3"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -67,10 +67,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/removed_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/removed_front_unordered.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,16 +50,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val3"
+                  ~ nestedProp: "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -67,10 +67,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/removed_middle.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,15 +50,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  ~ nestedProp: "val2" => "val3"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -66,9 +66,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/removed_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/removed_middle_unordered.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,16 +50,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val3"
+                  ~ nestedProp: "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -67,10 +67,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/same_element_updated.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/same_element_updated.golden
@@ -20,29 +20,29 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val4"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val4"
         }
     }
 
@@ -55,11 +55,11 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val4"
+                  ~ nestedProp: "val2" => "val4"
                 }
           ~ [2]: {
                 }
@@ -69,9 +69,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/same_element_updated_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/same_element_updated_unordered.golden
@@ -20,29 +20,29 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val4"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val4"
         }
     }
 
@@ -55,15 +55,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val4"
+                  ~ nestedProp: "val2" => "val4"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val1"
+                  ~ nestedProp: "val3" => "val1"
                 }
         ]
 Resources:
@@ -71,11 +71,11 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/shuffled_added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/shuffled_added_end.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,15 +50,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           + [2]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
@@ -66,10 +66,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/shuffled_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/shuffled_added_front.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,14 +50,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           ~ [1]: {
                 }
           + [2]: {
-                  + nested    : "val2"
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
@@ -65,9 +65,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/shuffled_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/shuffled_added_middle.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,15 +50,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val3"
+                  ~ nestedProp: "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val2"
+                  ~ nestedProp: "val3" => "val2"
                 }
           + [2]: {
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
@@ -66,10 +66,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/shuffled_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/shuffled_removed_end.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
     }
 
@@ -50,16 +50,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -67,10 +67,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/shuffled_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/shuffled_removed_front.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,15 +50,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val3"
+                  ~ nestedProp: "val1" => "val3"
                 }
           ~ [1]: {
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -66,9 +66,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/shuffled_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/shuffled_removed_middle.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,16 +50,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val3"
+                  ~ nestedProp: "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -67,10 +67,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/two_added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/two_added.golden
@@ -20,29 +20,29 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val4"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val4"
         }
     }
 
@@ -55,16 +55,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
                 }
           + [2]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
           + [3]: {
-                  + nested    : "val4"
+                  + nestedProp: "val4"
                 }
         ]
 Resources:
@@ -72,9 +72,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[3]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[3]":          map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/two_added_and_two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/two_added_and_two_removed.golden
@@ -22,37 +22,37 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val4" -> null
+      - prop { # forces replacement
+          - nested_prop = "val4" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val5"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val5"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val6"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val6"
         }
     }
 
@@ -65,16 +65,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val5"
+                  ~ nestedProp: "val3" => "val5"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val6"
+                  ~ nestedProp: "val4" => "val6"
                 }
         ]
 Resources:
@@ -82,11 +82,11 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -22,37 +22,37 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val4" -> null
+      - prop { # forces replacement
+          - nested_prop = "val4" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val5"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val5"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val6"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val6"
         }
     }
 
@@ -65,18 +65,18 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val5"
+                  ~ nestedProp: "val1" => "val5"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val6"
+                  ~ nestedProp: "val2" => "val6"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val1"
+                  ~ nestedProp: "val3" => "val1"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val2"
+                  ~ nestedProp: "val4" => "val2"
                 }
         ]
 Resources:
@@ -84,13 +84,13 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -22,37 +22,37 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val4" -> null
+      - prop { # forces replacement
+          - nested_prop = "val4" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val5"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val5"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val6"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val6"
         }
     }
 
@@ -65,17 +65,17 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val5"
+                  ~ nestedProp: "val2" => "val5"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val6"
+                  ~ nestedProp: "val3" => "val6"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val2"
+                  ~ nestedProp: "val4" => "val2"
                 }
         ]
 Resources:
@@ -83,12 +83,12 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -24,37 +24,37 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val4" -> null
+      - prop { # forces replacement
+          - nested_prop = "val4" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val5"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val5"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val6"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val6"
         }
     }
 
@@ -67,17 +67,17 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val5"
+                  ~ nestedProp: "val2" => "val5"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val6"
+                  ~ nestedProp: "val3" => "val6"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val2"
+                  ~ nestedProp: "val4" => "val2"
                 }
         ]
 Resources:
@@ -85,12 +85,12 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/two_removed.golden
@@ -20,29 +20,29 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val4" -> null
+      - prop { # forces replacement
+          - nested_prop = "val4" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
     }
 
@@ -55,18 +55,18 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
           - [3]: {
-                  - computed: ""
-                  - nested  : "val4"
+                  - computed  : ""
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -74,9 +74,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
-		"tests[3]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[3]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/added.golden
@@ -12,9 +12,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-value"
-          + nested   = "value"
+      + prop { # forces replacement
+          + computed    = "non-computed-value"
+          + nested_prop = "value"
         }
     }
 
@@ -27,15 +27,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
+      + props: [
       +     [0]: {
               + computed  : "non-computed-value"
-              + nested    : "value"
+              + nestedProp: "value"
             }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/added_end.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-val3"
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = "non-computed-val3"
+          + nested_prop = "val3"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: {
                   + computed  : "non-computed-val3"
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/added_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/added_end_unordered.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-val1"
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = "non-computed-val1"
+          + nested_prop = "val1"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: {
                   + computed  : "non-computed-val1"
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/added_front.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-val1"
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = "non-computed-val1"
+          + nested_prop = "val1"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: {
                   + computed  : "non-computed-val1"
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/added_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/added_front_unordered.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-val2"
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = "non-computed-val2"
+          + nested_prop = "val2"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: {
                   + computed  : "non-computed-val2"
-                  + nested    : "val2"
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/added_middle.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-val2"
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = "non-computed-val2"
+          + nested_prop = "val2"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
                   + computed  : "non-computed-val2"
-                  + nested    : "val2"
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/added_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/added_middle_unordered.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-val3"
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = "non-computed-val3"
+          + nested_prop = "val3"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
                   + computed  : "non-computed-val3"
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/changed_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/changed_non-null.golden
@@ -14,13 +14,13 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-value" -> null
-          - nested   = "value" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-value" -> null
+          - nested_prop = "value" -> null
         }
-      + test { # forces replacement
-          + computed = "non-computed-value1"
-          + nested   = "value1"
+      + prop { # forces replacement
+          + computed    = "non-computed-value1"
+          + nested_prop = "value1"
         }
     }
 
@@ -33,10 +33,10 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ computed: "non-computed-value" => "non-computed-value1"
-                  ~ nested  : "value" => "value1"
+                  ~ computed  : "non-computed-value" => "non-computed-value1"
+                  ~ nestedProp: "value" => "value1"
                 }
         ]
 Resources:
@@ -44,7 +44,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/changed_null_to_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/changed_null_to_non-null.golden
@@ -13,9 +13,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-value"
-          + nested   = "value"
+      + prop { # forces replacement
+          + computed    = "non-computed-value"
+          + nested_prop = "value"
         }
     }
 
@@ -28,15 +28,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
+      + props: [
       +     [0]: {
               + computed  : "non-computed-value"
-              + nested    : "value"
+              + nestedProp: "value"
             }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/removed_end.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: {
-                  - computed: "non-computed-val3"
-                  - nested  : "val3"
+                  - computed  : "non-computed-val3"
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/removed_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/removed_end_unordered.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val1" -> null
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val1" -> null
+          - nested_prop = "val1" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: {
-                  - computed: "non-computed-val1"
-                  - nested  : "val1"
+                  - computed  : "non-computed-val1"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/removed_front.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val1" -> null
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val1" -> null
+          - nested_prop = "val1" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: {
-                  - computed: "non-computed-val1"
-                  - nested  : "val1"
+                  - computed  : "non-computed-val1"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/removed_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/removed_front_unordered.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val2" -> null
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val2" -> null
+          - nested_prop = "val2" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+                  - computed  : "non-computed-val2"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/removed_middle.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val2" -> null
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val2" -> null
+          - nested_prop = "val2" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+                  - computed  : "non-computed-val2"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/removed_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/removed_middle_unordered.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val2" -> null
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val2" -> null
+          - nested_prop = "val2" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+                  - computed  : "non-computed-val2"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/same_element_updated.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/same_element_updated.golden
@@ -20,13 +20,13 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val2" -> null
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val2" -> null
+          - nested_prop = "val2" -> null
         }
-      + test { # forces replacement
-          + computed = "non-computed-val4"
-          + nested   = "val4"
+      + prop { # forces replacement
+          + computed    = "non-computed-val4"
+          + nested_prop = "val4"
         }
 
         # (2 unchanged blocks hidden)
@@ -41,10 +41,10 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [1]: {
-                  ~ computed: "non-computed-val2" => "non-computed-val4"
-                  ~ nested  : "val2" => "val4"
+                  ~ computed  : "non-computed-val2" => "non-computed-val4"
+                  ~ nestedProp: "val2" => "val4"
                 }
         ]
 Resources:
@@ -52,7 +52,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/same_element_updated_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/same_element_updated_unordered.golden
@@ -20,13 +20,13 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
-      + test { # forces replacement
-          + computed = "non-computed-val4"
-          + nested   = "val4"
+      + prop { # forces replacement
+          + computed    = "non-computed-val4"
+          + nested_prop = "val4"
         }
 
         # (2 unchanged blocks hidden)
@@ -41,14 +41,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
                   + computed  : "non-computed-val4"
-                  + nested    : "val4"
+                  + nestedProp: "val4"
                 }
           - [2]: {
-                  - computed: "non-computed-val3"
-                  - nested  : "val3"
+                  - computed  : "non-computed-val3"
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -56,7 +56,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_added_end.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-val3"
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = "non-computed-val3"
+          + nested_prop = "val3"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: {
                   + computed  : "non-computed-val3"
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_added_front.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-val1"
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = "non-computed-val1"
+          + nested_prop = "val1"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: {
                   + computed  : "non-computed-val1"
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_added_middle.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-val2"
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = "non-computed-val2"
+          + nested_prop = "val2"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
                   + computed  : "non-computed-val2"
-                  + nested    : "val2"
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_removed_end.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: {
-                  - computed: "non-computed-val3"
-                  - nested  : "val3"
+                  - computed  : "non-computed-val3"
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_removed_front.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val1" -> null
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val1" -> null
+          - nested_prop = "val1" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: {
-                  - computed: "non-computed-val1"
-                  - nested  : "val1"
+                  - computed  : "non-computed-val1"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/shuffled_removed_middle.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val2" -> null
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val2" -> null
+          - nested_prop = "val2" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+                  - computed  : "non-computed-val2"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/two_added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/two_added.golden
@@ -20,13 +20,13 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-val3"
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = "non-computed-val3"
+          + nested_prop = "val3"
         }
-      + test { # forces replacement
-          + computed = "non-computed-val4"
-          + nested   = "val4"
+      + prop { # forces replacement
+          + computed    = "non-computed-val4"
+          + nested_prop = "val4"
         }
 
         # (2 unchanged blocks hidden)
@@ -41,14 +41,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: {
                   + computed  : "non-computed-val3"
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
           + [3]: {
                   + computed  : "non-computed-val4"
-                  + nested    : "val4"
+                  + nestedProp: "val4"
                 }
         ]
 Resources:
@@ -56,7 +56,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[3]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[3]": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/two_added_and_two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/two_added_and_two_removed.golden
@@ -22,21 +22,21 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
-      - test { # forces replacement
-          - computed = "non-computed-val4" -> null
-          - nested   = "val4" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val4" -> null
+          - nested_prop = "val4" -> null
         }
-      + test { # forces replacement
-          + computed = "non-computed-val5"
-          + nested   = "val5"
+      + prop { # forces replacement
+          + computed    = "non-computed-val5"
+          + nested_prop = "val5"
         }
-      + test { # forces replacement
-          + computed = "non-computed-val6"
-          + nested   = "val6"
+      + prop { # forces replacement
+          + computed    = "non-computed-val6"
+          + nested_prop = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -51,14 +51,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val5"
-                  ~ nested  : "val3" => "val5"
+                  ~ computed  : "non-computed-val3" => "non-computed-val5"
+                  ~ nestedProp: "val3" => "val5"
                 }
           ~ [3]: {
-                  ~ computed: "non-computed-val4" => "non-computed-val6"
-                  ~ nested  : "val4" => "val6"
+                  ~ computed  : "non-computed-val4" => "non-computed-val6"
+                  ~ nestedProp: "val4" => "val6"
                 }
         ]
 Resources:
@@ -66,9 +66,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -22,21 +22,21 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
-      - test { # forces replacement
-          - computed = "non-computed-val4" -> null
-          - nested   = "val4" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val4" -> null
+          - nested_prop = "val4" -> null
         }
-      + test { # forces replacement
-          + computed = "non-computed-val5"
-          + nested   = "val5"
+      + prop { # forces replacement
+          + computed    = "non-computed-val5"
+          + nested_prop = "val5"
         }
-      + test { # forces replacement
-          + computed = "non-computed-val6"
-          + nested   = "val6"
+      + prop { # forces replacement
+          + computed    = "non-computed-val6"
+          + nested_prop = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -51,22 +51,22 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: {
                   + computed  : "non-computed-val5"
-                  + nested    : "val5"
+                  + nestedProp: "val5"
                 }
           + [1]: {
                   + computed  : "non-computed-val6"
-                  + nested    : "val6"
+                  + nestedProp: "val6"
                 }
           - [2]: {
-                  - computed: "non-computed-val3"
-                  - nested  : "val3"
+                  - computed  : "non-computed-val3"
+                  - nestedProp: "val3"
                 }
           - [3]: {
-                  - computed: "non-computed-val4"
-                  - nested  : "val4"
+                  - computed  : "non-computed-val4"
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -74,9 +74,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -22,21 +22,21 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
-      - test { # forces replacement
-          - computed = "non-computed-val4" -> null
-          - nested   = "val4" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val4" -> null
+          - nested_prop = "val4" -> null
         }
-      + test { # forces replacement
-          + computed = "non-computed-val5"
-          + nested   = "val5"
+      + prop { # forces replacement
+          + computed    = "non-computed-val5"
+          + nested_prop = "val5"
         }
-      + test { # forces replacement
-          + computed = "non-computed-val6"
-          + nested   = "val6"
+      + prop { # forces replacement
+          + computed    = "non-computed-val6"
+          + nested_prop = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -51,18 +51,18 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
                   + computed  : "non-computed-val5"
-                  + nested    : "val5"
+                  + nestedProp: "val5"
                 }
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val6"
-                  ~ nested  : "val3" => "val6"
+                  ~ computed  : "non-computed-val3" => "non-computed-val6"
+                  ~ nestedProp: "val3" => "val6"
                 }
           - [3]: {
-                  - computed: "non-computed-val4"
-                  - nested  : "val4"
+                  - computed  : "non-computed-val4"
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -70,9 +70,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]":          map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[1]":            map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[3]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -24,21 +24,21 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
-      - test { # forces replacement
-          - computed = "non-computed-val4" -> null
-          - nested   = "val4" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val4" -> null
+          - nested_prop = "val4" -> null
         }
-      + test { # forces replacement
-          + computed = "non-computed-val5"
-          + nested   = "val5"
+      + prop { # forces replacement
+          + computed    = "non-computed-val5"
+          + nested_prop = "val5"
         }
-      + test { # forces replacement
-          + computed = "non-computed-val6"
-          + nested   = "val6"
+      + prop { # forces replacement
+          + computed    = "non-computed-val6"
+          + nested_prop = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -53,18 +53,18 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
                   + computed  : "non-computed-val5"
-                  + nested    : "val5"
+                  + nestedProp: "val5"
                 }
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val6"
-                  ~ nested  : "val3" => "val6"
+                  ~ computed  : "non-computed-val3" => "non-computed-val6"
+                  ~ nestedProp: "val3" => "val6"
                 }
           - [3]: {
-                  - computed: "non-computed-val4"
-                  - nested  : "val4"
+                  - computed  : "non-computed-val4"
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -72,9 +72,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]":          map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[1]":            map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[3]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new_computed_specified_in_program/two_removed.golden
@@ -20,13 +20,13 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
-      - test { # forces replacement
-          - computed = "non-computed-val4" -> null
-          - nested   = "val4" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val4" -> null
+          - nested_prop = "val4" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -41,14 +41,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: {
-                  - computed: "non-computed-val3"
-                  - nested  : "val3"
+                  - computed  : "non-computed-val3"
+                  - nestedProp: "val3"
                 }
           - [3]: {
-                  - computed: "non-computed-val4"
-                  - nested  : "val4"
+                  - computed  : "non-computed-val4"
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -56,7 +56,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/added.golden
@@ -12,9 +12,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "value"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "value"
         }
     }
 
@@ -27,14 +27,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
+      + props: [
       +     [0]: {
-              + nested    : "value"
+              + nestedProp: "value"
             }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/added_end.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,13 +50,13 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
                 }
           + [2]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
@@ -64,8 +64,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/added_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/added_end_unordered.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,13 +50,13 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
                 }
           + [2]: {
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
@@ -64,8 +64,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/added_front.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,15 +50,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val2"
+                  ~ nestedProp: "val3" => "val2"
                 }
           + [2]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
@@ -66,10 +66,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/added_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/added_front_unordered.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,14 +50,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
                 }
           + [2]: {
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
@@ -65,9 +65,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/added_middle.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,14 +50,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val2"
+                  ~ nestedProp: "val3" => "val2"
                 }
           + [2]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
@@ -65,9 +65,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/added_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/added_middle_unordered.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,15 +50,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  ~ nestedProp: "val2" => "val3"
                 }
           + [2]: {
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
@@ -66,10 +66,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/changed_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/changed_non-null.golden
@@ -14,13 +14,13 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "value" -> null
+      - prop {
+          - nested_prop = "value" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "value1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "value1"
         }
     }
 
@@ -33,9 +33,9 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "value" => "value1"
+                  ~ nestedProp: "value" => "value1"
                 }
         ]
 Resources:
@@ -43,7 +43,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/changed_null_to_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/changed_null_to_non-null.golden
@@ -13,9 +13,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "value"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "value"
         }
     }
 
@@ -28,14 +28,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
+      + props: [
       +     [0]: {
-              + nested    : "value"
+              + nestedProp: "value"
             }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/removed_end.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
     }
 
@@ -50,14 +50,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -65,8 +65,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/removed_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/removed_end_unordered.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,16 +50,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  ~ nestedProp: "val2" => "val3"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -67,10 +67,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/removed_front.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,16 +50,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  ~ nestedProp: "val2" => "val3"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -67,10 +67,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/removed_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/removed_front_unordered.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,16 +50,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val3"
+                  ~ nestedProp: "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -67,10 +67,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/removed_middle.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,15 +50,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  ~ nestedProp: "val2" => "val3"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -66,9 +66,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/removed_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/removed_middle_unordered.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,16 +50,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val3"
+                  ~ nestedProp: "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -67,10 +67,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/same_element_updated.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/same_element_updated.golden
@@ -20,29 +20,29 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val4"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val4"
         }
     }
 
@@ -55,11 +55,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val4"
+                  ~ nestedProp: "val2" => "val4"
                 }
           ~ [2]: {
                 }
@@ -69,9 +69,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/same_element_updated_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/same_element_updated_unordered.golden
@@ -20,29 +20,29 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val4"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val4"
         }
     }
 
@@ -55,15 +55,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val4"
+                  ~ nestedProp: "val2" => "val4"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val1"
+                  ~ nestedProp: "val3" => "val1"
                 }
         ]
 Resources:
@@ -71,11 +71,11 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/shuffled_added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/shuffled_added_end.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,15 +50,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           + [2]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
@@ -66,10 +66,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/shuffled_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/shuffled_added_front.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,14 +50,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           ~ [1]: {
                 }
           + [2]: {
-                  + nested    : "val2"
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
@@ -65,9 +65,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/shuffled_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/shuffled_added_middle.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,15 +50,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val3"
+                  ~ nestedProp: "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val2"
+                  ~ nestedProp: "val3" => "val2"
                 }
           + [2]: {
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
@@ -66,10 +66,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/shuffled_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/shuffled_removed_end.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
     }
 
@@ -50,16 +50,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -67,10 +67,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/shuffled_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/shuffled_removed_front.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,15 +50,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val3"
+                  ~ nestedProp: "val1" => "val3"
                 }
           ~ [1]: {
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -66,9 +66,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/shuffled_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/shuffled_removed_middle.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,16 +50,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val3"
+                  ~ nestedProp: "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -67,10 +67,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/two_added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/two_added.golden
@@ -20,29 +20,29 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val4"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val4"
         }
     }
 
@@ -55,16 +55,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
                 }
           + [2]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
           + [3]: {
-                  + nested    : "val4"
+                  + nestedProp: "val4"
                 }
         ]
 Resources:
@@ -72,9 +72,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[3]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[3]":          map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/two_added_and_two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/two_added_and_two_removed.golden
@@ -22,37 +22,37 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val4" -> null
+      - prop {
+          - nested_prop = "val4" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val5"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val5"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val6"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val6"
         }
     }
 
@@ -65,16 +65,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val5"
+                  ~ nestedProp: "val3" => "val5"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val6"
+                  ~ nestedProp: "val4" => "val6"
                 }
         ]
 Resources:
@@ -82,11 +82,11 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -22,37 +22,37 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val4" -> null
+      - prop {
+          - nested_prop = "val4" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val5"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val5"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val6"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val6"
         }
     }
 
@@ -65,18 +65,18 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val5"
+                  ~ nestedProp: "val1" => "val5"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val6"
+                  ~ nestedProp: "val2" => "val6"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val1"
+                  ~ nestedProp: "val3" => "val1"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val2"
+                  ~ nestedProp: "val4" => "val2"
                 }
         ]
 Resources:
@@ -84,13 +84,13 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -22,37 +22,37 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val4" -> null
+      - prop {
+          - nested_prop = "val4" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val5"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val5"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val6"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val6"
         }
     }
 
@@ -65,17 +65,17 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val5"
+                  ~ nestedProp: "val2" => "val5"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val6"
+                  ~ nestedProp: "val3" => "val6"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val2"
+                  ~ nestedProp: "val4" => "val2"
                 }
         ]
 Resources:
@@ -83,12 +83,12 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -24,37 +24,37 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val4" -> null
+      - prop {
+          - nested_prop = "val4" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val5"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val5"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val6"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val6"
         }
     }
 
@@ -67,17 +67,17 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val5"
+                  ~ nestedProp: "val2" => "val5"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val6"
+                  ~ nestedProp: "val3" => "val6"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val2"
+                  ~ nestedProp: "val4" => "val2"
                 }
         ]
 Resources:
@@ -85,12 +85,12 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/two_removed.golden
@@ -20,29 +20,29 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val4" -> null
+      - prop { # forces replacement
+          - nested_prop = "val4" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
     }
 
@@ -55,18 +55,18 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
           - [3]: {
-                  - computed: ""
-                  - nested  : "val4"
+                  - computed  : ""
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -74,9 +74,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
-		"tests[3]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[3]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/added.golden
@@ -12,9 +12,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-value"
-          + nested   = "value"
+      + prop { # forces replacement
+          + computed    = "non-computed-value"
+          + nested_prop = "value"
         }
     }
 
@@ -27,15 +27,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
+      + props: [
       +     [0]: {
               + computed  : "non-computed-value"
-              + nested    : "value"
+              + nestedProp: "value"
             }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/added_end.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-val3"
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = "non-computed-val3"
+          + nested_prop = "val3"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: {
                   + computed  : "non-computed-val3"
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/added_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/added_end_unordered.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-val1"
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = "non-computed-val1"
+          + nested_prop = "val1"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: {
                   + computed  : "non-computed-val1"
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/added_front.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-val1"
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = "non-computed-val1"
+          + nested_prop = "val1"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: {
                   + computed  : "non-computed-val1"
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/added_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/added_front_unordered.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-val2"
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = "non-computed-val2"
+          + nested_prop = "val2"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: {
                   + computed  : "non-computed-val2"
-                  + nested    : "val2"
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/added_middle.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-val2"
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = "non-computed-val2"
+          + nested_prop = "val2"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
                   + computed  : "non-computed-val2"
-                  + nested    : "val2"
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/added_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/added_middle_unordered.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-val3"
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = "non-computed-val3"
+          + nested_prop = "val3"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
                   + computed  : "non-computed-val3"
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/changed_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/changed_non-null.golden
@@ -14,13 +14,13 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-value" -> null
-          - nested   = "value" -> null
+      - prop {
+          - computed    = "non-computed-value" -> null
+          - nested_prop = "value" -> null
         }
-      + test {
-          + computed = "non-computed-value1"
-          + nested   = "value1"
+      + prop {
+          + computed    = "non-computed-value1"
+          + nested_prop = "value1"
         }
     }
 
@@ -33,10 +33,10 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ computed: "non-computed-value" => "non-computed-value1"
-                  ~ nested  : "value" => "value1"
+                  ~ computed  : "non-computed-value" => "non-computed-value1"
+                  ~ nestedProp: "value" => "value1"
                 }
         ]
 Resources:
@@ -44,7 +44,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/changed_null_to_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/changed_null_to_non-null.golden
@@ -13,9 +13,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-value"
-          + nested   = "value"
+      + prop { # forces replacement
+          + computed    = "non-computed-value"
+          + nested_prop = "value"
         }
     }
 
@@ -28,15 +28,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
+      + props: [
       +     [0]: {
               + computed  : "non-computed-value"
-              + nested    : "value"
+              + nestedProp: "value"
             }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/removed_end.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: {
-                  - computed: "non-computed-val3"
-                  - nested  : "val3"
+                  - computed  : "non-computed-val3"
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/removed_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/removed_end_unordered.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val1" -> null
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val1" -> null
+          - nested_prop = "val1" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: {
-                  - computed: "non-computed-val1"
-                  - nested  : "val1"
+                  - computed  : "non-computed-val1"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/removed_front.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val1" -> null
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val1" -> null
+          - nested_prop = "val1" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: {
-                  - computed: "non-computed-val1"
-                  - nested  : "val1"
+                  - computed  : "non-computed-val1"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/removed_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/removed_front_unordered.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val2" -> null
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val2" -> null
+          - nested_prop = "val2" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+                  - computed  : "non-computed-val2"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/removed_middle.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val2" -> null
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val2" -> null
+          - nested_prop = "val2" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+                  - computed  : "non-computed-val2"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/removed_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/removed_middle_unordered.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val2" -> null
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val2" -> null
+          - nested_prop = "val2" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+                  - computed  : "non-computed-val2"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/same_element_updated.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/same_element_updated.golden
@@ -20,13 +20,13 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val2" -> null
-          - nested   = "val2" -> null
+      - prop {
+          - computed    = "non-computed-val2" -> null
+          - nested_prop = "val2" -> null
         }
-      + test {
-          + computed = "non-computed-val4"
-          + nested   = "val4"
+      + prop {
+          + computed    = "non-computed-val4"
+          + nested_prop = "val4"
         }
 
         # (2 unchanged blocks hidden)
@@ -41,10 +41,10 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [1]: {
-                  ~ computed: "non-computed-val2" => "non-computed-val4"
-                  ~ nested  : "val2" => "val4"
+                  ~ computed  : "non-computed-val2" => "non-computed-val4"
+                  ~ nestedProp: "val2" => "val4"
                 }
         ]
 Resources:
@@ -52,7 +52,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/same_element_updated_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/same_element_updated_unordered.golden
@@ -20,13 +20,13 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop {
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
-      + test {
-          + computed = "non-computed-val4"
-          + nested   = "val4"
+      + prop {
+          + computed    = "non-computed-val4"
+          + nested_prop = "val4"
         }
 
         # (2 unchanged blocks hidden)
@@ -41,14 +41,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
                   + computed  : "non-computed-val4"
-                  + nested    : "val4"
+                  + nestedProp: "val4"
                 }
           - [2]: {
-                  - computed: "non-computed-val3"
-                  - nested  : "val3"
+                  - computed  : "non-computed-val3"
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -56,7 +56,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]": map[string]interface{}{},
-		"tests[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[1]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/shuffled_added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/shuffled_added_end.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-val3"
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = "non-computed-val3"
+          + nested_prop = "val3"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: {
                   + computed  : "non-computed-val3"
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/shuffled_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/shuffled_added_front.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-val1"
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = "non-computed-val1"
+          + nested_prop = "val1"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: {
                   + computed  : "non-computed-val1"
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/shuffled_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/shuffled_added_middle.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-val2"
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = "non-computed-val2"
+          + nested_prop = "val2"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
                   + computed  : "non-computed-val2"
-                  + nested    : "val2"
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/shuffled_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/shuffled_removed_end.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: {
-                  - computed: "non-computed-val3"
-                  - nested  : "val3"
+                  - computed  : "non-computed-val3"
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/shuffled_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/shuffled_removed_front.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val1" -> null
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val1" -> null
+          - nested_prop = "val1" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: {
-                  - computed: "non-computed-val1"
-                  - nested  : "val1"
+                  - computed  : "non-computed-val1"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/shuffled_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/shuffled_removed_middle.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val2" -> null
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val2" -> null
+          - nested_prop = "val2" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+                  - computed  : "non-computed-val2"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/two_added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/two_added.golden
@@ -20,13 +20,13 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-val3"
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = "non-computed-val3"
+          + nested_prop = "val3"
         }
-      + test { # forces replacement
-          + computed = "non-computed-val4"
-          + nested   = "val4"
+      + prop { # forces replacement
+          + computed    = "non-computed-val4"
+          + nested_prop = "val4"
         }
 
         # (2 unchanged blocks hidden)
@@ -41,14 +41,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: {
                   + computed  : "non-computed-val3"
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
           + [3]: {
                   + computed  : "non-computed-val4"
-                  + nested    : "val4"
+                  + nestedProp: "val4"
                 }
         ]
 Resources:
@@ -56,7 +56,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[3]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[3]": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/two_added_and_two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/two_added_and_two_removed.golden
@@ -22,21 +22,21 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop {
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
-      - test {
-          - computed = "non-computed-val4" -> null
-          - nested   = "val4" -> null
+      - prop {
+          - computed    = "non-computed-val4" -> null
+          - nested_prop = "val4" -> null
         }
-      + test {
-          + computed = "non-computed-val5"
-          + nested   = "val5"
+      + prop {
+          + computed    = "non-computed-val5"
+          + nested_prop = "val5"
         }
-      + test {
-          + computed = "non-computed-val6"
-          + nested   = "val6"
+      + prop {
+          + computed    = "non-computed-val6"
+          + nested_prop = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -51,14 +51,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val5"
-                  ~ nested  : "val3" => "val5"
+                  ~ computed  : "non-computed-val3" => "non-computed-val5"
+                  ~ nestedProp: "val3" => "val5"
                 }
           ~ [3]: {
-                  ~ computed: "non-computed-val4" => "non-computed-val6"
-                  ~ nested  : "val4" => "val6"
+                  ~ computed  : "non-computed-val4" => "non-computed-val6"
+                  ~ nestedProp: "val4" => "val6"
                 }
         ]
 Resources:
@@ -66,9 +66,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -22,21 +22,21 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop {
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
-      - test {
-          - computed = "non-computed-val4" -> null
-          - nested   = "val4" -> null
+      - prop {
+          - computed    = "non-computed-val4" -> null
+          - nested_prop = "val4" -> null
         }
-      + test {
-          + computed = "non-computed-val5"
-          + nested   = "val5"
+      + prop {
+          + computed    = "non-computed-val5"
+          + nested_prop = "val5"
         }
-      + test {
-          + computed = "non-computed-val6"
-          + nested   = "val6"
+      + prop {
+          + computed    = "non-computed-val6"
+          + nested_prop = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -51,22 +51,22 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: {
                   + computed  : "non-computed-val5"
-                  + nested    : "val5"
+                  + nestedProp: "val5"
                 }
           + [1]: {
                   + computed  : "non-computed-val6"
-                  + nested    : "val6"
+                  + nestedProp: "val6"
                 }
           - [2]: {
-                  - computed: "non-computed-val3"
-                  - nested  : "val3"
+                  - computed  : "non-computed-val3"
+                  - nestedProp: "val3"
                 }
           - [3]: {
-                  - computed: "non-computed-val4"
-                  - nested  : "val4"
+                  - computed  : "non-computed-val4"
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -74,9 +74,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0]": map[string]interface{}{},
-		"tests[1]": map[string]interface{}{},
-		"tests[2]": map[string]interface{}{"kind": "DELETE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE"},
+		"props[0]": map[string]interface{}{},
+		"props[1]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -22,21 +22,21 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop {
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
-      - test {
-          - computed = "non-computed-val4" -> null
-          - nested   = "val4" -> null
+      - prop {
+          - computed    = "non-computed-val4" -> null
+          - nested_prop = "val4" -> null
         }
-      + test {
-          + computed = "non-computed-val5"
-          + nested   = "val5"
+      + prop {
+          + computed    = "non-computed-val5"
+          + nested_prop = "val5"
         }
-      + test {
-          + computed = "non-computed-val6"
-          + nested   = "val6"
+      + prop {
+          + computed    = "non-computed-val6"
+          + nested_prop = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -51,18 +51,18 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
                   + computed  : "non-computed-val5"
-                  + nested    : "val5"
+                  + nestedProp: "val5"
                 }
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val6"
-                  ~ nested  : "val3" => "val6"
+                  ~ computed  : "non-computed-val3" => "non-computed-val6"
+                  ~ nestedProp: "val3" => "val6"
                 }
           - [3]: {
-                  - computed: "non-computed-val4"
-                  - nested  : "val4"
+                  - computed  : "non-computed-val4"
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -70,9 +70,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]":          map[string]interface{}{},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]":          map[string]interface{}{"kind": "DELETE"},
+		"props[1]":            map[string]interface{}{},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -24,21 +24,21 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop {
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
-      - test {
-          - computed = "non-computed-val4" -> null
-          - nested   = "val4" -> null
+      - prop {
+          - computed    = "non-computed-val4" -> null
+          - nested_prop = "val4" -> null
         }
-      + test {
-          + computed = "non-computed-val5"
-          + nested   = "val5"
+      + prop {
+          + computed    = "non-computed-val5"
+          + nested_prop = "val5"
         }
-      + test {
-          + computed = "non-computed-val6"
-          + nested   = "val6"
+      + prop {
+          + computed    = "non-computed-val6"
+          + nested_prop = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -53,18 +53,18 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
                   + computed  : "non-computed-val5"
-                  + nested    : "val5"
+                  + nestedProp: "val5"
                 }
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val6"
-                  ~ nested  : "val3" => "val6"
+                  ~ computed  : "non-computed-val3" => "non-computed-val6"
+                  ~ nestedProp: "val3" => "val6"
                 }
           - [3]: {
-                  - computed: "non-computed-val4"
-                  - nested  : "val4"
+                  - computed  : "non-computed-val4"
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -72,9 +72,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]":          map[string]interface{}{},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]":          map[string]interface{}{"kind": "DELETE"},
+		"props[1]":            map[string]interface{}{},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new_computed_specified_in_program/two_removed.golden
@@ -20,13 +20,13 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
-      - test { # forces replacement
-          - computed = "non-computed-val4" -> null
-          - nested   = "val4" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val4" -> null
+          - nested_prop = "val4" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -41,14 +41,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: {
-                  - computed: "non-computed-val3"
-                  - nested  : "val3"
+                  - computed  : "non-computed-val3"
+                  - nestedProp: "val3"
                 }
           - [3]: {
-                  - computed: "non-computed-val4"
-                  - nested  : "val4"
+                  - computed  : "non-computed-val4"
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -56,7 +56,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/added.golden
@@ -12,9 +12,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      + test {
-          + computed = (known after apply)
-          + nested   = "value"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "value"
         }
     }
 
@@ -27,14 +27,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
+      + props: [
       +     [0]: {
-              + nested    : "value"
+              + nestedProp: "value"
             }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/added_end.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,13 +50,13 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
                 }
           + [2]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
@@ -64,8 +64,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{},
+		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":          map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/added_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/added_end_unordered.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,13 +50,13 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
                 }
           + [2]: {
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
@@ -64,8 +64,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{},
+		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":          map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/added_front.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,15 +50,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val2"
+                  ~ nestedProp: "val3" => "val2"
                 }
           + [2]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
@@ -66,10 +66,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/added_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/added_front_unordered.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,14 +50,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
                 }
           + [2]: {
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
@@ -65,9 +65,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/added_middle.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,14 +50,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val2"
+                  ~ nestedProp: "val3" => "val2"
                 }
           + [2]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
@@ -65,9 +65,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/added_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/added_middle_unordered.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,15 +50,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  ~ nestedProp: "val2" => "val3"
                 }
           + [2]: {
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
@@ -66,10 +66,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/changed_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/changed_non-null.golden
@@ -14,13 +14,13 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "value" -> null
+      - prop {
+          - nested_prop = "value" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "value1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "value1"
         }
     }
 
@@ -33,9 +33,9 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "value" => "value1"
+                  ~ nestedProp: "value" => "value1"
                 }
         ]
 Resources:
@@ -43,7 +43,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/changed_null_to_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/changed_null_to_non-null.golden
@@ -13,9 +13,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      + test {
-          + computed = (known after apply)
-          + nested   = "value"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "value"
         }
     }
 
@@ -28,14 +28,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
+      + props: [
       +     [0]: {
-              + nested    : "value"
+              + nestedProp: "value"
             }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/removed_end.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
     }
 
@@ -50,14 +50,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -65,8 +65,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":          map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/removed_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/removed_end_unordered.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,16 +50,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  ~ nestedProp: "val2" => "val3"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -67,10 +67,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/removed_front.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,16 +50,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  ~ nestedProp: "val2" => "val3"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -67,10 +67,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/removed_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/removed_front_unordered.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,16 +50,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val3"
+                  ~ nestedProp: "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -67,10 +67,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/removed_middle.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,15 +50,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  ~ nestedProp: "val2" => "val3"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -66,9 +66,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/removed_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/removed_middle_unordered.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,16 +50,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val3"
+                  ~ nestedProp: "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -67,10 +67,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/same_element_updated.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/same_element_updated.golden
@@ -20,29 +20,29 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val4"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val4"
         }
     }
 
@@ -55,11 +55,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val4"
+                  ~ nestedProp: "val2" => "val4"
                 }
           ~ [2]: {
                 }
@@ -69,9 +69,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/same_element_updated_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/same_element_updated_unordered.golden
@@ -20,29 +20,29 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val4"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val4"
         }
     }
 
@@ -55,15 +55,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val4"
+                  ~ nestedProp: "val2" => "val4"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val1"
+                  ~ nestedProp: "val3" => "val1"
                 }
         ]
 Resources:
@@ -71,11 +71,11 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/shuffled_added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/shuffled_added_end.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,15 +50,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           + [2]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
@@ -66,10 +66,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/shuffled_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/shuffled_added_front.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,14 +50,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           ~ [1]: {
                 }
           + [2]: {
-                  + nested    : "val2"
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
@@ -65,9 +65,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/shuffled_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/shuffled_added_middle.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,15 +50,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val3"
+                  ~ nestedProp: "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val2"
+                  ~ nestedProp: "val3" => "val2"
                 }
           + [2]: {
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
@@ -66,10 +66,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/shuffled_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/shuffled_removed_end.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
     }
 
@@ -50,16 +50,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -67,10 +67,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/shuffled_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/shuffled_removed_front.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,15 +50,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val3"
+                  ~ nestedProp: "val1" => "val3"
                 }
           ~ [1]: {
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -66,9 +66,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/shuffled_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/shuffled_removed_middle.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,16 +50,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val3"
+                  ~ nestedProp: "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -67,10 +67,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/two_added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/two_added.golden
@@ -20,29 +20,29 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val4"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val4"
         }
     }
 
@@ -55,16 +55,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
                 }
           + [2]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
           + [3]: {
-                  + nested    : "val4"
+                  + nestedProp: "val4"
                 }
         ]
 Resources:
@@ -72,9 +72,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{},
-		"tests[3]":          map[string]interface{}{},
+		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":          map[string]interface{}{},
+		"props[3]":          map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/two_added_and_two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/two_added_and_two_removed.golden
@@ -22,37 +22,37 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val4" -> null
+      - prop {
+          - nested_prop = "val4" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val5"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val5"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val6"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val6"
         }
     }
 
@@ -65,16 +65,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val5"
+                  ~ nestedProp: "val3" => "val5"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val6"
+                  ~ nestedProp: "val4" => "val6"
                 }
         ]
 Resources:
@@ -82,11 +82,11 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -22,37 +22,37 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val4" -> null
+      - prop {
+          - nested_prop = "val4" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val5"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val5"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val6"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val6"
         }
     }
 
@@ -65,18 +65,18 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val5"
+                  ~ nestedProp: "val1" => "val5"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val6"
+                  ~ nestedProp: "val2" => "val6"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val1"
+                  ~ nestedProp: "val3" => "val1"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val2"
+                  ~ nestedProp: "val4" => "val2"
                 }
         ]
 Resources:
@@ -84,13 +84,13 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -22,37 +22,37 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val4" -> null
+      - prop {
+          - nested_prop = "val4" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val5"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val5"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val6"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val6"
         }
     }
 
@@ -65,17 +65,17 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val5"
+                  ~ nestedProp: "val2" => "val5"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val6"
+                  ~ nestedProp: "val3" => "val6"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val2"
+                  ~ nestedProp: "val4" => "val2"
                 }
         ]
 Resources:
@@ -83,12 +83,12 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -24,37 +24,37 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val4" -> null
+      - prop {
+          - nested_prop = "val4" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val5"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val5"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val6"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val6"
         }
     }
 
@@ -67,17 +67,17 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val5"
+                  ~ nestedProp: "val2" => "val5"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val6"
+                  ~ nestedProp: "val3" => "val6"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val2"
+                  ~ nestedProp: "val4" => "val2"
                 }
         ]
 Resources:
@@ -85,12 +85,12 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/two_removed.golden
@@ -20,29 +20,29 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val4" -> null
+      - prop {
+          - nested_prop = "val4" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
     }
 
@@ -55,18 +55,18 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
           - [3]: {
-                  - computed: ""
-                  - nested  : "val4"
+                  - computed  : ""
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -74,9 +74,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
-		"tests[3]":          map[string]interface{}{"kind": "DELETE"},
+		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":          map[string]interface{}{"kind": "DELETE"},
+		"props[3]":          map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/added.golden
@@ -12,9 +12,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      + test {
-          + computed = "non-computed-value"
-          + nested   = "value"
+      + prop {
+          + computed    = "non-computed-value"
+          + nested_prop = "value"
         }
     }
 
@@ -27,15 +27,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
+      + props: [
       +     [0]: {
               + computed  : "non-computed-value"
-              + nested    : "value"
+              + nestedProp: "value"
             }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/added_end.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      + test {
-          + computed = "non-computed-val3"
-          + nested   = "val3"
+      + prop {
+          + computed    = "non-computed-val3"
+          + nested_prop = "val3"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: {
                   + computed  : "non-computed-val3"
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/added_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/added_end_unordered.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      + test {
-          + computed = "non-computed-val1"
-          + nested   = "val1"
+      + prop {
+          + computed    = "non-computed-val1"
+          + nested_prop = "val1"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: {
                   + computed  : "non-computed-val1"
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/added_front.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      + test {
-          + computed = "non-computed-val1"
-          + nested   = "val1"
+      + prop {
+          + computed    = "non-computed-val1"
+          + nested_prop = "val1"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: {
                   + computed  : "non-computed-val1"
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/added_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/added_front_unordered.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      + test {
-          + computed = "non-computed-val2"
-          + nested   = "val2"
+      + prop {
+          + computed    = "non-computed-val2"
+          + nested_prop = "val2"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: {
                   + computed  : "non-computed-val2"
-                  + nested    : "val2"
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/added_middle.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      + test {
-          + computed = "non-computed-val2"
-          + nested   = "val2"
+      + prop {
+          + computed    = "non-computed-val2"
+          + nested_prop = "val2"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
                   + computed  : "non-computed-val2"
-                  + nested    : "val2"
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/added_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/added_middle_unordered.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      + test {
-          + computed = "non-computed-val3"
-          + nested   = "val3"
+      + prop {
+          + computed    = "non-computed-val3"
+          + nested_prop = "val3"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
                   + computed  : "non-computed-val3"
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/changed_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/changed_non-null.golden
@@ -14,13 +14,13 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-value" -> null
-          - nested   = "value" -> null
+      - prop {
+          - computed    = "non-computed-value" -> null
+          - nested_prop = "value" -> null
         }
-      + test {
-          + computed = "non-computed-value1"
-          + nested   = "value1"
+      + prop {
+          + computed    = "non-computed-value1"
+          + nested_prop = "value1"
         }
     }
 
@@ -33,10 +33,10 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ computed: "non-computed-value" => "non-computed-value1"
-                  ~ nested  : "value" => "value1"
+                  ~ computed  : "non-computed-value" => "non-computed-value1"
+                  ~ nestedProp: "value" => "value1"
                 }
         ]
 Resources:
@@ -44,7 +44,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/changed_null_to_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/changed_null_to_non-null.golden
@@ -13,9 +13,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      + test {
-          + computed = "non-computed-value"
-          + nested   = "value"
+      + prop {
+          + computed    = "non-computed-value"
+          + nested_prop = "value"
         }
     }
 
@@ -28,15 +28,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
+      + props: [
       +     [0]: {
               + computed  : "non-computed-value"
-              + nested    : "value"
+              + nestedProp: "value"
             }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/removed_end.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop {
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: {
-                  - computed: "non-computed-val3"
-                  - nested  : "val3"
+                  - computed  : "non-computed-val3"
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/removed_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/removed_end_unordered.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val1" -> null
-          - nested   = "val1" -> null
+      - prop {
+          - computed    = "non-computed-val1" -> null
+          - nested_prop = "val1" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: {
-                  - computed: "non-computed-val1"
-                  - nested  : "val1"
+                  - computed  : "non-computed-val1"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/removed_front.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val1" -> null
-          - nested   = "val1" -> null
+      - prop {
+          - computed    = "non-computed-val1" -> null
+          - nested_prop = "val1" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: {
-                  - computed: "non-computed-val1"
-                  - nested  : "val1"
+                  - computed  : "non-computed-val1"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/removed_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/removed_front_unordered.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val2" -> null
-          - nested   = "val2" -> null
+      - prop {
+          - computed    = "non-computed-val2" -> null
+          - nested_prop = "val2" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+                  - computed  : "non-computed-val2"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/removed_middle.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val2" -> null
-          - nested   = "val2" -> null
+      - prop {
+          - computed    = "non-computed-val2" -> null
+          - nested_prop = "val2" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+                  - computed  : "non-computed-val2"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/removed_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/removed_middle_unordered.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val2" -> null
-          - nested   = "val2" -> null
+      - prop {
+          - computed    = "non-computed-val2" -> null
+          - nested_prop = "val2" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+                  - computed  : "non-computed-val2"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/same_element_updated.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/same_element_updated.golden
@@ -20,13 +20,13 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val2" -> null
-          - nested   = "val2" -> null
+      - prop {
+          - computed    = "non-computed-val2" -> null
+          - nested_prop = "val2" -> null
         }
-      + test {
-          + computed = "non-computed-val4"
-          + nested   = "val4"
+      + prop {
+          + computed    = "non-computed-val4"
+          + nested_prop = "val4"
         }
 
         # (2 unchanged blocks hidden)
@@ -41,10 +41,10 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [1]: {
-                  ~ computed: "non-computed-val2" => "non-computed-val4"
-                  ~ nested  : "val2" => "val4"
+                  ~ computed  : "non-computed-val2" => "non-computed-val4"
+                  ~ nestedProp: "val2" => "val4"
                 }
         ]
 Resources:
@@ -52,7 +52,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/same_element_updated_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/same_element_updated_unordered.golden
@@ -20,13 +20,13 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop {
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
-      + test {
-          + computed = "non-computed-val4"
-          + nested   = "val4"
+      + prop {
+          + computed    = "non-computed-val4"
+          + nested_prop = "val4"
         }
 
         # (2 unchanged blocks hidden)
@@ -41,14 +41,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
                   + computed  : "non-computed-val4"
-                  + nested    : "val4"
+                  + nestedProp: "val4"
                 }
           - [2]: {
-                  - computed: "non-computed-val3"
-                  - nested  : "val3"
+                  - computed  : "non-computed-val3"
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -56,7 +56,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]": map[string]interface{}{},
-		"tests[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[1]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/shuffled_added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/shuffled_added_end.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      + test {
-          + computed = "non-computed-val3"
-          + nested   = "val3"
+      + prop {
+          + computed    = "non-computed-val3"
+          + nested_prop = "val3"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: {
                   + computed  : "non-computed-val3"
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/shuffled_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/shuffled_added_front.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      + test {
-          + computed = "non-computed-val1"
-          + nested   = "val1"
+      + prop {
+          + computed    = "non-computed-val1"
+          + nested_prop = "val1"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: {
                   + computed  : "non-computed-val1"
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/shuffled_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/shuffled_added_middle.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      + test {
-          + computed = "non-computed-val2"
-          + nested   = "val2"
+      + prop {
+          + computed    = "non-computed-val2"
+          + nested_prop = "val2"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
                   + computed  : "non-computed-val2"
-                  + nested    : "val2"
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/shuffled_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/shuffled_removed_end.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop {
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: {
-                  - computed: "non-computed-val3"
-                  - nested  : "val3"
+                  - computed  : "non-computed-val3"
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/shuffled_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/shuffled_removed_front.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val1" -> null
-          - nested   = "val1" -> null
+      - prop {
+          - computed    = "non-computed-val1" -> null
+          - nested_prop = "val1" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: {
-                  - computed: "non-computed-val1"
-                  - nested  : "val1"
+                  - computed  : "non-computed-val1"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/shuffled_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/shuffled_removed_middle.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val2" -> null
-          - nested   = "val2" -> null
+      - prop {
+          - computed    = "non-computed-val2" -> null
+          - nested_prop = "val2" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+                  - computed  : "non-computed-val2"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/two_added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/two_added.golden
@@ -20,13 +20,13 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      + test {
-          + computed = "non-computed-val3"
-          + nested   = "val3"
+      + prop {
+          + computed    = "non-computed-val3"
+          + nested_prop = "val3"
         }
-      + test {
-          + computed = "non-computed-val4"
-          + nested   = "val4"
+      + prop {
+          + computed    = "non-computed-val4"
+          + nested_prop = "val4"
         }
 
         # (2 unchanged blocks hidden)
@@ -41,14 +41,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: {
                   + computed  : "non-computed-val3"
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
           + [3]: {
                   + computed  : "non-computed-val4"
-                  + nested    : "val4"
+                  + nestedProp: "val4"
                 }
         ]
 Resources:
@@ -56,7 +56,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{},
-		"tests[3]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{},
+		"props[3]": map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/two_added_and_two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/two_added_and_two_removed.golden
@@ -22,21 +22,21 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop {
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
-      - test {
-          - computed = "non-computed-val4" -> null
-          - nested   = "val4" -> null
+      - prop {
+          - computed    = "non-computed-val4" -> null
+          - nested_prop = "val4" -> null
         }
-      + test {
-          + computed = "non-computed-val5"
-          + nested   = "val5"
+      + prop {
+          + computed    = "non-computed-val5"
+          + nested_prop = "val5"
         }
-      + test {
-          + computed = "non-computed-val6"
-          + nested   = "val6"
+      + prop {
+          + computed    = "non-computed-val6"
+          + nested_prop = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -51,14 +51,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val5"
-                  ~ nested  : "val3" => "val5"
+                  ~ computed  : "non-computed-val3" => "non-computed-val5"
+                  ~ nestedProp: "val3" => "val5"
                 }
           ~ [3]: {
-                  ~ computed: "non-computed-val4" => "non-computed-val6"
-                  ~ nested  : "val4" => "val6"
+                  ~ computed  : "non-computed-val4" => "non-computed-val6"
+                  ~ nestedProp: "val4" => "val6"
                 }
         ]
 Resources:
@@ -66,9 +66,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -22,21 +22,21 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop {
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
-      - test {
-          - computed = "non-computed-val4" -> null
-          - nested   = "val4" -> null
+      - prop {
+          - computed    = "non-computed-val4" -> null
+          - nested_prop = "val4" -> null
         }
-      + test {
-          + computed = "non-computed-val5"
-          + nested   = "val5"
+      + prop {
+          + computed    = "non-computed-val5"
+          + nested_prop = "val5"
         }
-      + test {
-          + computed = "non-computed-val6"
-          + nested   = "val6"
+      + prop {
+          + computed    = "non-computed-val6"
+          + nested_prop = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -51,22 +51,22 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: {
                   + computed  : "non-computed-val5"
-                  + nested    : "val5"
+                  + nestedProp: "val5"
                 }
           + [1]: {
                   + computed  : "non-computed-val6"
-                  + nested    : "val6"
+                  + nestedProp: "val6"
                 }
           - [2]: {
-                  - computed: "non-computed-val3"
-                  - nested  : "val3"
+                  - computed  : "non-computed-val3"
+                  - nestedProp: "val3"
                 }
           - [3]: {
-                  - computed: "non-computed-val4"
-                  - nested  : "val4"
+                  - computed  : "non-computed-val4"
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -74,9 +74,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0]": map[string]interface{}{},
-		"tests[1]": map[string]interface{}{},
-		"tests[2]": map[string]interface{}{"kind": "DELETE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE"},
+		"props[0]": map[string]interface{}{},
+		"props[1]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -22,21 +22,21 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop {
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
-      - test {
-          - computed = "non-computed-val4" -> null
-          - nested   = "val4" -> null
+      - prop {
+          - computed    = "non-computed-val4" -> null
+          - nested_prop = "val4" -> null
         }
-      + test {
-          + computed = "non-computed-val5"
-          + nested   = "val5"
+      + prop {
+          + computed    = "non-computed-val5"
+          + nested_prop = "val5"
         }
-      + test {
-          + computed = "non-computed-val6"
-          + nested   = "val6"
+      + prop {
+          + computed    = "non-computed-val6"
+          + nested_prop = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -51,18 +51,18 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
                   + computed  : "non-computed-val5"
-                  + nested    : "val5"
+                  + nestedProp: "val5"
                 }
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val6"
-                  ~ nested  : "val3" => "val6"
+                  ~ computed  : "non-computed-val3" => "non-computed-val6"
+                  ~ nestedProp: "val3" => "val6"
                 }
           - [3]: {
-                  - computed: "non-computed-val4"
-                  - nested  : "val4"
+                  - computed  : "non-computed-val4"
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -70,9 +70,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]":          map[string]interface{}{},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]":          map[string]interface{}{"kind": "DELETE"},
+		"props[1]":            map[string]interface{}{},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -24,21 +24,21 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop {
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
-      - test {
-          - computed = "non-computed-val4" -> null
-          - nested   = "val4" -> null
+      - prop {
+          - computed    = "non-computed-val4" -> null
+          - nested_prop = "val4" -> null
         }
-      + test {
-          + computed = "non-computed-val5"
-          + nested   = "val5"
+      + prop {
+          + computed    = "non-computed-val5"
+          + nested_prop = "val5"
         }
-      + test {
-          + computed = "non-computed-val6"
-          + nested   = "val6"
+      + prop {
+          + computed    = "non-computed-val6"
+          + nested_prop = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -53,18 +53,18 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
                   + computed  : "non-computed-val5"
-                  + nested    : "val5"
+                  + nestedProp: "val5"
                 }
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val6"
-                  ~ nested  : "val3" => "val6"
+                  ~ computed  : "non-computed-val3" => "non-computed-val6"
+                  ~ nestedProp: "val3" => "val6"
                 }
           - [3]: {
-                  - computed: "non-computed-val4"
-                  - nested  : "val4"
+                  - computed  : "non-computed-val4"
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -72,9 +72,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]":          map[string]interface{}{},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]":          map[string]interface{}{"kind": "DELETE"},
+		"props[1]":            map[string]interface{}{},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace_computed_specified_in_program/two_removed.golden
@@ -20,13 +20,13 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop {
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
-      - test {
-          - computed = "non-computed-val4" -> null
-          - nested   = "val4" -> null
+      - prop {
+          - computed    = "non-computed-val4" -> null
+          - nested_prop = "val4" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -41,14 +41,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: {
-                  - computed: "non-computed-val3"
-                  - nested  : "val3"
+                  - computed  : "non-computed-val3"
+                  - nestedProp: "val3"
                 }
           - [3]: {
-                  - computed: "non-computed-val4"
-                  - nested  : "val4"
+                  - computed  : "non-computed-val4"
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -56,7 +56,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{"kind": "DELETE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/added.golden
@@ -12,9 +12,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "value"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "value"
         }
     }
 
@@ -27,14 +27,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
+      + props: [
       +     [0]: {
-              + nested    : "value"
+              + nestedProp: "value"
             }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/added_end.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,13 +50,13 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
                 }
           + [2]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
@@ -64,8 +64,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/added_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/added_end_unordered.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,13 +50,13 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
                 }
           + [2]: {
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
@@ -64,8 +64,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/added_front.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,15 +50,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val2"
+                  ~ nestedProp: "val3" => "val2"
                 }
           + [2]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
@@ -66,10 +66,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/added_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/added_front_unordered.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,14 +50,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
                 }
           + [2]: {
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
@@ -65,9 +65,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/added_middle.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,14 +50,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val2"
+                  ~ nestedProp: "val3" => "val2"
                 }
           + [2]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
@@ -65,9 +65,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/added_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/added_middle_unordered.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,15 +50,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  ~ nestedProp: "val2" => "val3"
                 }
           + [2]: {
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
@@ -66,10 +66,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/changed_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/changed_non-null.golden
@@ -14,13 +14,13 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "value" -> null
+      - prop {
+          - nested_prop = "value" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "value1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "value1"
         }
     }
 
@@ -33,9 +33,9 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "value" => "value1"
+                  ~ nestedProp: "value" => "value1"
                 }
         ]
 Resources:
@@ -43,7 +43,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/changed_non-null_to_null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/changed_non-null_to_null.golden
@@ -14,8 +14,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "value" -> null
+      - prop { # forces replacement
+          - nested_prop = "value" -> null
             # (1 unchanged attribute hidden)
         }
     }
@@ -29,15 +29,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - tests: [
+      - props: [
       -     [0]: {
-              - computed: ""
-              - nested  : "value"
+              - computed  : ""
+              - nestedProp: "value"
             }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/changed_null_to_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/changed_null_to_non-null.golden
@@ -13,9 +13,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "value"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "value"
         }
     }
 
@@ -28,14 +28,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
+      + props: [
       +     [0]: {
-              + nested    : "value"
+              + nestedProp: "value"
             }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/removed.golden
@@ -14,8 +14,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "value" -> null
+      - prop { # forces replacement
+          - nested_prop = "value" -> null
             # (1 unchanged attribute hidden)
         }
     }
@@ -29,15 +29,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - tests: [
+      - props: [
       -     [0]: {
-              - computed: ""
-              - nested  : "value"
+              - computed  : ""
+              - nestedProp: "value"
             }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/removed_end.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
     }
 
@@ -50,14 +50,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -65,8 +65,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/removed_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/removed_end_unordered.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,16 +50,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  ~ nestedProp: "val2" => "val3"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -67,10 +67,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/removed_front.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,16 +50,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  ~ nestedProp: "val2" => "val3"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -67,10 +67,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/removed_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/removed_front_unordered.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,16 +50,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val3"
+                  ~ nestedProp: "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -67,10 +67,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/removed_middle.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,15 +50,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  ~ nestedProp: "val2" => "val3"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -66,9 +66,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/removed_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/removed_middle_unordered.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,16 +50,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val3"
+                  ~ nestedProp: "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -67,10 +67,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/same_element_updated.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/same_element_updated.golden
@@ -20,29 +20,29 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val4"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val4"
         }
     }
 
@@ -55,11 +55,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val4"
+                  ~ nestedProp: "val2" => "val4"
                 }
           ~ [2]: {
                 }
@@ -69,9 +69,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/same_element_updated_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/same_element_updated_unordered.golden
@@ -20,29 +20,29 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val4"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val4"
         }
     }
 
@@ -55,15 +55,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val4"
+                  ~ nestedProp: "val2" => "val4"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val1"
+                  ~ nestedProp: "val3" => "val1"
                 }
         ]
 Resources:
@@ -71,11 +71,11 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/shuffled_added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/shuffled_added_end.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,15 +50,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           + [2]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
@@ -66,10 +66,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/shuffled_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/shuffled_added_front.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,14 +50,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           ~ [1]: {
                 }
           + [2]: {
-                  + nested    : "val2"
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
@@ -65,9 +65,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/shuffled_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/shuffled_added_middle.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,15 +50,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val3"
+                  ~ nestedProp: "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val2"
+                  ~ nestedProp: "val3" => "val2"
                 }
           + [2]: {
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
@@ -66,10 +66,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/shuffled_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/shuffled_removed_end.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
     }
 
@@ -50,16 +50,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -67,10 +67,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/shuffled_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/shuffled_removed_front.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,15 +50,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val3"
+                  ~ nestedProp: "val1" => "val3"
                 }
           ~ [1]: {
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -66,9 +66,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/shuffled_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/shuffled_removed_middle.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,16 +50,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val3"
+                  ~ nestedProp: "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -67,10 +67,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/two_added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/two_added.golden
@@ -20,29 +20,29 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val4"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val4"
         }
     }
 
@@ -55,16 +55,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
                 }
           + [2]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
           + [3]: {
-                  + nested    : "val4"
+                  + nestedProp: "val4"
                 }
         ]
 Resources:
@@ -72,9 +72,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[3]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[3]":          map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/two_added_and_two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/two_added_and_two_removed.golden
@@ -22,37 +22,37 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val4" -> null
+      - prop {
+          - nested_prop = "val4" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val5"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val5"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val6"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val6"
         }
     }
 
@@ -65,16 +65,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val5"
+                  ~ nestedProp: "val3" => "val5"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val6"
+                  ~ nestedProp: "val4" => "val6"
                 }
         ]
 Resources:
@@ -82,11 +82,11 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -22,37 +22,37 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val4" -> null
+      - prop {
+          - nested_prop = "val4" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val5"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val5"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val6"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val6"
         }
     }
 
@@ -65,18 +65,18 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val5"
+                  ~ nestedProp: "val1" => "val5"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val6"
+                  ~ nestedProp: "val2" => "val6"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val1"
+                  ~ nestedProp: "val3" => "val1"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val2"
+                  ~ nestedProp: "val4" => "val2"
                 }
         ]
 Resources:
@@ -84,13 +84,13 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -22,37 +22,37 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val4" -> null
+      - prop {
+          - nested_prop = "val4" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val5"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val5"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val6"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val6"
         }
     }
 
@@ -65,17 +65,17 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val5"
+                  ~ nestedProp: "val2" => "val5"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val6"
+                  ~ nestedProp: "val3" => "val6"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val2"
+                  ~ nestedProp: "val4" => "val2"
                 }
         ]
 Resources:
@@ -83,12 +83,12 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -24,37 +24,37 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val4" -> null
+      - prop {
+          - nested_prop = "val4" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val5"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val5"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val6"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val6"
         }
     }
 
@@ -67,17 +67,17 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val5"
+                  ~ nestedProp: "val2" => "val5"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val6"
+                  ~ nestedProp: "val3" => "val6"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val2"
+                  ~ nestedProp: "val4" => "val2"
                 }
         ]
 Resources:
@@ -85,12 +85,12 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/two_removed.golden
@@ -20,29 +20,29 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val4" -> null
+      - prop { # forces replacement
+          - nested_prop = "val4" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
     }
 
@@ -55,18 +55,18 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
           - [3]: {
-                  - computed: ""
-                  - nested  : "val4"
+                  - computed  : ""
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -74,9 +74,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
-		"tests[3]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[3]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/added.golden
@@ -12,9 +12,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-value"
-          + nested   = "value"
+      + prop { # forces replacement
+          + computed    = "non-computed-value"
+          + nested_prop = "value"
         }
     }
 
@@ -27,15 +27,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
+      + props: [
       +     [0]: {
               + computed  : "non-computed-value"
-              + nested    : "value"
+              + nestedProp: "value"
             }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/added_end.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-val3"
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = "non-computed-val3"
+          + nested_prop = "val3"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: {
                   + computed  : "non-computed-val3"
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/added_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/added_end_unordered.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-val1"
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = "non-computed-val1"
+          + nested_prop = "val1"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: {
                   + computed  : "non-computed-val1"
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/added_front.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-val1"
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = "non-computed-val1"
+          + nested_prop = "val1"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: {
                   + computed  : "non-computed-val1"
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/added_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/added_front_unordered.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-val2"
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = "non-computed-val2"
+          + nested_prop = "val2"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: {
                   + computed  : "non-computed-val2"
-                  + nested    : "val2"
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/added_middle.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-val2"
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = "non-computed-val2"
+          + nested_prop = "val2"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
                   + computed  : "non-computed-val2"
-                  + nested    : "val2"
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/added_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/added_middle_unordered.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-val3"
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = "non-computed-val3"
+          + nested_prop = "val3"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
                   + computed  : "non-computed-val3"
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/changed_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/changed_non-null.golden
@@ -14,13 +14,13 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-value" -> null
-          - nested   = "value" -> null
+      - prop {
+          - computed    = "non-computed-value" -> null
+          - nested_prop = "value" -> null
         }
-      + test {
-          + computed = "non-computed-value1"
-          + nested   = "value1"
+      + prop {
+          + computed    = "non-computed-value1"
+          + nested_prop = "value1"
         }
     }
 
@@ -33,10 +33,10 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ computed: "non-computed-value" => "non-computed-value1"
-                  ~ nested  : "value" => "value1"
+                  ~ computed  : "non-computed-value" => "non-computed-value1"
+                  ~ nestedProp: "value" => "value1"
                 }
         ]
 Resources:
@@ -44,7 +44,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/changed_non-null_to_null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/changed_non-null_to_null.golden
@@ -14,9 +14,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-value" -> null
-          - nested   = "value" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-value" -> null
+          - nested_prop = "value" -> null
         }
     }
 
@@ -29,15 +29,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - tests: [
+      - props: [
       -     [0]: {
-              - computed: "non-computed-value"
-              - nested  : "value"
+              - computed  : "non-computed-value"
+              - nestedProp: "value"
             }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/changed_null_to_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/changed_null_to_non-null.golden
@@ -13,9 +13,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-value"
-          + nested   = "value"
+      + prop { # forces replacement
+          + computed    = "non-computed-value"
+          + nested_prop = "value"
         }
     }
 
@@ -28,15 +28,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
+      + props: [
       +     [0]: {
               + computed  : "non-computed-value"
-              + nested    : "value"
+              + nestedProp: "value"
             }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/removed.golden
@@ -14,9 +14,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-value" -> null
-          - nested   = "value" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-value" -> null
+          - nested_prop = "value" -> null
         }
     }
 
@@ -29,15 +29,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - tests: [
+      - props: [
       -     [0]: {
-              - computed: "non-computed-value"
-              - nested  : "value"
+              - computed  : "non-computed-value"
+              - nestedProp: "value"
             }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/removed_end.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: {
-                  - computed: "non-computed-val3"
-                  - nested  : "val3"
+                  - computed  : "non-computed-val3"
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/removed_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/removed_end_unordered.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val1" -> null
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val1" -> null
+          - nested_prop = "val1" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: {
-                  - computed: "non-computed-val1"
-                  - nested  : "val1"
+                  - computed  : "non-computed-val1"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/removed_front.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val1" -> null
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val1" -> null
+          - nested_prop = "val1" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: {
-                  - computed: "non-computed-val1"
-                  - nested  : "val1"
+                  - computed  : "non-computed-val1"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/removed_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/removed_front_unordered.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val2" -> null
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val2" -> null
+          - nested_prop = "val2" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+                  - computed  : "non-computed-val2"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/removed_middle.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val2" -> null
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val2" -> null
+          - nested_prop = "val2" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+                  - computed  : "non-computed-val2"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/removed_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/removed_middle_unordered.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val2" -> null
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val2" -> null
+          - nested_prop = "val2" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+                  - computed  : "non-computed-val2"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/same_element_updated.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/same_element_updated.golden
@@ -20,13 +20,13 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val2" -> null
-          - nested   = "val2" -> null
+      - prop {
+          - computed    = "non-computed-val2" -> null
+          - nested_prop = "val2" -> null
         }
-      + test {
-          + computed = "non-computed-val4"
-          + nested   = "val4"
+      + prop {
+          + computed    = "non-computed-val4"
+          + nested_prop = "val4"
         }
 
         # (2 unchanged blocks hidden)
@@ -41,10 +41,10 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [1]: {
-                  ~ computed: "non-computed-val2" => "non-computed-val4"
-                  ~ nested  : "val2" => "val4"
+                  ~ computed  : "non-computed-val2" => "non-computed-val4"
+                  ~ nestedProp: "val2" => "val4"
                 }
         ]
 Resources:
@@ -52,7 +52,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/same_element_updated_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/same_element_updated_unordered.golden
@@ -20,13 +20,13 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop {
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
-      + test {
-          + computed = "non-computed-val4"
-          + nested   = "val4"
+      + prop {
+          + computed    = "non-computed-val4"
+          + nested_prop = "val4"
         }
 
         # (2 unchanged blocks hidden)
@@ -41,14 +41,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
                   + computed  : "non-computed-val4"
-                  + nested    : "val4"
+                  + nestedProp: "val4"
                 }
           - [2]: {
-                  - computed: "non-computed-val3"
-                  - nested  : "val3"
+                  - computed  : "non-computed-val3"
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -56,7 +56,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]": map[string]interface{}{},
-		"tests[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[1]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_added_end.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-val3"
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = "non-computed-val3"
+          + nested_prop = "val3"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: {
                   + computed  : "non-computed-val3"
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_added_front.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-val1"
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = "non-computed-val1"
+          + nested_prop = "val1"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: {
                   + computed  : "non-computed-val1"
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_added_middle.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-val2"
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = "non-computed-val2"
+          + nested_prop = "val2"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
                   + computed  : "non-computed-val2"
-                  + nested    : "val2"
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_removed_end.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: {
-                  - computed: "non-computed-val3"
-                  - nested  : "val3"
+                  - computed  : "non-computed-val3"
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_removed_front.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val1" -> null
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val1" -> null
+          - nested_prop = "val1" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: {
-                  - computed: "non-computed-val1"
-                  - nested  : "val1"
+                  - computed  : "non-computed-val1"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/shuffled_removed_middle.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val2" -> null
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val2" -> null
+          - nested_prop = "val2" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+                  - computed  : "non-computed-val2"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/two_added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/two_added.golden
@@ -20,13 +20,13 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-val3"
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = "non-computed-val3"
+          + nested_prop = "val3"
         }
-      + test { # forces replacement
-          + computed = "non-computed-val4"
-          + nested   = "val4"
+      + prop { # forces replacement
+          + computed    = "non-computed-val4"
+          + nested_prop = "val4"
         }
 
         # (2 unchanged blocks hidden)
@@ -41,14 +41,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: {
                   + computed  : "non-computed-val3"
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
           + [3]: {
                   + computed  : "non-computed-val4"
-                  + nested    : "val4"
+                  + nestedProp: "val4"
                 }
         ]
 Resources:
@@ -56,7 +56,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[3]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[3]": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/two_added_and_two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/two_added_and_two_removed.golden
@@ -22,21 +22,21 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop {
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
-      - test {
-          - computed = "non-computed-val4" -> null
-          - nested   = "val4" -> null
+      - prop {
+          - computed    = "non-computed-val4" -> null
+          - nested_prop = "val4" -> null
         }
-      + test {
-          + computed = "non-computed-val5"
-          + nested   = "val5"
+      + prop {
+          + computed    = "non-computed-val5"
+          + nested_prop = "val5"
         }
-      + test {
-          + computed = "non-computed-val6"
-          + nested   = "val6"
+      + prop {
+          + computed    = "non-computed-val6"
+          + nested_prop = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -51,14 +51,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val5"
-                  ~ nested  : "val3" => "val5"
+                  ~ computed  : "non-computed-val3" => "non-computed-val5"
+                  ~ nestedProp: "val3" => "val5"
                 }
           ~ [3]: {
-                  ~ computed: "non-computed-val4" => "non-computed-val6"
-                  ~ nested  : "val4" => "val6"
+                  ~ computed  : "non-computed-val4" => "non-computed-val6"
+                  ~ nestedProp: "val4" => "val6"
                 }
         ]
 Resources:
@@ -66,9 +66,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -22,21 +22,21 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop {
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
-      - test {
-          - computed = "non-computed-val4" -> null
-          - nested   = "val4" -> null
+      - prop {
+          - computed    = "non-computed-val4" -> null
+          - nested_prop = "val4" -> null
         }
-      + test {
-          + computed = "non-computed-val5"
-          + nested   = "val5"
+      + prop {
+          + computed    = "non-computed-val5"
+          + nested_prop = "val5"
         }
-      + test {
-          + computed = "non-computed-val6"
-          + nested   = "val6"
+      + prop {
+          + computed    = "non-computed-val6"
+          + nested_prop = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -51,22 +51,22 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: {
                   + computed  : "non-computed-val5"
-                  + nested    : "val5"
+                  + nestedProp: "val5"
                 }
           + [1]: {
                   + computed  : "non-computed-val6"
-                  + nested    : "val6"
+                  + nestedProp: "val6"
                 }
           - [2]: {
-                  - computed: "non-computed-val3"
-                  - nested  : "val3"
+                  - computed  : "non-computed-val3"
+                  - nestedProp: "val3"
                 }
           - [3]: {
-                  - computed: "non-computed-val4"
-                  - nested  : "val4"
+                  - computed  : "non-computed-val4"
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -74,9 +74,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0]": map[string]interface{}{},
-		"tests[1]": map[string]interface{}{},
-		"tests[2]": map[string]interface{}{"kind": "DELETE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE"},
+		"props[0]": map[string]interface{}{},
+		"props[1]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -22,21 +22,21 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop {
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
-      - test {
-          - computed = "non-computed-val4" -> null
-          - nested   = "val4" -> null
+      - prop {
+          - computed    = "non-computed-val4" -> null
+          - nested_prop = "val4" -> null
         }
-      + test {
-          + computed = "non-computed-val5"
-          + nested   = "val5"
+      + prop {
+          + computed    = "non-computed-val5"
+          + nested_prop = "val5"
         }
-      + test {
-          + computed = "non-computed-val6"
-          + nested   = "val6"
+      + prop {
+          + computed    = "non-computed-val6"
+          + nested_prop = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -51,18 +51,18 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
                   + computed  : "non-computed-val5"
-                  + nested    : "val5"
+                  + nestedProp: "val5"
                 }
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val6"
-                  ~ nested  : "val3" => "val6"
+                  ~ computed  : "non-computed-val3" => "non-computed-val6"
+                  ~ nestedProp: "val3" => "val6"
                 }
           - [3]: {
-                  - computed: "non-computed-val4"
-                  - nested  : "val4"
+                  - computed  : "non-computed-val4"
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -70,9 +70,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]":          map[string]interface{}{},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]":          map[string]interface{}{"kind": "DELETE"},
+		"props[1]":            map[string]interface{}{},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -24,21 +24,21 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop {
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
-      - test {
-          - computed = "non-computed-val4" -> null
-          - nested   = "val4" -> null
+      - prop {
+          - computed    = "non-computed-val4" -> null
+          - nested_prop = "val4" -> null
         }
-      + test {
-          + computed = "non-computed-val5"
-          + nested   = "val5"
+      + prop {
+          + computed    = "non-computed-val5"
+          + nested_prop = "val5"
         }
-      + test {
-          + computed = "non-computed-val6"
-          + nested   = "val6"
+      + prop {
+          + computed    = "non-computed-val6"
+          + nested_prop = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -53,18 +53,18 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
                   + computed  : "non-computed-val5"
-                  + nested    : "val5"
+                  + nestedProp: "val5"
                 }
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val6"
-                  ~ nested  : "val3" => "val6"
+                  ~ computed  : "non-computed-val3" => "non-computed-val6"
+                  ~ nestedProp: "val3" => "val6"
                 }
           - [3]: {
-                  - computed: "non-computed-val4"
-                  - nested  : "val4"
+                  - computed  : "non-computed-val4"
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -72,9 +72,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]":          map[string]interface{}{},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]":          map[string]interface{}{"kind": "DELETE"},
+		"props[1]":            map[string]interface{}{},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new_computed_specified_in_program/two_removed.golden
@@ -20,13 +20,13 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
-      - test { # forces replacement
-          - computed = "non-computed-val4" -> null
-          - nested   = "val4" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val4" -> null
+          - nested_prop = "val4" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -41,14 +41,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: {
-                  - computed: "non-computed-val3"
-                  - nested  : "val3"
+                  - computed  : "non-computed-val3"
+                  - nestedProp: "val3"
                 }
           - [3]: {
-                  - computed: "non-computed-val4"
-                  - nested  : "val4"
+                  - computed  : "non-computed-val4"
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -56,7 +56,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/added.golden
@@ -12,9 +12,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "value"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "value"
         }
     }
 
@@ -27,14 +27,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
+      + props: [
       +     [0]: {
-              + nested    : "value"
+              + nestedProp: "value"
             }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/added_end.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,13 +50,13 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
                 }
           + [2]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
@@ -64,8 +64,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/added_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/added_end_unordered.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,13 +50,13 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
                 }
           + [2]: {
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
@@ -64,8 +64,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/added_front.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,15 +50,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val2"
+                  ~ nestedProp: "val3" => "val2"
                 }
           + [2]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
@@ -66,10 +66,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/added_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/added_front_unordered.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,14 +50,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
                 }
           + [2]: {
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
@@ -65,9 +65,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/added_middle.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,14 +50,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val2"
+                  ~ nestedProp: "val3" => "val2"
                 }
           + [2]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
@@ -65,9 +65,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/added_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/added_middle_unordered.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,15 +50,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  ~ nestedProp: "val2" => "val3"
                 }
           + [2]: {
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
@@ -66,10 +66,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/changed_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/changed_non-null.golden
@@ -14,13 +14,13 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "value" -> null
+      - prop { # forces replacement
+          - nested_prop = "value" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "value1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "value1"
         }
     }
 
@@ -33,9 +33,9 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "value" => "value1"
+                  ~ nestedProp: "value" => "value1"
                 }
         ]
 Resources:
@@ -43,7 +43,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/changed_non-null_to_null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/changed_non-null_to_null.golden
@@ -14,8 +14,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "value" -> null
+      - prop { # forces replacement
+          - nested_prop = "value" -> null
             # (1 unchanged attribute hidden)
         }
     }
@@ -29,15 +29,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - tests: [
+      - props: [
       -     [0]: {
-              - computed: ""
-              - nested  : "value"
+              - computed  : ""
+              - nestedProp: "value"
             }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/changed_null_to_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/changed_null_to_non-null.golden
@@ -13,9 +13,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "value"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "value"
         }
     }
 
@@ -28,14 +28,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
+      + props: [
       +     [0]: {
-              + nested    : "value"
+              + nestedProp: "value"
             }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/removed.golden
@@ -14,8 +14,8 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "value" -> null
+      - prop { # forces replacement
+          - nested_prop = "value" -> null
             # (1 unchanged attribute hidden)
         }
     }
@@ -29,15 +29,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - tests: [
+      - props: [
       -     [0]: {
-              - computed: ""
-              - nested  : "value"
+              - computed  : ""
+              - nestedProp: "value"
             }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/removed_end.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
     }
 
@@ -50,14 +50,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -65,8 +65,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/removed_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/removed_end_unordered.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,16 +50,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  ~ nestedProp: "val2" => "val3"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -67,10 +67,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/removed_front.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,16 +50,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  ~ nestedProp: "val2" => "val3"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -67,10 +67,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/removed_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/removed_front_unordered.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,16 +50,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val3"
+                  ~ nestedProp: "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -67,10 +67,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/removed_middle.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,15 +50,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  ~ nestedProp: "val2" => "val3"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -66,9 +66,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/removed_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/removed_middle_unordered.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,16 +50,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val3"
+                  ~ nestedProp: "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -67,10 +67,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/same_element_updated.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/same_element_updated.golden
@@ -20,29 +20,29 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val4"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val4"
         }
     }
 
@@ -55,11 +55,11 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val4"
+                  ~ nestedProp: "val2" => "val4"
                 }
           ~ [2]: {
                 }
@@ -69,9 +69,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/same_element_updated_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/same_element_updated_unordered.golden
@@ -20,29 +20,29 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val4"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val4"
         }
     }
 
@@ -55,15 +55,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val4"
+                  ~ nestedProp: "val2" => "val4"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val1"
+                  ~ nestedProp: "val3" => "val1"
                 }
         ]
 Resources:
@@ -71,11 +71,11 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/shuffled_added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/shuffled_added_end.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,15 +50,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           + [2]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
@@ -66,10 +66,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/shuffled_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/shuffled_added_front.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,14 +50,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           ~ [1]: {
                 }
           + [2]: {
-                  + nested    : "val2"
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
@@ -65,9 +65,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/shuffled_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/shuffled_added_middle.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,15 +50,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val3"
+                  ~ nestedProp: "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val2"
+                  ~ nestedProp: "val3" => "val2"
                 }
           + [2]: {
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
@@ -66,10 +66,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/shuffled_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/shuffled_removed_end.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
     }
 
@@ -50,16 +50,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -67,10 +67,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/shuffled_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/shuffled_removed_front.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,15 +50,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val3"
+                  ~ nestedProp: "val1" => "val3"
                 }
           ~ [1]: {
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -66,9 +66,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/shuffled_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/shuffled_removed_middle.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,16 +50,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val3"
+                  ~ nestedProp: "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -67,10 +67,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/two_added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/two_added.golden
@@ -20,29 +20,29 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val4"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val4"
         }
     }
 
@@ -55,16 +55,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
                 }
           + [2]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
           + [3]: {
-                  + nested    : "val4"
+                  + nestedProp: "val4"
                 }
         ]
 Resources:
@@ -72,9 +72,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[3]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[3]":          map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/two_added_and_two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/two_added_and_two_removed.golden
@@ -22,37 +22,37 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val4" -> null
+      - prop { # forces replacement
+          - nested_prop = "val4" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val5"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val5"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val6"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val6"
         }
     }
 
@@ -65,16 +65,16 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val5"
+                  ~ nestedProp: "val3" => "val5"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val6"
+                  ~ nestedProp: "val4" => "val6"
                 }
         ]
 Resources:
@@ -82,11 +82,11 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -22,37 +22,37 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val4" -> null
+      - prop { # forces replacement
+          - nested_prop = "val4" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val5"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val5"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val6"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val6"
         }
     }
 
@@ -65,18 +65,18 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val5"
+                  ~ nestedProp: "val1" => "val5"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val6"
+                  ~ nestedProp: "val2" => "val6"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val1"
+                  ~ nestedProp: "val3" => "val1"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val2"
+                  ~ nestedProp: "val4" => "val2"
                 }
         ]
 Resources:
@@ -84,13 +84,13 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -22,37 +22,37 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val4" -> null
+      - prop { # forces replacement
+          - nested_prop = "val4" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val5"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val5"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val6"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val6"
         }
     }
 
@@ -65,17 +65,17 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val5"
+                  ~ nestedProp: "val2" => "val5"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val6"
+                  ~ nestedProp: "val3" => "val6"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val2"
+                  ~ nestedProp: "val4" => "val2"
                 }
         ]
 Resources:
@@ -83,12 +83,12 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -24,37 +24,37 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val4" -> null
+      - prop { # forces replacement
+          - nested_prop = "val4" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val5"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val5"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val6"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val6"
         }
     }
 
@@ -67,17 +67,17 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val5"
+                  ~ nestedProp: "val2" => "val5"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val6"
+                  ~ nestedProp: "val3" => "val6"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val2"
+                  ~ nestedProp: "val4" => "val2"
                 }
         ]
 Resources:
@@ -85,12 +85,12 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/two_removed.golden
@@ -20,29 +20,29 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      - test { # forces replacement
-          - nested   = "val4" -> null
+      - prop { # forces replacement
+          - nested_prop = "val4" -> null
             # (1 unchanged attribute hidden)
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test { # forces replacement
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
     }
 
@@ -55,18 +55,18 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
           - [3]: {
-                  - computed: ""
-                  - nested  : "val4"
+                  - computed  : ""
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -74,9 +74,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
-		"tests[3]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[3]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/added.golden
@@ -12,9 +12,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-value"
-          + nested   = "value"
+      + prop { # forces replacement
+          + computed    = "non-computed-value"
+          + nested_prop = "value"
         }
     }
 
@@ -27,15 +27,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
+      + props: [
       +     [0]: {
               + computed  : "non-computed-value"
-              + nested    : "value"
+              + nestedProp: "value"
             }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/added_end.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-val3"
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = "non-computed-val3"
+          + nested_prop = "val3"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: {
                   + computed  : "non-computed-val3"
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/added_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/added_end_unordered.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-val1"
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = "non-computed-val1"
+          + nested_prop = "val1"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: {
                   + computed  : "non-computed-val1"
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/added_front.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-val1"
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = "non-computed-val1"
+          + nested_prop = "val1"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: {
                   + computed  : "non-computed-val1"
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/added_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/added_front_unordered.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-val2"
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = "non-computed-val2"
+          + nested_prop = "val2"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: {
                   + computed  : "non-computed-val2"
-                  + nested    : "val2"
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/added_middle.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-val2"
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = "non-computed-val2"
+          + nested_prop = "val2"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
                   + computed  : "non-computed-val2"
-                  + nested    : "val2"
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/added_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/added_middle_unordered.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-val3"
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = "non-computed-val3"
+          + nested_prop = "val3"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
                   + computed  : "non-computed-val3"
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/changed_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/changed_non-null.golden
@@ -14,13 +14,13 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-value" -> null
-          - nested   = "value" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-value" -> null
+          - nested_prop = "value" -> null
         }
-      + test { # forces replacement
-          + computed = "non-computed-value1"
-          + nested   = "value1"
+      + prop { # forces replacement
+          + computed    = "non-computed-value1"
+          + nested_prop = "value1"
         }
     }
 
@@ -33,10 +33,10 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ computed: "non-computed-value" => "non-computed-value1"
-                  ~ nested  : "value" => "value1"
+                  ~ computed  : "non-computed-value" => "non-computed-value1"
+                  ~ nestedProp: "value" => "value1"
                 }
         ]
 Resources:
@@ -44,7 +44,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/changed_non-null_to_null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/changed_non-null_to_null.golden
@@ -14,9 +14,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-value" -> null
-          - nested   = "value" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-value" -> null
+          - nested_prop = "value" -> null
         }
     }
 
@@ -29,15 +29,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - tests: [
+      - props: [
       -     [0]: {
-              - computed: "non-computed-value"
-              - nested  : "value"
+              - computed  : "non-computed-value"
+              - nestedProp: "value"
             }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/changed_null_to_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/changed_null_to_non-null.golden
@@ -13,9 +13,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-value"
-          + nested   = "value"
+      + prop { # forces replacement
+          + computed    = "non-computed-value"
+          + nested_prop = "value"
         }
     }
 
@@ -28,15 +28,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
+      + props: [
       +     [0]: {
               + computed  : "non-computed-value"
-              + nested    : "value"
+              + nestedProp: "value"
             }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/removed.golden
@@ -14,9 +14,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-value" -> null
-          - nested   = "value" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-value" -> null
+          - nested_prop = "value" -> null
         }
     }
 
@@ -29,15 +29,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - tests: [
+      - props: [
       -     [0]: {
-              - computed: "non-computed-value"
-              - nested  : "value"
+              - computed  : "non-computed-value"
+              - nestedProp: "value"
             }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/removed_end.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: {
-                  - computed: "non-computed-val3"
-                  - nested  : "val3"
+                  - computed  : "non-computed-val3"
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/removed_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/removed_end_unordered.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val1" -> null
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val1" -> null
+          - nested_prop = "val1" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: {
-                  - computed: "non-computed-val1"
-                  - nested  : "val1"
+                  - computed  : "non-computed-val1"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/removed_front.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val1" -> null
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val1" -> null
+          - nested_prop = "val1" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: {
-                  - computed: "non-computed-val1"
-                  - nested  : "val1"
+                  - computed  : "non-computed-val1"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/removed_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/removed_front_unordered.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val2" -> null
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val2" -> null
+          - nested_prop = "val2" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+                  - computed  : "non-computed-val2"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/removed_middle.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val2" -> null
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val2" -> null
+          - nested_prop = "val2" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+                  - computed  : "non-computed-val2"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/removed_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/removed_middle_unordered.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val2" -> null
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val2" -> null
+          - nested_prop = "val2" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+                  - computed  : "non-computed-val2"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/same_element_updated.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/same_element_updated.golden
@@ -20,13 +20,13 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val2" -> null
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val2" -> null
+          - nested_prop = "val2" -> null
         }
-      + test { # forces replacement
-          + computed = "non-computed-val4"
-          + nested   = "val4"
+      + prop { # forces replacement
+          + computed    = "non-computed-val4"
+          + nested_prop = "val4"
         }
 
         # (2 unchanged blocks hidden)
@@ -41,10 +41,10 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [1]: {
-                  ~ computed: "non-computed-val2" => "non-computed-val4"
-                  ~ nested  : "val2" => "val4"
+                  ~ computed  : "non-computed-val2" => "non-computed-val4"
+                  ~ nestedProp: "val2" => "val4"
                 }
         ]
 Resources:
@@ -52,7 +52,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/same_element_updated_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/same_element_updated_unordered.golden
@@ -20,13 +20,13 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
-      + test { # forces replacement
-          + computed = "non-computed-val4"
-          + nested   = "val4"
+      + prop { # forces replacement
+          + computed    = "non-computed-val4"
+          + nested_prop = "val4"
         }
 
         # (2 unchanged blocks hidden)
@@ -41,14 +41,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
                   + computed  : "non-computed-val4"
-                  + nested    : "val4"
+                  + nestedProp: "val4"
                 }
           - [2]: {
-                  - computed: "non-computed-val3"
-                  - nested  : "val3"
+                  - computed  : "non-computed-val3"
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -56,7 +56,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/shuffled_added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/shuffled_added_end.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-val3"
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = "non-computed-val3"
+          + nested_prop = "val3"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: {
                   + computed  : "non-computed-val3"
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/shuffled_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/shuffled_added_front.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-val1"
-          + nested   = "val1"
+      + prop { # forces replacement
+          + computed    = "non-computed-val1"
+          + nested_prop = "val1"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: {
                   + computed  : "non-computed-val1"
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/shuffled_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/shuffled_added_middle.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-val2"
-          + nested   = "val2"
+      + prop { # forces replacement
+          + computed    = "non-computed-val2"
+          + nested_prop = "val2"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
                   + computed  : "non-computed-val2"
-                  + nested    : "val2"
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/shuffled_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/shuffled_removed_end.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: {
-                  - computed: "non-computed-val3"
-                  - nested  : "val3"
+                  - computed  : "non-computed-val3"
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/shuffled_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/shuffled_removed_front.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val1" -> null
-          - nested   = "val1" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val1" -> null
+          - nested_prop = "val1" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: {
-                  - computed: "non-computed-val1"
-                  - nested  : "val1"
+                  - computed  : "non-computed-val1"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/shuffled_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/shuffled_removed_middle.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val2" -> null
-          - nested   = "val2" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val2" -> null
+          - nested_prop = "val2" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+                  - computed  : "non-computed-val2"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/two_added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/two_added.golden
@@ -20,13 +20,13 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      + test { # forces replacement
-          + computed = "non-computed-val3"
-          + nested   = "val3"
+      + prop { # forces replacement
+          + computed    = "non-computed-val3"
+          + nested_prop = "val3"
         }
-      + test { # forces replacement
-          + computed = "non-computed-val4"
-          + nested   = "val4"
+      + prop { # forces replacement
+          + computed    = "non-computed-val4"
+          + nested_prop = "val4"
         }
 
         # (2 unchanged blocks hidden)
@@ -41,14 +41,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: {
                   + computed  : "non-computed-val3"
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
           + [3]: {
                   + computed  : "non-computed-val4"
-                  + nested    : "val4"
+                  + nestedProp: "val4"
                 }
         ]
 Resources:
@@ -56,7 +56,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[3]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[3]": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/two_added_and_two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/two_added_and_two_removed.golden
@@ -22,21 +22,21 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
-      - test { # forces replacement
-          - computed = "non-computed-val4" -> null
-          - nested   = "val4" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val4" -> null
+          - nested_prop = "val4" -> null
         }
-      + test { # forces replacement
-          + computed = "non-computed-val5"
-          + nested   = "val5"
+      + prop { # forces replacement
+          + computed    = "non-computed-val5"
+          + nested_prop = "val5"
         }
-      + test { # forces replacement
-          + computed = "non-computed-val6"
-          + nested   = "val6"
+      + prop { # forces replacement
+          + computed    = "non-computed-val6"
+          + nested_prop = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -51,14 +51,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val5"
-                  ~ nested  : "val3" => "val5"
+                  ~ computed  : "non-computed-val3" => "non-computed-val5"
+                  ~ nestedProp: "val3" => "val5"
                 }
           ~ [3]: {
-                  ~ computed: "non-computed-val4" => "non-computed-val6"
-                  ~ nested  : "val4" => "val6"
+                  ~ computed  : "non-computed-val4" => "non-computed-val6"
+                  ~ nestedProp: "val4" => "val6"
                 }
         ]
 Resources:
@@ -66,9 +66,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -22,21 +22,21 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
-      - test { # forces replacement
-          - computed = "non-computed-val4" -> null
-          - nested   = "val4" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val4" -> null
+          - nested_prop = "val4" -> null
         }
-      + test { # forces replacement
-          + computed = "non-computed-val5"
-          + nested   = "val5"
+      + prop { # forces replacement
+          + computed    = "non-computed-val5"
+          + nested_prop = "val5"
         }
-      + test { # forces replacement
-          + computed = "non-computed-val6"
-          + nested   = "val6"
+      + prop { # forces replacement
+          + computed    = "non-computed-val6"
+          + nested_prop = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -51,22 +51,22 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: {
                   + computed  : "non-computed-val5"
-                  + nested    : "val5"
+                  + nestedProp: "val5"
                 }
           + [1]: {
                   + computed  : "non-computed-val6"
-                  + nested    : "val6"
+                  + nestedProp: "val6"
                 }
           - [2]: {
-                  - computed: "non-computed-val3"
-                  - nested  : "val3"
+                  - computed  : "non-computed-val3"
+                  - nestedProp: "val3"
                 }
           - [3]: {
-                  - computed: "non-computed-val4"
-                  - nested  : "val4"
+                  - computed  : "non-computed-val4"
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -74,9 +74,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0]": map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[1]": map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -22,21 +22,21 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
-      - test { # forces replacement
-          - computed = "non-computed-val4" -> null
-          - nested   = "val4" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val4" -> null
+          - nested_prop = "val4" -> null
         }
-      + test { # forces replacement
-          + computed = "non-computed-val5"
-          + nested   = "val5"
+      + prop { # forces replacement
+          + computed    = "non-computed-val5"
+          + nested_prop = "val5"
         }
-      + test { # forces replacement
-          + computed = "non-computed-val6"
-          + nested   = "val6"
+      + prop { # forces replacement
+          + computed    = "non-computed-val6"
+          + nested_prop = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -51,18 +51,18 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
                   + computed  : "non-computed-val5"
-                  + nested    : "val5"
+                  + nestedProp: "val5"
                 }
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val6"
-                  ~ nested  : "val3" => "val6"
+                  ~ computed  : "non-computed-val3" => "non-computed-val6"
+                  ~ nestedProp: "val3" => "val6"
                 }
           - [3]: {
-                  - computed: "non-computed-val4"
-                  - nested  : "val4"
+                  - computed  : "non-computed-val4"
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -70,9 +70,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]":          map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[1]":            map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[3]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -24,21 +24,21 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
-      - test { # forces replacement
-          - computed = "non-computed-val4" -> null
-          - nested   = "val4" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val4" -> null
+          - nested_prop = "val4" -> null
         }
-      + test { # forces replacement
-          + computed = "non-computed-val5"
-          + nested   = "val5"
+      + prop { # forces replacement
+          + computed    = "non-computed-val5"
+          + nested_prop = "val5"
         }
-      + test { # forces replacement
-          + computed = "non-computed-val6"
-          + nested   = "val6"
+      + prop { # forces replacement
+          + computed    = "non-computed-val6"
+          + nested_prop = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -53,18 +53,18 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
                   + computed  : "non-computed-val5"
-                  + nested    : "val5"
+                  + nestedProp: "val5"
                 }
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val6"
-                  ~ nested  : "val3" => "val6"
+                  ~ computed  : "non-computed-val3" => "non-computed-val6"
+                  ~ nestedProp: "val3" => "val6"
                 }
           - [3]: {
-                  - computed: "non-computed-val4"
-                  - nested  : "val4"
+                  - computed  : "non-computed-val4"
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -72,9 +72,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]":          map[string]interface{}{"kind": "ADD_REPLACE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"tests[3]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[1]":            map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[3]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new_computed_specified/two_removed.golden
@@ -20,13 +20,13 @@ Terraform will perform the following actions:
 +/- resource "crossprovider_test_res" "example" {
       ~ id = "id" -> (known after apply)
 
-      - test { # forces replacement
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
-      - test { # forces replacement
-          - computed = "non-computed-val4" -> null
-          - nested   = "val4" -> null
+      - prop { # forces replacement
+          - computed    = "non-computed-val4" -> null
+          - nested_prop = "val4" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -41,14 +41,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: {
-                  - computed: "non-computed-val3"
-                  - nested  : "val3"
+                  - computed  : "non-computed-val3"
+                  - nestedProp: "val3"
                 }
           - [3]: {
-                  - computed: "non-computed-val4"
-                  - nested  : "val4"
+                  - computed  : "non-computed-val4"
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -56,7 +56,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/added.golden
@@ -12,9 +12,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      + test {
-          + computed = (known after apply)
-          + nested   = "value"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "value"
         }
     }
 
@@ -27,14 +27,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
+      + props: [
       +     [0]: {
-              + nested    : "value"
+              + nestedProp: "value"
             }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/added_end.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,13 +50,13 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
                 }
           + [2]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
@@ -64,8 +64,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{},
+		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":          map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/added_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/added_end_unordered.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,13 +50,13 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
                 }
           + [2]: {
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
@@ -64,8 +64,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{},
+		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":          map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/added_front.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,15 +50,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val2"
+                  ~ nestedProp: "val3" => "val2"
                 }
           + [2]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
@@ -66,10 +66,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/added_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/added_front_unordered.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,14 +50,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
                 }
           + [2]: {
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
@@ -65,9 +65,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/added_middle.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,14 +50,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val2"
+                  ~ nestedProp: "val3" => "val2"
                 }
           + [2]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
@@ -65,9 +65,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/added_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/added_middle_unordered.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,15 +50,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  ~ nestedProp: "val2" => "val3"
                 }
           + [2]: {
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
@@ -66,10 +66,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/changed_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/changed_non-null.golden
@@ -14,13 +14,13 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "value" -> null
+      - prop {
+          - nested_prop = "value" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "value1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "value1"
         }
     }
 
@@ -33,9 +33,9 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "value" => "value1"
+                  ~ nestedProp: "value" => "value1"
                 }
         ]
 Resources:
@@ -43,7 +43,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/changed_non-null_to_null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/changed_non-null_to_null.golden
@@ -14,8 +14,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "value" -> null
+      - prop {
+          - nested_prop = "value" -> null
             # (1 unchanged attribute hidden)
         }
     }
@@ -29,15 +29,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - tests: [
+      - props: [
       -     [0]: {
-              - computed: ""
-              - nested  : "value"
+              - computed  : ""
+              - nestedProp: "value"
             }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/changed_null_to_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/changed_null_to_non-null.golden
@@ -13,9 +13,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      + test {
-          + computed = (known after apply)
-          + nested   = "value"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "value"
         }
     }
 
@@ -28,14 +28,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
+      + props: [
       +     [0]: {
-              + nested    : "value"
+              + nestedProp: "value"
             }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/removed.golden
@@ -14,8 +14,8 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "value" -> null
+      - prop {
+          - nested_prop = "value" -> null
             # (1 unchanged attribute hidden)
         }
     }
@@ -29,15 +29,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - tests: [
+      - props: [
       -     [0]: {
-              - computed: ""
-              - nested  : "value"
+              - computed  : ""
+              - nestedProp: "value"
             }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/removed_end.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
     }
 
@@ -50,14 +50,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -65,8 +65,8 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":          map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/removed_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/removed_end_unordered.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,16 +50,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  ~ nestedProp: "val2" => "val3"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -67,10 +67,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/removed_front.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,16 +50,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  ~ nestedProp: "val2" => "val3"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -67,10 +67,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/removed_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/removed_front_unordered.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,16 +50,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val3"
+                  ~ nestedProp: "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -67,10 +67,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/removed_middle.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,15 +50,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val3"
+                  ~ nestedProp: "val2" => "val3"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -66,9 +66,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/removed_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/removed_middle_unordered.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,16 +50,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val3"
+                  ~ nestedProp: "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -67,10 +67,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/same_element_updated.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/same_element_updated.golden
@@ -20,29 +20,29 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val4"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val4"
         }
     }
 
@@ -55,11 +55,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val4"
+                  ~ nestedProp: "val2" => "val4"
                 }
           ~ [2]: {
                 }
@@ -69,9 +69,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/same_element_updated_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/same_element_updated_unordered.golden
@@ -20,29 +20,29 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val4"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val4"
         }
     }
 
@@ -55,15 +55,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val4"
+                  ~ nestedProp: "val2" => "val4"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val1"
+                  ~ nestedProp: "val3" => "val1"
                 }
         ]
 Resources:
@@ -71,11 +71,11 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/shuffled_added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/shuffled_added_end.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,15 +50,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           + [2]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
@@ -66,10 +66,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/shuffled_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/shuffled_added_front.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,14 +50,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           ~ [1]: {
                 }
           + [2]: {
-                  + nested    : "val2"
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
@@ -65,9 +65,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/shuffled_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/shuffled_added_middle.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,15 +50,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val3"
+                  ~ nestedProp: "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val3" => "val2"
+                  ~ nestedProp: "val3" => "val2"
                 }
           + [2]: {
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
@@ -66,10 +66,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/shuffled_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/shuffled_removed_end.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
     }
 
@@ -50,16 +50,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val2"
+                  ~ nestedProp: "val1" => "val2"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -67,10 +67,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/shuffled_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/shuffled_removed_front.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,15 +50,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val3"
+                  ~ nestedProp: "val1" => "val3"
                 }
           ~ [1]: {
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -66,9 +66,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/shuffled_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/shuffled_removed_middle.golden
@@ -19,25 +19,25 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
     }
 
@@ -50,16 +50,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val3"
+                  ~ nestedProp: "val1" => "val3"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val1"
+                  ~ nestedProp: "val2" => "val1"
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -67,10 +67,10 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/two_added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/two_added.golden
@@ -20,29 +20,29 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val3"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val3"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val4"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val4"
         }
     }
 
@@ -55,16 +55,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
                 }
           + [2]: {
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
           + [3]: {
-                  + nested    : "val4"
+                  + nestedProp: "val4"
                 }
         ]
 Resources:
@@ -72,9 +72,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{},
-		"tests[3]":          map[string]interface{}{},
+		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":          map[string]interface{}{},
+		"props[3]":          map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/two_added_and_two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/two_added_and_two_removed.golden
@@ -22,37 +22,37 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val4" -> null
+      - prop {
+          - nested_prop = "val4" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val5"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val5"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val6"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val6"
         }
     }
 
@@ -65,16 +65,16 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val5"
+                  ~ nestedProp: "val3" => "val5"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val6"
+                  ~ nestedProp: "val4" => "val6"
                 }
         ]
 Resources:
@@ -82,11 +82,11 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -22,37 +22,37 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val4" -> null
+      - prop {
+          - nested_prop = "val4" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val5"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val5"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val6"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val6"
         }
     }
 
@@ -65,18 +65,18 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ nested  : "val1" => "val5"
+                  ~ nestedProp: "val1" => "val5"
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val6"
+                  ~ nestedProp: "val2" => "val6"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val1"
+                  ~ nestedProp: "val3" => "val1"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val2"
+                  ~ nestedProp: "val4" => "val2"
                 }
         ]
 Resources:
@@ -84,13 +84,13 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -22,37 +22,37 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val4" -> null
+      - prop {
+          - nested_prop = "val4" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val5"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val5"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val6"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val6"
         }
     }
 
@@ -65,17 +65,17 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val5"
+                  ~ nestedProp: "val2" => "val5"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val6"
+                  ~ nestedProp: "val3" => "val6"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val2"
+                  ~ nestedProp: "val4" => "val2"
                 }
         ]
 Resources:
@@ -83,12 +83,12 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -24,37 +24,37 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val4" -> null
+      - prop {
+          - nested_prop = "val4" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val5"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val5"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val6"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val6"
         }
     }
 
@@ -67,17 +67,17 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
-                  ~ nested  : "val2" => "val5"
+                  ~ nestedProp: "val2" => "val5"
                 }
           ~ [2]: {
-                  ~ nested  : "val3" => "val6"
+                  ~ nestedProp: "val3" => "val6"
                 }
           ~ [3]: {
-                  ~ nested  : "val4" => "val2"
+                  ~ nestedProp: "val4" => "val2"
                 }
         ]
 Resources:
@@ -85,12 +85,12 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/two_removed.golden
@@ -20,29 +20,29 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - nested   = "val1" -> null
+      - prop {
+          - nested_prop = "val1" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val2" -> null
+      - prop {
+          - nested_prop = "val2" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val3" -> null
+      - prop {
+          - nested_prop = "val3" -> null
             # (1 unchanged attribute hidden)
         }
-      - test {
-          - nested   = "val4" -> null
+      - prop {
+          - nested_prop = "val4" -> null
             # (1 unchanged attribute hidden)
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val1"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val1"
         }
-      + test {
-          + computed = (known after apply)
-          + nested   = "val2"
+      + prop {
+          + computed    = (known after apply)
+          + nested_prop = "val2"
         }
     }
 
@@ -55,18 +55,18 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
                 }
           ~ [1]: {
                 }
           - [2]: {
-                  - computed: ""
-                  - nested  : "val3"
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
           - [3]: {
-                  - computed: ""
-                  - nested  : "val4"
+                  - computed  : ""
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -74,9 +74,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2]":          map[string]interface{}{"kind": "DELETE"},
-		"tests[3]":          map[string]interface{}{"kind": "DELETE"},
+		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":          map[string]interface{}{"kind": "DELETE"},
+		"props[3]":          map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/added.golden
@@ -12,9 +12,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      + test {
-          + computed = "non-computed-value"
-          + nested   = "value"
+      + prop {
+          + computed    = "non-computed-value"
+          + nested_prop = "value"
         }
     }
 
@@ -27,15 +27,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
+      + props: [
       +     [0]: {
               + computed  : "non-computed-value"
-              + nested    : "value"
+              + nestedProp: "value"
             }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/added_end.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      + test {
-          + computed = "non-computed-val3"
-          + nested   = "val3"
+      + prop {
+          + computed    = "non-computed-val3"
+          + nested_prop = "val3"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: {
                   + computed  : "non-computed-val3"
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/added_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/added_end_unordered.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      + test {
-          + computed = "non-computed-val1"
-          + nested   = "val1"
+      + prop {
+          + computed    = "non-computed-val1"
+          + nested_prop = "val1"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: {
                   + computed  : "non-computed-val1"
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/added_front.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      + test {
-          + computed = "non-computed-val1"
-          + nested   = "val1"
+      + prop {
+          + computed    = "non-computed-val1"
+          + nested_prop = "val1"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: {
                   + computed  : "non-computed-val1"
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/added_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/added_front_unordered.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      + test {
-          + computed = "non-computed-val2"
-          + nested   = "val2"
+      + prop {
+          + computed    = "non-computed-val2"
+          + nested_prop = "val2"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: {
                   + computed  : "non-computed-val2"
-                  + nested    : "val2"
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/added_middle.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      + test {
-          + computed = "non-computed-val2"
-          + nested   = "val2"
+      + prop {
+          + computed    = "non-computed-val2"
+          + nested_prop = "val2"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
                   + computed  : "non-computed-val2"
-                  + nested    : "val2"
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/added_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/added_middle_unordered.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      + test {
-          + computed = "non-computed-val3"
-          + nested   = "val3"
+      + prop {
+          + computed    = "non-computed-val3"
+          + nested_prop = "val3"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
                   + computed  : "non-computed-val3"
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/changed_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/changed_non-null.golden
@@ -14,13 +14,13 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-value" -> null
-          - nested   = "value" -> null
+      - prop {
+          - computed    = "non-computed-value" -> null
+          - nested_prop = "value" -> null
         }
-      + test {
-          + computed = "non-computed-value1"
-          + nested   = "value1"
+      + prop {
+          + computed    = "non-computed-value1"
+          + nested_prop = "value1"
         }
     }
 
@@ -33,10 +33,10 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [0]: {
-                  ~ computed: "non-computed-value" => "non-computed-value1"
-                  ~ nested  : "value" => "value1"
+                  ~ computed  : "non-computed-value" => "non-computed-value1"
+                  ~ nestedProp: "value" => "value1"
                 }
         ]
 Resources:
@@ -44,7 +44,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[0].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/changed_non-null_to_null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/changed_non-null_to_null.golden
@@ -14,9 +14,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-value" -> null
-          - nested   = "value" -> null
+      - prop {
+          - computed    = "non-computed-value" -> null
+          - nested_prop = "value" -> null
         }
     }
 
@@ -29,15 +29,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - tests: [
+      - props: [
       -     [0]: {
-              - computed: "non-computed-value"
-              - nested  : "value"
+              - computed  : "non-computed-value"
+              - nestedProp: "value"
             }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/changed_null_to_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/changed_null_to_non-null.golden
@@ -13,9 +13,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      + test {
-          + computed = "non-computed-value"
-          + nested   = "value"
+      + prop {
+          + computed    = "non-computed-value"
+          + nested_prop = "value"
         }
     }
 
@@ -28,15 +28,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      + tests: [
+      + props: [
       +     [0]: {
               + computed  : "non-computed-value"
-              + nested    : "value"
+              + nestedProp: "value"
             }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/removed.golden
@@ -14,9 +14,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-value" -> null
-          - nested   = "value" -> null
+      - prop {
+          - computed    = "non-computed-value" -> null
+          - nested_prop = "value" -> null
         }
     }
 
@@ -29,15 +29,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      - tests: [
+      - props: [
       -     [0]: {
-              - computed: "non-computed-value"
-              - nested  : "value"
+              - computed  : "non-computed-value"
+              - nestedProp: "value"
             }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/removed_end.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop {
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: {
-                  - computed: "non-computed-val3"
-                  - nested  : "val3"
+                  - computed  : "non-computed-val3"
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/removed_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/removed_end_unordered.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val1" -> null
-          - nested   = "val1" -> null
+      - prop {
+          - computed    = "non-computed-val1" -> null
+          - nested_prop = "val1" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: {
-                  - computed: "non-computed-val1"
-                  - nested  : "val1"
+                  - computed  : "non-computed-val1"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/removed_front.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val1" -> null
-          - nested   = "val1" -> null
+      - prop {
+          - computed    = "non-computed-val1" -> null
+          - nested_prop = "val1" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: {
-                  - computed: "non-computed-val1"
-                  - nested  : "val1"
+                  - computed  : "non-computed-val1"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/removed_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/removed_front_unordered.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val2" -> null
-          - nested   = "val2" -> null
+      - prop {
+          - computed    = "non-computed-val2" -> null
+          - nested_prop = "val2" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+                  - computed  : "non-computed-val2"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/removed_middle.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val2" -> null
-          - nested   = "val2" -> null
+      - prop {
+          - computed    = "non-computed-val2" -> null
+          - nested_prop = "val2" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+                  - computed  : "non-computed-val2"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/removed_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/removed_middle_unordered.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val2" -> null
-          - nested   = "val2" -> null
+      - prop {
+          - computed    = "non-computed-val2" -> null
+          - nested_prop = "val2" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+                  - computed  : "non-computed-val2"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/same_element_updated.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/same_element_updated.golden
@@ -20,13 +20,13 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val2" -> null
-          - nested   = "val2" -> null
+      - prop {
+          - computed    = "non-computed-val2" -> null
+          - nested_prop = "val2" -> null
         }
-      + test {
-          + computed = "non-computed-val4"
-          + nested   = "val4"
+      + prop {
+          + computed    = "non-computed-val4"
+          + nested_prop = "val4"
         }
 
         # (2 unchanged blocks hidden)
@@ -41,10 +41,10 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [1]: {
-                  ~ computed: "non-computed-val2" => "non-computed-val4"
-                  ~ nested  : "val2" => "val4"
+                  ~ computed  : "non-computed-val2" => "non-computed-val4"
+                  ~ nestedProp: "val2" => "val4"
                 }
         ]
 Resources:
@@ -52,7 +52,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[1].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/same_element_updated_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/same_element_updated_unordered.golden
@@ -20,13 +20,13 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop {
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
-      + test {
-          + computed = "non-computed-val4"
-          + nested   = "val4"
+      + prop {
+          + computed    = "non-computed-val4"
+          + nested_prop = "val4"
         }
 
         # (2 unchanged blocks hidden)
@@ -41,14 +41,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
                   + computed  : "non-computed-val4"
-                  + nested    : "val4"
+                  + nestedProp: "val4"
                 }
           - [2]: {
-                  - computed: "non-computed-val3"
-                  - nested  : "val3"
+                  - computed  : "non-computed-val3"
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -56,7 +56,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]": map[string]interface{}{},
-		"tests[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[1]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_added_end.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      + test {
-          + computed = "non-computed-val3"
-          + nested   = "val3"
+      + prop {
+          + computed    = "non-computed-val3"
+          + nested_prop = "val3"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: {
                   + computed  : "non-computed-val3"
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_added_front.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      + test {
-          + computed = "non-computed-val1"
-          + nested   = "val1"
+      + prop {
+          + computed    = "non-computed-val1"
+          + nested_prop = "val1"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: {
                   + computed  : "non-computed-val1"
-                  + nested    : "val1"
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_added_middle.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      + test {
-          + computed = "non-computed-val2"
-          + nested   = "val2"
+      + prop {
+          + computed    = "non-computed-val2"
+          + nested_prop = "val2"
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
                   + computed  : "non-computed-val2"
-                  + nested    : "val2"
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_removed_end.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop {
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: {
-                  - computed: "non-computed-val3"
-                  - nested  : "val3"
+                  - computed  : "non-computed-val3"
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[2]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_removed_front.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val1" -> null
-          - nested   = "val1" -> null
+      - prop {
+          - computed    = "non-computed-val1" -> null
+          - nested_prop = "val1" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [0]: {
-                  - computed: "non-computed-val1"
-                  - nested  : "val1"
+                  - computed  : "non-computed-val1"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[0]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/shuffled_removed_middle.golden
@@ -19,9 +19,9 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val2" -> null
-          - nested   = "val2" -> null
+      - prop {
+          - computed    = "non-computed-val2" -> null
+          - nested_prop = "val2" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -36,15 +36,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [1]: {
-                  - computed: "non-computed-val2"
-                  - nested  : "val2"
+                  - computed  : "non-computed-val2"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"tests[1]": map[string]interface{}{"kind": "DELETE"}},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/two_added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/two_added.golden
@@ -20,13 +20,13 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      + test {
-          + computed = "non-computed-val3"
-          + nested   = "val3"
+      + prop {
+          + computed    = "non-computed-val3"
+          + nested_prop = "val3"
         }
-      + test {
-          + computed = "non-computed-val4"
-          + nested   = "val4"
+      + prop {
+          + computed    = "non-computed-val4"
+          + nested_prop = "val4"
         }
 
         # (2 unchanged blocks hidden)
@@ -41,14 +41,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [2]: {
                   + computed  : "non-computed-val3"
-                  + nested    : "val3"
+                  + nestedProp: "val3"
                 }
           + [3]: {
                   + computed  : "non-computed-val4"
-                  + nested    : "val4"
+                  + nestedProp: "val4"
                 }
         ]
 Resources:
@@ -56,7 +56,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{},
-		"tests[3]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{},
+		"props[3]": map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/two_added_and_two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/two_added_and_two_removed.golden
@@ -22,21 +22,21 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop {
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
-      - test {
-          - computed = "non-computed-val4" -> null
-          - nested   = "val4" -> null
+      - prop {
+          - computed    = "non-computed-val4" -> null
+          - nested_prop = "val4" -> null
         }
-      + test {
-          + computed = "non-computed-val5"
-          + nested   = "val5"
+      + prop {
+          + computed    = "non-computed-val5"
+          + nested_prop = "val5"
         }
-      + test {
-          + computed = "non-computed-val6"
-          + nested   = "val6"
+      + prop {
+          + computed    = "non-computed-val6"
+          + nested_prop = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -51,14 +51,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val5"
-                  ~ nested  : "val3" => "val5"
+                  ~ computed  : "non-computed-val3" => "non-computed-val5"
+                  ~ nestedProp: "val3" => "val5"
                 }
           ~ [3]: {
-                  ~ computed: "non-computed-val4" => "non-computed-val6"
-                  ~ nested  : "val4" => "val6"
+                  ~ computed  : "non-computed-val4" => "non-computed-val6"
+                  ~ nestedProp: "val4" => "val6"
                 }
         ]
 Resources:
@@ -66,9 +66,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[3].nested":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -22,21 +22,21 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop {
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
-      - test {
-          - computed = "non-computed-val4" -> null
-          - nested   = "val4" -> null
+      - prop {
+          - computed    = "non-computed-val4" -> null
+          - nested_prop = "val4" -> null
         }
-      + test {
-          + computed = "non-computed-val5"
-          + nested   = "val5"
+      + prop {
+          + computed    = "non-computed-val5"
+          + nested_prop = "val5"
         }
-      + test {
-          + computed = "non-computed-val6"
-          + nested   = "val6"
+      + prop {
+          + computed    = "non-computed-val6"
+          + nested_prop = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -51,22 +51,22 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [0]: {
                   + computed  : "non-computed-val5"
-                  + nested    : "val5"
+                  + nestedProp: "val5"
                 }
           + [1]: {
                   + computed  : "non-computed-val6"
-                  + nested    : "val6"
+                  + nestedProp: "val6"
                 }
           - [2]: {
-                  - computed: "non-computed-val3"
-                  - nested  : "val3"
+                  - computed  : "non-computed-val3"
+                  - nestedProp: "val3"
                 }
           - [3]: {
-                  - computed: "non-computed-val4"
-                  - nested  : "val4"
+                  - computed  : "non-computed-val4"
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -74,9 +74,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[0]": map[string]interface{}{},
-		"tests[1]": map[string]interface{}{},
-		"tests[2]": map[string]interface{}{"kind": "DELETE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE"},
+		"props[0]": map[string]interface{}{},
+		"props[1]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -22,21 +22,21 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop {
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
-      - test {
-          - computed = "non-computed-val4" -> null
-          - nested   = "val4" -> null
+      - prop {
+          - computed    = "non-computed-val4" -> null
+          - nested_prop = "val4" -> null
         }
-      + test {
-          + computed = "non-computed-val5"
-          + nested   = "val5"
+      + prop {
+          + computed    = "non-computed-val5"
+          + nested_prop = "val5"
         }
-      + test {
-          + computed = "non-computed-val6"
-          + nested   = "val6"
+      + prop {
+          + computed    = "non-computed-val6"
+          + nested_prop = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -51,18 +51,18 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
                   + computed  : "non-computed-val5"
-                  + nested    : "val5"
+                  + nestedProp: "val5"
                 }
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val6"
-                  ~ nested  : "val3" => "val6"
+                  ~ computed  : "non-computed-val3" => "non-computed-val6"
+                  ~ nestedProp: "val3" => "val6"
                 }
           - [3]: {
-                  - computed: "non-computed-val4"
-                  - nested  : "val4"
+                  - computed  : "non-computed-val4"
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -70,9 +70,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]":          map[string]interface{}{},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]":          map[string]interface{}{"kind": "DELETE"},
+		"props[1]":            map[string]interface{}{},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -24,21 +24,21 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop {
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
-      - test {
-          - computed = "non-computed-val4" -> null
-          - nested   = "val4" -> null
+      - prop {
+          - computed    = "non-computed-val4" -> null
+          - nested_prop = "val4" -> null
         }
-      + test {
-          + computed = "non-computed-val5"
-          + nested   = "val5"
+      + prop {
+          + computed    = "non-computed-val5"
+          + nested_prop = "val5"
         }
-      + test {
-          + computed = "non-computed-val6"
-          + nested   = "val6"
+      + prop {
+          + computed    = "non-computed-val6"
+          + nested_prop = "val6"
         }
 
         # (2 unchanged blocks hidden)
@@ -53,18 +53,18 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           + [1]: {
                   + computed  : "non-computed-val5"
-                  + nested    : "val5"
+                  + nestedProp: "val5"
                 }
           ~ [2]: {
-                  ~ computed: "non-computed-val3" => "non-computed-val6"
-                  ~ nested  : "val3" => "val6"
+                  ~ computed  : "non-computed-val3" => "non-computed-val6"
+                  ~ nestedProp: "val3" => "val6"
                 }
           - [3]: {
-                  - computed: "non-computed-val4"
-                  - nested  : "val4"
+                  - computed  : "non-computed-val4"
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -72,9 +72,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[1]":          map[string]interface{}{},
-		"tests[2].computed": map[string]interface{}{"kind": "UPDATE"},
-		"tests[2].nested":   map[string]interface{}{"kind": "UPDATE"},
-		"tests[3]":          map[string]interface{}{"kind": "DELETE"},
+		"props[1]":            map[string]interface{}{},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace_computed_specified_in_program/two_removed.golden
@@ -20,13 +20,13 @@ Terraform will perform the following actions:
   ~ resource "crossprovider_test_res" "example" {
         id = "id"
 
-      - test {
-          - computed = "non-computed-val3" -> null
-          - nested   = "val3" -> null
+      - prop {
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
         }
-      - test {
-          - computed = "non-computed-val4" -> null
-          - nested   = "val4" -> null
+      - prop {
+          - computed    = "non-computed-val4" -> null
+          - nested_prop = "val4" -> null
         }
 
         # (2 unchanged blocks hidden)
@@ -41,14 +41,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
     ~ crossprovider:index/testRes:TestRes: (update)
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ tests: [
+      ~ props: [
           - [2]: {
-                  - computed: "non-computed-val3"
-                  - nested  : "val3"
+                  - computed  : "non-computed-val3"
+                  - nestedProp: "val3"
                 }
           - [3]: {
-                  - computed: "non-computed-val4"
-                  - nested  : "val4"
+                  - computed  : "non-computed-val4"
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -56,7 +56,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"tests[2]": map[string]interface{}{"kind": "DELETE"},
-		"tests[3]": map[string]interface{}{"kind": "DELETE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE"},
 	},
 }


### PR DESCRIPTION
This PR refactors the Set and List Diff tests to use the generic diff utility functions and types introduced in https://github.com/pulumi/pulumi-terraform-bridge/pull/2829. This should make the tests more maintainable and more in-line with what other tests do.

[861ec1f](https://github.com/pulumi/pulumi-terraform-bridge/pull/2837/commits/861ec1f52899b575125d86d1f3bda42da858d125) contains the changes:
- Refactors the tests to use the generic `diffSchemaValueMakerPair` and `diffScenario` types for their tests.
- Refactors the tests to use `prop` for top-level properties and `nested_prop` for nested ones, like the rest of the tests.
- Refactors the tests to use the generic `runSDKv2TestMatrix` test function.
- Refactors the `valueMaker` functions from `value_makers.go` to return a `map[string]cty.Value ` instead of a `cty.Value` which needs to be transformed further after.
- Corrects three tests in `list element removed`, where the order of the elements was wrong in the changed values.


[f800d2d](https://github.com/pulumi/pulumi-terraform-bridge/pull/2837/commits/f800d2dda79ce5f80320a7cef0298e4fe1fad9b7) contains the test recordings.

Related to https://github.com/pulumi/pulumi-terraform-bridge/issues/2788
Related to https://github.com/pulumi/pulumi-terraform-bridge/issues/2789