### PR TITLE
SDKv2 Diff tests for Defaults in sets and lists

### DIFF
--- a/pkg/tests/diff_test/detailed_diff_list_test.go
+++ b/pkg/tests/diff_test/detailed_diff_list_test.go
@@ -199,6 +199,28 @@ func TestSDKv2DetailedDiffList(t *testing.T) {
 		},
 	}
 
+	listBlockSchemaNestedDefault := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"prop": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"nested_prop": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"default": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "default",
+						},
+					},
+				},
+			},
+		},
+	}
+
 	listPairs := []diffSchemaValueMakerPair[[]string]{
 		{"list attribute", listAttrSchema, listValueMaker},
 		{"list attribute force new", listAttrSchemaForceNew, listValueMaker},
@@ -207,6 +229,11 @@ func TestSDKv2DetailedDiffList(t *testing.T) {
 		{"list block nested force new", listBlockSchemaNestedForceNew, nestedListValueMaker},
 		{"list block sensitive", listBlockSchemaSensitive, nestedListValueMaker},
 		{"list block nested sensitive", listBlockSchemaNestedSensitive, nestedListValueMaker},
+		{"list block nested default", listBlockSchemaNestedDefault, nestedListValueMaker},
+		{
+			"list block nested default with default specified in program",
+			listBlockSchemaNestedDefault, nestedListValueMakerWithDefaultSpecified,
+		},
 	}
 
 	maxItemsOnePairs := []diffSchemaValueMakerPair[[]string]{

--- a/pkg/tests/diff_test/detailed_diff_set_test.go
+++ b/pkg/tests/diff_test/detailed_diff_set_test.go
@@ -546,3 +546,37 @@ func TestSDKv2DetailedDiffSetBlockSensitive(t *testing.T) {
 
 	runSDKv2TestMatrix(t, diffSchemaValueMakerPairs, setScenarios())
 }
+
+func TestSDKv2DetailedDiffSetDefault(t *testing.T) {
+	t.Parallel()
+	// Note Default is not valid for set types.
+
+	blockSchemaNestedDefault := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"prop": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"nested_prop": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"default": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "default",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	diffSchemaValueMakerPairs := []diffSchemaValueMakerPair[[]string]{
+		{"block nested default", blockSchemaNestedDefault, nestedListValueMaker},
+		{"block nested default with default specified in program", blockSchemaNestedDefault, nestedListValueMakerWithDefaultSpecified},
+	}
+
+	runSDKv2TestMatrix(t, diffSchemaValueMakerPairs, setScenarios())
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default/added_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default/added_empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: nil, changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default/added_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default/added_non-empty.golden
@@ -1,0 +1,42 @@
+tests.testOutput{
+	initialValue: nil, changeValue: &[]string{
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + prop {
+          + default     = "default"
+          + nested_prop = "val1"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + props: [
+      +     [0]: {
+              + default   : "default"
+              + nestedProp: "val1"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default/changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default/changed.golden
@@ -1,0 +1,42 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+	},
+	changeValue: &[]string{"val2"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      ~ prop {
+          ~ nested_prop = "val1" -> "val2"
+            # (1 unchanged attribute hidden)
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProp: "val1" => "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default/list_element_added_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default/list_element_added_back.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + prop {
+          + default     = "default"
+          + nested_prop = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [2]: {
+                  + default   : "default"
+                  + nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default/list_element_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default/list_element_added_front.golden
@@ -1,0 +1,66 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      ~ prop {
+          ~ nested_prop = "val2" -> "val1"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "val3" -> "val2"
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + default     = "default"
+          + nested_prop = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProp: "val2" => "val1"
+                }
+          ~ [1]: {
+                  ~ nestedProp: "val3" => "val2"
+                }
+          + [2]: {
+                  + default   : "default"
+                  + nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default/list_element_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default/list_element_added_middle.golden
@@ -1,0 +1,60 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      ~ prop {
+          ~ nested_prop = "val3" -> "val2"
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + default     = "default"
+          + nested_prop = "val3"
+        }
+
+        # (1 unchanged block hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [1]: {
+                  ~ nestedProp: "val3" => "val2"
+                }
+          + [2]: {
+                  + default   : "default"
+                  + nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default/list_element_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default/list_element_removed_end.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "default" -> null
+          - nested_prop = "val3" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [2]: {
+                  - default   : "default"
+                  - nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default/list_element_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default/list_element_removed_front.golden
@@ -1,0 +1,66 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      ~ prop {
+          ~ nested_prop = "val1" -> "val2"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "val2" -> "val3"
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - default     = "default" -> null
+          - nested_prop = "val3" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProp: "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ nestedProp: "val2" => "val3"
+                }
+          - [2]: {
+                  - default   : "default"
+                  - nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default/list_element_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default/list_element_removed_middle.golden
@@ -1,0 +1,60 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      ~ prop {
+          ~ nested_prop = "val2" -> "val3"
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - default     = "default" -> null
+          - nested_prop = "val3" -> null
+        }
+
+        # (1 unchanged block hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [1]: {
+                  ~ nestedProp: "val2" => "val3"
+                }
+          - [2]: {
+                  - default   : "default"
+                  - nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default/long_list_added_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default/long_list_added_back.golden
@@ -1,0 +1,86 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+		"value20",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + prop {
+          + default     = "default"
+          + nested_prop = "value20"
+        }
+
+        # (20 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [20]: {
+                  + default   : "default"
+                  + nestedProp: "value20"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[20]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default/long_list_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default/long_list_added_front.golden
@@ -1,0 +1,246 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value20",
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      ~ prop {
+          ~ nested_prop = "value0" -> "value20"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value1" -> "value0"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value2" -> "value1"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value3" -> "value2"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value4" -> "value3"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value5" -> "value4"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value6" -> "value5"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value7" -> "value6"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value8" -> "value7"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value9" -> "value8"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value10" -> "value9"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value11" -> "value10"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value12" -> "value11"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value13" -> "value12"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value14" -> "value13"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value15" -> "value14"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value16" -> "value15"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value17" -> "value16"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value18" -> "value17"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value19" -> "value18"
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + default     = "default"
+          + nested_prop = "value19"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProp: "value0" => "value20"
+                }
+          ~ [1]: {
+                  ~ nestedProp: "value1" => "value0"
+                }
+          ~ [2]: {
+                  ~ nestedProp: "value2" => "value1"
+                }
+          ~ [3]: {
+                  ~ nestedProp: "value3" => "value2"
+                }
+          ~ [4]: {
+                  ~ nestedProp: "value4" => "value3"
+                }
+          ~ [5]: {
+                  ~ nestedProp: "value5" => "value4"
+                }
+          ~ [6]: {
+                  ~ nestedProp: "value6" => "value5"
+                }
+          ~ [7]: {
+                  ~ nestedProp: "value7" => "value6"
+                }
+          ~ [8]: {
+                  ~ nestedProp: "value8" => "value7"
+                }
+          ~ [9]: {
+                  ~ nestedProp: "value9" => "value8"
+                }
+          ~ [10]: {
+                  ~ nestedProp: "value10" => "value9"
+                }
+          ~ [11]: {
+                  ~ nestedProp: "value11" => "value10"
+                }
+          ~ [12]: {
+                  ~ nestedProp: "value12" => "value11"
+                }
+          ~ [13]: {
+                  ~ nestedProp: "value13" => "value12"
+                }
+          ~ [14]: {
+                  ~ nestedProp: "value14" => "value13"
+                }
+          ~ [15]: {
+                  ~ nestedProp: "value15" => "value14"
+                }
+          ~ [16]: {
+                  ~ nestedProp: "value16" => "value15"
+                }
+          ~ [17]: {
+                  ~ nestedProp: "value17" => "value16"
+                }
+          ~ [18]: {
+                  ~ nestedProp: "value18" => "value17"
+                }
+          ~ [19]: {
+                  ~ nestedProp: "value19" => "value18"
+                }
+          + [20]: {
+                  + default   : "default"
+                  + nestedProp: "value19"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[0].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[10].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[11].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[12].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[13].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[14].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[15].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[16].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[17].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[18].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[19].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[20]":            map[string]interface{}{},
+		"props[2].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[4].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[5].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[6].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[7].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[8].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[9].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default/long_list_removed_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default/long_list_removed_back.golden
@@ -1,0 +1,86 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+		"value20",
+	},
+	changeValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "default" -> null
+          - nested_prop = "value20" -> null
+        }
+
+        # (20 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [20]: {
+                  - default   : "default"
+                  - nestedProp: "value20"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[20]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default/long_list_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default/long_list_removed_front.golden
@@ -1,0 +1,246 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value20",
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      ~ prop {
+          ~ nested_prop = "value20" -> "value0"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value0" -> "value1"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value1" -> "value2"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value2" -> "value3"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value3" -> "value4"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value4" -> "value5"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value5" -> "value6"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value6" -> "value7"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value7" -> "value8"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value8" -> "value9"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value9" -> "value10"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value10" -> "value11"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value11" -> "value12"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value12" -> "value13"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value13" -> "value14"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value14" -> "value15"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value15" -> "value16"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value16" -> "value17"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value17" -> "value18"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value18" -> "value19"
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - default     = "default" -> null
+          - nested_prop = "value19" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProp: "value20" => "value0"
+                }
+          ~ [1]: {
+                  ~ nestedProp: "value0" => "value1"
+                }
+          ~ [2]: {
+                  ~ nestedProp: "value1" => "value2"
+                }
+          ~ [3]: {
+                  ~ nestedProp: "value2" => "value3"
+                }
+          ~ [4]: {
+                  ~ nestedProp: "value3" => "value4"
+                }
+          ~ [5]: {
+                  ~ nestedProp: "value4" => "value5"
+                }
+          ~ [6]: {
+                  ~ nestedProp: "value5" => "value6"
+                }
+          ~ [7]: {
+                  ~ nestedProp: "value6" => "value7"
+                }
+          ~ [8]: {
+                  ~ nestedProp: "value7" => "value8"
+                }
+          ~ [9]: {
+                  ~ nestedProp: "value8" => "value9"
+                }
+          ~ [10]: {
+                  ~ nestedProp: "value9" => "value10"
+                }
+          ~ [11]: {
+                  ~ nestedProp: "value10" => "value11"
+                }
+          ~ [12]: {
+                  ~ nestedProp: "value11" => "value12"
+                }
+          ~ [13]: {
+                  ~ nestedProp: "value12" => "value13"
+                }
+          ~ [14]: {
+                  ~ nestedProp: "value13" => "value14"
+                }
+          ~ [15]: {
+                  ~ nestedProp: "value14" => "value15"
+                }
+          ~ [16]: {
+                  ~ nestedProp: "value15" => "value16"
+                }
+          ~ [17]: {
+                  ~ nestedProp: "value16" => "value17"
+                }
+          ~ [18]: {
+                  ~ nestedProp: "value17" => "value18"
+                }
+          ~ [19]: {
+                  ~ nestedProp: "value18" => "value19"
+                }
+          - [20]: {
+                  - default   : "default"
+                  - nestedProp: "value19"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[0].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[10].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[11].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[12].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[13].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[14].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[15].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[16].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[17].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[18].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[19].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[20]":            map[string]interface{}{"kind": "DELETE"},
+		"props[2].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[4].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[5].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[6].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[7].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[8].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[9].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default/one_added,_one_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default/one_added,_one_removed.golden
@@ -1,0 +1,66 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val4",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      ~ prop {
+          ~ nested_prop = "val1" -> "val2"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "val2" -> "val3"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "val3" -> "val4"
+            # (1 unchanged attribute hidden)
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProp: "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ nestedProp: "val2" => "val3"
+                }
+          ~ [2]: {
+                  ~ nestedProp: "val3" => "val4"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default/removed_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default/removed_empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  nil,
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default/removed_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default/removed_non-empty.golden
@@ -1,0 +1,43 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+	},
+	changeValue: nil,
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "default" -> null
+          - nested_prop = "val1" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      - props: [
+      -     [0]: {
+              - default   : "default"
+              - nestedProp: "val1"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default/unchanged_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default/unchanged_empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: nil, changeValue: nil,
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default/unchanged_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+	},
+	changeValue: &[]string{"val1"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default_with_default_specified_in_program/added_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default_with_default_specified_in_program/added_empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: nil, changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default_with_default_specified_in_program/added_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default_with_default_specified_in_program/added_non-empty.golden
@@ -1,0 +1,42 @@
+tests.testOutput{
+	initialValue: nil, changeValue: &[]string{
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + prop {
+          + default     = "non-default-val1"
+          + nested_prop = "val1"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + props: [
+      +     [0]: {
+              + default   : "non-default-val1"
+              + nestedProp: "val1"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default_with_default_specified_in_program/changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default_with_default_specified_in_program/changed.golden
@@ -1,0 +1,46 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+	},
+	changeValue: &[]string{"val2"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      ~ prop {
+          ~ default     = "non-default-val1" -> "non-default-val2"
+          ~ nested_prop = "val1" -> "val2"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ default   : "non-default-val1" => "non-default-val2"
+                  ~ nestedProp: "val1" => "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[0].default":    map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default_with_default_specified_in_program/list_element_added_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default_with_default_specified_in_program/list_element_added_back.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + prop {
+          + default     = "non-default-val3"
+          + nested_prop = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [2]: {
+                  + default   : "non-default-val3"
+                  + nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default_with_default_specified_in_program/list_element_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default_with_default_specified_in_program/list_element_added_front.golden
@@ -1,0 +1,70 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      ~ prop {
+          ~ default     = "non-default-val2" -> "non-default-val1"
+          ~ nested_prop = "val2" -> "val1"
+        }
+      ~ prop {
+          ~ default     = "non-default-val3" -> "non-default-val2"
+          ~ nested_prop = "val3" -> "val2"
+        }
+      + prop {
+          + default     = "non-default-val3"
+          + nested_prop = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ default   : "non-default-val2" => "non-default-val1"
+                  ~ nestedProp: "val2" => "val1"
+                }
+          ~ [1]: {
+                  ~ default   : "non-default-val3" => "non-default-val2"
+                  ~ nestedProp: "val3" => "val2"
+                }
+          + [2]: {
+                  + default   : "non-default-val3"
+                  + nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[0].default":    map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].default":    map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default_with_default_specified_in_program/list_element_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default_with_default_specified_in_program/list_element_added_middle.golden
@@ -1,0 +1,62 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      ~ prop {
+          ~ default     = "non-default-val3" -> "non-default-val2"
+          ~ nested_prop = "val3" -> "val2"
+        }
+      + prop {
+          + default     = "non-default-val3"
+          + nested_prop = "val3"
+        }
+
+        # (1 unchanged block hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [1]: {
+                  ~ default   : "non-default-val3" => "non-default-val2"
+                  ~ nestedProp: "val3" => "val2"
+                }
+          + [2]: {
+                  + default   : "non-default-val3"
+                  + nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[1].default":    map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default_with_default_specified_in_program/list_element_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default_with_default_specified_in_program/list_element_removed_end.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "non-default-val3" -> null
+          - nested_prop = "val3" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [2]: {
+                  - default   : "non-default-val3"
+                  - nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default_with_default_specified_in_program/list_element_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default_with_default_specified_in_program/list_element_removed_front.golden
@@ -1,0 +1,70 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      ~ prop {
+          ~ default     = "non-default-val1" -> "non-default-val2"
+          ~ nested_prop = "val1" -> "val2"
+        }
+      ~ prop {
+          ~ default     = "non-default-val2" -> "non-default-val3"
+          ~ nested_prop = "val2" -> "val3"
+        }
+      - prop {
+          - default     = "non-default-val3" -> null
+          - nested_prop = "val3" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ default   : "non-default-val1" => "non-default-val2"
+                  ~ nestedProp: "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ default   : "non-default-val2" => "non-default-val3"
+                  ~ nestedProp: "val2" => "val3"
+                }
+          - [2]: {
+                  - default   : "non-default-val3"
+                  - nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[0].default":    map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].default":    map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default_with_default_specified_in_program/list_element_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default_with_default_specified_in_program/list_element_removed_middle.golden
@@ -1,0 +1,62 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      ~ prop {
+          ~ default     = "non-default-val2" -> "non-default-val3"
+          ~ nested_prop = "val2" -> "val3"
+        }
+      - prop {
+          - default     = "non-default-val3" -> null
+          - nested_prop = "val3" -> null
+        }
+
+        # (1 unchanged block hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [1]: {
+                  ~ default   : "non-default-val2" => "non-default-val3"
+                  ~ nestedProp: "val2" => "val3"
+                }
+          - [2]: {
+                  - default   : "non-default-val3"
+                  - nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[1].default":    map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default_with_default_specified_in_program/long_list_added_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default_with_default_specified_in_program/long_list_added_back.golden
@@ -1,0 +1,86 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+		"value20",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + prop {
+          + default     = "non-default-value20"
+          + nested_prop = "value20"
+        }
+
+        # (20 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [20]: {
+                  + default   : "non-default-value20"
+                  + nestedProp: "value20"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[20]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default_with_default_specified_in_program/long_list_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default_with_default_specified_in_program/long_list_added_front.golden
@@ -1,0 +1,286 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value20",
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      ~ prop {
+          ~ default     = "non-default-value0" -> "non-default-value20"
+          ~ nested_prop = "value0" -> "value20"
+        }
+      ~ prop {
+          ~ default     = "non-default-value1" -> "non-default-value0"
+          ~ nested_prop = "value1" -> "value0"
+        }
+      ~ prop {
+          ~ default     = "non-default-value2" -> "non-default-value1"
+          ~ nested_prop = "value2" -> "value1"
+        }
+      ~ prop {
+          ~ default     = "non-default-value3" -> "non-default-value2"
+          ~ nested_prop = "value3" -> "value2"
+        }
+      ~ prop {
+          ~ default     = "non-default-value4" -> "non-default-value3"
+          ~ nested_prop = "value4" -> "value3"
+        }
+      ~ prop {
+          ~ default     = "non-default-value5" -> "non-default-value4"
+          ~ nested_prop = "value5" -> "value4"
+        }
+      ~ prop {
+          ~ default     = "non-default-value6" -> "non-default-value5"
+          ~ nested_prop = "value6" -> "value5"
+        }
+      ~ prop {
+          ~ default     = "non-default-value7" -> "non-default-value6"
+          ~ nested_prop = "value7" -> "value6"
+        }
+      ~ prop {
+          ~ default     = "non-default-value8" -> "non-default-value7"
+          ~ nested_prop = "value8" -> "value7"
+        }
+      ~ prop {
+          ~ default     = "non-default-value9" -> "non-default-value8"
+          ~ nested_prop = "value9" -> "value8"
+        }
+      ~ prop {
+          ~ default     = "non-default-value10" -> "non-default-value9"
+          ~ nested_prop = "value10" -> "value9"
+        }
+      ~ prop {
+          ~ default     = "non-default-value11" -> "non-default-value10"
+          ~ nested_prop = "value11" -> "value10"
+        }
+      ~ prop {
+          ~ default     = "non-default-value12" -> "non-default-value11"
+          ~ nested_prop = "value12" -> "value11"
+        }
+      ~ prop {
+          ~ default     = "non-default-value13" -> "non-default-value12"
+          ~ nested_prop = "value13" -> "value12"
+        }
+      ~ prop {
+          ~ default     = "non-default-value14" -> "non-default-value13"
+          ~ nested_prop = "value14" -> "value13"
+        }
+      ~ prop {
+          ~ default     = "non-default-value15" -> "non-default-value14"
+          ~ nested_prop = "value15" -> "value14"
+        }
+      ~ prop {
+          ~ default     = "non-default-value16" -> "non-default-value15"
+          ~ nested_prop = "value16" -> "value15"
+        }
+      ~ prop {
+          ~ default     = "non-default-value17" -> "non-default-value16"
+          ~ nested_prop = "value17" -> "value16"
+        }
+      ~ prop {
+          ~ default     = "non-default-value18" -> "non-default-value17"
+          ~ nested_prop = "value18" -> "value17"
+        }
+      ~ prop {
+          ~ default     = "non-default-value19" -> "non-default-value18"
+          ~ nested_prop = "value19" -> "value18"
+        }
+      + prop {
+          + default     = "non-default-value19"
+          + nested_prop = "value19"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ default   : "non-default-value0" => "non-default-value20"
+                  ~ nestedProp: "value0" => "value20"
+                }
+          ~ [1]: {
+                  ~ default   : "non-default-value1" => "non-default-value0"
+                  ~ nestedProp: "value1" => "value0"
+                }
+          ~ [2]: {
+                  ~ default   : "non-default-value2" => "non-default-value1"
+                  ~ nestedProp: "value2" => "value1"
+                }
+          ~ [3]: {
+                  ~ default   : "non-default-value3" => "non-default-value2"
+                  ~ nestedProp: "value3" => "value2"
+                }
+          ~ [4]: {
+                  ~ default   : "non-default-value4" => "non-default-value3"
+                  ~ nestedProp: "value4" => "value3"
+                }
+          ~ [5]: {
+                  ~ default   : "non-default-value5" => "non-default-value4"
+                  ~ nestedProp: "value5" => "value4"
+                }
+          ~ [6]: {
+                  ~ default   : "non-default-value6" => "non-default-value5"
+                  ~ nestedProp: "value6" => "value5"
+                }
+          ~ [7]: {
+                  ~ default   : "non-default-value7" => "non-default-value6"
+                  ~ nestedProp: "value7" => "value6"
+                }
+          ~ [8]: {
+                  ~ default   : "non-default-value8" => "non-default-value7"
+                  ~ nestedProp: "value8" => "value7"
+                }
+          ~ [9]: {
+                  ~ default   : "non-default-value9" => "non-default-value8"
+                  ~ nestedProp: "value9" => "value8"
+                }
+          ~ [10]: {
+                  ~ default   : "non-default-value10" => "non-default-value9"
+                  ~ nestedProp: "value10" => "value9"
+                }
+          ~ [11]: {
+                  ~ default   : "non-default-value11" => "non-default-value10"
+                  ~ nestedProp: "value11" => "value10"
+                }
+          ~ [12]: {
+                  ~ default   : "non-default-value12" => "non-default-value11"
+                  ~ nestedProp: "value12" => "value11"
+                }
+          ~ [13]: {
+                  ~ default   : "non-default-value13" => "non-default-value12"
+                  ~ nestedProp: "value13" => "value12"
+                }
+          ~ [14]: {
+                  ~ default   : "non-default-value14" => "non-default-value13"
+                  ~ nestedProp: "value14" => "value13"
+                }
+          ~ [15]: {
+                  ~ default   : "non-default-value15" => "non-default-value14"
+                  ~ nestedProp: "value15" => "value14"
+                }
+          ~ [16]: {
+                  ~ default   : "non-default-value16" => "non-default-value15"
+                  ~ nestedProp: "value16" => "value15"
+                }
+          ~ [17]: {
+                  ~ default   : "non-default-value17" => "non-default-value16"
+                  ~ nestedProp: "value17" => "value16"
+                }
+          ~ [18]: {
+                  ~ default   : "non-default-value18" => "non-default-value17"
+                  ~ nestedProp: "value18" => "value17"
+                }
+          ~ [19]: {
+                  ~ default   : "non-default-value19" => "non-default-value18"
+                  ~ nestedProp: "value19" => "value18"
+                }
+          + [20]: {
+                  + default   : "non-default-value19"
+                  + nestedProp: "value19"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[0].default":     map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[10].default":    map[string]interface{}{"kind": "UPDATE"},
+		"props[10].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[11].default":    map[string]interface{}{"kind": "UPDATE"},
+		"props[11].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[12].default":    map[string]interface{}{"kind": "UPDATE"},
+		"props[12].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[13].default":    map[string]interface{}{"kind": "UPDATE"},
+		"props[13].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[14].default":    map[string]interface{}{"kind": "UPDATE"},
+		"props[14].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[15].default":    map[string]interface{}{"kind": "UPDATE"},
+		"props[15].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[16].default":    map[string]interface{}{"kind": "UPDATE"},
+		"props[16].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[17].default":    map[string]interface{}{"kind": "UPDATE"},
+		"props[17].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[18].default":    map[string]interface{}{"kind": "UPDATE"},
+		"props[18].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[19].default":    map[string]interface{}{"kind": "UPDATE"},
+		"props[19].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].default":     map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[20]":            map[string]interface{}{},
+		"props[2].default":     map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[3].default":     map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[4].default":     map[string]interface{}{"kind": "UPDATE"},
+		"props[4].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[5].default":     map[string]interface{}{"kind": "UPDATE"},
+		"props[5].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[6].default":     map[string]interface{}{"kind": "UPDATE"},
+		"props[6].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[7].default":     map[string]interface{}{"kind": "UPDATE"},
+		"props[7].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[8].default":     map[string]interface{}{"kind": "UPDATE"},
+		"props[8].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[9].default":     map[string]interface{}{"kind": "UPDATE"},
+		"props[9].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default_with_default_specified_in_program/long_list_removed_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default_with_default_specified_in_program/long_list_removed_back.golden
@@ -1,0 +1,86 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+		"value20",
+	},
+	changeValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "non-default-value20" -> null
+          - nested_prop = "value20" -> null
+        }
+
+        # (20 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [20]: {
+                  - default   : "non-default-value20"
+                  - nestedProp: "value20"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[20]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default_with_default_specified_in_program/long_list_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default_with_default_specified_in_program/long_list_removed_front.golden
@@ -1,0 +1,286 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value20",
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      ~ prop {
+          ~ default     = "non-default-value20" -> "non-default-value0"
+          ~ nested_prop = "value20" -> "value0"
+        }
+      ~ prop {
+          ~ default     = "non-default-value0" -> "non-default-value1"
+          ~ nested_prop = "value0" -> "value1"
+        }
+      ~ prop {
+          ~ default     = "non-default-value1" -> "non-default-value2"
+          ~ nested_prop = "value1" -> "value2"
+        }
+      ~ prop {
+          ~ default     = "non-default-value2" -> "non-default-value3"
+          ~ nested_prop = "value2" -> "value3"
+        }
+      ~ prop {
+          ~ default     = "non-default-value3" -> "non-default-value4"
+          ~ nested_prop = "value3" -> "value4"
+        }
+      ~ prop {
+          ~ default     = "non-default-value4" -> "non-default-value5"
+          ~ nested_prop = "value4" -> "value5"
+        }
+      ~ prop {
+          ~ default     = "non-default-value5" -> "non-default-value6"
+          ~ nested_prop = "value5" -> "value6"
+        }
+      ~ prop {
+          ~ default     = "non-default-value6" -> "non-default-value7"
+          ~ nested_prop = "value6" -> "value7"
+        }
+      ~ prop {
+          ~ default     = "non-default-value7" -> "non-default-value8"
+          ~ nested_prop = "value7" -> "value8"
+        }
+      ~ prop {
+          ~ default     = "non-default-value8" -> "non-default-value9"
+          ~ nested_prop = "value8" -> "value9"
+        }
+      ~ prop {
+          ~ default     = "non-default-value9" -> "non-default-value10"
+          ~ nested_prop = "value9" -> "value10"
+        }
+      ~ prop {
+          ~ default     = "non-default-value10" -> "non-default-value11"
+          ~ nested_prop = "value10" -> "value11"
+        }
+      ~ prop {
+          ~ default     = "non-default-value11" -> "non-default-value12"
+          ~ nested_prop = "value11" -> "value12"
+        }
+      ~ prop {
+          ~ default     = "non-default-value12" -> "non-default-value13"
+          ~ nested_prop = "value12" -> "value13"
+        }
+      ~ prop {
+          ~ default     = "non-default-value13" -> "non-default-value14"
+          ~ nested_prop = "value13" -> "value14"
+        }
+      ~ prop {
+          ~ default     = "non-default-value14" -> "non-default-value15"
+          ~ nested_prop = "value14" -> "value15"
+        }
+      ~ prop {
+          ~ default     = "non-default-value15" -> "non-default-value16"
+          ~ nested_prop = "value15" -> "value16"
+        }
+      ~ prop {
+          ~ default     = "non-default-value16" -> "non-default-value17"
+          ~ nested_prop = "value16" -> "value17"
+        }
+      ~ prop {
+          ~ default     = "non-default-value17" -> "non-default-value18"
+          ~ nested_prop = "value17" -> "value18"
+        }
+      ~ prop {
+          ~ default     = "non-default-value18" -> "non-default-value19"
+          ~ nested_prop = "value18" -> "value19"
+        }
+      - prop {
+          - default     = "non-default-value19" -> null
+          - nested_prop = "value19" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ default   : "non-default-value20" => "non-default-value0"
+                  ~ nestedProp: "value20" => "value0"
+                }
+          ~ [1]: {
+                  ~ default   : "non-default-value0" => "non-default-value1"
+                  ~ nestedProp: "value0" => "value1"
+                }
+          ~ [2]: {
+                  ~ default   : "non-default-value1" => "non-default-value2"
+                  ~ nestedProp: "value1" => "value2"
+                }
+          ~ [3]: {
+                  ~ default   : "non-default-value2" => "non-default-value3"
+                  ~ nestedProp: "value2" => "value3"
+                }
+          ~ [4]: {
+                  ~ default   : "non-default-value3" => "non-default-value4"
+                  ~ nestedProp: "value3" => "value4"
+                }
+          ~ [5]: {
+                  ~ default   : "non-default-value4" => "non-default-value5"
+                  ~ nestedProp: "value4" => "value5"
+                }
+          ~ [6]: {
+                  ~ default   : "non-default-value5" => "non-default-value6"
+                  ~ nestedProp: "value5" => "value6"
+                }
+          ~ [7]: {
+                  ~ default   : "non-default-value6" => "non-default-value7"
+                  ~ nestedProp: "value6" => "value7"
+                }
+          ~ [8]: {
+                  ~ default   : "non-default-value7" => "non-default-value8"
+                  ~ nestedProp: "value7" => "value8"
+                }
+          ~ [9]: {
+                  ~ default   : "non-default-value8" => "non-default-value9"
+                  ~ nestedProp: "value8" => "value9"
+                }
+          ~ [10]: {
+                  ~ default   : "non-default-value9" => "non-default-value10"
+                  ~ nestedProp: "value9" => "value10"
+                }
+          ~ [11]: {
+                  ~ default   : "non-default-value10" => "non-default-value11"
+                  ~ nestedProp: "value10" => "value11"
+                }
+          ~ [12]: {
+                  ~ default   : "non-default-value11" => "non-default-value12"
+                  ~ nestedProp: "value11" => "value12"
+                }
+          ~ [13]: {
+                  ~ default   : "non-default-value12" => "non-default-value13"
+                  ~ nestedProp: "value12" => "value13"
+                }
+          ~ [14]: {
+                  ~ default   : "non-default-value13" => "non-default-value14"
+                  ~ nestedProp: "value13" => "value14"
+                }
+          ~ [15]: {
+                  ~ default   : "non-default-value14" => "non-default-value15"
+                  ~ nestedProp: "value14" => "value15"
+                }
+          ~ [16]: {
+                  ~ default   : "non-default-value15" => "non-default-value16"
+                  ~ nestedProp: "value15" => "value16"
+                }
+          ~ [17]: {
+                  ~ default   : "non-default-value16" => "non-default-value17"
+                  ~ nestedProp: "value16" => "value17"
+                }
+          ~ [18]: {
+                  ~ default   : "non-default-value17" => "non-default-value18"
+                  ~ nestedProp: "value17" => "value18"
+                }
+          ~ [19]: {
+                  ~ default   : "non-default-value18" => "non-default-value19"
+                  ~ nestedProp: "value18" => "value19"
+                }
+          - [20]: {
+                  - default   : "non-default-value19"
+                  - nestedProp: "value19"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[0].default":     map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[10].default":    map[string]interface{}{"kind": "UPDATE"},
+		"props[10].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[11].default":    map[string]interface{}{"kind": "UPDATE"},
+		"props[11].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[12].default":    map[string]interface{}{"kind": "UPDATE"},
+		"props[12].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[13].default":    map[string]interface{}{"kind": "UPDATE"},
+		"props[13].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[14].default":    map[string]interface{}{"kind": "UPDATE"},
+		"props[14].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[15].default":    map[string]interface{}{"kind": "UPDATE"},
+		"props[15].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[16].default":    map[string]interface{}{"kind": "UPDATE"},
+		"props[16].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[17].default":    map[string]interface{}{"kind": "UPDATE"},
+		"props[17].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[18].default":    map[string]interface{}{"kind": "UPDATE"},
+		"props[18].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[19].default":    map[string]interface{}{"kind": "UPDATE"},
+		"props[19].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].default":     map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[20]":            map[string]interface{}{"kind": "DELETE"},
+		"props[2].default":     map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[3].default":     map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[4].default":     map[string]interface{}{"kind": "UPDATE"},
+		"props[4].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[5].default":     map[string]interface{}{"kind": "UPDATE"},
+		"props[5].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[6].default":     map[string]interface{}{"kind": "UPDATE"},
+		"props[6].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[7].default":     map[string]interface{}{"kind": "UPDATE"},
+		"props[7].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[8].default":     map[string]interface{}{"kind": "UPDATE"},
+		"props[8].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[9].default":     map[string]interface{}{"kind": "UPDATE"},
+		"props[9].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default_with_default_specified_in_program/one_added,_one_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default_with_default_specified_in_program/one_added,_one_removed.golden
@@ -1,0 +1,72 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val4",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      ~ prop {
+          ~ default     = "non-default-val1" -> "non-default-val2"
+          ~ nested_prop = "val1" -> "val2"
+        }
+      ~ prop {
+          ~ default     = "non-default-val2" -> "non-default-val3"
+          ~ nested_prop = "val2" -> "val3"
+        }
+      ~ prop {
+          ~ default     = "non-default-val3" -> "non-default-val4"
+          ~ nested_prop = "val3" -> "val4"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ default   : "non-default-val1" => "non-default-val2"
+                  ~ nestedProp: "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ default   : "non-default-val2" => "non-default-val3"
+                  ~ nestedProp: "val2" => "val3"
+                }
+          ~ [2]: {
+                  ~ default   : "non-default-val3" => "non-default-val4"
+                  ~ nestedProp: "val3" => "val4"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[0].default":    map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].default":    map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2].default":    map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default_with_default_specified_in_program/removed_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default_with_default_specified_in_program/removed_empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  nil,
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default_with_default_specified_in_program/removed_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default_with_default_specified_in_program/removed_non-empty.golden
@@ -1,0 +1,43 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+	},
+	changeValue: nil,
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "non-default-val1" -> null
+          - nested_prop = "val1" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      - props: [
+      -     [0]: {
+              - default   : "non-default-val1"
+              - nestedProp: "val1"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default_with_default_specified_in_program/unchanged_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default_with_default_specified_in_program/unchanged_empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: nil, changeValue: nil,
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default_with_default_specified_in_program/unchanged_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_default_with_default_specified_in_program/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+	},
+	changeValue: &[]string{"val1"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/added.golden
@@ -1,0 +1,41 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{"value"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + prop {
+          + default     = "default"
+          + nested_prop = "value"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + props: [
+      +     [0]: {
+              + default   : "default"
+              + nestedProp: "value"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/added_end.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + prop {
+          + default     = "default"
+          + nested_prop = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [2]: {
+                  + default   : "default"
+                  + nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/added_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/added_end_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + prop {
+          + default     = "default"
+          + nested_prop = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [2]: {
+                  + default   : "default"
+                  + nestedProp: "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/added_front.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + prop {
+          + default     = "default"
+          + nested_prop = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [0]: {
+                  + default   : "default"
+                  + nestedProp: "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/added_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/added_front_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + prop {
+          + default     = "default"
+          + nested_prop = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [0]: {
+                  + default   : "default"
+                  + nestedProp: "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/added_middle.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + prop {
+          + default     = "default"
+          + nested_prop = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [1]: {
+                  + default   : "default"
+                  + nestedProp: "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/added_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/added_middle_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + prop {
+          + default     = "default"
+          + nested_prop = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [1]: {
+                  + default   : "default"
+                  + nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/changed_empty_to_null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/changed_empty_to_null.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  nil,
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/changed_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/changed_non-null.golden
@@ -1,0 +1,46 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "default" -> null
+          - nested_prop = "value" -> null
+        }
+      + prop {
+          + default     = "default"
+          + nested_prop = "value1"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProp: "value" => "value1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/changed_non-null_to_null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/changed_non-null_to_null.golden
@@ -1,0 +1,43 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: nil,
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "default" -> null
+          - nested_prop = "value" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      - props: [
+      -     [0]: {
+              - default   : "default"
+              - nestedProp: "value"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/changed_null_to_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/changed_null_to_empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: nil, changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/changed_null_to_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/changed_null_to_non-null.golden
@@ -1,0 +1,42 @@
+tests.testOutput{
+	initialValue: nil, changeValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + prop {
+          + default     = "default"
+          + nested_prop = "value"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + props: [
+      +     [0]: {
+              + default   : "default"
+              + nestedProp: "value"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/removed.golden
@@ -1,0 +1,43 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "default" -> null
+          - nested_prop = "value" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      - props: [
+      -     [0]: {
+              - default   : "default"
+              - nestedProp: "value"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/removed_end.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "default" -> null
+          - nested_prop = "val3" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [2]: {
+                  - default   : "default"
+                  - nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/removed_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/removed_end_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "default" -> null
+          - nested_prop = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [0]: {
+                  - default   : "default"
+                  - nestedProp: "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/removed_front.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "default" -> null
+          - nested_prop = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [0]: {
+                  - default   : "default"
+                  - nestedProp: "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/removed_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/removed_front_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "default" -> null
+          - nested_prop = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [1]: {
+                  - default   : "default"
+                  - nestedProp: "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/removed_middle.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "default" -> null
+          - nested_prop = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [1]: {
+                  - default   : "default"
+                  - nestedProp: "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/removed_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/removed_middle_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "default" -> null
+          - nested_prop = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [1]: {
+                  - default   : "default"
+                  - nestedProp: "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/same_element_updated.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/same_element_updated.golden
@@ -1,0 +1,54 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val4",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "default" -> null
+          - nested_prop = "val2" -> null
+        }
+      + prop {
+          + default     = "default"
+          + nested_prop = "val4"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [1]: {
+                  ~ nestedProp: "val2" => "val4"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/same_element_updated_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/same_element_updated_unordered.golden
@@ -1,0 +1,62 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val4",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "default" -> null
+          - nested_prop = "val3" -> null
+        }
+      + prop {
+          + default     = "default"
+          + nested_prop = "val4"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [1]: {
+                  + default   : "default"
+                  + nestedProp: "val4"
+                }
+          - [2]: {
+                  - default   : "default"
+                  - nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[1]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/shuffled.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/shuffled.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/shuffled_added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/shuffled_added_end.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + prop {
+          + default     = "default"
+          + nested_prop = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [2]: {
+                  + default   : "default"
+                  + nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/shuffled_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/shuffled_added_front.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + prop {
+          + default     = "default"
+          + nested_prop = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [0]: {
+                  + default   : "default"
+                  + nestedProp: "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/shuffled_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/shuffled_added_middle.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + prop {
+          + default     = "default"
+          + nested_prop = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [1]: {
+                  + default   : "default"
+                  + nestedProp: "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/shuffled_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/shuffled_removed_end.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "default" -> null
+          - nested_prop = "val3" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [2]: {
+                  - default   : "default"
+                  - nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/shuffled_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/shuffled_removed_front.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "default" -> null
+          - nested_prop = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [0]: {
+                  - default   : "default"
+                  - nestedProp: "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/shuffled_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/shuffled_removed_middle.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "default" -> null
+          - nested_prop = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [1]: {
+                  - default   : "default"
+                  - nestedProp: "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/shuffled_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/shuffled_unordered.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/shuffled_with_duplicates.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/shuffled_with_duplicates.golden
@@ -1,0 +1,25 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/shuffled_with_duplicates_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/shuffled_with_duplicates_unordered.golden
@@ -1,0 +1,25 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/two_added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/two_added.golden
@@ -1,0 +1,62 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + prop {
+          + default     = "default"
+          + nested_prop = "val3"
+        }
+      + prop {
+          + default     = "default"
+          + nested_prop = "val4"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [2]: {
+                  + default   : "default"
+                  + nestedProp: "val3"
+                }
+          + [3]: {
+                  + default   : "default"
+                  + nestedProp: "val4"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[2]": map[string]interface{}{},
+		"props[3]": map[string]interface{}{},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/two_added_and_two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/two_added_and_two_removed.golden
@@ -1,0 +1,70 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val5",
+		"val6",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "default" -> null
+          - nested_prop = "val3" -> null
+        }
+      - prop {
+          - default     = "default" -> null
+          - nested_prop = "val4" -> null
+        }
+      + prop {
+          + default     = "default"
+          + nested_prop = "val5"
+        }
+      + prop {
+          + default     = "default"
+          + nested_prop = "val6"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [2]: {
+                  ~ nestedProp: "val3" => "val5"
+                }
+          ~ [3]: {
+                  ~ nestedProp: "val4" => "val6"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -1,0 +1,82 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val5",
+		"val6",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "default" -> null
+          - nested_prop = "val3" -> null
+        }
+      - prop {
+          - default     = "default" -> null
+          - nested_prop = "val4" -> null
+        }
+      + prop {
+          + default     = "default"
+          + nested_prop = "val5"
+        }
+      + prop {
+          + default     = "default"
+          + nested_prop = "val6"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [0]: {
+                  + default   : "default"
+                  + nestedProp: "val5"
+                }
+          + [1]: {
+                  + default   : "default"
+                  + nestedProp: "val6"
+                }
+          - [2]: {
+                  - default   : "default"
+                  - nestedProp: "val3"
+                }
+          - [3]: {
+                  - default   : "default"
+                  - nestedProp: "val4"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[0]": map[string]interface{}{},
+		"props[1]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -1,0 +1,76 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val5",
+		"val6",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "default" -> null
+          - nested_prop = "val3" -> null
+        }
+      - prop {
+          - default     = "default" -> null
+          - nested_prop = "val4" -> null
+        }
+      + prop {
+          + default     = "default"
+          + nested_prop = "val5"
+        }
+      + prop {
+          + default     = "default"
+          + nested_prop = "val6"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [1]: {
+                  + default   : "default"
+                  + nestedProp: "val5"
+                }
+          ~ [2]: {
+                  ~ nestedProp: "val3" => "val6"
+                }
+          - [3]: {
+                  - default   : "default"
+                  - nestedProp: "val4"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[1]":            map[string]interface{}{},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3]":            map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -1,0 +1,78 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val5",
+		"val6",
+		"val2",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "default" -> null
+          - nested_prop = "val3" -> null
+        }
+      - prop {
+          - default     = "default" -> null
+          - nested_prop = "val4" -> null
+        }
+      + prop {
+          + default     = "default"
+          + nested_prop = "val5"
+        }
+      + prop {
+          + default     = "default"
+          + nested_prop = "val6"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [1]: {
+                  + default   : "default"
+                  + nestedProp: "val5"
+                }
+          ~ [2]: {
+                  ~ nestedProp: "val3" => "val6"
+                }
+          - [3]: {
+                  - default   : "default"
+                  - nestedProp: "val4"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[1]":            map[string]interface{}{},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3]":            map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/two_removed.golden
@@ -1,0 +1,62 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "default" -> null
+          - nested_prop = "val3" -> null
+        }
+      - prop {
+          - default     = "default" -> null
+          - nested_prop = "val4" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [2]: {
+                  - default   : "default"
+                  - nestedProp: "val3"
+                }
+          - [3]: {
+                  - default   : "default"
+                  - nestedProp: "val4"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/unchanged_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/unchanged_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/unchanged_null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default/unchanged_null.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: nil, changeValue: nil,
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/added.golden
@@ -1,0 +1,41 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{"value"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + prop {
+          + default     = "non-default-value"
+          + nested_prop = "value"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + props: [
+      +     [0]: {
+              + default   : "non-default-value"
+              + nestedProp: "value"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/added_end.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + prop {
+          + default     = "non-default-val3"
+          + nested_prop = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [2]: {
+                  + default   : "non-default-val3"
+                  + nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/added_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/added_end_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + prop {
+          + default     = "non-default-val1"
+          + nested_prop = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [2]: {
+                  + default   : "non-default-val1"
+                  + nestedProp: "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/added_front.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + prop {
+          + default     = "non-default-val1"
+          + nested_prop = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [0]: {
+                  + default   : "non-default-val1"
+                  + nestedProp: "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/added_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/added_front_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + prop {
+          + default     = "non-default-val2"
+          + nested_prop = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [0]: {
+                  + default   : "non-default-val2"
+                  + nestedProp: "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/added_middle.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + prop {
+          + default     = "non-default-val2"
+          + nested_prop = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [1]: {
+                  + default   : "non-default-val2"
+                  + nestedProp: "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/added_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/added_middle_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + prop {
+          + default     = "non-default-val3"
+          + nested_prop = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [1]: {
+                  + default   : "non-default-val3"
+                  + nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/changed_empty_to_null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/changed_empty_to_null.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  nil,
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/changed_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/changed_non-null.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "non-default-value" -> null
+          - nested_prop = "value" -> null
+        }
+      + prop {
+          + default     = "non-default-value1"
+          + nested_prop = "value1"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ default   : "non-default-value" => "non-default-value1"
+                  ~ nestedProp: "value" => "value1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[0].default":    map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/changed_non-null_to_null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/changed_non-null_to_null.golden
@@ -1,0 +1,43 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: nil,
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "non-default-value" -> null
+          - nested_prop = "value" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      - props: [
+      -     [0]: {
+              - default   : "non-default-value"
+              - nestedProp: "value"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/changed_null_to_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/changed_null_to_empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: nil, changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/changed_null_to_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/changed_null_to_non-null.golden
@@ -1,0 +1,42 @@
+tests.testOutput{
+	initialValue: nil, changeValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + prop {
+          + default     = "non-default-value"
+          + nested_prop = "value"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + props: [
+      +     [0]: {
+              + default   : "non-default-value"
+              + nestedProp: "value"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/removed.golden
@@ -1,0 +1,43 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "non-default-value" -> null
+          - nested_prop = "value" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      - props: [
+      -     [0]: {
+              - default   : "non-default-value"
+              - nestedProp: "value"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/removed_end.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "non-default-val3" -> null
+          - nested_prop = "val3" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [2]: {
+                  - default   : "non-default-val3"
+                  - nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/removed_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/removed_end_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "non-default-val1" -> null
+          - nested_prop = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [0]: {
+                  - default   : "non-default-val1"
+                  - nestedProp: "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/removed_front.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "non-default-val1" -> null
+          - nested_prop = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [0]: {
+                  - default   : "non-default-val1"
+                  - nestedProp: "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/removed_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/removed_front_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "non-default-val2" -> null
+          - nested_prop = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [1]: {
+                  - default   : "non-default-val2"
+                  - nestedProp: "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/removed_middle.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "non-default-val2" -> null
+          - nested_prop = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [1]: {
+                  - default   : "non-default-val2"
+                  - nestedProp: "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/removed_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/removed_middle_unordered.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "non-default-val2" -> null
+          - nested_prop = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [1]: {
+                  - default   : "non-default-val2"
+                  - nestedProp: "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/same_element_updated.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/same_element_updated.golden
@@ -1,0 +1,58 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val4",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "non-default-val2" -> null
+          - nested_prop = "val2" -> null
+        }
+      + prop {
+          + default     = "non-default-val4"
+          + nested_prop = "val4"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [1]: {
+                  ~ default   : "non-default-val2" => "non-default-val4"
+                  ~ nestedProp: "val2" => "val4"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[1].default":    map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/same_element_updated_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/same_element_updated_unordered.golden
@@ -1,0 +1,62 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val4",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "non-default-val3" -> null
+          - nested_prop = "val3" -> null
+        }
+      + prop {
+          + default     = "non-default-val4"
+          + nested_prop = "val4"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [1]: {
+                  + default   : "non-default-val4"
+                  + nestedProp: "val4"
+                }
+          - [2]: {
+                  - default   : "non-default-val3"
+                  - nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[1]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/shuffled.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/shuffled.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/shuffled_added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/shuffled_added_end.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + prop {
+          + default     = "non-default-val3"
+          + nested_prop = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [2]: {
+                  + default   : "non-default-val3"
+                  + nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/shuffled_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/shuffled_added_front.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + prop {
+          + default     = "non-default-val1"
+          + nested_prop = "val1"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [0]: {
+                  + default   : "non-default-val1"
+                  + nestedProp: "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/shuffled_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/shuffled_added_middle.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + prop {
+          + default     = "non-default-val2"
+          + nested_prop = "val2"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [1]: {
+                  + default   : "non-default-val2"
+                  + nestedProp: "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/shuffled_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/shuffled_removed_end.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "non-default-val3" -> null
+          - nested_prop = "val3" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [2]: {
+                  - default   : "non-default-val3"
+                  - nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/shuffled_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/shuffled_removed_front.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "non-default-val1" -> null
+          - nested_prop = "val1" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [0]: {
+                  - default   : "non-default-val1"
+                  - nestedProp: "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/shuffled_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/shuffled_removed_middle.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "non-default-val2" -> null
+          - nested_prop = "val2" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [1]: {
+                  - default   : "non-default-val2"
+                  - nestedProp: "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/shuffled_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/shuffled_unordered.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/shuffled_with_duplicates.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/shuffled_with_duplicates.golden
@@ -1,0 +1,25 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/shuffled_with_duplicates_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/shuffled_with_duplicates_unordered.golden
@@ -1,0 +1,25 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/two_added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/two_added.golden
@@ -1,0 +1,62 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + prop {
+          + default     = "non-default-val3"
+          + nested_prop = "val3"
+        }
+      + prop {
+          + default     = "non-default-val4"
+          + nested_prop = "val4"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [2]: {
+                  + default   : "non-default-val3"
+                  + nestedProp: "val3"
+                }
+          + [3]: {
+                  + default   : "non-default-val4"
+                  + nestedProp: "val4"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[2]": map[string]interface{}{},
+		"props[3]": map[string]interface{}{},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/two_added_and_two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/two_added_and_two_removed.golden
@@ -1,0 +1,74 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val5",
+		"val6",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "non-default-val3" -> null
+          - nested_prop = "val3" -> null
+        }
+      - prop {
+          - default     = "non-default-val4" -> null
+          - nested_prop = "val4" -> null
+        }
+      + prop {
+          + default     = "non-default-val5"
+          + nested_prop = "val5"
+        }
+      + prop {
+          + default     = "non-default-val6"
+          + nested_prop = "val6"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [2]: {
+                  ~ default   : "non-default-val3" => "non-default-val5"
+                  ~ nestedProp: "val3" => "val5"
+                }
+          ~ [3]: {
+                  ~ default   : "non-default-val4" => "non-default-val6"
+                  ~ nestedProp: "val4" => "val6"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[2].default":    map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3].default":    map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -1,0 +1,82 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val5",
+		"val6",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "non-default-val3" -> null
+          - nested_prop = "val3" -> null
+        }
+      - prop {
+          - default     = "non-default-val4" -> null
+          - nested_prop = "val4" -> null
+        }
+      + prop {
+          + default     = "non-default-val5"
+          + nested_prop = "val5"
+        }
+      + prop {
+          + default     = "non-default-val6"
+          + nested_prop = "val6"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [0]: {
+                  + default   : "non-default-val5"
+                  + nestedProp: "val5"
+                }
+          + [1]: {
+                  + default   : "non-default-val6"
+                  + nestedProp: "val6"
+                }
+          - [2]: {
+                  - default   : "non-default-val3"
+                  - nestedProp: "val3"
+                }
+          - [3]: {
+                  - default   : "non-default-val4"
+                  - nestedProp: "val4"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[0]": map[string]interface{}{},
+		"props[1]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -1,0 +1,78 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val5",
+		"val6",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "non-default-val3" -> null
+          - nested_prop = "val3" -> null
+        }
+      - prop {
+          - default     = "non-default-val4" -> null
+          - nested_prop = "val4" -> null
+        }
+      + prop {
+          + default     = "non-default-val5"
+          + nested_prop = "val5"
+        }
+      + prop {
+          + default     = "non-default-val6"
+          + nested_prop = "val6"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [1]: {
+                  + default   : "non-default-val5"
+                  + nestedProp: "val5"
+                }
+          ~ [2]: {
+                  ~ default   : "non-default-val3" => "non-default-val6"
+                  ~ nestedProp: "val3" => "val6"
+                }
+          - [3]: {
+                  - default   : "non-default-val4"
+                  - nestedProp: "val4"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[1]":            map[string]interface{}{},
+		"props[2].default":    map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3]":            map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -1,0 +1,80 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val5",
+		"val6",
+		"val2",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "non-default-val3" -> null
+          - nested_prop = "val3" -> null
+        }
+      - prop {
+          - default     = "non-default-val4" -> null
+          - nested_prop = "val4" -> null
+        }
+      + prop {
+          + default     = "non-default-val5"
+          + nested_prop = "val5"
+        }
+      + prop {
+          + default     = "non-default-val6"
+          + nested_prop = "val6"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [1]: {
+                  + default   : "non-default-val5"
+                  + nestedProp: "val5"
+                }
+          ~ [2]: {
+                  ~ default   : "non-default-val3" => "non-default-val6"
+                  ~ nestedProp: "val3" => "val6"
+                }
+          - [3]: {
+                  - default   : "non-default-val4"
+                  - nestedProp: "val4"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[1]":            map[string]interface{}{},
+		"props[2].default":    map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3]":            map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/two_removed.golden
@@ -1,0 +1,62 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - default     = "non-default-val3" -> null
+          - nested_prop = "val3" -> null
+        }
+      - prop {
+          - default     = "non-default-val4" -> null
+          - nested_prop = "val4" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [2]: {
+                  - default   : "non-default-val3"
+                  - nestedProp: "val3"
+                }
+          - [3]: {
+                  - default   : "non-default-val4"
+                  - nestedProp: "val4"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/unchanged_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/unchanged_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/unchanged_null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetDefault/block_nested_default_with_default_specified_in_program/unchanged_null.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: nil, changeValue: nil,
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/value_makers.go
+++ b/pkg/tests/diff_test/value_makers.go
@@ -294,6 +294,29 @@ func nestedListValueMakerWithComputedSpecified(arr *[]string) map[string]cty.Val
 	}
 }
 
+func nestedListValueMakerWithDefaultSpecified(arr *[]string) map[string]cty.Value {
+	if arr == nil {
+		return map[string]cty.Value{}
+	}
+
+	if len(*arr) == 0 {
+		return map[string]cty.Value{
+			"prop": cty.ListValEmpty(cty.DynamicPseudoType),
+		}
+	}
+
+	slice := make([]cty.Value, len(*arr))
+	for i, v := range *arr {
+		slice[i] = cty.ObjectVal(map[string]cty.Value{
+			"nested_prop": cty.StringVal(v),
+			"default":     cty.StringVal("non-default-" + v),
+		})
+	}
+	return map[string]cty.Value{
+		"prop": cty.ListVal(slice),
+	}
+}
+
 var _ valueMaker[[]string] = nestedListValueMakerWithComputedSpecified
 
 type testOutput struct {


### PR DESCRIPTION
This PR adds Diff tests for Defaults in Set and List schemas. Note that the List and Set themselves can not have Defaults, since TF throws an error on these: `Default is not valid for lists or sets`.

Related to https://github.com/pulumi/pulumi-terraform-bridge/issues/2788
Related to https://github.com/pulumi/pulumi-terraform-bridge/issues/2789