### PR TITLE
Full fidelity SDKv2 `crosstest.Create` equality

### DIFF
--- a/pkg/tfshim/sdk-v2/provider2.go
+++ b/pkg/tfshim/sdk-v2/provider2.go
@@ -637,11 +637,26 @@ func (s *grpcServer) ApplyResourceChange(
 	if err != nil {
 		return nil, err
 	}
+
+	var providerMetaVal []byte
+	if providerMeta != nil {
+		providerMetaVal, err = msgpack.Marshal(*providerMeta, providerMeta.Type())
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		providerMetaVal, err = msgpack.Marshal(cty.NullVal(cty.EmptyObject), cty.EmptyObject)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	req := &tfprotov5.ApplyResourceChangeRequest{
 		TypeName:     typeName,
 		Config:       &tfprotov5.DynamicValue{MsgPack: configVal},
 		PriorState:   &tfprotov5.DynamicValue{MsgPack: priorStateVal},
 		PlannedState: &tfprotov5.DynamicValue{MsgPack: plannedStateVal},
+		ProviderMeta: &tfprotov5.DynamicValue{MsgPack: providerMetaVal},
 	}
 	if len(plannedMeta) > 0 {
 		plannedPrivate, err := json.Marshal(plannedMeta)


### PR DESCRIPTION
Supply `tfprotov5.ApplyResourceChangeRequest.ProviderMeta` when we call `ApplyResourceChange` in SDKv2 providers. This gets us to a byte for byte identical result for SDKv2 `crosstest.Create`. This allows us to simplify (and strengthen) the comparison to general equality.

Related to #2521