### PR TITLE
Detailed diff use minimal edit distance for list attribute diffs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.22.3
 toolchain go1.23.2
 
 require (
-	github.com/VenelinMartinov/godifft v0.0.0-20250121184509-75ac876c1bf3
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/apparentlymart/go-versions v1.0.3
 	github.com/blang/semver v3.5.1+incompatible

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22.3
 toolchain go1.23.2
 
 require (
+	github.com/VenelinMartinov/godifft v0.0.0-20250121184509-75ac876c1bf3
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/apparentlymart/go-versions v1.0.3
 	github.com/blang/semver v3.5.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1188,6 +1188,8 @@ github.com/ProtonMail/go-crypto v0.0.0-20230828082145-3c4c8a2d2371/go.mod h1:EjA
 github.com/ProtonMail/go-crypto v1.1.0-alpha.0/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
 github.com/ProtonMail/go-crypto v1.1.3 h1:nRBOetoydLeUb4nHajyO2bKqMLfWQ/ZPwkXqXxPxCFk=
 github.com/ProtonMail/go-crypto v1.1.3/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
+github.com/VenelinMartinov/godifft v0.0.0-20250121184509-75ac876c1bf3 h1:jR8UtH1Vouai1mwIMg2NBqR1rTiSEOe2GDR6jnW1QdE=
+github.com/VenelinMartinov/godifft v0.0.0-20250121184509-75ac876c1bf3/go.mod h1:KUoYA402RjPRpJmsYLAzW+t28MW2qn5K0YNShayEINc=
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da h1:KjTM2ks9d14ZYCvmHS9iAKVt9AyzRSqNU1qabPih5BY=
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da/go.mod h1:eHEWzANqSiWQsof+nXEI9bUVUyV6F53Fp89EuCh2EAA=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=

--- a/go.sum
+++ b/go.sum
@@ -1188,8 +1188,6 @@ github.com/ProtonMail/go-crypto v0.0.0-20230828082145-3c4c8a2d2371/go.mod h1:EjA
 github.com/ProtonMail/go-crypto v1.1.0-alpha.0/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
 github.com/ProtonMail/go-crypto v1.1.3 h1:nRBOetoydLeUb4nHajyO2bKqMLfWQ/ZPwkXqXxPxCFk=
 github.com/ProtonMail/go-crypto v1.1.3/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
-github.com/VenelinMartinov/godifft v0.0.0-20250121184509-75ac876c1bf3 h1:jR8UtH1Vouai1mwIMg2NBqR1rTiSEOe2GDR6jnW1QdE=
-github.com/VenelinMartinov/godifft v0.0.0-20250121184509-75ac876c1bf3/go.mod h1:KUoYA402RjPRpJmsYLAzW+t28MW2qn5K0YNShayEINc=
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da h1:KjTM2ks9d14ZYCvmHS9iAKVt9AyzRSqNU1qabPih5BY=
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da/go.mod h1:eHEWzANqSiWQsof+nXEI9bUVUyV6F53Fp89EuCh2EAA=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/list_element_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/list_element_added_front.golden
@@ -35,17 +35,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: "val2" => "val1"
-          ~ [1]: "val3" => "val2"
-          + [2]: "val3"
+          + [0]: "val1"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0]": map[string]interface{}{"kind": "UPDATE"},
-		"props[1]": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]": map[string]interface{}{},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/list_element_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/list_element_added_middle.golden
@@ -35,15 +35,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [1]: "val3" => "val2"
-          + [2]: "val3"
+          + [1]: "val2"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[1]": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]": map[string]interface{}{},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/list_element_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/list_element_removed_front.golden
@@ -35,17 +35,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: "val1" => "val2"
-          ~ [1]: "val2" => "val3"
-          - [2]: "val3"
+          - [0]: "val1"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0]": map[string]interface{}{"kind": "UPDATE"},
-		"props[1]": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]": map[string]interface{}{"kind": "DELETE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/list_element_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/list_element_removed_middle.golden
@@ -35,15 +35,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [1]: "val2" => "val3"
-          - [2]: "val3"
+          - [1]: "val2"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[1]": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]": map[string]interface{}{"kind": "DELETE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/long_list_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/long_list_added_front.golden
@@ -71,53 +71,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: "value0" => "value20"
-          ~ [1]: "value1" => "value0"
-          ~ [2]: "value2" => "value1"
-          ~ [3]: "value3" => "value2"
-          ~ [4]: "value4" => "value3"
-          ~ [5]: "value5" => "value4"
-          ~ [6]: "value6" => "value5"
-          ~ [7]: "value7" => "value6"
-          ~ [8]: "value8" => "value7"
-          ~ [9]: "value9" => "value8"
-          ~ [10]: "value10" => "value9"
-          ~ [11]: "value11" => "value10"
-          ~ [12]: "value12" => "value11"
-          ~ [13]: "value13" => "value12"
-          ~ [14]: "value14" => "value13"
-          ~ [15]: "value15" => "value14"
-          ~ [16]: "value16" => "value15"
-          ~ [17]: "value17" => "value16"
-          ~ [18]: "value18" => "value17"
-          ~ [19]: "value19" => "value18"
-          + [20]: "value19"
+          + [0]: "value20"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[10]": map[string]interface{}{"kind": "UPDATE"},
-		"props[11]": map[string]interface{}{"kind": "UPDATE"},
-		"props[12]": map[string]interface{}{"kind": "UPDATE"},
-		"props[13]": map[string]interface{}{"kind": "UPDATE"},
-		"props[14]": map[string]interface{}{"kind": "UPDATE"},
-		"props[15]": map[string]interface{}{"kind": "UPDATE"},
-		"props[16]": map[string]interface{}{"kind": "UPDATE"},
-		"props[17]": map[string]interface{}{"kind": "UPDATE"},
-		"props[18]": map[string]interface{}{"kind": "UPDATE"},
-		"props[19]": map[string]interface{}{"kind": "UPDATE"},
-		"props[1]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[20]": map[string]interface{}{},
-		"props[2]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[3]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[4]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[5]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[6]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[7]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[8]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[9]":  map[string]interface{}{"kind": "UPDATE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/long_list_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/long_list_removed_front.golden
@@ -71,53 +71,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: "value20" => "value0"
-          ~ [1]: "value0" => "value1"
-          ~ [2]: "value1" => "value2"
-          ~ [3]: "value2" => "value3"
-          ~ [4]: "value3" => "value4"
-          ~ [5]: "value4" => "value5"
-          ~ [6]: "value5" => "value6"
-          ~ [7]: "value6" => "value7"
-          ~ [8]: "value7" => "value8"
-          ~ [9]: "value8" => "value9"
-          ~ [10]: "value9" => "value10"
-          ~ [11]: "value10" => "value11"
-          ~ [12]: "value11" => "value12"
-          ~ [13]: "value12" => "value13"
-          ~ [14]: "value13" => "value14"
-          ~ [15]: "value14" => "value15"
-          ~ [16]: "value15" => "value16"
-          ~ [17]: "value16" => "value17"
-          ~ [18]: "value17" => "value18"
-          ~ [19]: "value18" => "value19"
-          - [20]: "value19"
+          - [0]: "value20"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[10]": map[string]interface{}{"kind": "UPDATE"},
-		"props[11]": map[string]interface{}{"kind": "UPDATE"},
-		"props[12]": map[string]interface{}{"kind": "UPDATE"},
-		"props[13]": map[string]interface{}{"kind": "UPDATE"},
-		"props[14]": map[string]interface{}{"kind": "UPDATE"},
-		"props[15]": map[string]interface{}{"kind": "UPDATE"},
-		"props[16]": map[string]interface{}{"kind": "UPDATE"},
-		"props[17]": map[string]interface{}{"kind": "UPDATE"},
-		"props[18]": map[string]interface{}{"kind": "UPDATE"},
-		"props[19]": map[string]interface{}{"kind": "UPDATE"},
-		"props[1]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[20]": map[string]interface{}{"kind": "DELETE"},
-		"props[2]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[3]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[4]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[5]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[6]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[7]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[8]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[9]":  map[string]interface{}{"kind": "UPDATE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/one_added,_one_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute/one_added,_one_removed.golden
@@ -36,17 +36,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: "val1" => "val2"
-          ~ [1]: "val2" => "val3"
-          ~ [2]: "val3" => "val4"
+          - [0]: "val1"
+          + [2]: "val4"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0]": map[string]interface{}{"kind": "UPDATE"},
-		"props[1]": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]": map[string]interface{}{"kind": "UPDATE"},
+		"props[0]": map[string]interface{}{"kind": "DELETE"},
+		"props[2]": map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/list_element_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/list_element_added_front.golden
@@ -35,17 +35,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: "val2" => "val1"
-          ~ [1]: "val3" => "val2"
-          + [2]: "val3"
+          + [0]: "val1"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0]": map[string]interface{}{"kind": "UPDATE"},
-		"props[1]": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]": map[string]interface{}{},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/list_element_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/list_element_added_middle.golden
@@ -35,15 +35,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [1]: "val3" => "val2"
-          + [2]: "val3"
+          + [1]: "val2"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[1]": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]": map[string]interface{}{},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/list_element_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/list_element_removed_front.golden
@@ -35,17 +35,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: "val1" => "val2"
-          ~ [1]: "val2" => "val3"
-          - [2]: "val3"
+          - [0]: "val1"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0]": map[string]interface{}{"kind": "UPDATE"},
-		"props[1]": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]": map[string]interface{}{"kind": "DELETE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/list_element_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/list_element_removed_middle.golden
@@ -35,15 +35,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [1]: "val2" => "val3"
-          - [2]: "val3"
+          - [1]: "val2"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[1]": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]": map[string]interface{}{"kind": "DELETE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/long_list_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/long_list_added_front.golden
@@ -71,53 +71,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: "value0" => "value20"
-          ~ [1]: "value1" => "value0"
-          ~ [2]: "value2" => "value1"
-          ~ [3]: "value3" => "value2"
-          ~ [4]: "value4" => "value3"
-          ~ [5]: "value5" => "value4"
-          ~ [6]: "value6" => "value5"
-          ~ [7]: "value7" => "value6"
-          ~ [8]: "value8" => "value7"
-          ~ [9]: "value9" => "value8"
-          ~ [10]: "value10" => "value9"
-          ~ [11]: "value11" => "value10"
-          ~ [12]: "value12" => "value11"
-          ~ [13]: "value13" => "value12"
-          ~ [14]: "value14" => "value13"
-          ~ [15]: "value15" => "value14"
-          ~ [16]: "value16" => "value15"
-          ~ [17]: "value17" => "value16"
-          ~ [18]: "value18" => "value17"
-          ~ [19]: "value19" => "value18"
-          + [20]: "value19"
+          + [0]: "value20"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[10]": map[string]interface{}{"kind": "UPDATE"},
-		"props[11]": map[string]interface{}{"kind": "UPDATE"},
-		"props[12]": map[string]interface{}{"kind": "UPDATE"},
-		"props[13]": map[string]interface{}{"kind": "UPDATE"},
-		"props[14]": map[string]interface{}{"kind": "UPDATE"},
-		"props[15]": map[string]interface{}{"kind": "UPDATE"},
-		"props[16]": map[string]interface{}{"kind": "UPDATE"},
-		"props[17]": map[string]interface{}{"kind": "UPDATE"},
-		"props[18]": map[string]interface{}{"kind": "UPDATE"},
-		"props[19]": map[string]interface{}{"kind": "UPDATE"},
-		"props[1]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[20]": map[string]interface{}{},
-		"props[2]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[3]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[4]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[5]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[6]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[7]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[8]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[9]":  map[string]interface{}{"kind": "UPDATE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/long_list_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/long_list_removed_front.golden
@@ -71,53 +71,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: "value20" => "value0"
-          ~ [1]: "value0" => "value1"
-          ~ [2]: "value1" => "value2"
-          ~ [3]: "value2" => "value3"
-          ~ [4]: "value3" => "value4"
-          ~ [5]: "value4" => "value5"
-          ~ [6]: "value5" => "value6"
-          ~ [7]: "value6" => "value7"
-          ~ [8]: "value7" => "value8"
-          ~ [9]: "value8" => "value9"
-          ~ [10]: "value9" => "value10"
-          ~ [11]: "value10" => "value11"
-          ~ [12]: "value11" => "value12"
-          ~ [13]: "value12" => "value13"
-          ~ [14]: "value13" => "value14"
-          ~ [15]: "value14" => "value15"
-          ~ [16]: "value15" => "value16"
-          ~ [17]: "value16" => "value17"
-          ~ [18]: "value17" => "value18"
-          ~ [19]: "value18" => "value19"
-          - [20]: "value19"
+          - [0]: "value20"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[10]": map[string]interface{}{"kind": "UPDATE"},
-		"props[11]": map[string]interface{}{"kind": "UPDATE"},
-		"props[12]": map[string]interface{}{"kind": "UPDATE"},
-		"props[13]": map[string]interface{}{"kind": "UPDATE"},
-		"props[14]": map[string]interface{}{"kind": "UPDATE"},
-		"props[15]": map[string]interface{}{"kind": "UPDATE"},
-		"props[16]": map[string]interface{}{"kind": "UPDATE"},
-		"props[17]": map[string]interface{}{"kind": "UPDATE"},
-		"props[18]": map[string]interface{}{"kind": "UPDATE"},
-		"props[19]": map[string]interface{}{"kind": "UPDATE"},
-		"props[1]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[20]": map[string]interface{}{"kind": "DELETE"},
-		"props[2]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[3]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[4]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[5]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[6]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[7]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[8]":  map[string]interface{}{"kind": "UPDATE"},
-		"props[9]":  map[string]interface{}{"kind": "UPDATE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/one_added,_one_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_computed/one_added,_one_removed.golden
@@ -36,17 +36,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: "val1" => "val2"
-          ~ [1]: "val2" => "val3"
-          ~ [2]: "val3" => "val4"
+          - [0]: "val1"
+          + [2]: "val4"
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0]": map[string]interface{}{"kind": "UPDATE"},
-		"props[1]": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]": map[string]interface{}{"kind": "UPDATE"},
+		"props[0]": map[string]interface{}{"kind": "DELETE"},
+		"props[2]": map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_added_front.golden
@@ -35,17 +35,11 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: "val2" => "val1"
-          ~ [1]: "val3" => "val2"
-          + [2]: "val3"
+          + [0]: "val1"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_added_middle.golden
@@ -35,15 +35,11 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [1]: "val3" => "val2"
-          + [2]: "val3"
+          + [1]: "val2"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[1]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_removed_front.golden
@@ -35,17 +35,11 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: "val1" => "val2"
-          ~ [1]: "val2" => "val3"
-          - [2]: "val3"
+          - [0]: "val1"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/list_element_removed_middle.golden
@@ -35,15 +35,11 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [1]: "val2" => "val3"
-          - [2]: "val3"
+          - [1]: "val2"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[1]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/long_list_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/long_list_added_front.golden
@@ -71,53 +71,11 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: "value0" => "value20"
-          ~ [1]: "value1" => "value0"
-          ~ [2]: "value2" => "value1"
-          ~ [3]: "value3" => "value2"
-          ~ [4]: "value4" => "value3"
-          ~ [5]: "value5" => "value4"
-          ~ [6]: "value6" => "value5"
-          ~ [7]: "value7" => "value6"
-          ~ [8]: "value8" => "value7"
-          ~ [9]: "value9" => "value8"
-          ~ [10]: "value10" => "value9"
-          ~ [11]: "value11" => "value10"
-          ~ [12]: "value12" => "value11"
-          ~ [13]: "value13" => "value12"
-          ~ [14]: "value14" => "value13"
-          ~ [15]: "value15" => "value14"
-          ~ [16]: "value16" => "value15"
-          ~ [17]: "value17" => "value16"
-          ~ [18]: "value18" => "value17"
-          ~ [19]: "value19" => "value18"
-          + [20]: "value19"
+          + [0]: "value20"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[10]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[11]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[12]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[13]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[14]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[15]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[16]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[17]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[18]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[19]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[20]": map[string]interface{}{"kind": "ADD_REPLACE"},
-		"props[2]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[3]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[4]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[5]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[6]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[7]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[8]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[9]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/long_list_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/long_list_removed_front.golden
@@ -71,53 +71,11 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: "value20" => "value0"
-          ~ [1]: "value0" => "value1"
-          ~ [2]: "value1" => "value2"
-          ~ [3]: "value2" => "value3"
-          ~ [4]: "value3" => "value4"
-          ~ [5]: "value4" => "value5"
-          ~ [6]: "value5" => "value6"
-          ~ [7]: "value6" => "value7"
-          ~ [8]: "value7" => "value8"
-          ~ [9]: "value8" => "value9"
-          ~ [10]: "value9" => "value10"
-          ~ [11]: "value10" => "value11"
-          ~ [12]: "value11" => "value12"
-          ~ [13]: "value12" => "value13"
-          ~ [14]: "value13" => "value14"
-          ~ [15]: "value14" => "value15"
-          ~ [16]: "value15" => "value16"
-          ~ [17]: "value16" => "value17"
-          ~ [18]: "value17" => "value18"
-          ~ [19]: "value18" => "value19"
-          - [20]: "value19"
+          - [0]: "value20"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[10]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[11]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[12]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[13]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[14]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[15]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[16]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[17]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[18]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[19]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[20]": map[string]interface{}{"kind": "DELETE_REPLACE"},
-		"props[2]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[3]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[4]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[5]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[6]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[7]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[8]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[9]":  map[string]interface{}{"kind": "UPDATE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/one_added,_one_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffList/list_attribute_force_new/one_added,_one_removed.golden
@@ -36,17 +36,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=newid]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: "val1" => "val2"
-          ~ [1]: "val2" => "val3"
-          ~ [2]: "val3" => "val4"
+          - [0]: "val1"
+          + [2]: "val4"
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2]": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tfbridge/detailed_diff.go
+++ b/pkg/tfbridge/detailed_diff.go
@@ -433,6 +433,7 @@ func (differ detailedDiffer) makePropDiff(
 func makeListAttributeDiff(
 	path propertyPath, old, new []resource.PropertyValue,
 ) map[detailedDiffKey]*pulumirpc.PropertyDiff {
+	contract.Assertf(len(old) < 1000 && len(new) < 1000, "makeListAttributeDiff should not be used for large lists")
 	diff := make(map[detailedDiffKey]*pulumirpc.PropertyDiff)
 	type valIndex struct {
 		Value resource.PropertyValue
@@ -489,7 +490,8 @@ func (differ detailedDiffer) makeListDiff(
 	}
 
 	// We attempt to optimize the diff displayed for list attributes with a reasonable number of elements.
-	if _, ok := tfs.Elem().(shim.Schema); ok || tfs.Elem() == nil && len(oldList) < 1000 && len(newList) < 1000 {
+	_, scalarElemType := tfs.Elem().(shim.Schema)
+	if scalarElemType && len(oldList) < 1000 && len(newList) < 1000 {
 		listDiff := makeListAttributeDiff(path, oldList, newList)
 		if tfs.ForceNew() {
 			for k, v := range listDiff {

--- a/pkg/tfbridge/detailed_diff.go
+++ b/pkg/tfbridge/detailed_diff.go
@@ -7,7 +7,6 @@ import (
 	"slices"
 	"sort"
 
-	"github.com/VenelinMartinov/godifft"
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -16,6 +15,7 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/walk"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/difft"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/propertyvalue"
 )
 
@@ -448,14 +448,14 @@ func makeListAttributeDiff(
 		newVals = append(newVals, valIndex{Value: v, Index: i})
 	}
 
-	edits := godifft.DiffT(oldVals, newVals, godifft.DiffTOptions[valIndex]{
+	edits := difft.DiffT(oldVals, newVals, difft.DiffOptions[valIndex]{
 		Equals: func(a, b valIndex) bool {
 			return a.Value.DeepEquals(b.Value)
 		},
 	})
 
 	for _, edit := range edits {
-		if edit.Change == godifft.Insert {
+		if edit.Change == difft.Insert {
 			key := path.Index(edit.Element.Index)
 			if diff[key.Key()] == nil {
 				diff[key.Key()] = &pulumirpc.PropertyDiff{Kind: pulumirpc.PropertyDiff_ADD}
@@ -463,7 +463,7 @@ func makeListAttributeDiff(
 				diff[key.Key()] = &pulumirpc.PropertyDiff{Kind: pulumirpc.PropertyDiff_UPDATE}
 			}
 		}
-		if edit.Change == godifft.Remove {
+		if edit.Change == difft.Remove {
 			key := path.Index(edit.Element.Index)
 			if diff[key.Key()] == nil {
 				diff[key.Key()] = &pulumirpc.PropertyDiff{Kind: pulumirpc.PropertyDiff_DELETE}


### PR DESCRIPTION
This PR uses a minimal edit distance algorithm to compute a sensible list attribute diff.

Uses https://github.com/t0yv0/godifft with a small modification.

Note that this is only done for list attributes as blocks might trigger replaces from a nested property. This matches the terraform behaviour, more details in https://github.com/pulumi/pulumi-terraform-bridge/issues/2295#issuecomment-2605231529

Alternative to https://github.com/pulumi/pulumi-terraform-bridge/pull/2862
fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/2295
fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/2239