### PR TITLE
Add code for computing optional sequence diffs

### DIFF
--- a/unstable/difft/difft.go
+++ b/unstable/difft/difft.go
@@ -1,3 +1,17 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package difft
 
 import (

--- a/unstable/difft/difft.go
+++ b/unstable/difft/difft.go
@@ -79,14 +79,13 @@ func (edits Edits[T]) apply(xs []T, equals func(T, T) bool) ([]T, error) {
 	return output, nil
 }
 
-type DiffTOptions[T any] struct {
+type DiffOptions[T any] struct {
 	Equals func(T, T) bool
 }
 
-func DiffT[T any](xs, ys []T, opts DiffTOptions[T]) Edits[T] {
-	eq := opts.Equals
-	if eq == nil {
-		eq = func(x T, y T) bool {
+func DiffT[T any](xs, ys []T, opts DiffOptions[T]) Edits[T] {
+	if opts.Equals == nil {
+		opts.Equals = func(x T, y T) bool {
 			return any(x) == any(y)
 		}
 	}

--- a/unstable/difft/difft.go
+++ b/unstable/difft/difft.go
@@ -1,0 +1,163 @@
+package difft
+
+import (
+	"fmt"
+)
+
+type Change int
+
+const (
+	Insert Change = iota
+	Remove
+	Keep
+)
+
+type Edit[T any] struct {
+	Change  Change
+	Element T
+}
+
+func (e Edit[T]) String() string {
+	switch e.Change {
+	case Insert:
+		return fmt.Sprintf("insert[%v]", e.Element)
+	case Remove:
+		return fmt.Sprintf("remove[%v]", e.Element)
+	default:
+		return fmt.Sprintf("keep[%v]", e.Element)
+	}
+}
+
+type Edits[T any] []Edit[T]
+
+func (edits Edits[T]) Apply(xs []T) ([]T, error) {
+	return edits.apply(xs, nil /* equals checks are only for testing */)
+}
+
+func (edits Edits[T]) apply(xs []T, equals func(T, T) bool) ([]T, error) {
+	remainder := xs
+	var output []T
+	for _, ed := range edits {
+		switch ed.Change {
+		case Keep:
+			if len(remainder) == 0 {
+				return nil, fmt.Errorf("edits do not apply")
+			}
+			element := remainder[0]
+			remainder = remainder[1:]
+			output = append(output, ed.Element)
+			if equals != nil && !equals(ed.Element, element) {
+				return nil, fmt.Errorf("edits are inconsistent with the original")
+			}
+		case Insert:
+			output = append(output, ed.Element)
+		case Remove:
+			if len(remainder) == 0 {
+				return nil, fmt.Errorf("edits do not apply")
+			}
+			element := remainder[0]
+			remainder = remainder[1:]
+			if equals != nil && !equals(ed.Element, element) {
+				return nil, fmt.Errorf("wanted to remove %v but seeing %v", ed.Element, element)
+			}
+		}
+	}
+	return output, nil
+}
+
+type DiffTOptions[T any] struct {
+	Equals func(T, T) bool
+}
+
+func DiffT[T any](xs, ys []T, opts DiffTOptions[T]) Edits[T] {
+	eq := opts.Equals
+	if eq == nil {
+		eq = func(x T, y T) bool {
+			return any(x) == any(y)
+		}
+	}
+	d := &differ[T]{opts.Equals, xs, ys}
+	return d.diff()
+}
+
+type differ[T any] struct {
+	eq func(T, T) bool
+	xs []T
+	ys []T
+}
+
+func (d *differ[T]) difflen() *matrix {
+	difflen := newMatrix(len(d.xs)+1, len(d.ys)+1)
+	for xp := len(d.xs); xp >= 0; xp-- {
+		for yp := len(d.ys); yp >= 0; yp-- {
+			l, _ := d.choose(difflen, xp, yp)
+			difflen.set(xp, yp, l)
+		}
+	}
+	return difflen
+}
+
+func (d *differ[T]) choose(difflen *matrix, xp, yp int) (int, Change) {
+	xrem := len(d.xs) - xp
+	yrem := len(d.ys) - yp
+	switch {
+	case xrem == 0:
+		return yrem, Insert
+	case yrem == 0:
+		return xrem, Remove
+	}
+	l := 1 + difflen.get(xp+1, yp)
+	c := Remove
+	if n := 1 + difflen.get(xp, yp+1); n < l {
+		l = n
+		c = Insert
+	}
+	if d.eq(d.xs[xp], d.ys[yp]) {
+		if n := difflen.get(xp+1, yp+1); n < l {
+			l = n
+			c = Keep
+		}
+	}
+	return l, c
+}
+
+func (d *differ[T]) diff() []Edit[T] {
+	var edits []Edit[T]
+	difflen, xs, ys := d.difflen(), d.xs, d.ys
+	for {
+		if len(xs) == 0 {
+			for _, y := range ys {
+				edits = append(edits, d.insert(y))
+			}
+			return edits
+		}
+		if len(ys) == 0 {
+			for _, x := range xs {
+				edits = append(edits, d.remove(x))
+			}
+			return edits
+		}
+		xp, yp := len(d.xs)-len(xs), len(d.ys)-len(ys)
+		_, diff := d.choose(difflen, xp, yp)
+		switch diff {
+		case Remove:
+			edits, xs = append(edits, d.remove(xs[0])), xs[1:]
+		case Insert:
+			edits, ys = append(edits, d.insert(ys[0])), ys[1:]
+		default: // keep
+			edits, xs, ys = append(edits, d.keep(xs[0])), xs[1:], ys[1:]
+		}
+	}
+}
+
+func (d *differ[T]) insert(x T) Edit[T] {
+	return Edit[T]{Insert, x}
+}
+
+func (d *differ[T]) remove(x T) Edit[T] {
+	return Edit[T]{Remove, x}
+}
+
+func (d *differ[T]) keep(x T) Edit[T] {
+	return Edit[T]{Keep, x}
+}

--- a/unstable/difft/difft_test.go
+++ b/unstable/difft/difft_test.go
@@ -1,3 +1,17 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package difft
 
 import (

--- a/unstable/difft/difft_test.go
+++ b/unstable/difft/difft_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestDiffAppliesCorrectly(t *testing.T) {
+	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {
 		s1 := rapid.StringMatching(`^[abc]{0,5}`).Draw(t, "s1")
 		s2 := rapid.StringMatching(`^[abc]{0,5}`).Draw(t, "s2")
@@ -29,7 +30,7 @@ func TestDiffAppliesCorrectly(t *testing.T) {
 		eq := func(b1, b2 byte) bool {
 			return b1 == b2
 		}
-		edits := DiffT([]byte(s1), []byte(s2), DiffTOptions[byte]{
+		edits := DiffT([]byte(s1), []byte(s2), DiffOptions[byte]{
 			Equals: eq,
 		})
 
@@ -50,11 +51,12 @@ func TestDiffAppliesCorrectly(t *testing.T) {
 }
 
 func TestDiff(t *testing.T) {
+	t.Parallel()
 	eq := func(a, b byte) bool {
 		return a == b
 	}
 	input := []byte(`mario`)
-	dd := DiffT(input, []byte(`darius`), DiffTOptions[byte]{Equals: eq})
+	dd := DiffT(input, []byte(`darius`), DiffOptions[byte]{Equals: eq})
 	assert.Equal(t, Remove, dd[0].Change)
 	assert.Equal(t, Insert, dd[1].Change)
 	assert.Equal(t, Keep, dd[2].Change)

--- a/unstable/difft/difft_test.go
+++ b/unstable/difft/difft_test.go
@@ -1,0 +1,52 @@
+package difft
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"pgregory.net/rapid"
+)
+
+func TestDiffAppliesCorrectly(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		s1 := rapid.StringMatching(`^[abc]{0,5}`).Draw(t, "s1")
+		s2 := rapid.StringMatching(`^[abc]{0,5}`).Draw(t, "s2")
+
+		eq := func(b1, b2 byte) bool {
+			return b1 == b2
+		}
+		edits := DiffT([]byte(s1), []byte(s2), DiffTOptions[byte]{
+			Equals: eq,
+		})
+
+		t.Logf("edits:")
+		for _, ed := range edits {
+			t.Logf("  %v", ed)
+		}
+
+		s3, err := edits.apply([]byte(s1), eq)
+		if err != nil {
+			t.Fatalf("apply failed: %v", err)
+		}
+		t.Logf("s3: %v", s3)
+		if string(s3) != s2 {
+			t.Fatalf("reconstructed string does not match: %q != %q", s3, s3)
+		}
+	})
+}
+
+func TestDiff(t *testing.T) {
+	eq := func(a, b byte) bool {
+		return a == b
+	}
+	input := []byte(`mario`)
+	dd := DiffT(input, []byte(`darius`), DiffTOptions[byte]{Equals: eq})
+	assert.Equal(t, Remove, dd[0].Change)
+	assert.Equal(t, Insert, dd[1].Change)
+	assert.Equal(t, Keep, dd[2].Change)
+	assert.Equal(t, Keep, dd[3].Change)
+	assert.Equal(t, Keep, dd[4].Change)
+	assert.Equal(t, Remove, dd[5].Change)
+	assert.Equal(t, Insert, dd[6].Change)
+	assert.Equal(t, Insert, dd[7].Change)
+}

--- a/unstable/difft/matrix.go
+++ b/unstable/difft/matrix.go
@@ -1,0 +1,38 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package difft
+
+type matrix struct {
+	m    int
+	n    int
+	data []int
+}
+
+func newMatrix(m, n int) *matrix {
+	data := make([]int, m*n)
+	return &matrix{m, n, data}
+}
+
+func (m *matrix) get(i, j int) int {
+	return m.data[m.index(i, j)]
+}
+
+func (m *matrix) set(i, j int, v int) {
+	m.data[m.index(i, j)] = v
+}
+
+func (m *matrix) index(i, j int) int {
+	return m.n*i + j
+}

--- a/unstable/difft/matrix_test.go
+++ b/unstable/difft/matrix_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestMatrix(t *testing.T) {
+	t.Parallel()
 	m := newMatrix(3, 3)
 	m.set(1, 1, 42)
 	assert.Equal(t, 42, m.get(1, 1))

--- a/unstable/difft/matrix_test.go
+++ b/unstable/difft/matrix_test.go
@@ -1,0 +1,27 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package difft
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatrix(t *testing.T) {
+	m := newMatrix(3, 3)
+	m.set(1, 1, 42)
+	assert.Equal(t, 42, m.get(1, 1))
+}


### PR DESCRIPTION
Originating from t0yv0/godifft - this may be useful for computing list diffs for display. Compared to the https://github.com/t0yv0/godifft version adds rapid tests and a function to apply the edit sequence. 

Note that memory is still O(N^2) for large strings, and the naive matrix implementation may allocate a lot of memory. This is intended for comparing fairly short strings <1000 in length.