### PR TITLE
Detailed diff use longest common sequence for list attribute diffs

### DIFF
--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/list_element_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/list_element_added_front.golden
@@ -35,17 +35,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: "val2" => "val1"
-          ~ [1]: "val3" => "val2"
-          + [2]: "val3"
+          + [0]: "val1"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0]": map[string]interface{}{"kind": "UPDATE"},
-		"props[1]": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]": map[string]interface{}{},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/list_element_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/list_element_added_middle.golden
@@ -35,15 +35,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [1]: "val3" => "val2"
-          + [2]: "val3"
+          + [1]: "val2"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[1]": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]": map[string]interface{}{},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/list_element_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/list_element_removed_front.golden
@@ -35,17 +35,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: "val1" => "val2"
-          ~ [1]: "val2" => "val3"
-          - [2]: "val3"
+          - [0]: "val1"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0]": map[string]interface{}{"kind": "UPDATE"},
-		"props[1]": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]": map[string]interface{}{"kind": "DELETE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/list_element_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/list_element_removed_middle.golden
@@ -35,15 +35,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [1]: "val2" => "val3"
-          - [2]: "val3"
+          - [1]: "val2"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[1]": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]": map[string]interface{}{"kind": "DELETE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/long_list_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/long_list_added_front.golden
@@ -71,53 +71,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: "value0" => "value20"
-          ~ [1]: "value1" => "value0"
-          ~ [2]: "value2" => "value1"
-          ~ [3]: "value3" => "value2"
-          ~ [4]: "value4" => "value3"
-          ~ [5]: "value5" => "value4"
-          ~ [6]: "value6" => "value5"
-          ~ [7]: "value7" => "value6"
-          ~ [8]: "value8" => "value7"
-          ~ [9]: "value9" => "value8"
-          ~ [10]: "value10" => "value9"
-          ~ [11]: "value11" => "value10"
-          ~ [12]: "value12" => "value11"
-          ~ [13]: "value13" => "value12"
-          ~ [14]: "value14" => "value13"
-          ~ [15]: "value15" => "value14"
-          ~ [16]: "value16" => "value15"
-          ~ [17]: "value17" => "value16"
-          ~ [18]: "value18" => "value17"
-          ~ [19]: "value19" => "value18"
-          + [20]: "value19"
+          + [0]: "value20"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[10]": map[string]interface{}{"kind": "UPDATE"},
-		"props[11]": map[string]interface{}{"kind": "UPDATE"},
-		"props[12]": map[string]interface{}{"kind": "UPDATE"},
-		"props[13]": map[string]interface{}{"kind": "UPDATE"},
-		"props[14]": map[string]interface{}{"kind": "UPDATE"},
-		"props[15]": map[string]interface{}{"kind": "UPDATE"},
-		"props[16]": map[string]interface{}{"kind": "UPDATE"},
-		"props[17]": map[string]interface{}{"kind": "UPDATE"},
-		"props[18]": map[string]interface{}{"kind": "UPDATE"},
-		"props[19]": map[string]interface{}{"kind": "UPDATE"},
-		"props[1]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[20]": map[string]interface{}{},
-		"props[2]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[3]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[4]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[5]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[6]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[7]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[8]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[9]":  map[string]interface{}{"kind": "UPDATE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/long_list_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/long_list_removed_front.golden
@@ -71,53 +71,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: "value20" => "value0"
-          ~ [1]: "value0" => "value1"
-          ~ [2]: "value1" => "value2"
-          ~ [3]: "value2" => "value3"
-          ~ [4]: "value3" => "value4"
-          ~ [5]: "value4" => "value5"
-          ~ [6]: "value5" => "value6"
-          ~ [7]: "value6" => "value7"
-          ~ [8]: "value7" => "value8"
-          ~ [9]: "value8" => "value9"
-          ~ [10]: "value9" => "value10"
-          ~ [11]: "value10" => "value11"
-          ~ [12]: "value11" => "value12"
-          ~ [13]: "value12" => "value13"
-          ~ [14]: "value13" => "value14"
-          ~ [15]: "value14" => "value15"
-          ~ [16]: "value15" => "value16"
-          ~ [17]: "value16" => "value17"
-          ~ [18]: "value17" => "value18"
-          ~ [19]: "value18" => "value19"
-          - [20]: "value19"
+          - [0]: "value20"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[10]": map[string]interface{}{"kind": "UPDATE"},
-		"props[11]": map[string]interface{}{"kind": "UPDATE"},
-		"props[12]": map[string]interface{}{"kind": "UPDATE"},
-		"props[13]": map[string]interface{}{"kind": "UPDATE"},
-		"props[14]": map[string]interface{}{"kind": "UPDATE"},
-		"props[15]": map[string]interface{}{"kind": "UPDATE"},
-		"props[16]": map[string]interface{}{"kind": "UPDATE"},
-		"props[17]": map[string]interface{}{"kind": "UPDATE"},
-		"props[18]": map[string]interface{}{"kind": "UPDATE"},
-		"props[19]": map[string]interface{}{"kind": "UPDATE"},
-		"props[1]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[20]": map[string]interface{}{"kind": "DELETE"},
-		"props[2]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[3]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[4]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[5]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[6]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[7]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[8]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[9]":  map[string]interface{}{"kind": "UPDATE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/one_added,_one_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/one_added,_one_removed.golden
@@ -36,17 +36,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: "val1" => "val2"
-          ~ [1]: "val2" => "val3"
-          ~ [2]: "val3" => "val4"
+          - [0]: "val1"
+          + [2]: "val4"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0]": map[string]interface{}{"kind": "UPDATE"},
-		"props[1]": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]": map[string]interface{}{"kind": "UPDATE"},
+		"props[0]": map[string]interface{}{"kind": "DELETE"},
+		"props[2]": map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/added_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/added_empty.golden
@@ -1,0 +1,35 @@
+tests.testOutput{
+	initialValue: nil, changeValue: &[]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ prop = [
+          - "computed",
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      - props: [
+      -     [0]: "computed"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/added_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/added_non-empty.golden
@@ -1,0 +1,37 @@
+tests.testOutput{
+	initialValue: nil, changeValue: &[]string{
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ prop = [
+          ~ "computed" -> "val1",
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: "computed" => "val1"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "UPDATE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/changed.golden
@@ -1,0 +1,38 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+	},
+	changeValue: &[]string{"val2"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ prop = [
+          ~ "val1" -> "val2",
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: "val1" => "val2"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "UPDATE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/list_element_added_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/list_element_added_back.golden
@@ -1,0 +1,45 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ prop = [
+            # (1 unchanged element hidden)
+            "val2",
+          + "val3",
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [2]: "val3"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/list_element_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/list_element_added_front.golden
@@ -35,17 +35,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: "val2" => "val1"
-          ~ [1]: "val3" => "val2"
-          + [2]: "val3"
+          + [0]: "val1"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0]": map[string]interface{}{"kind": "UPDATE"},
-		"props[1]": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]": map[string]interface{}{},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/list_element_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/list_element_added_front.golden
@@ -1,0 +1,51 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ prop = [
+          + "val1",
+            "val2",
+            # (1 unchanged element hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: "val2" => "val1"
+          ~ [1]: "val3" => "val2"
+          + [2]: "val3"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[0]": map[string]interface{}{"kind": "UPDATE"},
+		"props[1]": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]": map[string]interface{}{},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/list_element_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/list_element_added_middle.golden
@@ -1,0 +1,49 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ prop = [
+            "val1",
+          + "val2",
+            "val3",
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [1]: "val3" => "val2"
+          + [2]: "val3"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[1]": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]": map[string]interface{}{},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/list_element_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/list_element_added_middle.golden
@@ -35,15 +35,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [1]: "val3" => "val2"
-          + [2]: "val3"
+          + [1]: "val2"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[1]": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]": map[string]interface{}{},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/list_element_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/list_element_removed_end.golden
@@ -1,0 +1,45 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ prop = [
+            # (1 unchanged element hidden)
+            "val2",
+          - "val3",
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [2]: "val3"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/list_element_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/list_element_removed_front.golden
@@ -1,0 +1,51 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ prop = [
+          - "val1",
+            "val2",
+            # (1 unchanged element hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: "val1" => "val2"
+          ~ [1]: "val2" => "val3"
+          - [2]: "val3"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[0]": map[string]interface{}{"kind": "UPDATE"},
+		"props[1]": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/list_element_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/list_element_removed_front.golden
@@ -35,17 +35,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: "val1" => "val2"
-          ~ [1]: "val2" => "val3"
-          - [2]: "val3"
+          - [0]: "val1"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0]": map[string]interface{}{"kind": "UPDATE"},
-		"props[1]": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]": map[string]interface{}{"kind": "DELETE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/list_element_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/list_element_removed_middle.golden
@@ -1,0 +1,49 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ prop = [
+            "val1",
+          - "val2",
+            "val3",
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [1]: "val2" => "val3"
+          - [2]: "val3"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[1]": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/list_element_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/list_element_removed_middle.golden
@@ -35,15 +35,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [1]: "val2" => "val3"
-          - [2]: "val3"
+          - [1]: "val2"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[1]": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]": map[string]interface{}{"kind": "DELETE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/long_list_added_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/long_list_added_back.golden
@@ -1,0 +1,81 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+		"value20",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ prop = [
+            # (19 unchanged elements hidden)
+            "value19",
+          + "value20",
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [20]: "value20"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[20]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/long_list_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/long_list_added_front.golden
@@ -71,53 +71,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: "value0" => "value20"
-          ~ [1]: "value1" => "value0"
-          ~ [2]: "value2" => "value1"
-          ~ [3]: "value3" => "value2"
-          ~ [4]: "value4" => "value3"
-          ~ [5]: "value5" => "value4"
-          ~ [6]: "value6" => "value5"
-          ~ [7]: "value7" => "value6"
-          ~ [8]: "value8" => "value7"
-          ~ [9]: "value9" => "value8"
-          ~ [10]: "value10" => "value9"
-          ~ [11]: "value11" => "value10"
-          ~ [12]: "value12" => "value11"
-          ~ [13]: "value13" => "value12"
-          ~ [14]: "value14" => "value13"
-          ~ [15]: "value15" => "value14"
-          ~ [16]: "value16" => "value15"
-          ~ [17]: "value17" => "value16"
-          ~ [18]: "value18" => "value17"
-          ~ [19]: "value19" => "value18"
-          + [20]: "value19"
+          + [0]: "value20"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[10]": map[string]interface{}{"kind": "UPDATE"},
-		"props[11]": map[string]interface{}{"kind": "UPDATE"},
-		"props[12]": map[string]interface{}{"kind": "UPDATE"},
-		"props[13]": map[string]interface{}{"kind": "UPDATE"},
-		"props[14]": map[string]interface{}{"kind": "UPDATE"},
-		"props[15]": map[string]interface{}{"kind": "UPDATE"},
-		"props[16]": map[string]interface{}{"kind": "UPDATE"},
-		"props[17]": map[string]interface{}{"kind": "UPDATE"},
-		"props[18]": map[string]interface{}{"kind": "UPDATE"},
-		"props[19]": map[string]interface{}{"kind": "UPDATE"},
-		"props[1]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[20]": map[string]interface{}{},
-		"props[2]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[3]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[4]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[5]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[6]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[7]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[8]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[9]":  map[string]interface{}{"kind": "UPDATE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/long_list_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/long_list_added_front.golden
@@ -1,0 +1,123 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value20",
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ prop = [
+          + "value20",
+            "value0",
+            # (19 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: "value0" => "value20"
+          ~ [1]: "value1" => "value0"
+          ~ [2]: "value2" => "value1"
+          ~ [3]: "value3" => "value2"
+          ~ [4]: "value4" => "value3"
+          ~ [5]: "value5" => "value4"
+          ~ [6]: "value6" => "value5"
+          ~ [7]: "value7" => "value6"
+          ~ [8]: "value8" => "value7"
+          ~ [9]: "value9" => "value8"
+          ~ [10]: "value10" => "value9"
+          ~ [11]: "value11" => "value10"
+          ~ [12]: "value12" => "value11"
+          ~ [13]: "value13" => "value12"
+          ~ [14]: "value14" => "value13"
+          ~ [15]: "value15" => "value14"
+          ~ [16]: "value16" => "value15"
+          ~ [17]: "value17" => "value16"
+          ~ [18]: "value18" => "value17"
+          ~ [19]: "value19" => "value18"
+          + [20]: "value19"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[0]":  map[string]interface{}{"kind": "UPDATE"},
+		"props[10]": map[string]interface{}{"kind": "UPDATE"},
+		"props[11]": map[string]interface{}{"kind": "UPDATE"},
+		"props[12]": map[string]interface{}{"kind": "UPDATE"},
+		"props[13]": map[string]interface{}{"kind": "UPDATE"},
+		"props[14]": map[string]interface{}{"kind": "UPDATE"},
+		"props[15]": map[string]interface{}{"kind": "UPDATE"},
+		"props[16]": map[string]interface{}{"kind": "UPDATE"},
+		"props[17]": map[string]interface{}{"kind": "UPDATE"},
+		"props[18]": map[string]interface{}{"kind": "UPDATE"},
+		"props[19]": map[string]interface{}{"kind": "UPDATE"},
+		"props[1]":  map[string]interface{}{"kind": "UPDATE"},
+		"props[20]": map[string]interface{}{},
+		"props[2]":  map[string]interface{}{"kind": "UPDATE"},
+		"props[3]":  map[string]interface{}{"kind": "UPDATE"},
+		"props[4]":  map[string]interface{}{"kind": "UPDATE"},
+		"props[5]":  map[string]interface{}{"kind": "UPDATE"},
+		"props[6]":  map[string]interface{}{"kind": "UPDATE"},
+		"props[7]":  map[string]interface{}{"kind": "UPDATE"},
+		"props[8]":  map[string]interface{}{"kind": "UPDATE"},
+		"props[9]":  map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/long_list_removed_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/long_list_removed_back.golden
@@ -1,0 +1,81 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+		"value20",
+	},
+	changeValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ prop = [
+            # (19 unchanged elements hidden)
+            "value19",
+          - "value20",
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [20]: "value20"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[20]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/long_list_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/long_list_removed_front.golden
@@ -1,0 +1,123 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value20",
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ prop = [
+          - "value20",
+            "value0",
+            # (19 unchanged elements hidden)
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: "value20" => "value0"
+          ~ [1]: "value0" => "value1"
+          ~ [2]: "value1" => "value2"
+          ~ [3]: "value2" => "value3"
+          ~ [4]: "value3" => "value4"
+          ~ [5]: "value4" => "value5"
+          ~ [6]: "value5" => "value6"
+          ~ [7]: "value6" => "value7"
+          ~ [8]: "value7" => "value8"
+          ~ [9]: "value8" => "value9"
+          ~ [10]: "value9" => "value10"
+          ~ [11]: "value10" => "value11"
+          ~ [12]: "value11" => "value12"
+          ~ [13]: "value12" => "value13"
+          ~ [14]: "value13" => "value14"
+          ~ [15]: "value14" => "value15"
+          ~ [16]: "value15" => "value16"
+          ~ [17]: "value16" => "value17"
+          ~ [18]: "value17" => "value18"
+          ~ [19]: "value18" => "value19"
+          - [20]: "value19"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[0]":  map[string]interface{}{"kind": "UPDATE"},
+		"props[10]": map[string]interface{}{"kind": "UPDATE"},
+		"props[11]": map[string]interface{}{"kind": "UPDATE"},
+		"props[12]": map[string]interface{}{"kind": "UPDATE"},
+		"props[13]": map[string]interface{}{"kind": "UPDATE"},
+		"props[14]": map[string]interface{}{"kind": "UPDATE"},
+		"props[15]": map[string]interface{}{"kind": "UPDATE"},
+		"props[16]": map[string]interface{}{"kind": "UPDATE"},
+		"props[17]": map[string]interface{}{"kind": "UPDATE"},
+		"props[18]": map[string]interface{}{"kind": "UPDATE"},
+		"props[19]": map[string]interface{}{"kind": "UPDATE"},
+		"props[1]":  map[string]interface{}{"kind": "UPDATE"},
+		"props[20]": map[string]interface{}{"kind": "DELETE"},
+		"props[2]":  map[string]interface{}{"kind": "UPDATE"},
+		"props[3]":  map[string]interface{}{"kind": "UPDATE"},
+		"props[4]":  map[string]interface{}{"kind": "UPDATE"},
+		"props[5]":  map[string]interface{}{"kind": "UPDATE"},
+		"props[6]":  map[string]interface{}{"kind": "UPDATE"},
+		"props[7]":  map[string]interface{}{"kind": "UPDATE"},
+		"props[8]":  map[string]interface{}{"kind": "UPDATE"},
+		"props[9]":  map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/long_list_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/long_list_removed_front.golden
@@ -71,53 +71,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: "value20" => "value0"
-          ~ [1]: "value0" => "value1"
-          ~ [2]: "value1" => "value2"
-          ~ [3]: "value2" => "value3"
-          ~ [4]: "value3" => "value4"
-          ~ [5]: "value4" => "value5"
-          ~ [6]: "value5" => "value6"
-          ~ [7]: "value6" => "value7"
-          ~ [8]: "value7" => "value8"
-          ~ [9]: "value8" => "value9"
-          ~ [10]: "value9" => "value10"
-          ~ [11]: "value10" => "value11"
-          ~ [12]: "value11" => "value12"
-          ~ [13]: "value12" => "value13"
-          ~ [14]: "value13" => "value14"
-          ~ [15]: "value14" => "value15"
-          ~ [16]: "value15" => "value16"
-          ~ [17]: "value16" => "value17"
-          ~ [18]: "value17" => "value18"
-          ~ [19]: "value18" => "value19"
-          - [20]: "value19"
+          - [0]: "value20"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[10]": map[string]interface{}{"kind": "UPDATE"},
-		"props[11]": map[string]interface{}{"kind": "UPDATE"},
-		"props[12]": map[string]interface{}{"kind": "UPDATE"},
-		"props[13]": map[string]interface{}{"kind": "UPDATE"},
-		"props[14]": map[string]interface{}{"kind": "UPDATE"},
-		"props[15]": map[string]interface{}{"kind": "UPDATE"},
-		"props[16]": map[string]interface{}{"kind": "UPDATE"},
-		"props[17]": map[string]interface{}{"kind": "UPDATE"},
-		"props[18]": map[string]interface{}{"kind": "UPDATE"},
-		"props[19]": map[string]interface{}{"kind": "UPDATE"},
-		"props[1]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[20]": map[string]interface{}{"kind": "DELETE"},
-		"props[2]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[3]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[4]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[5]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[6]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[7]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[8]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[9]":  map[string]interface{}{"kind": "UPDATE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/one_added,_one_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/one_added,_one_removed.golden
@@ -36,17 +36,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: "val1" => "val2"
-          ~ [1]: "val2" => "val3"
-          ~ [2]: "val3" => "val4"
+          - [0]: "val1"
+          + [2]: "val4"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0]": map[string]interface{}{"kind": "UPDATE"},
-		"props[1]": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]": map[string]interface{}{"kind": "UPDATE"},
+		"props[0]": map[string]interface{}{"kind": "DELETE"},
+		"props[2]": map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/one_added,_one_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/one_added,_one_removed.golden
@@ -1,0 +1,52 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val4",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id   = "id"
+      ~ prop = [
+          ~ "val1" -> "val2",
+          ~ "val2" -> "val3",
+          ~ "val3" -> "val4",
+        ]
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: "val1" => "val2"
+          ~ [1]: "val2" => "val3"
+          ~ [2]: "val3" => "val4"
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[0]": map[string]interface{}{"kind": "UPDATE"},
+		"props[1]": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]": map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/removed_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/removed_empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  nil,
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/removed_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/removed_non-empty.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+	},
+	changeValue: nil,
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/unchanged_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/unchanged_empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: nil, changeValue: nil,
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/unchanged_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+	},
+	changeValue: &[]string{"val1"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/changed.golden
@@ -27,12 +27,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ props: [
+      ~ props : [
           ~ [0]: "val1" => "val2"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"__meta":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[0]": map[string]interface{}{"kind": "UPDATE"},
+	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/changed.golden
@@ -27,15 +27,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ props : [
+      ~ props: [
           ~ [0]: "val1" => "val2"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"__meta":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[0]": map[string]interface{}{"kind": "UPDATE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "UPDATE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_added_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_added_back.golden
@@ -34,15 +34,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ props : [
+      ~ props: [
           + [2]: "val3"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"__meta":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2]": map[string]interface{}{},
-	},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_added_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_added_back.golden
@@ -34,12 +34,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ props: [
+      ~ props : [
           + [2]: "val3"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"__meta":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2]": map[string]interface{}{},
+	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_added_front.golden
@@ -34,18 +34,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ props: [
-          ~ [0]: "val2" => "val1"
-          ~ [1]: "val3" => "val2"
-          + [2]: "val3"
+      ~ props : [
+          + [0]: "val1"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"__meta":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[0]": map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_added_front.golden
@@ -34,15 +34,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ props : [
+      ~ props: [
           + [0]: "val1"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"__meta":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[0]": map[string]interface{}{},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_added_middle.golden
@@ -34,15 +34,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ props : [
+      ~ props: [
           + [1]: "val2"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"__meta":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1]": map[string]interface{}{},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_added_middle.golden
@@ -34,16 +34,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ props: [
-          ~ [1]: "val3" => "val2"
-          + [2]: "val3"
+      ~ props : [
+          + [1]: "val2"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[1]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"__meta":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1]": map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_removed_end.golden
@@ -34,15 +34,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ props : [
+      ~ props: [
           - [2]: "val3"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"__meta":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2]": map[string]interface{}{"kind": "DELETE"},
-	},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_removed_end.golden
@@ -34,12 +34,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ props: [
+      ~ props : [
           - [2]: "val3"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"__meta":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_removed_front.golden
@@ -34,15 +34,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ props : [
+      ~ props: [
           - [0]: "val1"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"__meta":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[0]": map[string]interface{}{"kind": "DELETE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_removed_front.golden
@@ -34,18 +34,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ props: [
-          ~ [0]: "val1" => "val2"
-          ~ [1]: "val2" => "val3"
-          - [2]: "val3"
+      ~ props : [
+          - [0]: "val1"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"__meta":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[0]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_removed_middle.golden
@@ -34,16 +34,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ props: [
-          ~ [1]: "val2" => "val3"
-          - [2]: "val3"
+      ~ props : [
+          - [1]: "val2"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[1]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"__meta":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_removed_middle.golden
@@ -34,15 +34,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ props : [
+      ~ props: [
           - [1]: "val2"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"__meta":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1]": map[string]interface{}{"kind": "DELETE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/long_list_added_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/long_list_added_back.golden
@@ -70,15 +70,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ props : [
+      ~ props: [
           + [20]: "value20"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"__meta":    map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[20]": map[string]interface{}{},
-	},
+	detailedDiff: map[string]interface{}{"props[20]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/long_list_added_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/long_list_added_back.golden
@@ -70,12 +70,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ props: [
+      ~ props : [
           + [20]: "value20"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"props[20]": map[string]interface{}{"kind": "ADD_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"__meta":    map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[20]": map[string]interface{}{},
+	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/long_list_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/long_list_added_front.golden
@@ -70,15 +70,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ props : [
+      ~ props: [
           + [0]: "value20"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"__meta":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[0]": map[string]interface{}{},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/long_list_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/long_list_added_front.golden
@@ -70,54 +70,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ props: [
-          ~ [0]: "value0" => "value20"
-          ~ [1]: "value1" => "value0"
-          ~ [2]: "value2" => "value1"
-          ~ [3]: "value3" => "value2"
-          ~ [4]: "value4" => "value3"
-          ~ [5]: "value5" => "value4"
-          ~ [6]: "value6" => "value5"
-          ~ [7]: "value7" => "value6"
-          ~ [8]: "value8" => "value7"
-          ~ [9]: "value9" => "value8"
-          ~ [10]: "value10" => "value9"
-          ~ [11]: "value11" => "value10"
-          ~ [12]: "value12" => "value11"
-          ~ [13]: "value13" => "value12"
-          ~ [14]: "value14" => "value13"
-          ~ [15]: "value15" => "value14"
-          ~ [16]: "value16" => "value15"
-          ~ [17]: "value17" => "value16"
-          ~ [18]: "value18" => "value17"
-          ~ [19]: "value19" => "value18"
-          + [20]: "value19"
+      ~ props : [
+          + [0]: "value20"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[10]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[11]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[12]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[13]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[14]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[15]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[16]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[17]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[18]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[19]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[20]": map[string]interface{}{"kind": "ADD_REPLACE"},
-		"props[2]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[3]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[4]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[5]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[6]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[7]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[8]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[9]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"__meta":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[0]": map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/long_list_removed_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/long_list_removed_back.golden
@@ -70,12 +70,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ props: [
+      ~ props : [
           - [20]: "value20"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"props[20]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
+	detailedDiff: map[string]interface{}{
+		"__meta":    map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[20]": map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/long_list_removed_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/long_list_removed_back.golden
@@ -70,15 +70,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ props : [
+      ~ props: [
           - [20]: "value20"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"__meta":    map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[20]": map[string]interface{}{"kind": "DELETE"},
-	},
+	detailedDiff: map[string]interface{}{"props[20]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/long_list_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/long_list_removed_front.golden
@@ -70,15 +70,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ props : [
+      ~ props: [
           - [0]: "value20"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"__meta":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[0]": map[string]interface{}{"kind": "DELETE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/long_list_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/long_list_removed_front.golden
@@ -70,54 +70,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ props: [
-          ~ [0]: "value20" => "value0"
-          ~ [1]: "value0" => "value1"
-          ~ [2]: "value1" => "value2"
-          ~ [3]: "value2" => "value3"
-          ~ [4]: "value3" => "value4"
-          ~ [5]: "value4" => "value5"
-          ~ [6]: "value5" => "value6"
-          ~ [7]: "value6" => "value7"
-          ~ [8]: "value7" => "value8"
-          ~ [9]: "value8" => "value9"
-          ~ [10]: "value9" => "value10"
-          ~ [11]: "value10" => "value11"
-          ~ [12]: "value11" => "value12"
-          ~ [13]: "value12" => "value13"
-          ~ [14]: "value13" => "value14"
-          ~ [15]: "value14" => "value15"
-          ~ [16]: "value15" => "value16"
-          ~ [17]: "value16" => "value17"
-          ~ [18]: "value17" => "value18"
-          ~ [19]: "value18" => "value19"
-          - [20]: "value19"
+      ~ props : [
+          - [0]: "value20"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[10]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[11]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[12]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[13]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[14]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[15]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[16]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[17]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[18]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[19]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[20]": map[string]interface{}{"kind": "DELETE_REPLACE"},
-		"props[2]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[3]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[4]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[5]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[6]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[7]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[8]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[9]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"__meta":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[0]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/one_added,_one_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/one_added,_one_removed.golden
@@ -35,7 +35,7 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ props : [
+      ~ props: [
           - [0]: "val1"
           + [2]: "val4"
         ]
@@ -44,8 +44,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"__meta":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[0]": map[string]interface{}{"kind": "DELETE"},
-		"props[2]": map[string]interface{}{},
+		"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/one_added,_one_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/one_added,_one_removed.golden
@@ -35,18 +35,17 @@ Plan: 1 to add, 0 to change, 1 to destroy.
     +-crossprovider:index/testRes:TestRes: (replace)
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
-      ~ props: [
-          ~ [0]: "val1" => "val2"
-          ~ [1]: "val2" => "val3"
-          ~ [2]: "val3" => "val4"
+      ~ props : [
+          - [0]: "val1"
+          + [2]: "val4"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"__meta":   map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[0]": map[string]interface{}{"kind": "DELETE"},
+		"props[2]": map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed/added_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed/added_empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: nil, changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed/added_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed/added_non-empty.golden
@@ -1,0 +1,40 @@
+tests.testOutput{
+	initialValue: nil, changeValue: &[]string{
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      ~ prop {
+          ~ nested_prop = "computed" -> "val1"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProp: "computed" => "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed/changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed/changed.golden
@@ -1,0 +1,41 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+	},
+	changeValue: &[]string{"val2"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      ~ prop {
+          ~ nested_prop = "val1" -> "val2"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProp: "val1" => "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed/list_element_added_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed/list_element_added_back.golden
@@ -1,0 +1,48 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      + prop {
+          + nested_prop = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [2]: {
+                  + nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed/list_element_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed/list_element_added_front.golden
@@ -1,0 +1,62 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      ~ prop {
+          ~ nested_prop = "val2" -> "val1"
+        }
+      ~ prop {
+          ~ nested_prop = "val3" -> "val2"
+        }
+      + prop {
+          + nested_prop = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProp: "val2" => "val1"
+                }
+          ~ [1]: {
+                  ~ nestedProp: "val3" => "val2"
+                }
+          + [2]: {
+                  + nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed/list_element_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed/list_element_added_middle.golden
@@ -1,0 +1,57 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      ~ prop {
+          ~ nested_prop = "val3" -> "val2"
+        }
+      + prop {
+          + nested_prop = "val3"
+        }
+
+        # (1 unchanged block hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [1]: {
+                  ~ nestedProp: "val3" => "val2"
+                }
+          + [2]: {
+                  + nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed/list_element_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed/list_element_removed_end.golden
@@ -1,0 +1,48 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - prop {
+          - nested_prop = "val3" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [2]: {
+                  - nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed/list_element_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed/list_element_removed_front.golden
@@ -1,0 +1,62 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      ~ prop {
+          ~ nested_prop = "val1" -> "val2"
+        }
+      ~ prop {
+          ~ nested_prop = "val2" -> "val3"
+        }
+      - prop {
+          - nested_prop = "val3" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProp: "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ nestedProp: "val2" => "val3"
+                }
+          - [2]: {
+                  - nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed/list_element_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed/list_element_removed_middle.golden
@@ -1,0 +1,57 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      ~ prop {
+          ~ nested_prop = "val2" -> "val3"
+        }
+      - prop {
+          - nested_prop = "val3" -> null
+        }
+
+        # (1 unchanged block hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [1]: {
+                  ~ nestedProp: "val2" => "val3"
+                }
+          - [2]: {
+                  - nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed/long_list_added_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed/long_list_added_back.golden
@@ -1,0 +1,84 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+		"value20",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      + prop {
+          + nested_prop = "value20"
+        }
+
+        # (20 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [20]: {
+                  + nestedProp: "value20"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[20]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed/long_list_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed/long_list_added_front.golden
@@ -1,0 +1,224 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value20",
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      ~ prop {
+          ~ nested_prop = "value0" -> "value20"
+        }
+      ~ prop {
+          ~ nested_prop = "value1" -> "value0"
+        }
+      ~ prop {
+          ~ nested_prop = "value2" -> "value1"
+        }
+      ~ prop {
+          ~ nested_prop = "value3" -> "value2"
+        }
+      ~ prop {
+          ~ nested_prop = "value4" -> "value3"
+        }
+      ~ prop {
+          ~ nested_prop = "value5" -> "value4"
+        }
+      ~ prop {
+          ~ nested_prop = "value6" -> "value5"
+        }
+      ~ prop {
+          ~ nested_prop = "value7" -> "value6"
+        }
+      ~ prop {
+          ~ nested_prop = "value8" -> "value7"
+        }
+      ~ prop {
+          ~ nested_prop = "value9" -> "value8"
+        }
+      ~ prop {
+          ~ nested_prop = "value10" -> "value9"
+        }
+      ~ prop {
+          ~ nested_prop = "value11" -> "value10"
+        }
+      ~ prop {
+          ~ nested_prop = "value12" -> "value11"
+        }
+      ~ prop {
+          ~ nested_prop = "value13" -> "value12"
+        }
+      ~ prop {
+          ~ nested_prop = "value14" -> "value13"
+        }
+      ~ prop {
+          ~ nested_prop = "value15" -> "value14"
+        }
+      ~ prop {
+          ~ nested_prop = "value16" -> "value15"
+        }
+      ~ prop {
+          ~ nested_prop = "value17" -> "value16"
+        }
+      ~ prop {
+          ~ nested_prop = "value18" -> "value17"
+        }
+      ~ prop {
+          ~ nested_prop = "value19" -> "value18"
+        }
+      + prop {
+          + nested_prop = "value19"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProp: "value0" => "value20"
+                }
+          ~ [1]: {
+                  ~ nestedProp: "value1" => "value0"
+                }
+          ~ [2]: {
+                  ~ nestedProp: "value2" => "value1"
+                }
+          ~ [3]: {
+                  ~ nestedProp: "value3" => "value2"
+                }
+          ~ [4]: {
+                  ~ nestedProp: "value4" => "value3"
+                }
+          ~ [5]: {
+                  ~ nestedProp: "value5" => "value4"
+                }
+          ~ [6]: {
+                  ~ nestedProp: "value6" => "value5"
+                }
+          ~ [7]: {
+                  ~ nestedProp: "value7" => "value6"
+                }
+          ~ [8]: {
+                  ~ nestedProp: "value8" => "value7"
+                }
+          ~ [9]: {
+                  ~ nestedProp: "value9" => "value8"
+                }
+          ~ [10]: {
+                  ~ nestedProp: "value10" => "value9"
+                }
+          ~ [11]: {
+                  ~ nestedProp: "value11" => "value10"
+                }
+          ~ [12]: {
+                  ~ nestedProp: "value12" => "value11"
+                }
+          ~ [13]: {
+                  ~ nestedProp: "value13" => "value12"
+                }
+          ~ [14]: {
+                  ~ nestedProp: "value14" => "value13"
+                }
+          ~ [15]: {
+                  ~ nestedProp: "value15" => "value14"
+                }
+          ~ [16]: {
+                  ~ nestedProp: "value16" => "value15"
+                }
+          ~ [17]: {
+                  ~ nestedProp: "value17" => "value16"
+                }
+          ~ [18]: {
+                  ~ nestedProp: "value18" => "value17"
+                }
+          ~ [19]: {
+                  ~ nestedProp: "value19" => "value18"
+                }
+          + [20]: {
+                  + nestedProp: "value19"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[0].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[10].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[11].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[12].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[13].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[14].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[15].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[16].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[17].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[18].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[19].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[20]":            map[string]interface{}{},
+		"props[2].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[4].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[5].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[6].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[7].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[8].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[9].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed/long_list_removed_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed/long_list_removed_back.golden
@@ -1,0 +1,84 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+		"value20",
+	},
+	changeValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - prop {
+          - nested_prop = "value20" -> null
+        }
+
+        # (20 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [20]: {
+                  - nestedProp: "value20"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[20]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed/long_list_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed/long_list_removed_front.golden
@@ -1,0 +1,224 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value20",
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      ~ prop {
+          ~ nested_prop = "value20" -> "value0"
+        }
+      ~ prop {
+          ~ nested_prop = "value0" -> "value1"
+        }
+      ~ prop {
+          ~ nested_prop = "value1" -> "value2"
+        }
+      ~ prop {
+          ~ nested_prop = "value2" -> "value3"
+        }
+      ~ prop {
+          ~ nested_prop = "value3" -> "value4"
+        }
+      ~ prop {
+          ~ nested_prop = "value4" -> "value5"
+        }
+      ~ prop {
+          ~ nested_prop = "value5" -> "value6"
+        }
+      ~ prop {
+          ~ nested_prop = "value6" -> "value7"
+        }
+      ~ prop {
+          ~ nested_prop = "value7" -> "value8"
+        }
+      ~ prop {
+          ~ nested_prop = "value8" -> "value9"
+        }
+      ~ prop {
+          ~ nested_prop = "value9" -> "value10"
+        }
+      ~ prop {
+          ~ nested_prop = "value10" -> "value11"
+        }
+      ~ prop {
+          ~ nested_prop = "value11" -> "value12"
+        }
+      ~ prop {
+          ~ nested_prop = "value12" -> "value13"
+        }
+      ~ prop {
+          ~ nested_prop = "value13" -> "value14"
+        }
+      ~ prop {
+          ~ nested_prop = "value14" -> "value15"
+        }
+      ~ prop {
+          ~ nested_prop = "value15" -> "value16"
+        }
+      ~ prop {
+          ~ nested_prop = "value16" -> "value17"
+        }
+      ~ prop {
+          ~ nested_prop = "value17" -> "value18"
+        }
+      ~ prop {
+          ~ nested_prop = "value18" -> "value19"
+        }
+      - prop {
+          - nested_prop = "value19" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProp: "value20" => "value0"
+                }
+          ~ [1]: {
+                  ~ nestedProp: "value0" => "value1"
+                }
+          ~ [2]: {
+                  ~ nestedProp: "value1" => "value2"
+                }
+          ~ [3]: {
+                  ~ nestedProp: "value2" => "value3"
+                }
+          ~ [4]: {
+                  ~ nestedProp: "value3" => "value4"
+                }
+          ~ [5]: {
+                  ~ nestedProp: "value4" => "value5"
+                }
+          ~ [6]: {
+                  ~ nestedProp: "value5" => "value6"
+                }
+          ~ [7]: {
+                  ~ nestedProp: "value6" => "value7"
+                }
+          ~ [8]: {
+                  ~ nestedProp: "value7" => "value8"
+                }
+          ~ [9]: {
+                  ~ nestedProp: "value8" => "value9"
+                }
+          ~ [10]: {
+                  ~ nestedProp: "value9" => "value10"
+                }
+          ~ [11]: {
+                  ~ nestedProp: "value10" => "value11"
+                }
+          ~ [12]: {
+                  ~ nestedProp: "value11" => "value12"
+                }
+          ~ [13]: {
+                  ~ nestedProp: "value12" => "value13"
+                }
+          ~ [14]: {
+                  ~ nestedProp: "value13" => "value14"
+                }
+          ~ [15]: {
+                  ~ nestedProp: "value14" => "value15"
+                }
+          ~ [16]: {
+                  ~ nestedProp: "value15" => "value16"
+                }
+          ~ [17]: {
+                  ~ nestedProp: "value16" => "value17"
+                }
+          ~ [18]: {
+                  ~ nestedProp: "value17" => "value18"
+                }
+          ~ [19]: {
+                  ~ nestedProp: "value18" => "value19"
+                }
+          - [20]: {
+                  - nestedProp: "value19"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[0].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[10].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[11].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[12].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[13].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[14].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[15].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[16].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[17].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[18].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[19].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[20]":            map[string]interface{}{"kind": "DELETE"},
+		"props[2].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[4].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[5].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[6].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[7].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[8].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[9].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed/one_added,_one_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed/one_added,_one_removed.golden
@@ -1,0 +1,63 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val4",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      ~ prop {
+          ~ nested_prop = "val1" -> "val2"
+        }
+      ~ prop {
+          ~ nested_prop = "val2" -> "val3"
+        }
+      ~ prop {
+          ~ nested_prop = "val3" -> "val4"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProp: "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ nestedProp: "val2" => "val3"
+                }
+          ~ [2]: {
+                  ~ nestedProp: "val3" => "val4"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed/removed_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed/removed_empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  nil,
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed/removed_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed/removed_non-empty.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+	},
+	changeValue: nil,
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed/unchanged_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed/unchanged_empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: nil, changeValue: nil,
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed/unchanged_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+	},
+	changeValue: &[]string{"val1"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed_with_computed_specified_in_program/added_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed_with_computed_specified_in_program/added_empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: nil, changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed_with_computed_specified_in_program/added_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed_with_computed_specified_in_program/added_non-empty.golden
@@ -1,0 +1,40 @@
+tests.testOutput{
+	initialValue: nil, changeValue: &[]string{
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      ~ prop {
+          ~ nested_prop = "computed" -> "val1"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProp: "computed" => "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed_with_computed_specified_in_program/changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed_with_computed_specified_in_program/changed.golden
@@ -1,0 +1,41 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+	},
+	changeValue: &[]string{"val2"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      ~ prop {
+          ~ nested_prop = "val1" -> "val2"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProp: "val1" => "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed_with_computed_specified_in_program/list_element_added_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed_with_computed_specified_in_program/list_element_added_back.golden
@@ -1,0 +1,48 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      + prop {
+          + nested_prop = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [2]: {
+                  + nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed_with_computed_specified_in_program/list_element_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed_with_computed_specified_in_program/list_element_added_front.golden
@@ -1,0 +1,62 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      ~ prop {
+          ~ nested_prop = "val2" -> "val1"
+        }
+      ~ prop {
+          ~ nested_prop = "val3" -> "val2"
+        }
+      + prop {
+          + nested_prop = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProp: "val2" => "val1"
+                }
+          ~ [1]: {
+                  ~ nestedProp: "val3" => "val2"
+                }
+          + [2]: {
+                  + nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed_with_computed_specified_in_program/list_element_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed_with_computed_specified_in_program/list_element_added_middle.golden
@@ -1,0 +1,57 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      ~ prop {
+          ~ nested_prop = "val3" -> "val2"
+        }
+      + prop {
+          + nested_prop = "val3"
+        }
+
+        # (1 unchanged block hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [1]: {
+                  ~ nestedProp: "val3" => "val2"
+                }
+          + [2]: {
+                  + nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed_with_computed_specified_in_program/list_element_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed_with_computed_specified_in_program/list_element_removed_end.golden
@@ -1,0 +1,48 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - prop {
+          - nested_prop = "val3" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [2]: {
+                  - nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed_with_computed_specified_in_program/list_element_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed_with_computed_specified_in_program/list_element_removed_front.golden
@@ -1,0 +1,62 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      ~ prop {
+          ~ nested_prop = "val1" -> "val2"
+        }
+      ~ prop {
+          ~ nested_prop = "val2" -> "val3"
+        }
+      - prop {
+          - nested_prop = "val3" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProp: "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ nestedProp: "val2" => "val3"
+                }
+          - [2]: {
+                  - nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed_with_computed_specified_in_program/list_element_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed_with_computed_specified_in_program/list_element_removed_middle.golden
@@ -1,0 +1,57 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      ~ prop {
+          ~ nested_prop = "val2" -> "val3"
+        }
+      - prop {
+          - nested_prop = "val3" -> null
+        }
+
+        # (1 unchanged block hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [1]: {
+                  ~ nestedProp: "val2" => "val3"
+                }
+          - [2]: {
+                  - nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed_with_computed_specified_in_program/long_list_added_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed_with_computed_specified_in_program/long_list_added_back.golden
@@ -1,0 +1,84 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+		"value20",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      + prop {
+          + nested_prop = "value20"
+        }
+
+        # (20 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [20]: {
+                  + nestedProp: "value20"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[20]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed_with_computed_specified_in_program/long_list_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed_with_computed_specified_in_program/long_list_added_front.golden
@@ -1,0 +1,224 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value20",
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      ~ prop {
+          ~ nested_prop = "value0" -> "value20"
+        }
+      ~ prop {
+          ~ nested_prop = "value1" -> "value0"
+        }
+      ~ prop {
+          ~ nested_prop = "value2" -> "value1"
+        }
+      ~ prop {
+          ~ nested_prop = "value3" -> "value2"
+        }
+      ~ prop {
+          ~ nested_prop = "value4" -> "value3"
+        }
+      ~ prop {
+          ~ nested_prop = "value5" -> "value4"
+        }
+      ~ prop {
+          ~ nested_prop = "value6" -> "value5"
+        }
+      ~ prop {
+          ~ nested_prop = "value7" -> "value6"
+        }
+      ~ prop {
+          ~ nested_prop = "value8" -> "value7"
+        }
+      ~ prop {
+          ~ nested_prop = "value9" -> "value8"
+        }
+      ~ prop {
+          ~ nested_prop = "value10" -> "value9"
+        }
+      ~ prop {
+          ~ nested_prop = "value11" -> "value10"
+        }
+      ~ prop {
+          ~ nested_prop = "value12" -> "value11"
+        }
+      ~ prop {
+          ~ nested_prop = "value13" -> "value12"
+        }
+      ~ prop {
+          ~ nested_prop = "value14" -> "value13"
+        }
+      ~ prop {
+          ~ nested_prop = "value15" -> "value14"
+        }
+      ~ prop {
+          ~ nested_prop = "value16" -> "value15"
+        }
+      ~ prop {
+          ~ nested_prop = "value17" -> "value16"
+        }
+      ~ prop {
+          ~ nested_prop = "value18" -> "value17"
+        }
+      ~ prop {
+          ~ nested_prop = "value19" -> "value18"
+        }
+      + prop {
+          + nested_prop = "value19"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProp: "value0" => "value20"
+                }
+          ~ [1]: {
+                  ~ nestedProp: "value1" => "value0"
+                }
+          ~ [2]: {
+                  ~ nestedProp: "value2" => "value1"
+                }
+          ~ [3]: {
+                  ~ nestedProp: "value3" => "value2"
+                }
+          ~ [4]: {
+                  ~ nestedProp: "value4" => "value3"
+                }
+          ~ [5]: {
+                  ~ nestedProp: "value5" => "value4"
+                }
+          ~ [6]: {
+                  ~ nestedProp: "value6" => "value5"
+                }
+          ~ [7]: {
+                  ~ nestedProp: "value7" => "value6"
+                }
+          ~ [8]: {
+                  ~ nestedProp: "value8" => "value7"
+                }
+          ~ [9]: {
+                  ~ nestedProp: "value9" => "value8"
+                }
+          ~ [10]: {
+                  ~ nestedProp: "value10" => "value9"
+                }
+          ~ [11]: {
+                  ~ nestedProp: "value11" => "value10"
+                }
+          ~ [12]: {
+                  ~ nestedProp: "value12" => "value11"
+                }
+          ~ [13]: {
+                  ~ nestedProp: "value13" => "value12"
+                }
+          ~ [14]: {
+                  ~ nestedProp: "value14" => "value13"
+                }
+          ~ [15]: {
+                  ~ nestedProp: "value15" => "value14"
+                }
+          ~ [16]: {
+                  ~ nestedProp: "value16" => "value15"
+                }
+          ~ [17]: {
+                  ~ nestedProp: "value17" => "value16"
+                }
+          ~ [18]: {
+                  ~ nestedProp: "value18" => "value17"
+                }
+          ~ [19]: {
+                  ~ nestedProp: "value19" => "value18"
+                }
+          + [20]: {
+                  + nestedProp: "value19"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[0].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[10].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[11].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[12].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[13].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[14].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[15].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[16].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[17].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[18].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[19].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[20]":            map[string]interface{}{},
+		"props[2].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[4].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[5].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[6].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[7].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[8].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[9].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed_with_computed_specified_in_program/long_list_removed_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed_with_computed_specified_in_program/long_list_removed_back.golden
@@ -1,0 +1,84 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+		"value20",
+	},
+	changeValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - prop {
+          - nested_prop = "value20" -> null
+        }
+
+        # (20 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [20]: {
+                  - nestedProp: "value20"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[20]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed_with_computed_specified_in_program/long_list_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed_with_computed_specified_in_program/long_list_removed_front.golden
@@ -1,0 +1,224 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value20",
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      ~ prop {
+          ~ nested_prop = "value20" -> "value0"
+        }
+      ~ prop {
+          ~ nested_prop = "value0" -> "value1"
+        }
+      ~ prop {
+          ~ nested_prop = "value1" -> "value2"
+        }
+      ~ prop {
+          ~ nested_prop = "value2" -> "value3"
+        }
+      ~ prop {
+          ~ nested_prop = "value3" -> "value4"
+        }
+      ~ prop {
+          ~ nested_prop = "value4" -> "value5"
+        }
+      ~ prop {
+          ~ nested_prop = "value5" -> "value6"
+        }
+      ~ prop {
+          ~ nested_prop = "value6" -> "value7"
+        }
+      ~ prop {
+          ~ nested_prop = "value7" -> "value8"
+        }
+      ~ prop {
+          ~ nested_prop = "value8" -> "value9"
+        }
+      ~ prop {
+          ~ nested_prop = "value9" -> "value10"
+        }
+      ~ prop {
+          ~ nested_prop = "value10" -> "value11"
+        }
+      ~ prop {
+          ~ nested_prop = "value11" -> "value12"
+        }
+      ~ prop {
+          ~ nested_prop = "value12" -> "value13"
+        }
+      ~ prop {
+          ~ nested_prop = "value13" -> "value14"
+        }
+      ~ prop {
+          ~ nested_prop = "value14" -> "value15"
+        }
+      ~ prop {
+          ~ nested_prop = "value15" -> "value16"
+        }
+      ~ prop {
+          ~ nested_prop = "value16" -> "value17"
+        }
+      ~ prop {
+          ~ nested_prop = "value17" -> "value18"
+        }
+      ~ prop {
+          ~ nested_prop = "value18" -> "value19"
+        }
+      - prop {
+          - nested_prop = "value19" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProp: "value20" => "value0"
+                }
+          ~ [1]: {
+                  ~ nestedProp: "value0" => "value1"
+                }
+          ~ [2]: {
+                  ~ nestedProp: "value1" => "value2"
+                }
+          ~ [3]: {
+                  ~ nestedProp: "value2" => "value3"
+                }
+          ~ [4]: {
+                  ~ nestedProp: "value3" => "value4"
+                }
+          ~ [5]: {
+                  ~ nestedProp: "value4" => "value5"
+                }
+          ~ [6]: {
+                  ~ nestedProp: "value5" => "value6"
+                }
+          ~ [7]: {
+                  ~ nestedProp: "value6" => "value7"
+                }
+          ~ [8]: {
+                  ~ nestedProp: "value7" => "value8"
+                }
+          ~ [9]: {
+                  ~ nestedProp: "value8" => "value9"
+                }
+          ~ [10]: {
+                  ~ nestedProp: "value9" => "value10"
+                }
+          ~ [11]: {
+                  ~ nestedProp: "value10" => "value11"
+                }
+          ~ [12]: {
+                  ~ nestedProp: "value11" => "value12"
+                }
+          ~ [13]: {
+                  ~ nestedProp: "value12" => "value13"
+                }
+          ~ [14]: {
+                  ~ nestedProp: "value13" => "value14"
+                }
+          ~ [15]: {
+                  ~ nestedProp: "value14" => "value15"
+                }
+          ~ [16]: {
+                  ~ nestedProp: "value15" => "value16"
+                }
+          ~ [17]: {
+                  ~ nestedProp: "value16" => "value17"
+                }
+          ~ [18]: {
+                  ~ nestedProp: "value17" => "value18"
+                }
+          ~ [19]: {
+                  ~ nestedProp: "value18" => "value19"
+                }
+          - [20]: {
+                  - nestedProp: "value19"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[0].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[10].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[11].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[12].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[13].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[14].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[15].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[16].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[17].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[18].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[19].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[20]":            map[string]interface{}{"kind": "DELETE"},
+		"props[2].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[4].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[5].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[6].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[7].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[8].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[9].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed_with_computed_specified_in_program/one_added,_one_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed_with_computed_specified_in_program/one_added,_one_removed.golden
@@ -1,0 +1,63 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val4",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      ~ prop {
+          ~ nested_prop = "val1" -> "val2"
+        }
+      ~ prop {
+          ~ nested_prop = "val2" -> "val3"
+        }
+      ~ prop {
+          ~ nested_prop = "val3" -> "val4"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProp: "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ nestedProp: "val2" => "val3"
+                }
+          ~ [2]: {
+                  ~ nestedProp: "val3" => "val4"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed_with_computed_specified_in_program/removed_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed_with_computed_specified_in_program/removed_empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  nil,
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed_with_computed_specified_in_program/removed_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed_with_computed_specified_in_program/removed_non-empty.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+	},
+	changeValue: nil,
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed_with_computed_specified_in_program/unchanged_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed_with_computed_specified_in_program/unchanged_empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: nil, changeValue: nil,
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed_with_computed_specified_in_program/unchanged_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_computed_with_computed_specified_in_program/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+	},
+	changeValue: &[]string{"val1"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed/added_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed/added_empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: nil, changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed/added_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed/added_non-empty.golden
@@ -1,0 +1,40 @@
+tests.testOutput{
+	initialValue: nil, changeValue: &[]string{
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      + prop {
+          + nested_prop = "val1"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + props: [
+      +     [0]: {
+              + nestedProp: "val1"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed/changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed/changed.golden
@@ -1,0 +1,42 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+	},
+	changeValue: &[]string{"val2"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      ~ prop {
+          ~ nested_prop = "val1" -> "val2"
+            # (1 unchanged attribute hidden)
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProp: "val1" => "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed/list_element_added_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed/list_element_added_back.golden
@@ -1,0 +1,48 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      + prop {
+          + nested_prop = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [2]: {
+                  + nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed/list_element_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed/list_element_added_front.golden
@@ -1,0 +1,64 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      ~ prop {
+          ~ nested_prop = "val2" -> "val1"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "val3" -> "val2"
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProp: "val2" => "val1"
+                }
+          ~ [1]: {
+                  ~ nestedProp: "val3" => "val2"
+                }
+          + [2]: {
+                  + nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed/list_element_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed/list_element_added_middle.golden
@@ -1,0 +1,58 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      ~ prop {
+          ~ nested_prop = "val3" -> "val2"
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val3"
+        }
+
+        # (1 unchanged block hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [1]: {
+                  ~ nestedProp: "val3" => "val2"
+                }
+          + [2]: {
+                  + nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed/list_element_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed/list_element_removed_end.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - prop {
+          - computed    = "val3" -> null
+          - nested_prop = "val3" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [2]: {
+                  - computed  : "val3"
+                  - nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed/list_element_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed/list_element_removed_front.golden
@@ -1,0 +1,66 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      ~ prop {
+          ~ nested_prop = "val1" -> "val2"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "val2" -> "val3"
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - computed    = "val3" -> null
+          - nested_prop = "val3" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProp: "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ nestedProp: "val2" => "val3"
+                }
+          - [2]: {
+                  - computed  : "val3"
+                  - nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed/list_element_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed/list_element_removed_middle.golden
@@ -1,0 +1,60 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      ~ prop {
+          ~ nested_prop = "val2" -> "val3"
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - computed    = "val3" -> null
+          - nested_prop = "val3" -> null
+        }
+
+        # (1 unchanged block hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [1]: {
+                  ~ nestedProp: "val2" => "val3"
+                }
+          - [2]: {
+                  - computed  : "val3"
+                  - nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed/long_list_added_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed/long_list_added_back.golden
@@ -1,0 +1,84 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+		"value20",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      + prop {
+          + nested_prop = "value20"
+        }
+
+        # (20 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [20]: {
+                  + nestedProp: "value20"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[20]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed/long_list_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed/long_list_added_front.golden
@@ -1,0 +1,244 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value20",
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      ~ prop {
+          ~ nested_prop = "value0" -> "value20"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value1" -> "value0"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value2" -> "value1"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value3" -> "value2"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value4" -> "value3"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value5" -> "value4"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value6" -> "value5"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value7" -> "value6"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value8" -> "value7"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value9" -> "value8"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value10" -> "value9"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value11" -> "value10"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value12" -> "value11"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value13" -> "value12"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value14" -> "value13"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value15" -> "value14"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value16" -> "value15"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value17" -> "value16"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value18" -> "value17"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value19" -> "value18"
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "value19"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProp: "value0" => "value20"
+                }
+          ~ [1]: {
+                  ~ nestedProp: "value1" => "value0"
+                }
+          ~ [2]: {
+                  ~ nestedProp: "value2" => "value1"
+                }
+          ~ [3]: {
+                  ~ nestedProp: "value3" => "value2"
+                }
+          ~ [4]: {
+                  ~ nestedProp: "value4" => "value3"
+                }
+          ~ [5]: {
+                  ~ nestedProp: "value5" => "value4"
+                }
+          ~ [6]: {
+                  ~ nestedProp: "value6" => "value5"
+                }
+          ~ [7]: {
+                  ~ nestedProp: "value7" => "value6"
+                }
+          ~ [8]: {
+                  ~ nestedProp: "value8" => "value7"
+                }
+          ~ [9]: {
+                  ~ nestedProp: "value9" => "value8"
+                }
+          ~ [10]: {
+                  ~ nestedProp: "value10" => "value9"
+                }
+          ~ [11]: {
+                  ~ nestedProp: "value11" => "value10"
+                }
+          ~ [12]: {
+                  ~ nestedProp: "value12" => "value11"
+                }
+          ~ [13]: {
+                  ~ nestedProp: "value13" => "value12"
+                }
+          ~ [14]: {
+                  ~ nestedProp: "value14" => "value13"
+                }
+          ~ [15]: {
+                  ~ nestedProp: "value15" => "value14"
+                }
+          ~ [16]: {
+                  ~ nestedProp: "value16" => "value15"
+                }
+          ~ [17]: {
+                  ~ nestedProp: "value17" => "value16"
+                }
+          ~ [18]: {
+                  ~ nestedProp: "value18" => "value17"
+                }
+          ~ [19]: {
+                  ~ nestedProp: "value19" => "value18"
+                }
+          + [20]: {
+                  + nestedProp: "value19"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[0].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[10].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[11].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[12].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[13].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[14].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[15].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[16].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[17].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[18].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[19].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[20]":            map[string]interface{}{},
+		"props[2].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[4].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[5].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[6].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[7].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[8].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[9].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed/long_list_removed_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed/long_list_removed_back.golden
@@ -1,0 +1,86 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+		"value20",
+	},
+	changeValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - prop {
+          - computed    = "value20" -> null
+          - nested_prop = "value20" -> null
+        }
+
+        # (20 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [20]: {
+                  - computed  : "value20"
+                  - nestedProp: "value20"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[20]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed/long_list_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed/long_list_removed_front.golden
@@ -1,0 +1,246 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value20",
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      ~ prop {
+          ~ nested_prop = "value20" -> "value0"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value0" -> "value1"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value1" -> "value2"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value2" -> "value3"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value3" -> "value4"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value4" -> "value5"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value5" -> "value6"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value6" -> "value7"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value7" -> "value8"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value8" -> "value9"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value9" -> "value10"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value10" -> "value11"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value11" -> "value12"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value12" -> "value13"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value13" -> "value14"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value14" -> "value15"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value15" -> "value16"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value16" -> "value17"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value17" -> "value18"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "value18" -> "value19"
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - computed    = "value19" -> null
+          - nested_prop = "value19" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProp: "value20" => "value0"
+                }
+          ~ [1]: {
+                  ~ nestedProp: "value0" => "value1"
+                }
+          ~ [2]: {
+                  ~ nestedProp: "value1" => "value2"
+                }
+          ~ [3]: {
+                  ~ nestedProp: "value2" => "value3"
+                }
+          ~ [4]: {
+                  ~ nestedProp: "value3" => "value4"
+                }
+          ~ [5]: {
+                  ~ nestedProp: "value4" => "value5"
+                }
+          ~ [6]: {
+                  ~ nestedProp: "value5" => "value6"
+                }
+          ~ [7]: {
+                  ~ nestedProp: "value6" => "value7"
+                }
+          ~ [8]: {
+                  ~ nestedProp: "value7" => "value8"
+                }
+          ~ [9]: {
+                  ~ nestedProp: "value8" => "value9"
+                }
+          ~ [10]: {
+                  ~ nestedProp: "value9" => "value10"
+                }
+          ~ [11]: {
+                  ~ nestedProp: "value10" => "value11"
+                }
+          ~ [12]: {
+                  ~ nestedProp: "value11" => "value12"
+                }
+          ~ [13]: {
+                  ~ nestedProp: "value12" => "value13"
+                }
+          ~ [14]: {
+                  ~ nestedProp: "value13" => "value14"
+                }
+          ~ [15]: {
+                  ~ nestedProp: "value14" => "value15"
+                }
+          ~ [16]: {
+                  ~ nestedProp: "value15" => "value16"
+                }
+          ~ [17]: {
+                  ~ nestedProp: "value16" => "value17"
+                }
+          ~ [18]: {
+                  ~ nestedProp: "value17" => "value18"
+                }
+          ~ [19]: {
+                  ~ nestedProp: "value18" => "value19"
+                }
+          - [20]: {
+                  - computed  : "value19"
+                  - nestedProp: "value19"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[0].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[10].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[11].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[12].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[13].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[14].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[15].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[16].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[17].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[18].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[19].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[20]":            map[string]interface{}{"kind": "DELETE"},
+		"props[2].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[4].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[5].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[6].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[7].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[8].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[9].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed/one_added,_one_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed/one_added,_one_removed.golden
@@ -1,0 +1,66 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val4",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      ~ prop {
+          ~ nested_prop = "val1" -> "val2"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "val2" -> "val3"
+            # (1 unchanged attribute hidden)
+        }
+      ~ prop {
+          ~ nested_prop = "val3" -> "val4"
+            # (1 unchanged attribute hidden)
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProp: "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ nestedProp: "val2" => "val3"
+                }
+          ~ [2]: {
+                  ~ nestedProp: "val3" => "val4"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed/removed_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed/removed_empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  nil,
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed/removed_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed/removed_non-empty.golden
@@ -1,0 +1,43 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+	},
+	changeValue: nil,
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - prop {
+          - computed    = "val1" -> null
+          - nested_prop = "val1" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      - props: [
+      -     [0]: {
+              - computed  : "val1"
+              - nestedProp: "val1"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed/unchanged_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed/unchanged_empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: nil, changeValue: nil,
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed/unchanged_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+	},
+	changeValue: &[]string{"val1"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed_with_computed_specified_in_program/added_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed_with_computed_specified_in_program/added_empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: nil, changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed_with_computed_specified_in_program/added_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed_with_computed_specified_in_program/added_non-empty.golden
@@ -1,0 +1,42 @@
+tests.testOutput{
+	initialValue: nil, changeValue: &[]string{
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      + prop {
+          + computed    = "non-computed-val1"
+          + nested_prop = "val1"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + props: [
+      +     [0]: {
+              + computed  : "non-computed-val1"
+              + nestedProp: "val1"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed_with_computed_specified_in_program/changed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed_with_computed_specified_in_program/changed.golden
@@ -1,0 +1,46 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+	},
+	changeValue: &[]string{"val2"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      ~ prop {
+          ~ computed    = "non-computed-val1" -> "non-computed-val2"
+          ~ nested_prop = "val1" -> "val2"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ computed  : "non-computed-val1" => "non-computed-val2"
+                  ~ nestedProp: "val1" => "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed_with_computed_specified_in_program/list_element_added_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed_with_computed_specified_in_program/list_element_added_back.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      + prop {
+          + computed    = "non-computed-val3"
+          + nested_prop = "val3"
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [2]: {
+                  + computed  : "non-computed-val3"
+                  + nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed_with_computed_specified_in_program/list_element_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed_with_computed_specified_in_program/list_element_added_front.golden
@@ -1,0 +1,70 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      ~ prop {
+          ~ computed    = "non-computed-val2" -> "non-computed-val1"
+          ~ nested_prop = "val2" -> "val1"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-val3" -> "non-computed-val2"
+          ~ nested_prop = "val3" -> "val2"
+        }
+      + prop {
+          + computed    = "non-computed-val3"
+          + nested_prop = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ computed  : "non-computed-val2" => "non-computed-val1"
+                  ~ nestedProp: "val2" => "val1"
+                }
+          ~ [1]: {
+                  ~ computed  : "non-computed-val3" => "non-computed-val2"
+                  ~ nestedProp: "val3" => "val2"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val3"
+                  + nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed_with_computed_specified_in_program/list_element_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed_with_computed_specified_in_program/list_element_added_middle.golden
@@ -1,0 +1,62 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      ~ prop {
+          ~ computed    = "non-computed-val3" -> "non-computed-val2"
+          ~ nested_prop = "val3" -> "val2"
+        }
+      + prop {
+          + computed    = "non-computed-val3"
+          + nested_prop = "val3"
+        }
+
+        # (1 unchanged block hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [1]: {
+                  ~ computed  : "non-computed-val3" => "non-computed-val2"
+                  ~ nestedProp: "val3" => "val2"
+                }
+          + [2]: {
+                  + computed  : "non-computed-val3"
+                  + nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed_with_computed_specified_in_program/list_element_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed_with_computed_specified_in_program/list_element_removed_end.golden
@@ -1,0 +1,50 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - prop {
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
+        }
+
+        # (2 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [2]: {
+                  - computed  : "non-computed-val3"
+                  - nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed_with_computed_specified_in_program/list_element_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed_with_computed_specified_in_program/list_element_removed_front.golden
@@ -1,0 +1,70 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      ~ prop {
+          ~ computed    = "non-computed-val1" -> "non-computed-val2"
+          ~ nested_prop = "val1" -> "val2"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-val2" -> "non-computed-val3"
+          ~ nested_prop = "val2" -> "val3"
+        }
+      - prop {
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ computed  : "non-computed-val1" => "non-computed-val2"
+                  ~ nestedProp: "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ computed  : "non-computed-val2" => "non-computed-val3"
+                  ~ nestedProp: "val2" => "val3"
+                }
+          - [2]: {
+                  - computed  : "non-computed-val3"
+                  - nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed_with_computed_specified_in_program/list_element_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed_with_computed_specified_in_program/list_element_removed_middle.golden
@@ -1,0 +1,62 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      ~ prop {
+          ~ computed    = "non-computed-val2" -> "non-computed-val3"
+          ~ nested_prop = "val2" -> "val3"
+        }
+      - prop {
+          - computed    = "non-computed-val3" -> null
+          - nested_prop = "val3" -> null
+        }
+
+        # (1 unchanged block hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [1]: {
+                  ~ computed  : "non-computed-val2" => "non-computed-val3"
+                  ~ nestedProp: "val2" => "val3"
+                }
+          - [2]: {
+                  - computed  : "non-computed-val3"
+                  - nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2]":            map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed_with_computed_specified_in_program/long_list_added_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed_with_computed_specified_in_program/long_list_added_back.golden
@@ -1,0 +1,86 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+		"value20",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      + prop {
+          + computed    = "non-computed-value20"
+          + nested_prop = "value20"
+        }
+
+        # (20 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [20]: {
+                  + computed  : "non-computed-value20"
+                  + nestedProp: "value20"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[20]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed_with_computed_specified_in_program/long_list_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed_with_computed_specified_in_program/long_list_added_front.golden
@@ -1,0 +1,286 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value20",
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      ~ prop {
+          ~ computed    = "non-computed-value0" -> "non-computed-value20"
+          ~ nested_prop = "value0" -> "value20"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-value1" -> "non-computed-value0"
+          ~ nested_prop = "value1" -> "value0"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-value2" -> "non-computed-value1"
+          ~ nested_prop = "value2" -> "value1"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-value3" -> "non-computed-value2"
+          ~ nested_prop = "value3" -> "value2"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-value4" -> "non-computed-value3"
+          ~ nested_prop = "value4" -> "value3"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-value5" -> "non-computed-value4"
+          ~ nested_prop = "value5" -> "value4"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-value6" -> "non-computed-value5"
+          ~ nested_prop = "value6" -> "value5"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-value7" -> "non-computed-value6"
+          ~ nested_prop = "value7" -> "value6"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-value8" -> "non-computed-value7"
+          ~ nested_prop = "value8" -> "value7"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-value9" -> "non-computed-value8"
+          ~ nested_prop = "value9" -> "value8"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-value10" -> "non-computed-value9"
+          ~ nested_prop = "value10" -> "value9"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-value11" -> "non-computed-value10"
+          ~ nested_prop = "value11" -> "value10"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-value12" -> "non-computed-value11"
+          ~ nested_prop = "value12" -> "value11"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-value13" -> "non-computed-value12"
+          ~ nested_prop = "value13" -> "value12"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-value14" -> "non-computed-value13"
+          ~ nested_prop = "value14" -> "value13"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-value15" -> "non-computed-value14"
+          ~ nested_prop = "value15" -> "value14"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-value16" -> "non-computed-value15"
+          ~ nested_prop = "value16" -> "value15"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-value17" -> "non-computed-value16"
+          ~ nested_prop = "value17" -> "value16"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-value18" -> "non-computed-value17"
+          ~ nested_prop = "value18" -> "value17"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-value19" -> "non-computed-value18"
+          ~ nested_prop = "value19" -> "value18"
+        }
+      + prop {
+          + computed    = "non-computed-value19"
+          + nested_prop = "value19"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ computed  : "non-computed-value0" => "non-computed-value20"
+                  ~ nestedProp: "value0" => "value20"
+                }
+          ~ [1]: {
+                  ~ computed  : "non-computed-value1" => "non-computed-value0"
+                  ~ nestedProp: "value1" => "value0"
+                }
+          ~ [2]: {
+                  ~ computed  : "non-computed-value2" => "non-computed-value1"
+                  ~ nestedProp: "value2" => "value1"
+                }
+          ~ [3]: {
+                  ~ computed  : "non-computed-value3" => "non-computed-value2"
+                  ~ nestedProp: "value3" => "value2"
+                }
+          ~ [4]: {
+                  ~ computed  : "non-computed-value4" => "non-computed-value3"
+                  ~ nestedProp: "value4" => "value3"
+                }
+          ~ [5]: {
+                  ~ computed  : "non-computed-value5" => "non-computed-value4"
+                  ~ nestedProp: "value5" => "value4"
+                }
+          ~ [6]: {
+                  ~ computed  : "non-computed-value6" => "non-computed-value5"
+                  ~ nestedProp: "value6" => "value5"
+                }
+          ~ [7]: {
+                  ~ computed  : "non-computed-value7" => "non-computed-value6"
+                  ~ nestedProp: "value7" => "value6"
+                }
+          ~ [8]: {
+                  ~ computed  : "non-computed-value8" => "non-computed-value7"
+                  ~ nestedProp: "value8" => "value7"
+                }
+          ~ [9]: {
+                  ~ computed  : "non-computed-value9" => "non-computed-value8"
+                  ~ nestedProp: "value9" => "value8"
+                }
+          ~ [10]: {
+                  ~ computed  : "non-computed-value10" => "non-computed-value9"
+                  ~ nestedProp: "value10" => "value9"
+                }
+          ~ [11]: {
+                  ~ computed  : "non-computed-value11" => "non-computed-value10"
+                  ~ nestedProp: "value11" => "value10"
+                }
+          ~ [12]: {
+                  ~ computed  : "non-computed-value12" => "non-computed-value11"
+                  ~ nestedProp: "value12" => "value11"
+                }
+          ~ [13]: {
+                  ~ computed  : "non-computed-value13" => "non-computed-value12"
+                  ~ nestedProp: "value13" => "value12"
+                }
+          ~ [14]: {
+                  ~ computed  : "non-computed-value14" => "non-computed-value13"
+                  ~ nestedProp: "value14" => "value13"
+                }
+          ~ [15]: {
+                  ~ computed  : "non-computed-value15" => "non-computed-value14"
+                  ~ nestedProp: "value15" => "value14"
+                }
+          ~ [16]: {
+                  ~ computed  : "non-computed-value16" => "non-computed-value15"
+                  ~ nestedProp: "value16" => "value15"
+                }
+          ~ [17]: {
+                  ~ computed  : "non-computed-value17" => "non-computed-value16"
+                  ~ nestedProp: "value17" => "value16"
+                }
+          ~ [18]: {
+                  ~ computed  : "non-computed-value18" => "non-computed-value17"
+                  ~ nestedProp: "value18" => "value17"
+                }
+          ~ [19]: {
+                  ~ computed  : "non-computed-value19" => "non-computed-value18"
+                  ~ nestedProp: "value19" => "value18"
+                }
+          + [20]: {
+                  + computed  : "non-computed-value19"
+                  + nestedProp: "value19"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[0].computed":    map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[10].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[10].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[11].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[11].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[12].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[12].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[13].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[13].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[14].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[14].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[15].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[15].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[16].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[16].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[17].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[17].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[18].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[18].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[19].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[19].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":    map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[20]":            map[string]interface{}{},
+		"props[2].computed":    map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[3].computed":    map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[4].computed":    map[string]interface{}{"kind": "UPDATE"},
+		"props[4].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[5].computed":    map[string]interface{}{"kind": "UPDATE"},
+		"props[5].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[6].computed":    map[string]interface{}{"kind": "UPDATE"},
+		"props[6].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[7].computed":    map[string]interface{}{"kind": "UPDATE"},
+		"props[7].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[8].computed":    map[string]interface{}{"kind": "UPDATE"},
+		"props[8].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[9].computed":    map[string]interface{}{"kind": "UPDATE"},
+		"props[9].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed_with_computed_specified_in_program/long_list_removed_back.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed_with_computed_specified_in_program/long_list_removed_back.golden
@@ -1,0 +1,86 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+		"value20",
+	},
+	changeValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - prop {
+          - computed    = "non-computed-value20" -> null
+          - nested_prop = "value20" -> null
+        }
+
+        # (20 unchanged blocks hidden)
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [20]: {
+                  - computed  : "non-computed-value20"
+                  - nestedProp: "value20"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[20]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed_with_computed_specified_in_program/long_list_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed_with_computed_specified_in_program/long_list_removed_front.golden
@@ -1,0 +1,286 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value20",
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	changeValue: &[]string{
+		"value0",
+		"value1",
+		"value2",
+		"value3",
+		"value4",
+		"value5",
+		"value6",
+		"value7",
+		"value8",
+		"value9",
+		"value10",
+		"value11",
+		"value12",
+		"value13",
+		"value14",
+		"value15",
+		"value16",
+		"value17",
+		"value18",
+		"value19",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      ~ prop {
+          ~ computed    = "non-computed-value20" -> "non-computed-value0"
+          ~ nested_prop = "value20" -> "value0"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-value0" -> "non-computed-value1"
+          ~ nested_prop = "value0" -> "value1"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-value1" -> "non-computed-value2"
+          ~ nested_prop = "value1" -> "value2"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-value2" -> "non-computed-value3"
+          ~ nested_prop = "value2" -> "value3"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-value3" -> "non-computed-value4"
+          ~ nested_prop = "value3" -> "value4"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-value4" -> "non-computed-value5"
+          ~ nested_prop = "value4" -> "value5"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-value5" -> "non-computed-value6"
+          ~ nested_prop = "value5" -> "value6"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-value6" -> "non-computed-value7"
+          ~ nested_prop = "value6" -> "value7"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-value7" -> "non-computed-value8"
+          ~ nested_prop = "value7" -> "value8"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-value8" -> "non-computed-value9"
+          ~ nested_prop = "value8" -> "value9"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-value9" -> "non-computed-value10"
+          ~ nested_prop = "value9" -> "value10"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-value10" -> "non-computed-value11"
+          ~ nested_prop = "value10" -> "value11"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-value11" -> "non-computed-value12"
+          ~ nested_prop = "value11" -> "value12"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-value12" -> "non-computed-value13"
+          ~ nested_prop = "value12" -> "value13"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-value13" -> "non-computed-value14"
+          ~ nested_prop = "value13" -> "value14"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-value14" -> "non-computed-value15"
+          ~ nested_prop = "value14" -> "value15"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-value15" -> "non-computed-value16"
+          ~ nested_prop = "value15" -> "value16"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-value16" -> "non-computed-value17"
+          ~ nested_prop = "value16" -> "value17"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-value17" -> "non-computed-value18"
+          ~ nested_prop = "value17" -> "value18"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-value18" -> "non-computed-value19"
+          ~ nested_prop = "value18" -> "value19"
+        }
+      - prop {
+          - computed    = "non-computed-value19" -> null
+          - nested_prop = "value19" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ computed  : "non-computed-value20" => "non-computed-value0"
+                  ~ nestedProp: "value20" => "value0"
+                }
+          ~ [1]: {
+                  ~ computed  : "non-computed-value0" => "non-computed-value1"
+                  ~ nestedProp: "value0" => "value1"
+                }
+          ~ [2]: {
+                  ~ computed  : "non-computed-value1" => "non-computed-value2"
+                  ~ nestedProp: "value1" => "value2"
+                }
+          ~ [3]: {
+                  ~ computed  : "non-computed-value2" => "non-computed-value3"
+                  ~ nestedProp: "value2" => "value3"
+                }
+          ~ [4]: {
+                  ~ computed  : "non-computed-value3" => "non-computed-value4"
+                  ~ nestedProp: "value3" => "value4"
+                }
+          ~ [5]: {
+                  ~ computed  : "non-computed-value4" => "non-computed-value5"
+                  ~ nestedProp: "value4" => "value5"
+                }
+          ~ [6]: {
+                  ~ computed  : "non-computed-value5" => "non-computed-value6"
+                  ~ nestedProp: "value5" => "value6"
+                }
+          ~ [7]: {
+                  ~ computed  : "non-computed-value6" => "non-computed-value7"
+                  ~ nestedProp: "value6" => "value7"
+                }
+          ~ [8]: {
+                  ~ computed  : "non-computed-value7" => "non-computed-value8"
+                  ~ nestedProp: "value7" => "value8"
+                }
+          ~ [9]: {
+                  ~ computed  : "non-computed-value8" => "non-computed-value9"
+                  ~ nestedProp: "value8" => "value9"
+                }
+          ~ [10]: {
+                  ~ computed  : "non-computed-value9" => "non-computed-value10"
+                  ~ nestedProp: "value9" => "value10"
+                }
+          ~ [11]: {
+                  ~ computed  : "non-computed-value10" => "non-computed-value11"
+                  ~ nestedProp: "value10" => "value11"
+                }
+          ~ [12]: {
+                  ~ computed  : "non-computed-value11" => "non-computed-value12"
+                  ~ nestedProp: "value11" => "value12"
+                }
+          ~ [13]: {
+                  ~ computed  : "non-computed-value12" => "non-computed-value13"
+                  ~ nestedProp: "value12" => "value13"
+                }
+          ~ [14]: {
+                  ~ computed  : "non-computed-value13" => "non-computed-value14"
+                  ~ nestedProp: "value13" => "value14"
+                }
+          ~ [15]: {
+                  ~ computed  : "non-computed-value14" => "non-computed-value15"
+                  ~ nestedProp: "value14" => "value15"
+                }
+          ~ [16]: {
+                  ~ computed  : "non-computed-value15" => "non-computed-value16"
+                  ~ nestedProp: "value15" => "value16"
+                }
+          ~ [17]: {
+                  ~ computed  : "non-computed-value16" => "non-computed-value17"
+                  ~ nestedProp: "value16" => "value17"
+                }
+          ~ [18]: {
+                  ~ computed  : "non-computed-value17" => "non-computed-value18"
+                  ~ nestedProp: "value17" => "value18"
+                }
+          ~ [19]: {
+                  ~ computed  : "non-computed-value18" => "non-computed-value19"
+                  ~ nestedProp: "value18" => "value19"
+                }
+          - [20]: {
+                  - computed  : "non-computed-value19"
+                  - nestedProp: "value19"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[0].computed":    map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[10].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[10].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[11].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[11].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[12].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[12].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[13].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[13].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[14].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[14].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[15].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[15].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[16].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[16].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[17].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[17].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[18].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[18].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[19].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[19].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":    map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[20]":            map[string]interface{}{"kind": "DELETE"},
+		"props[2].computed":    map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[3].computed":    map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[4].computed":    map[string]interface{}{"kind": "UPDATE"},
+		"props[4].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[5].computed":    map[string]interface{}{"kind": "UPDATE"},
+		"props[5].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[6].computed":    map[string]interface{}{"kind": "UPDATE"},
+		"props[6].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[7].computed":    map[string]interface{}{"kind": "UPDATE"},
+		"props[7].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[8].computed":    map[string]interface{}{"kind": "UPDATE"},
+		"props[8].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+		"props[9].computed":    map[string]interface{}{"kind": "UPDATE"},
+		"props[9].nestedProp":  map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed_with_computed_specified_in_program/one_added,_one_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed_with_computed_specified_in_program/one_added,_one_removed.golden
@@ -1,0 +1,72 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val4",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      ~ prop {
+          ~ computed    = "non-computed-val1" -> "non-computed-val2"
+          ~ nested_prop = "val1" -> "val2"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-val2" -> "non-computed-val3"
+          ~ nested_prop = "val2" -> "val3"
+        }
+      ~ prop {
+          ~ computed    = "non-computed-val3" -> "non-computed-val4"
+          ~ nested_prop = "val3" -> "val4"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ computed  : "non-computed-val1" => "non-computed-val2"
+                  ~ nestedProp: "val1" => "val2"
+                }
+          ~ [1]: {
+                  ~ computed  : "non-computed-val2" => "non-computed-val3"
+                  ~ nestedProp: "val2" => "val3"
+                }
+          ~ [2]: {
+                  ~ computed  : "non-computed-val3" => "non-computed-val4"
+                  ~ nestedProp: "val3" => "val4"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed_with_computed_specified_in_program/removed_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed_with_computed_specified_in_program/removed_empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  nil,
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed_with_computed_specified_in_program/removed_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed_with_computed_specified_in_program/removed_non-empty.golden
@@ -1,0 +1,43 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+	},
+	changeValue: nil,
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "id"
+
+      - prop {
+          - computed    = "non-computed-val1" -> null
+          - nested_prop = "val1" -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=id]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      - props: [
+      -     [0]: {
+              - computed  : "non-computed-val1"
+              - nestedProp: "val1"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed_with_computed_specified_in_program/unchanged_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed_with_computed_specified_in_program/unchanged_empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: nil, changeValue: nil,
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed_with_computed_specified_in_program/unchanged_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_block_nested_computed_with_computed_specified_in_program/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+	},
+	changeValue: &[]string{"val1"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tfbridge/detailed_diff.go
+++ b/pkg/tfbridge/detailed_diff.go
@@ -486,7 +486,17 @@ func (differ detailedDiffer) makeListDiff(
 		return nil
 	}
 	if _, ok := tfs.Elem().(shim.Schema); ok || tfs.Elem() == nil {
-		return makeListAttributeDiff(path, oldList, newList)
+		listDiff := makeListAttributeDiff(path, oldList, newList)
+		if tfs.ForceNew() {
+			for k, v := range listDiff {
+				diff[k] = promoteToReplace(v)
+			}
+		} else {
+			for k, v := range listDiff {
+				diff[k] = v
+			}
+		}
+		return diff
 	}
 
 	longerLen := max(len(oldList), len(newList))

--- a/pkg/vendored/generate.go
+++ b/pkg/vendored/generate.go
@@ -211,6 +211,11 @@ func vendorOpenTOFU(version string) {
 			transforms: transforms,
 		},
 		{
+			src:        "internal/plans/objchange/lcs.go",
+			dest:       "plans/objchange/lcs.go",
+			transforms: transforms,
+		},
+		{
 			src:  "internal/plugin6/convert/schema.go",
 			dest: "convert/schema.go",
 			transforms: append(transforms, func(s string) string {

--- a/pkg/vendored/opentofu/plans/objchange/lcs.go
+++ b/pkg/vendored/opentofu/plans/objchange/lcs.go
@@ -1,0 +1,124 @@
+// Code copied from github.com/opentofu/opentofu by go generate; DO NOT EDIT.
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package objchange
+
+import (
+	"github.com/zclconf/go-cty/cty"
+)
+
+// ValueEqual provides an implementation of the equals function that can be
+// passed into LongestCommonSubsequence when comparing cty.Value types.
+func ValueEqual(x, y cty.Value) bool {
+	unmarkedX, xMarks := x.UnmarkDeep()
+	unmarkedY, yMarks := y.UnmarkDeep()
+	eqV := unmarkedX.Equals(unmarkedY)
+	if len(xMarks) != len(yMarks) {
+		eqV = cty.False
+	}
+	if eqV.IsKnown() && eqV.True() {
+		return true
+	}
+	return false
+}
+
+// LongestCommonSubsequence finds a sequence of values that are common to both
+// x and y, with the same relative ordering as in both collections. This result
+// is useful as a first step towards computing a diff showing added/removed
+// elements in a sequence.
+//
+// The approached used here is a "naive" one, assuming that both xs and ys will
+// generally be small in most reasonable OpenTofu configurations. For larger
+// lists the time/space usage may be sub-optimal.
+//
+// A pair of lists may have multiple longest common subsequences. In that
+// case, the one selected by this function is undefined.
+func LongestCommonSubsequence[V any](xs, ys []V, equals func(x, y V) bool) []V {
+	if len(xs) == 0 || len(ys) == 0 {
+		return make([]V, 0)
+	}
+
+	c := make([]int, len(xs)*len(ys))
+	eqs := make([]bool, len(xs)*len(ys))
+	w := len(xs)
+
+	for y := 0; y < len(ys); y++ {
+		for x := 0; x < len(xs); x++ {
+			eq := false
+			if equals(xs[x], ys[y]) {
+				eq = true
+				eqs[(w*y)+x] = true // equality tests can be expensive, so cache it
+			}
+			if eq {
+				// Sequence gets one longer than for the cell at top left,
+				// since we'd append a new item to the sequence here.
+				if x == 0 || y == 0 {
+					c[(w*y)+x] = 1
+				} else {
+					c[(w*y)+x] = c[(w*(y-1))+(x-1)] + 1
+				}
+			} else {
+				// We follow the longest of the sequence above and the sequence
+				// to the left of us in the matrix.
+				l := 0
+				u := 0
+				if x > 0 {
+					l = c[(w*y)+(x-1)]
+				}
+				if y > 0 {
+					u = c[(w*(y-1))+x]
+				}
+				if l > u {
+					c[(w*y)+x] = l
+				} else {
+					c[(w*y)+x] = u
+				}
+			}
+		}
+	}
+
+	// The bottom right cell tells us how long our longest sequence will be
+	seq := make([]V, c[len(c)-1])
+
+	// Now we will walk back from the bottom right cell, finding again all
+	// of the equal pairs to construct our sequence.
+	x := len(xs) - 1
+	y := len(ys) - 1
+	i := len(seq) - 1
+
+	for x > -1 && y > -1 {
+		if eqs[(w*y)+x] {
+			// Add the value to our result list and then walk diagonally
+			// up and to the left.
+			seq[i] = xs[x]
+			x--
+			y--
+			i--
+		} else {
+			// Take the path with the greatest sequence length in the matrix.
+			l := 0
+			u := 0
+			if x > 0 {
+				l = c[(w*y)+(x-1)]
+			}
+			if y > 0 {
+				u = c[(w*(y-1))+x]
+			}
+			if l > u {
+				x--
+			} else {
+				y--
+			}
+		}
+	}
+
+	if i > -1 {
+		// should never happen if the matrix was constructed properly
+		panic("not enough elements in sequence")
+	}
+
+	return seq
+}


### PR DESCRIPTION
This PR uses a longest common sequence algorithm to compute a sensible list attribute diff. 

Adapted from opentofu: https://github.com/opentofu/opentofu/blob/cb2e9119aa75eeb8e1fa175e2b7a205a4fef129f/internal/command/jsonformat/collections/slice.go#L39

Note that this is only done for list attributes as blocks might trigger replaces from a nested property. This matches the terraform behaviour, more details in https://github.com/pulumi/pulumi-terraform-bridge/issues/2295#issuecomment-2605231529

Alternative to https://github.com/pulumi/pulumi-terraform-bridge/pull/2863
fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/2295
fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/2239