### PR TITLE
Annotate panics with provider metadata and origin

### DIFF
--- a/dynamic/provider_test.go
+++ b/dynamic/provider_test.go
@@ -23,6 +23,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	helper "github.com/pulumi/pulumi-terraform-bridge/v3/dynamic/internal/testing"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/internal/logging"
 	pfbridge "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
 )
 
@@ -375,7 +376,7 @@ var (
 func grpcTestServer(ctx context.Context, t *testing.T) pulumirpc.ResourceProviderServer {
 	defaultInfo, metadata, close := initialSetup()
 	t.Cleanup(func() { assert.NoError(t, close()) })
-	s, err := pfbridge.NewProviderServer(ctx, nil, defaultInfo, metadata)
+	s, err := pfbridge.NewProviderServer(ctx, logging.NewTestingSink(t), defaultInfo, metadata)
 	require.NoError(t, err)
 	return s
 }

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -367,3 +367,18 @@ func (s testingLogSink) log(kind string, sev diag.Severity, urn resource.URN, ms
 	s.t.Logf("Provider[%s]: %s%s: %s", kind, sev, urnMsg, msg)
 	return nil
 }
+
+// This logging sink discards all messages.
+func NewDiscardSink() Sink {
+	return &discardSink{}
+}
+
+type discardSink struct{}
+
+func (s discardSink) Log(_ context.Context, sev diag.Severity, urn resource.URN, msg string) error {
+	return nil
+}
+
+func (s discardSink) LogStatus(_ context.Context, sev diag.Severity, urn resource.URN, msg string) error {
+	return nil
+}

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -338,3 +338,32 @@ type logLike interface {
 	Warn(msg string)
 	Error(msg string)
 }
+
+// Methods required by [NewTestingSink] from *testing.T.
+type T interface {
+	Logf(string, ...any)
+}
+
+// Build a Sink that flushes to *testing.T or a similar context.
+func NewTestingSink(t T) Sink {
+	return &testingLogSink{t: t}
+}
+
+type testingLogSink struct{ t T }
+
+func (s testingLogSink) Log(_ context.Context, sev diag.Severity, urn resource.URN, msg string) error {
+	return s.log("LOG", sev, urn, msg)
+}
+
+func (s testingLogSink) LogStatus(_ context.Context, sev diag.Severity, urn resource.URN, msg string) error {
+	return s.log("STATUS", sev, urn, msg)
+}
+
+func (s testingLogSink) log(kind string, sev diag.Severity, urn resource.URN, msg string) error {
+	var urnMsg string
+	if urn != "" {
+		urnMsg = " (" + string(urn) + ")"
+	}
+	s.t.Logf("Provider[%s]: %s%s: %s", kind, sev, urnMsg, msg)
+	return nil
+}

--- a/pkg/pf/tests/internal/cross-tests/configure.go
+++ b/pkg/pf/tests/internal/cross-tests/configure.go
@@ -35,6 +35,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 	"gopkg.in/yaml.v3"
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/internal/logging"
 	crosstests "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/tests/cross-tests"
 	crosstestsimpl "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/tests/cross-tests/impl"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/tests/cross-tests/impl/hclwrite"
@@ -174,7 +175,7 @@ resource "` + providerName + `_res" "res" {}
 		require.NoError(t, err)
 
 		makeProvider := func(providers.PulumiTest) (pulumirpc.ResourceProviderServer, error) {
-			ctx, sink := context.Background(), testLogSink{t}
+			ctx, sink := context.Background(), logging.NewTestingSink(t)
 
 			p := info.Provider{
 				Name:             providerName,

--- a/pkg/pf/tests/internal/cross-tests/util.go
+++ b/pkg/pf/tests/internal/cross-tests/util.go
@@ -15,37 +15,14 @@
 package crosstests
 
 import (
-	"context"
 	"os"
 	"runtime"
 	"strings"
-
-	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 
 	crosstestsimpl "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/tests/cross-tests/impl"
 )
 
 type T = crosstestsimpl.T
-
-type testLogSink struct{ t T }
-
-func (s testLogSink) Log(_ context.Context, sev diag.Severity, urn resource.URN, msg string) error {
-	return s.log("LOG", sev, urn, msg)
-}
-
-func (s testLogSink) LogStatus(_ context.Context, sev diag.Severity, urn resource.URN, msg string) error {
-	return s.log("STATUS", sev, urn, msg)
-}
-
-func (s testLogSink) log(kind string, sev diag.Severity, urn resource.URN, msg string) error {
-	var urnMsg string
-	if urn != "" {
-		urnMsg = " (" + string(urn) + ")"
-	}
-	s.t.Logf("Provider[%s]: %s%s: %s", kind, sev, urnMsg, msg)
-	return nil
-}
 
 func skipUnlessLinux(t T) {
 	if ci, ok := os.LookupEnv("CI"); ok && ci == "true" && !strings.Contains(strings.ToLower(runtime.GOOS), "linux") {

--- a/pkg/pf/tests/pulcheck/pulcheck.go
+++ b/pkg/pf/tests/pulcheck/pulcheck.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/internal/logging"
 	crosstestsimpl "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/tests/cross-tests/impl"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfgen"
@@ -64,7 +65,7 @@ func newProviderServer(t T, info tfbridge0.ProviderInfo) (pulumirpc.ResourceProv
 	if err != nil {
 		return nil, err
 	}
-	srv, err := tfbridge.NewProviderServer(ctx, nil, info, meta)
+	srv, err := tfbridge.NewProviderServer(ctx, logging.NewTestingSink(t), info, meta)
 	require.NoError(t, err)
 	return srv, nil
 }

--- a/pkg/pf/tests/util.go
+++ b/pkg/pf/tests/util.go
@@ -21,6 +21,7 @@ import (
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/require"
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/internal/logging"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
 	tfbridge0 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 )
@@ -31,7 +32,7 @@ func newProviderServer(t *testing.T, info tfbridge0.ProviderInfo) (pulumirpc.Res
 	if err != nil {
 		return nil, err
 	}
-	srv, err := tfbridge.NewProviderServer(ctx, nil, info, meta)
+	srv, err := tfbridge.NewProviderServer(ctx, logging.NewTestingSink(t), info, meta)
 	require.NoError(t, err)
 	return srv, nil
 }

--- a/pkg/pf/tfbridge/provider.go
+++ b/pkg/pf/tfbridge/provider.go
@@ -40,6 +40,7 @@ import (
 	pl "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/plugin"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/runtypes"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/schemashim"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/providerserver"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
@@ -216,7 +217,14 @@ func NewProviderServer(
 	}
 
 	p.Unwrap().logSink = logSink
-	return pl.NewProviderServerWithContext(p), nil
+	srv := pl.NewProviderServerWithContext(p)
+
+	return providerserver.NewPanicRecoveringProviderServer(&providerserver.PanicRecoveringProviderServerOptions{
+		Logger:                 logSink,
+		ResourceProviderServer: srv,
+		ProviderName:           info.Name,
+		ProviderVersion:        info.Version,
+	}), nil
 }
 
 // Closer closes any underlying OS resources associated with this provider (like processes, RPC channels, etc).

--- a/pkg/providerserver/panic_recovering_provider.go
+++ b/pkg/providerserver/panic_recovering_provider.go
@@ -1,0 +1,482 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package providerserver
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"runtime/debug"
+	"strings"
+
+	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+// A wrapper around a ResourceProviderServer that logs panics.
+//
+// While bridged providers should never panic, when this does happen it is helpful to include the provider name, version
+// and resource information in the error message to assist reproducing the problem quickly.
+type PanicRecoveringProviderServer struct {
+	pulumirpc.UnimplementedResourceProviderServer
+	innerServer     pulumirpc.ResourceProviderServer
+	providerName    string
+	providerVersion string
+	logger          Logger
+
+	// A slot to communicate the URN across CheckConfig and Configure calls.
+	currentProviderUrn string
+
+	// Exposed for testing.
+	includeStackTraces bool
+}
+
+// The minimal interface implemented by HostClient where Error messages will be logged for each panic.
+type Logger interface {
+	Log(context context.Context, sev diag.Severity, urn resource.URN, msg string) error
+}
+
+var _ Logger = (*provider.HostClient)(nil)
+
+type PanicRecoveringProviderServerOptions struct {
+	Logger                 Logger
+	ResourceProviderServer pulumirpc.ResourceProviderServer
+	ProviderName           string
+	ProviderVersion        string
+}
+
+func NewPanicRecoveringProviderServer(opts *PanicRecoveringProviderServerOptions) *PanicRecoveringProviderServer {
+	contract.Assertf(opts.ResourceProviderServer != nil, "wrappedServer must not be nil")
+	contract.Assertf(opts.Logger != nil, "logger must not be nil")
+	contract.Assertf(opts.ProviderName != "", "providerName must not be empty")
+	return &PanicRecoveringProviderServer{
+		innerServer:     opts.ResourceProviderServer,
+		providerName:    opts.ProviderName,
+		providerVersion: opts.ProviderVersion,
+		logger:          opts.Logger,
+	}
+}
+
+var _ pulumirpc.ResourceProviderServer = &PanicRecoveringProviderServer{}
+
+type logPanicOptions struct {
+	// If the panic was in response to a resource operation, the URN of the resource.
+	resourceURN string
+
+	// If the panic was in response to provider configuration, the URN of the provider. This may help distinguishing
+	// default from explicit providers.
+	providerURN string
+
+	// If the panic was in response to an Invoke call, the token of the invoked function.
+	invokeToken string
+
+	// Lifecycle method that caused the panic.
+	method string
+}
+
+func (s *PanicRecoveringProviderServer) formatPanicMessage(
+	err interface{},
+	stack []byte,
+	opts *logPanicOptions,
+) string {
+	// Format metadata key-value pairs in slog default format.
+	var buf bytes.Buffer
+	l := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+			if a.Key == slog.TimeKey {
+				return slog.Attr{}
+			}
+			if a.Key == slog.LevelKey {
+				return slog.Attr{}
+			}
+			if a.Key == slog.MessageKey {
+				return slog.Attr{}
+			}
+			return a
+		},
+	}))
+	var attrs []slog.Attr
+	attrs = append(attrs, slog.String("provider", s.providerName))
+	if s.providerVersion != "" {
+		attrs = append(attrs, slog.String("providerVersion", s.providerVersion))
+	}
+	if opts.providerURN != "" {
+		attrs = append(attrs, slog.String("providerURN", opts.providerURN))
+	}
+	if opts.invokeToken != "" {
+		attrs = append(attrs, slog.String("invokeToken", opts.invokeToken))
+	}
+	if opts.providerURN != "" {
+		attrs = append(attrs, slog.String("providerURN", opts.providerURN))
+	}
+	if opts.method != "" {
+		attrs = append(attrs, slog.String("method", opts.method))
+	}
+	l.LogAttrs(context.Background(), slog.LevelError, fmt.Sprintf("%s", err), attrs...)
+	metadata := strings.TrimSpace(buf.String())
+	if !s.includeStackTraces {
+		return fmt.Sprintf("Bridged provider panic (%s): %v", metadata, err)
+	}
+	return fmt.Sprintf("Bridged provider panic (%s): %v\n%s", metadata, err, stack)
+}
+
+func (s *PanicRecoveringProviderServer) determinePanicResourceURN(opts *logPanicOptions) resource.URN {
+	if opts.resourceURN != "" {
+		return urn.URN(opts.resourceURN)
+	}
+	return ""
+}
+
+func (s *PanicRecoveringProviderServer) logPanic(
+	ctx context.Context,
+	method string,
+	err interface{},
+	stack []byte,
+	opts *logPanicOptions,
+) {
+	if opts == nil {
+		opts = &logPanicOptions{}
+	}
+	opts.method = method
+	msg := s.formatPanicMessage(err, stack, opts)
+	urn := s.determinePanicResourceURN(opts)
+	logErr := s.logger.Log(ctx, diag.Error, urn, msg)
+	contract.IgnoreError(logErr)
+}
+
+func (s *PanicRecoveringProviderServer) Handshake(
+	ctx context.Context,
+	req *pulumirpc.ProviderHandshakeRequest,
+) (*pulumirpc.ProviderHandshakeResponse, error) {
+	defer func() {
+		if err := recover(); err != nil {
+			s.logPanic(ctx, "Handshake", err, debug.Stack(), nil)
+			panic(err) // rethrow
+		}
+	}()
+	return s.innerServer.Handshake(ctx, req)
+}
+
+func (s *PanicRecoveringProviderServer) Parameterize(
+	ctx context.Context,
+	req *pulumirpc.ParameterizeRequest,
+) (*pulumirpc.ParameterizeResponse, error) {
+	defer func() {
+		if err := recover(); err != nil {
+			s.logPanic(ctx, "Parameterize", err, debug.Stack(), nil)
+			panic(err) // rethrow
+		}
+	}()
+	return s.innerServer.Parameterize(ctx, req)
+}
+
+func (s *PanicRecoveringProviderServer) GetSchema(
+	ctx context.Context,
+	req *pulumirpc.GetSchemaRequest,
+) (*pulumirpc.GetSchemaResponse, error) {
+	defer func() {
+		if err := recover(); err != nil {
+			s.logPanic(ctx, "GetSchema", err, debug.Stack(), nil)
+			panic(err) // rethrow
+		}
+	}()
+	return s.innerServer.GetSchema(ctx, req)
+}
+
+func (s *PanicRecoveringProviderServer) CheckConfig(
+	ctx context.Context,
+	req *pulumirpc.CheckRequest,
+) (*pulumirpc.CheckResponse, error) {
+	s.currentProviderUrn = req.Urn
+	defer func() {
+		if err := recover(); err != nil {
+			s.logPanic(ctx, "CheckConfig", err, debug.Stack(), &logPanicOptions{
+				providerURN: req.Urn,
+			})
+			panic(err) // rethrow
+		}
+	}()
+	return s.innerServer.CheckConfig(ctx, req)
+}
+
+func (s *PanicRecoveringProviderServer) DiffConfig(
+	ctx context.Context,
+	req *pulumirpc.DiffRequest,
+) (*pulumirpc.DiffResponse, error) {
+	defer func() {
+		if err := recover(); err != nil {
+			s.logPanic(ctx, "DiffConfig", err, debug.Stack(), &logPanicOptions{
+				providerURN: req.Urn,
+			})
+			panic(err) // rethrow
+		}
+	}()
+	return s.innerServer.DiffConfig(ctx, req)
+}
+
+func (s *PanicRecoveringProviderServer) Configure(
+	ctx context.Context,
+	req *pulumirpc.ConfigureRequest,
+) (*pulumirpc.ConfigureResponse, error) {
+	defer func() {
+		if err := recover(); err != nil {
+			s.logPanic(ctx, "Configure", err, debug.Stack(), &logPanicOptions{
+				providerURN: s.currentProviderUrn,
+			})
+			panic(err) // rethrow
+		}
+	}()
+	return s.innerServer.Configure(ctx, req)
+}
+
+func (s *PanicRecoveringProviderServer) Invoke(
+	ctx context.Context,
+	req *pulumirpc.InvokeRequest,
+) (*pulumirpc.InvokeResponse, error) {
+	defer func() {
+		if err := recover(); err != nil {
+			s.logPanic(ctx, "Invoke", err, debug.Stack(), &logPanicOptions{
+				invokeToken: req.Tok,
+			})
+			panic(err) // rethrow
+		}
+	}()
+	return s.innerServer.Invoke(ctx, req)
+}
+
+func (s *PanicRecoveringProviderServer) StreamInvoke(
+	req *pulumirpc.InvokeRequest,
+	srv pulumirpc.ResourceProvider_StreamInvokeServer,
+) error {
+	defer func() {
+		if err := recover(); err != nil {
+			s.logPanic(srv.Context(), "StreamInvoke", err, debug.Stack(), &logPanicOptions{
+				invokeToken: req.Tok,
+			})
+			panic(err) // rethrow
+		}
+	}()
+	return s.StreamInvoke(req, srv)
+}
+
+func (s *PanicRecoveringProviderServer) Call(
+	ctx context.Context,
+	req *pulumirpc.CallRequest,
+) (*pulumirpc.CallResponse, error) {
+	defer func() {
+		if err := recover(); err != nil {
+			// We could possibly do better here if we inferred the URN of the __self__ argument.
+			s.logPanic(ctx, "Call", err, debug.Stack(), &logPanicOptions{
+				invokeToken: req.Tok,
+			})
+			panic(err) // rethrow
+		}
+	}()
+	return s.innerServer.Call(ctx, req)
+}
+
+func (s *PanicRecoveringProviderServer) Check(
+	ctx context.Context,
+	req *pulumirpc.CheckRequest,
+) (*pulumirpc.CheckResponse, error) {
+	defer func() {
+		if err := recover(); err != nil {
+			s.logPanic(ctx, "Check", err, debug.Stack(), &logPanicOptions{
+				resourceURN: req.Urn,
+			})
+			panic(err) // rethrow
+		}
+	}()
+	return s.innerServer.Check(ctx, req)
+}
+
+func (s *PanicRecoveringProviderServer) Diff(
+	ctx context.Context,
+	req *pulumirpc.DiffRequest,
+) (*pulumirpc.DiffResponse, error) {
+	defer func() {
+		if err := recover(); err != nil {
+			s.logPanic(ctx, "Diff", err, debug.Stack(), &logPanicOptions{
+				resourceURN: req.Urn,
+			})
+			panic(err) // rethrow
+		}
+	}()
+	return s.innerServer.Diff(ctx, req)
+}
+
+func (s *PanicRecoveringProviderServer) Create(
+	ctx context.Context,
+	req *pulumirpc.CreateRequest,
+) (*pulumirpc.CreateResponse, error) {
+	defer func() {
+		if err := recover(); err != nil {
+			s.logPanic(ctx, "Create", err, debug.Stack(), &logPanicOptions{
+				resourceURN: req.Urn,
+			})
+			panic(err) // rethrow
+		}
+	}()
+	return s.innerServer.Create(ctx, req)
+}
+
+func (s *PanicRecoveringProviderServer) Read(
+	ctx context.Context,
+	req *pulumirpc.ReadRequest,
+) (*pulumirpc.ReadResponse, error) {
+	defer func() {
+		if err := recover(); err != nil {
+			s.logPanic(ctx, "Read", err, debug.Stack(), &logPanicOptions{
+				resourceURN: req.Urn,
+			})
+			panic(err) // rethrow
+		}
+	}()
+	return s.innerServer.Read(ctx, req)
+}
+
+func (s *PanicRecoveringProviderServer) Update(
+	ctx context.Context,
+	req *pulumirpc.UpdateRequest,
+) (*pulumirpc.UpdateResponse, error) {
+	defer func() {
+		if err := recover(); err != nil {
+			s.logPanic(ctx, "Update", err, debug.Stack(), &logPanicOptions{
+				resourceURN: req.Urn,
+			})
+			panic(err) // rethrow
+		}
+	}()
+	return s.innerServer.Update(ctx, req)
+}
+
+func (s *PanicRecoveringProviderServer) Delete(
+	ctx context.Context,
+	req *pulumirpc.DeleteRequest,
+) (*emptypb.Empty, error) {
+	defer func() {
+		if err := recover(); err != nil {
+			s.logPanic(ctx, "Delete", err, debug.Stack(), &logPanicOptions{
+				resourceURN: req.Urn,
+			})
+			panic(err) // rethrow
+		}
+	}()
+	return s.innerServer.Delete(ctx, req)
+}
+
+func (s *PanicRecoveringProviderServer) Construct(
+	ctx context.Context,
+	req *pulumirpc.ConstructRequest,
+) (resp *pulumirpc.ConstructResponse, finalError error) {
+	defer func() {
+		if err := recover(); err != nil {
+			opts := &logPanicOptions{}
+			if resp != nil && resp.Urn != "" {
+				opts.resourceURN = resp.Urn
+			} else {
+				opts.resourceURN = string(constructURN(req))
+			}
+			s.logPanic(ctx, "Construct", err, debug.Stack(), opts)
+			panic(err) // rethrow
+		}
+	}()
+	return s.innerServer.Construct(ctx, req)
+}
+
+func (s *PanicRecoveringProviderServer) Cancel(ctx context.Context, empty *emptypb.Empty) (*emptypb.Empty, error) {
+	defer func() {
+		if err := recover(); err != nil {
+			s.logPanic(ctx, "Cancel", err, debug.Stack(), nil)
+			panic(err) // rethrow
+		}
+	}()
+	return s.innerServer.Cancel(ctx, empty)
+}
+
+func (s *PanicRecoveringProviderServer) GetPluginInfo(
+	ctx context.Context,
+	empty *emptypb.Empty,
+) (*pulumirpc.PluginInfo, error) {
+	defer func() {
+		if err := recover(); err != nil {
+			s.logPanic(ctx, "GetPluginInfo", err, debug.Stack(), nil)
+			panic(err) // rethrow
+		}
+	}()
+	return s.innerServer.GetPluginInfo(ctx, empty)
+}
+
+func (s *PanicRecoveringProviderServer) Attach(
+	ctx context.Context,
+	attach *pulumirpc.PluginAttach,
+) (*emptypb.Empty, error) {
+	defer func() {
+		if err := recover(); err != nil {
+			s.logPanic(ctx, "Attach", err, debug.Stack(), nil)
+			panic(err) // rethrow
+		}
+	}()
+	return s.innerServer.Attach(ctx, attach)
+}
+
+func (s *PanicRecoveringProviderServer) GetMapping(
+	ctx context.Context,
+	req *pulumirpc.GetMappingRequest,
+) (*pulumirpc.GetMappingResponse, error) {
+	defer func() {
+		if err := recover(); err != nil {
+			s.logPanic(ctx, "GetMapping", err, debug.Stack(), nil)
+			panic(err) // rethrow
+		}
+	}()
+	return s.innerServer.GetMapping(ctx, req)
+}
+
+func (s *PanicRecoveringProviderServer) GetMappings(
+	ctx context.Context,
+	req *pulumirpc.GetMappingsRequest,
+) (*pulumirpc.GetMappingsResponse, error) {
+	defer func() {
+		if err := recover(); err != nil {
+			s.logPanic(ctx, "GetMappings", err, debug.Stack(), nil)
+			panic(err) // rethrow
+		}
+	}()
+	return s.innerServer.GetMappings(ctx, req)
+}
+
+// Guess Pulumi URN from ConstructRequest.
+func constructURN(req *pulumirpc.ConstructRequest) urn.URN {
+	// Guess Pulumi URN from ConstructRequest
+	stack := tokens.QName(req.Stack)
+	proj := tokens.PackageName(req.Project)
+	var parentType tokens.Type
+	if req.Parent != "" {
+		parentUrn, err := urn.Parse(req.Parent)
+		if err == nil {
+			parentType = parentUrn.Type()
+		}
+	}
+	baseType := tokens.Type(req.Type)
+	return urn.New(stack, proj, parentType, baseType, req.Name)
+}

--- a/pkg/providerserver/panic_recovering_provider.go
+++ b/pkg/providerserver/panic_recovering_provider.go
@@ -47,7 +47,7 @@ type PanicRecoveringProviderServer struct {
 	currentProviderUrn string
 
 	// Exposed for testing.
-	includeStackTraces bool
+	omitStackTraces bool
 }
 
 // The minimal interface implemented by HostClient where Error messages will be logged for each panic.
@@ -133,7 +133,7 @@ func (s *PanicRecoveringProviderServer) formatPanicMessage(
 	}
 	l.LogAttrs(context.Background(), slog.LevelError, fmt.Sprintf("%s", err), attrs...)
 	metadata := strings.TrimSpace(buf.String())
-	if !s.includeStackTraces {
+	if s.omitStackTraces {
 		return fmt.Sprintf("Bridged provider panic (%s): %v", metadata, err)
 	}
 	return fmt.Sprintf("Bridged provider panic (%s): %v\n%s", metadata, err, stack)

--- a/pkg/providerserver/panic_recovering_provider.go
+++ b/pkg/providerserver/panic_recovering_provider.go
@@ -391,11 +391,7 @@ func (s *PanicRecoveringProviderServer) Construct(
 	defer func() {
 		if err := recover(); err != nil {
 			opts := &logPanicOptions{}
-			if resp != nil && resp.Urn != "" {
-				opts.resourceURN = resp.Urn
-			} else {
-				opts.resourceURN = string(constructURN(req))
-			}
+			opts.resourceURN = string(constructURN(req))
 			s.logPanic(ctx, "Construct", err, debug.Stack(), opts)
 			panic(err) // rethrow
 		}

--- a/pkg/providerserver/panic_recovering_provider.go
+++ b/pkg/providerserver/panic_recovering_provider.go
@@ -467,6 +467,10 @@ func (s *PanicRecoveringProviderServer) GetMappings(
 
 // Guess Pulumi URN from ConstructRequest.
 func constructURN(req *pulumirpc.ConstructRequest) urn.URN {
+	if req.Stack == "" && req.Project == "" && req.Type == "" && req.Name == "" && req.Parent == "" {
+		return ""
+	}
+
 	// Guess Pulumi URN from ConstructRequest
 	stack := tokens.QName(req.Stack)
 	proj := tokens.PackageName(req.Project)

--- a/pkg/providerserver/panic_recovering_provider.go
+++ b/pkg/providerserver/panic_recovering_provider.go
@@ -117,7 +117,7 @@ func (s *PanicRecoveringProviderServer) formatPanicMessage(
 	var attrs []slog.Attr
 	attrs = append(attrs, slog.String("provider", s.providerName))
 	if s.providerVersion != "" {
-		attrs = append(attrs, slog.String("providerVersion", s.providerVersion))
+		attrs = append(attrs, slog.String("v", s.providerVersion))
 	}
 	if opts.providerURN != "" {
 		attrs = append(attrs, slog.String("providerURN", opts.providerURN))
@@ -125,8 +125,8 @@ func (s *PanicRecoveringProviderServer) formatPanicMessage(
 	if opts.invokeToken != "" {
 		attrs = append(attrs, slog.String("invokeToken", opts.invokeToken))
 	}
-	if opts.providerURN != "" {
-		attrs = append(attrs, slog.String("providerURN", opts.providerURN))
+	if opts.resourceURN != "" {
+		attrs = append(attrs, slog.String("resourceURN", opts.resourceURN))
 	}
 	if opts.method != "" {
 		attrs = append(attrs, slog.String("method", opts.method))

--- a/pkg/providerserver/panic_recovering_provider.go
+++ b/pkg/providerserver/panic_recovering_provider.go
@@ -164,7 +164,7 @@ func (s *PanicRecoveringProviderServer) Handshake(
 	ctx context.Context,
 	req *pulumirpc.ProviderHandshakeRequest,
 ) (*pulumirpc.ProviderHandshakeResponse, error) {
-	if isPanicHandlerInstalled(ctx) {
+	if !isPanicHandlerInstalled(ctx) {
 		defer func() {
 			if err := recover(); err != nil {
 				s.logPanic(ctx, "Handshake", err, debug.Stack(), nil)
@@ -179,7 +179,7 @@ func (s *PanicRecoveringProviderServer) Parameterize(
 	ctx context.Context,
 	req *pulumirpc.ParameterizeRequest,
 ) (*pulumirpc.ParameterizeResponse, error) {
-	if isPanicHandlerInstalled(ctx) {
+	if !isPanicHandlerInstalled(ctx) {
 		defer func() {
 			if err := recover(); err != nil {
 				s.logPanic(ctx, "Parameterize", err, debug.Stack(), nil)
@@ -194,7 +194,7 @@ func (s *PanicRecoveringProviderServer) GetSchema(
 	ctx context.Context,
 	req *pulumirpc.GetSchemaRequest,
 ) (*pulumirpc.GetSchemaResponse, error) {
-	if isPanicHandlerInstalled(ctx) {
+	if !isPanicHandlerInstalled(ctx) {
 		defer func() {
 			if err := recover(); err != nil {
 				s.logPanic(ctx, "GetSchema", err, debug.Stack(), nil)
@@ -210,7 +210,7 @@ func (s *PanicRecoveringProviderServer) CheckConfig(
 	req *pulumirpc.CheckRequest,
 ) (*pulumirpc.CheckResponse, error) {
 	s.currentProviderUrn = req.Urn
-	if isPanicHandlerInstalled(ctx) {
+	if !isPanicHandlerInstalled(ctx) {
 		defer func() {
 			if err := recover(); err != nil {
 				s.logPanic(ctx, "CheckConfig", err, debug.Stack(), &logPanicOptions{
@@ -227,7 +227,7 @@ func (s *PanicRecoveringProviderServer) DiffConfig(
 	ctx context.Context,
 	req *pulumirpc.DiffRequest,
 ) (*pulumirpc.DiffResponse, error) {
-	if isPanicHandlerInstalled(ctx) {
+	if !isPanicHandlerInstalled(ctx) {
 		defer func() {
 			if err := recover(); err != nil {
 				s.logPanic(ctx, "DiffConfig", err, debug.Stack(), &logPanicOptions{
@@ -244,7 +244,7 @@ func (s *PanicRecoveringProviderServer) Configure(
 	ctx context.Context,
 	req *pulumirpc.ConfigureRequest,
 ) (*pulumirpc.ConfigureResponse, error) {
-	if isPanicHandlerInstalled(ctx) {
+	if !isPanicHandlerInstalled(ctx) {
 		defer func() {
 			if err := recover(); err != nil {
 				s.logPanic(ctx, "Configure", err, debug.Stack(), &logPanicOptions{
@@ -261,7 +261,7 @@ func (s *PanicRecoveringProviderServer) Invoke(
 	ctx context.Context,
 	req *pulumirpc.InvokeRequest,
 ) (*pulumirpc.InvokeResponse, error) {
-	if isPanicHandlerInstalled(ctx) {
+	if !isPanicHandlerInstalled(ctx) {
 		defer func() {
 			if err := recover(); err != nil {
 				s.logPanic(ctx, "Invoke", err, debug.Stack(), &logPanicOptions{
@@ -294,7 +294,7 @@ func (s *PanicRecoveringProviderServer) Call(
 	ctx context.Context,
 	req *pulumirpc.CallRequest,
 ) (*pulumirpc.CallResponse, error) {
-	if isPanicHandlerInstalled(ctx) {
+	if !isPanicHandlerInstalled(ctx) {
 		defer func() {
 			if err := recover(); err != nil {
 				// We could possibly do better here if we inferred the URN of the __self__ argument.
@@ -312,7 +312,7 @@ func (s *PanicRecoveringProviderServer) Check(
 	ctx context.Context,
 	req *pulumirpc.CheckRequest,
 ) (*pulumirpc.CheckResponse, error) {
-	if isPanicHandlerInstalled(ctx) {
+	if !isPanicHandlerInstalled(ctx) {
 		defer func() {
 			if err := recover(); err != nil {
 				s.logPanic(ctx, "Check", err, debug.Stack(), &logPanicOptions{
@@ -329,7 +329,7 @@ func (s *PanicRecoveringProviderServer) Diff(
 	ctx context.Context,
 	req *pulumirpc.DiffRequest,
 ) (*pulumirpc.DiffResponse, error) {
-	if isPanicHandlerInstalled(ctx) {
+	if !isPanicHandlerInstalled(ctx) {
 		defer func() {
 			if err := recover(); err != nil {
 				s.logPanic(ctx, "Diff", err, debug.Stack(), &logPanicOptions{
@@ -346,7 +346,7 @@ func (s *PanicRecoveringProviderServer) Create(
 	ctx context.Context,
 	req *pulumirpc.CreateRequest,
 ) (*pulumirpc.CreateResponse, error) {
-	if isPanicHandlerInstalled(ctx) {
+	if !isPanicHandlerInstalled(ctx) {
 		defer func() {
 			if err := recover(); err != nil {
 				s.logPanic(ctx, "Create", err, debug.Stack(), &logPanicOptions{
@@ -363,7 +363,7 @@ func (s *PanicRecoveringProviderServer) Read(
 	ctx context.Context,
 	req *pulumirpc.ReadRequest,
 ) (*pulumirpc.ReadResponse, error) {
-	if isPanicHandlerInstalled(ctx) {
+	if !isPanicHandlerInstalled(ctx) {
 		defer func() {
 			if err := recover(); err != nil {
 				s.logPanic(ctx, "Read", err, debug.Stack(), &logPanicOptions{
@@ -380,7 +380,7 @@ func (s *PanicRecoveringProviderServer) Update(
 	ctx context.Context,
 	req *pulumirpc.UpdateRequest,
 ) (*pulumirpc.UpdateResponse, error) {
-	if isPanicHandlerInstalled(ctx) {
+	if !isPanicHandlerInstalled(ctx) {
 		defer func() {
 			if err := recover(); err != nil {
 				s.logPanic(ctx, "Update", err, debug.Stack(), &logPanicOptions{

--- a/pkg/providerserver/panic_recovering_provider.go
+++ b/pkg/providerserver/panic_recovering_provider.go
@@ -463,10 +463,6 @@ func (s *PanicRecoveringProviderServer) GetMappings(
 
 // Guess Pulumi URN from ConstructRequest.
 func constructURN(req *pulumirpc.ConstructRequest) urn.URN {
-	if req.Stack == "" && req.Project == "" && req.Type == "" && req.Name == "" && req.Parent == "" {
-		return ""
-	}
-
 	// Guess Pulumi URN from ConstructRequest
 	stack := tokens.QName(req.Stack)
 	proj := tokens.PackageName(req.Project)

--- a/pkg/providerserver/panic_recovering_provider.go
+++ b/pkg/providerserver/panic_recovering_provider.go
@@ -269,13 +269,13 @@ func (s *PanicRecoveringProviderServer) StreamInvoke(
 ) error {
 	defer func() {
 		if err := recover(); err != nil {
-			s.logPanic(srv.Context(), "StreamInvoke", err, debug.Stack(), &logPanicOptions{
+			s.logPanic(context.Background(), "StreamInvoke", err, debug.Stack(), &logPanicOptions{
 				invokeToken: req.Tok,
 			})
 			panic(err) // rethrow
 		}
 	}()
-	return s.StreamInvoke(req, srv)
+	return s.innerServer.StreamInvoke(req, srv)
 }
 
 func (s *PanicRecoveringProviderServer) Call(

--- a/pkg/providerserver/panic_recovering_provider.go
+++ b/pkg/providerserver/panic_recovering_provider.go
@@ -163,39 +163,45 @@ func (s *PanicRecoveringProviderServer) Handshake(
 	ctx context.Context,
 	req *pulumirpc.ProviderHandshakeRequest,
 ) (*pulumirpc.ProviderHandshakeResponse, error) {
-	defer func() {
-		if err := recover(); err != nil {
-			s.logPanic(ctx, "Handshake", err, debug.Stack(), nil)
-			panic(err) // rethrow
-		}
-	}()
-	return s.innerServer.Handshake(ctx, req)
+	if isPanicHandlerInstalled(ctx) {
+		defer func() {
+			if err := recover(); err != nil {
+				s.logPanic(ctx, "Handshake", err, debug.Stack(), nil)
+				panic(err) // rethrow
+			}
+		}()
+	}
+	return s.innerServer.Handshake(withPanicHandlerInstalled(ctx), req)
 }
 
 func (s *PanicRecoveringProviderServer) Parameterize(
 	ctx context.Context,
 	req *pulumirpc.ParameterizeRequest,
 ) (*pulumirpc.ParameterizeResponse, error) {
-	defer func() {
-		if err := recover(); err != nil {
-			s.logPanic(ctx, "Parameterize", err, debug.Stack(), nil)
-			panic(err) // rethrow
-		}
-	}()
-	return s.innerServer.Parameterize(ctx, req)
+	if isPanicHandlerInstalled(ctx) {
+		defer func() {
+			if err := recover(); err != nil {
+				s.logPanic(ctx, "Parameterize", err, debug.Stack(), nil)
+				panic(err) // rethrow
+			}
+		}()
+	}
+	return s.innerServer.Parameterize(withPanicHandlerInstalled(ctx), req)
 }
 
 func (s *PanicRecoveringProviderServer) GetSchema(
 	ctx context.Context,
 	req *pulumirpc.GetSchemaRequest,
 ) (*pulumirpc.GetSchemaResponse, error) {
-	defer func() {
-		if err := recover(); err != nil {
-			s.logPanic(ctx, "GetSchema", err, debug.Stack(), nil)
-			panic(err) // rethrow
-		}
-	}()
-	return s.innerServer.GetSchema(ctx, req)
+	if isPanicHandlerInstalled(ctx) {
+		defer func() {
+			if err := recover(); err != nil {
+				s.logPanic(ctx, "GetSchema", err, debug.Stack(), nil)
+				panic(err) // rethrow
+			}
+		}()
+	}
+	return s.innerServer.GetSchema(withPanicHandlerInstalled(ctx), req)
 }
 
 func (s *PanicRecoveringProviderServer) CheckConfig(
@@ -203,66 +209,75 @@ func (s *PanicRecoveringProviderServer) CheckConfig(
 	req *pulumirpc.CheckRequest,
 ) (*pulumirpc.CheckResponse, error) {
 	s.currentProviderUrn = req.Urn
-	defer func() {
-		if err := recover(); err != nil {
-			s.logPanic(ctx, "CheckConfig", err, debug.Stack(), &logPanicOptions{
-				providerURN: req.Urn,
-			})
-			panic(err) // rethrow
-		}
-	}()
-	return s.innerServer.CheckConfig(ctx, req)
+	if isPanicHandlerInstalled(ctx) {
+		defer func() {
+			if err := recover(); err != nil {
+				s.logPanic(ctx, "CheckConfig", err, debug.Stack(), &logPanicOptions{
+					providerURN: req.Urn,
+				})
+				panic(err) // rethrow
+			}
+		}()
+	}
+	return s.innerServer.CheckConfig(withPanicHandlerInstalled(ctx), req)
 }
 
 func (s *PanicRecoveringProviderServer) DiffConfig(
 	ctx context.Context,
 	req *pulumirpc.DiffRequest,
 ) (*pulumirpc.DiffResponse, error) {
-	defer func() {
-		if err := recover(); err != nil {
-			s.logPanic(ctx, "DiffConfig", err, debug.Stack(), &logPanicOptions{
-				providerURN: req.Urn,
-			})
-			panic(err) // rethrow
-		}
-	}()
-	return s.innerServer.DiffConfig(ctx, req)
+	if isPanicHandlerInstalled(ctx) {
+		defer func() {
+			if err := recover(); err != nil {
+				s.logPanic(ctx, "DiffConfig", err, debug.Stack(), &logPanicOptions{
+					providerURN: req.Urn,
+				})
+				panic(err) // rethrow
+			}
+		}()
+	}
+	return s.innerServer.DiffConfig(withPanicHandlerInstalled(ctx), req)
 }
 
 func (s *PanicRecoveringProviderServer) Configure(
 	ctx context.Context,
 	req *pulumirpc.ConfigureRequest,
 ) (*pulumirpc.ConfigureResponse, error) {
-	defer func() {
-		if err := recover(); err != nil {
-			s.logPanic(ctx, "Configure", err, debug.Stack(), &logPanicOptions{
-				providerURN: s.currentProviderUrn,
-			})
-			panic(err) // rethrow
-		}
-	}()
-	return s.innerServer.Configure(ctx, req)
+	if isPanicHandlerInstalled(ctx) {
+		defer func() {
+			if err := recover(); err != nil {
+				s.logPanic(ctx, "Configure", err, debug.Stack(), &logPanicOptions{
+					providerURN: s.currentProviderUrn,
+				})
+				panic(err) // rethrow
+			}
+		}()
+	}
+	return s.innerServer.Configure(withPanicHandlerInstalled(ctx), req)
 }
 
 func (s *PanicRecoveringProviderServer) Invoke(
 	ctx context.Context,
 	req *pulumirpc.InvokeRequest,
 ) (*pulumirpc.InvokeResponse, error) {
-	defer func() {
-		if err := recover(); err != nil {
-			s.logPanic(ctx, "Invoke", err, debug.Stack(), &logPanicOptions{
-				invokeToken: req.Tok,
-			})
-			panic(err) // rethrow
-		}
-	}()
-	return s.innerServer.Invoke(ctx, req)
+	if isPanicHandlerInstalled(ctx) {
+		defer func() {
+			if err := recover(); err != nil {
+				s.logPanic(ctx, "Invoke", err, debug.Stack(), &logPanicOptions{
+					invokeToken: req.Tok,
+				})
+				panic(err) // rethrow
+			}
+		}()
+	}
+	return s.innerServer.Invoke(withPanicHandlerInstalled(ctx), req)
 }
 
 func (s *PanicRecoveringProviderServer) StreamInvoke(
 	req *pulumirpc.InvokeRequest,
 	srv pulumirpc.ResourceProvider_StreamInvokeServer,
 ) error {
+	// This may not handle isPanicHandlerInstalled idempotency yet. Not used in bridged providers for now.
 	defer func() {
 		if err := recover(); err != nil {
 			s.logPanic(context.Background(), "StreamInvoke", err, debug.Stack(), &logPanicOptions{
@@ -278,183 +293,209 @@ func (s *PanicRecoveringProviderServer) Call(
 	ctx context.Context,
 	req *pulumirpc.CallRequest,
 ) (*pulumirpc.CallResponse, error) {
-	defer func() {
-		if err := recover(); err != nil {
-			// We could possibly do better here if we inferred the URN of the __self__ argument.
-			s.logPanic(ctx, "Call", err, debug.Stack(), &logPanicOptions{
-				invokeToken: req.Tok,
-			})
-			panic(err) // rethrow
-		}
-	}()
-	return s.innerServer.Call(ctx, req)
+	if isPanicHandlerInstalled(ctx) {
+		defer func() {
+			if err := recover(); err != nil {
+				// We could possibly do better here if we inferred the URN of the __self__ argument.
+				s.logPanic(ctx, "Call", err, debug.Stack(), &logPanicOptions{
+					invokeToken: req.Tok,
+				})
+				panic(err) // rethrow
+			}
+		}()
+	}
+	return s.innerServer.Call(withPanicHandlerInstalled(ctx), req)
 }
 
 func (s *PanicRecoveringProviderServer) Check(
 	ctx context.Context,
 	req *pulumirpc.CheckRequest,
 ) (*pulumirpc.CheckResponse, error) {
-	defer func() {
-		if err := recover(); err != nil {
-			s.logPanic(ctx, "Check", err, debug.Stack(), &logPanicOptions{
-				resourceURN: req.Urn,
-			})
-			panic(err) // rethrow
-		}
-	}()
-	return s.innerServer.Check(ctx, req)
+	if isPanicHandlerInstalled(ctx) {
+		defer func() {
+			if err := recover(); err != nil {
+				s.logPanic(ctx, "Check", err, debug.Stack(), &logPanicOptions{
+					resourceURN: req.Urn,
+				})
+				panic(err) // rethrow
+			}
+		}()
+	}
+	return s.innerServer.Check(withPanicHandlerInstalled(ctx), req)
 }
 
 func (s *PanicRecoveringProviderServer) Diff(
 	ctx context.Context,
 	req *pulumirpc.DiffRequest,
 ) (*pulumirpc.DiffResponse, error) {
-	defer func() {
-		if err := recover(); err != nil {
-			s.logPanic(ctx, "Diff", err, debug.Stack(), &logPanicOptions{
-				resourceURN: req.Urn,
-			})
-			panic(err) // rethrow
-		}
-	}()
-	return s.innerServer.Diff(ctx, req)
+	if isPanicHandlerInstalled(ctx) {
+		defer func() {
+			if err := recover(); err != nil {
+				s.logPanic(ctx, "Diff", err, debug.Stack(), &logPanicOptions{
+					resourceURN: req.Urn,
+				})
+				panic(err) // rethrow
+			}
+		}()
+	}
+	return s.innerServer.Diff(withPanicHandlerInstalled(ctx), req)
 }
 
 func (s *PanicRecoveringProviderServer) Create(
 	ctx context.Context,
 	req *pulumirpc.CreateRequest,
 ) (*pulumirpc.CreateResponse, error) {
-	defer func() {
-		if err := recover(); err != nil {
-			s.logPanic(ctx, "Create", err, debug.Stack(), &logPanicOptions{
-				resourceURN: req.Urn,
-			})
-			panic(err) // rethrow
-		}
-	}()
-	return s.innerServer.Create(ctx, req)
+	if isPanicHandlerInstalled(ctx) {
+		defer func() {
+			if err := recover(); err != nil {
+				s.logPanic(ctx, "Create", err, debug.Stack(), &logPanicOptions{
+					resourceURN: req.Urn,
+				})
+				panic(err) // rethrow
+			}
+		}()
+	}
+	return s.innerServer.Create(withPanicHandlerInstalled(ctx), req)
 }
 
 func (s *PanicRecoveringProviderServer) Read(
 	ctx context.Context,
 	req *pulumirpc.ReadRequest,
 ) (*pulumirpc.ReadResponse, error) {
-	defer func() {
-		if err := recover(); err != nil {
-			s.logPanic(ctx, "Read", err, debug.Stack(), &logPanicOptions{
-				resourceURN: req.Urn,
-			})
-			panic(err) // rethrow
-		}
-	}()
-	return s.innerServer.Read(ctx, req)
+	if isPanicHandlerInstalled(ctx) {
+		defer func() {
+			if err := recover(); err != nil {
+				s.logPanic(ctx, "Read", err, debug.Stack(), &logPanicOptions{
+					resourceURN: req.Urn,
+				})
+				panic(err) // rethrow
+			}
+		}()
+	}
+	return s.innerServer.Read(withPanicHandlerInstalled(ctx), req)
 }
 
 func (s *PanicRecoveringProviderServer) Update(
 	ctx context.Context,
 	req *pulumirpc.UpdateRequest,
 ) (*pulumirpc.UpdateResponse, error) {
-	defer func() {
-		if err := recover(); err != nil {
-			s.logPanic(ctx, "Update", err, debug.Stack(), &logPanicOptions{
-				resourceURN: req.Urn,
-			})
-			panic(err) // rethrow
-		}
-	}()
-	return s.innerServer.Update(ctx, req)
+	if isPanicHandlerInstalled(ctx) {
+		defer func() {
+			if err := recover(); err != nil {
+				s.logPanic(ctx, "Update", err, debug.Stack(), &logPanicOptions{
+					resourceURN: req.Urn,
+				})
+				panic(err) // rethrow
+			}
+		}()
+	}
+	return s.innerServer.Update(withPanicHandlerInstalled(ctx), req)
 }
 
 func (s *PanicRecoveringProviderServer) Delete(
 	ctx context.Context,
 	req *pulumirpc.DeleteRequest,
 ) (*emptypb.Empty, error) {
-	defer func() {
-		if err := recover(); err != nil {
-			s.logPanic(ctx, "Delete", err, debug.Stack(), &logPanicOptions{
-				resourceURN: req.Urn,
-			})
-			panic(err) // rethrow
-		}
-	}()
-	return s.innerServer.Delete(ctx, req)
+	if !isPanicHandlerInstalled(ctx) {
+		defer func() {
+			if err := recover(); err != nil {
+				s.logPanic(ctx, "Delete", err, debug.Stack(), &logPanicOptions{
+					resourceURN: req.Urn,
+				})
+				panic(err) // rethrow
+			}
+		}()
+	}
+	return s.innerServer.Delete(withPanicHandlerInstalled(ctx), req)
 }
 
 func (s *PanicRecoveringProviderServer) Construct(
 	ctx context.Context,
 	req *pulumirpc.ConstructRequest,
 ) (resp *pulumirpc.ConstructResponse, finalError error) {
-	defer func() {
-		if err := recover(); err != nil {
-			opts := &logPanicOptions{}
-			opts.resourceURN = string(constructURN(req))
-			s.logPanic(ctx, "Construct", err, debug.Stack(), opts)
-			panic(err) // rethrow
-		}
-	}()
-	return s.innerServer.Construct(ctx, req)
+	if !isPanicHandlerInstalled(ctx) {
+		defer func() {
+			if err := recover(); err != nil {
+				opts := &logPanicOptions{}
+				opts.resourceURN = string(constructURN(req))
+				s.logPanic(ctx, "Construct", err, debug.Stack(), opts)
+				panic(err) // rethrow
+			}
+		}()
+	}
+	return s.innerServer.Construct(withPanicHandlerInstalled(ctx), req)
 }
 
 func (s *PanicRecoveringProviderServer) Cancel(ctx context.Context, empty *emptypb.Empty) (*emptypb.Empty, error) {
-	defer func() {
-		if err := recover(); err != nil {
-			s.logPanic(ctx, "Cancel", err, debug.Stack(), nil)
-			panic(err) // rethrow
-		}
-	}()
-	return s.innerServer.Cancel(ctx, empty)
+	if !isPanicHandlerInstalled(ctx) {
+		defer func() {
+			if err := recover(); err != nil {
+				s.logPanic(ctx, "Cancel", err, debug.Stack(), nil)
+				panic(err) // rethrow
+			}
+		}()
+	}
+	return s.innerServer.Cancel(withPanicHandlerInstalled(ctx), empty)
 }
 
 func (s *PanicRecoveringProviderServer) GetPluginInfo(
 	ctx context.Context,
 	empty *emptypb.Empty,
 ) (*pulumirpc.PluginInfo, error) {
-	defer func() {
-		if err := recover(); err != nil {
-			s.logPanic(ctx, "GetPluginInfo", err, debug.Stack(), nil)
-			panic(err) // rethrow
-		}
-	}()
-	return s.innerServer.GetPluginInfo(ctx, empty)
+	if !isPanicHandlerInstalled(ctx) {
+		defer func() {
+			if err := recover(); err != nil {
+				s.logPanic(ctx, "GetPluginInfo", err, debug.Stack(), nil)
+				panic(err) // rethrow
+			}
+		}()
+	}
+	return s.innerServer.GetPluginInfo(withPanicHandlerInstalled(ctx), empty)
 }
 
 func (s *PanicRecoveringProviderServer) Attach(
 	ctx context.Context,
 	attach *pulumirpc.PluginAttach,
 ) (*emptypb.Empty, error) {
-	defer func() {
-		if err := recover(); err != nil {
-			s.logPanic(ctx, "Attach", err, debug.Stack(), nil)
-			panic(err) // rethrow
-		}
-	}()
-	return s.innerServer.Attach(ctx, attach)
+	if !isPanicHandlerInstalled(ctx) {
+		defer func() {
+			if err := recover(); err != nil {
+				s.logPanic(ctx, "Attach", err, debug.Stack(), nil)
+				panic(err) // rethrow
+			}
+		}()
+	}
+	return s.innerServer.Attach(withPanicHandlerInstalled(ctx), attach)
 }
 
 func (s *PanicRecoveringProviderServer) GetMapping(
 	ctx context.Context,
 	req *pulumirpc.GetMappingRequest,
 ) (*pulumirpc.GetMappingResponse, error) {
-	defer func() {
-		if err := recover(); err != nil {
-			s.logPanic(ctx, "GetMapping", err, debug.Stack(), nil)
-			panic(err) // rethrow
-		}
-	}()
-	return s.innerServer.GetMapping(ctx, req)
+	if !isPanicHandlerInstalled(ctx) {
+		defer func() {
+			if err := recover(); err != nil {
+				s.logPanic(ctx, "GetMapping", err, debug.Stack(), nil)
+				panic(err) // rethrow
+			}
+		}()
+	}
+	return s.innerServer.GetMapping(withPanicHandlerInstalled(ctx), req)
 }
 
 func (s *PanicRecoveringProviderServer) GetMappings(
 	ctx context.Context,
 	req *pulumirpc.GetMappingsRequest,
 ) (*pulumirpc.GetMappingsResponse, error) {
-	defer func() {
-		if err := recover(); err != nil {
-			s.logPanic(ctx, "GetMappings", err, debug.Stack(), nil)
-			panic(err) // rethrow
-		}
-	}()
-	return s.innerServer.GetMappings(ctx, req)
+	if !isPanicHandlerInstalled(ctx) {
+		defer func() {
+			if err := recover(); err != nil {
+				s.logPanic(ctx, "GetMappings", err, debug.Stack(), nil)
+				panic(err) // rethrow
+			}
+		}()
+	}
+	return s.innerServer.GetMappings(withPanicHandlerInstalled(ctx), req)
 }
 
 // Guess Pulumi URN from ConstructRequest.
@@ -471,4 +512,23 @@ func constructURN(req *pulumirpc.ConstructRequest) urn.URN {
 	}
 	baseType := tokens.Type(req.Type)
 	return urn.New(stack, proj, parentType, baseType, req.Name)
+}
+
+// Define a context.Context key to manage idempotency.
+type ctxKey struct{}
+
+// The key to manage idempotency.
+var theCtxKey = ctxKey{}
+
+func isPanicHandlerInstalled(ctx context.Context) bool {
+	switch v := ctx.Value(theCtxKey).(type) {
+	case bool:
+		return v
+	default:
+		return false
+	}
+}
+
+func withPanicHandlerInstalled(ctx context.Context) context.Context {
+	return context.WithValue(ctx, theCtxKey, true)
 }

--- a/pkg/providerserver/panic_recovering_provider.go
+++ b/pkg/providerserver/panic_recovering_provider.go
@@ -22,7 +22,6 @@ import (
 	"runtime/debug"
 	"strings"
 
-	"github.com/pulumi/pulumi-terraform-bridge/v3/internal/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
@@ -30,6 +29,8 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/internal/logging"
 )
 
 // A wrapper around a ResourceProviderServer that logs panics.

--- a/pkg/providerserver/panic_recovering_provider_test.go
+++ b/pkg/providerserver/panic_recovering_provider_test.go
@@ -209,6 +209,20 @@ func TestPanicRecoveryByMethod(t *testing.T) {
 		{
 			testName: "Construct",
 			send: func(rps pulumirpc.ResourceProviderServer) {
+				rps.Construct(ctx, &pulumirpc.ConstructRequest{
+					Stack:   "pulumi:production",
+					Project: "acmecorp-website",
+					Type:    "aws:s3/bucketv2:BucketV2",
+					Name:    "myBucket",
+					Parent:  exampleResourceURN(),
+				})
+			},
+			expectURN:     autogold.Expect(urn.URN("urn:pulumi:pulumi:production::acmecorp-website::aws:s3/bucketv2:BucketV2$aws:s3/bucketv2:BucketV2::myBucket")),
+			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 resourceURN=urn:pulumi:pulumi:production::acmecorp-website::aws:s3/bucketv2:BucketV2$aws:s3/bucketv2:BucketV2::myBucket method=Construct): Construct panic"),
+		},
+		{
+			testName: "Construct/inferURN",
+			send: func(rps pulumirpc.ResourceProviderServer) {
 				rps.Construct(ctx, &pulumirpc.ConstructRequest{})
 			},
 			expectURN:     autogold.Expect(urn.URN("")),

--- a/pkg/providerserver/panic_recovering_provider_test.go
+++ b/pkg/providerserver/panic_recovering_provider_test.go
@@ -112,26 +112,32 @@ func TestPanicRecoveryByMethod(t *testing.T) {
 		{
 			testName: "Invoke",
 			send: func(rps pulumirpc.ResourceProviderServer) {
-				rps.Invoke(ctx, &pulumirpc.InvokeRequest{})
+				rps.Invoke(ctx, &pulumirpc.InvokeRequest{
+					Tok: exampleInvokeToken(),
+				})
 			},
 			expectURN:     autogold.Expect(urn.URN("")),
-			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 method=Invoke): Invoke panic"),
+			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 invokeToken=aws:acm/getCertificate:getCertificate method=Invoke): Invoke panic"),
 		},
 		{
 			testName: "StreamInvoke",
 			send: func(rps pulumirpc.ResourceProviderServer) {
-				rps.StreamInvoke(&pulumirpc.InvokeRequest{}, nil)
+				rps.StreamInvoke(&pulumirpc.InvokeRequest{
+					Tok: exampleInvokeToken(),
+				}, nil)
 			},
 			expectURN:     autogold.Expect(urn.URN("")),
-			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 method=StreamInvoke): StreamInvoke panic"),
+			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 invokeToken=aws:acm/getCertificate:getCertificate method=StreamInvoke): StreamInvoke panic"),
 		},
 		{
 			testName: "Call",
 			send: func(rps pulumirpc.ResourceProviderServer) {
-				rps.Call(ctx, &pulumirpc.CallRequest{})
+				rps.Call(ctx, &pulumirpc.CallRequest{
+					Tok: exampleInvokeToken(), // Not a great example, could be improved to show actual Call.
+				})
 			},
 			expectURN:     autogold.Expect(urn.URN("")),
-			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 method=Call): Call panic"),
+			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 invokeToken=aws:acm/getCertificate:getCertificate method=Call): Call panic"),
 		},
 		{
 			testName: "Check",
@@ -283,6 +289,10 @@ func expectPanic(t *testing.T, f func()) {
 		}
 	}()
 	f()
+}
+
+func exampleInvokeToken() string {
+	return "aws:acm/getCertificate:getCertificate"
 }
 
 func exampleResourceURN() string {

--- a/pkg/providerserver/panic_recovering_provider_test.go
+++ b/pkg/providerserver/panic_recovering_provider_test.go
@@ -136,50 +136,62 @@ func TestPanicRecoveryByMethod(t *testing.T) {
 		{
 			testName: "Check",
 			send: func(rps pulumirpc.ResourceProviderServer) {
-				rps.Check(ctx, &pulumirpc.CheckRequest{})
+				rps.Check(ctx, &pulumirpc.CheckRequest{
+					Urn: exampleResourceURN(),
+				})
 			},
-			expectURN:     autogold.Expect(urn.URN("")),
-			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 method=Check): Check panic"),
+			expectURN:     autogold.Expect(urn.URN("urn:pulumi:production::acmecorp-website::custom:resources:Resource$aws:s3/bucketv2:BucketV2::my-bucket")),
+			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 resourceURN=urn:pulumi:production::acmecorp-website::custom:resources:Resource$aws:s3/bucketv2:BucketV2::my-bucket method=Check): Check panic"),
 		},
 		{
 			testName: "Diff",
 			send: func(rps pulumirpc.ResourceProviderServer) {
-				rps.Diff(ctx, &pulumirpc.DiffRequest{})
+				rps.Diff(ctx, &pulumirpc.DiffRequest{
+					Urn: exampleResourceURN(),
+				})
 			},
-			expectURN:     autogold.Expect(urn.URN("")),
-			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 method=Diff): Diff panic"),
+			expectURN:     autogold.Expect(urn.URN("urn:pulumi:production::acmecorp-website::custom:resources:Resource$aws:s3/bucketv2:BucketV2::my-bucket")),
+			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 resourceURN=urn:pulumi:production::acmecorp-website::custom:resources:Resource$aws:s3/bucketv2:BucketV2::my-bucket method=Diff): Diff panic"),
 		},
 		{
 			testName: "Create",
 			send: func(rps pulumirpc.ResourceProviderServer) {
-				rps.Create(ctx, &pulumirpc.CreateRequest{})
+				rps.Create(ctx, &pulumirpc.CreateRequest{
+					Urn: exampleResourceURN(),
+				})
 			},
-			expectURN:     autogold.Expect(urn.URN("")),
-			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 method=Create): Create panic"),
+			expectURN:     autogold.Expect(urn.URN("urn:pulumi:production::acmecorp-website::custom:resources:Resource$aws:s3/bucketv2:BucketV2::my-bucket")),
+			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 resourceURN=urn:pulumi:production::acmecorp-website::custom:resources:Resource$aws:s3/bucketv2:BucketV2::my-bucket method=Create): Create panic"),
 		},
 		{
 			testName: "Read",
 			send: func(rps pulumirpc.ResourceProviderServer) {
-				rps.Read(ctx, &pulumirpc.ReadRequest{})
+				rps.Read(ctx, &pulumirpc.ReadRequest{
+					Urn: exampleResourceURN(),
+				})
 			},
-			expectURN:     autogold.Expect(urn.URN("")),
-			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 method=Read): Read panic"),
+			expectURN:     autogold.Expect(urn.URN("urn:pulumi:production::acmecorp-website::custom:resources:Resource$aws:s3/bucketv2:BucketV2::my-bucket")),
+			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 resourceURN=urn:pulumi:production::acmecorp-website::custom:resources:Resource$aws:s3/bucketv2:BucketV2::my-bucket method=Read): Read panic"),
 		},
 		{
 			testName: "Update",
 			send: func(rps pulumirpc.ResourceProviderServer) {
-				rps.Update(ctx, &pulumirpc.UpdateRequest{})
+				rps.Update(ctx, &pulumirpc.UpdateRequest{
+					Urn: exampleResourceURN(),
+				})
 			},
-			expectURN:     autogold.Expect(urn.URN("")),
-			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 method=Update): Update panic"),
+			expectURN:     autogold.Expect(urn.URN("urn:pulumi:production::acmecorp-website::custom:resources:Resource$aws:s3/bucketv2:BucketV2::my-bucket")),
+			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 resourceURN=urn:pulumi:production::acmecorp-website::custom:resources:Resource$aws:s3/bucketv2:BucketV2::my-bucket method=Update): Update panic"),
 		},
 		{
 			testName: "Delete",
 			send: func(rps pulumirpc.ResourceProviderServer) {
-				rps.Delete(ctx, &pulumirpc.DeleteRequest{})
+				rps.Delete(ctx, &pulumirpc.DeleteRequest{
+					Urn: exampleResourceURN(),
+				})
 			},
-			expectURN:     autogold.Expect(urn.URN("")),
-			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 method=Delete): Delete panic"),
+			expectURN:     autogold.Expect(urn.URN("urn:pulumi:production::acmecorp-website::custom:resources:Resource$aws:s3/bucketv2:BucketV2::my-bucket")),
+			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 resourceURN=urn:pulumi:production::acmecorp-website::custom:resources:Resource$aws:s3/bucketv2:BucketV2::my-bucket method=Delete): Delete panic"),
 		},
 		{
 			testName: "Construct",

--- a/pkg/providerserver/panic_recovering_provider_test.go
+++ b/pkg/providerserver/panic_recovering_provider_test.go
@@ -16,7 +16,6 @@ package providerserver
 
 import (
 	"context"
-	"fmt"
 	"runtime/debug"
 	"testing"
 
@@ -338,6 +337,7 @@ func TestPanicRecoveryByMethod(t *testing.T) {
 // With muxed providers, if we accidentally wrap the provider server twice with the log interceptor it should still
 // annotate the panic only once.
 func TestWrappingIdempotency(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	logger := &testLogger{}
 	provName := "myprov"
@@ -355,7 +355,10 @@ func TestWrappingIdempotency(t *testing.T) {
 		ProviderName:           provName,
 		ProviderVersion:        ver,
 	})
-	expectPanic(t, func() { s2.Check(ctx, &pulumirpc.CheckRequest{}) })
+	expectPanic(t, func() {
+		_, err := s2.Check(ctx, &pulumirpc.CheckRequest{})
+		contract.IgnoreError(err)
+	})
 	assert.Equal(t, 1, logger.messageCount)
 }
 

--- a/pkg/providerserver/panic_recovering_provider_test.go
+++ b/pkg/providerserver/panic_recovering_provider_test.go
@@ -1,0 +1,278 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package providerserver
+
+import (
+	"context"
+	"runtime/debug"
+	"testing"
+
+	"github.com/hexops/autogold/v2"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"google.golang.org/protobuf/types/known/emptypb"
+	"gotest.tools/v3/assert"
+)
+
+func TestFormatPanicMessage(t *testing.T) {
+	s := &PanicRecoveringProviderServer{
+		providerName:    "myprov",
+		providerVersion: "1.2.3",
+	}
+
+	panicErr, _ := examplePanic()
+
+	exampleStack := `
+        goroutine 5 [running]:
+        runtime/debug.Stack()
+        	/nix/store/lb8wx7xsk7vryjxbbf9wlj820pdfvnbj-go-1.23.3/share/go/src/runtime/debug/stack.go:26 +0x64
+`
+
+	msg := s.formatPanicMessage(panicErr, []byte(exampleStack), &logPanicOptions{resourceURN: exampleResourceURN()})
+	autogold.Expect(`Bridged provider panic (provider=myprov providerVersion=1.2.3): Something went wrong
+
+        goroutine 5 [running]:
+        runtime/debug.Stack()
+         /nix/store/lb8wx7xsk7vryjxbbf9wlj820pdfvnbj-go-1.23.3/share/go/src/runtime/debug/stack.go:26 +0x64
+`).Equal(t, msg)
+}
+
+func TestPanicRecoveryByMethod(t *testing.T) {
+	ctx := context.Background()
+	type testCase struct {
+		testName      string
+		send          func(pulumirpc.ResourceProviderServer)
+		expectURN     autogold.Value
+		expectMessage autogold.Value
+	}
+
+	testCases := []testCase{
+		{
+			testName: "Handshake",
+			send: func(rps pulumirpc.ResourceProviderServer) {
+				rps.Handshake(ctx, &pulumirpc.ProviderHandshakeRequest{EngineAddress: "localhost"})
+			},
+			expectURN:     autogold.Expect(urn.URN("")),
+			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov providerVersion=1.2.3 method=Handshake): Handshake panic"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			logger := &testLogger{}
+			s := NewPanicRecoveringProviderServer(&PanicRecoveringProviderServerOptions{
+				Logger:                 logger,
+				ResourceProviderServer: &testRPS{},
+				ProviderName:           "myprov",
+				ProviderVersion:        "1.2.3",
+			})
+			s.includeStackTraces = false
+
+			expectPanic(t, func() { tc.send(s) })
+
+			assert.Equal(t, 1, logger.messageCount)
+			tc.expectURN.Equal(t, logger.lastURN)
+			tc.expectMessage.Equal(t, logger.lastMsg)
+		})
+	}
+}
+
+type testLogger struct {
+	messageCount int
+	lastURN      resource.URN
+	lastMsg      string
+}
+
+func (log *testLogger) Log(context context.Context, sev diag.Severity, urn resource.URN, msg string) error {
+	log.messageCount++
+	log.lastURN = urn
+	log.lastMsg = msg
+	return nil
+}
+
+func expectPanic(t *testing.T, f func()) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("The code did not panic")
+		}
+	}()
+	f()
+}
+
+func exampleResourceURN() string {
+	return "urn:pulumi:production::acmecorp-website::custom:resources:Resource$aws:s3/bucketv2:BucketV2::my-bucket"
+}
+
+func examplePanic() (finalError any, debugStack []byte) {
+	defer func() {
+		if r := recover(); r != nil {
+			debugStack = debug.Stack()
+			finalError = r
+		}
+	}()
+	panic("Something went wrong")
+}
+
+type testRPS struct {
+	pulumirpc.UnimplementedResourceProviderServer
+}
+
+var _ pulumirpc.ResourceProviderServer = (*testRPS)(nil)
+
+func (s *testRPS) Handshake(
+	ctx context.Context,
+	req *pulumirpc.ProviderHandshakeRequest,
+) (*pulumirpc.ProviderHandshakeResponse, error) {
+	panic("Handshake panic")
+}
+
+func (s *testRPS) Parameterize(
+	ctx context.Context,
+	req *pulumirpc.ParameterizeRequest,
+) (*pulumirpc.ParameterizeResponse, error) {
+	panic("Parameterize panic")
+}
+
+func (s *testRPS) GetSchema(
+	ctx context.Context,
+	req *pulumirpc.GetSchemaRequest,
+) (*pulumirpc.GetSchemaResponse, error) {
+	panic("GetSchema panic")
+}
+
+func (s *testRPS) CheckConfig(
+	ctx context.Context,
+	req *pulumirpc.CheckRequest,
+) (*pulumirpc.CheckResponse, error) {
+	panic("CheckConfig panic")
+}
+
+func (s *testRPS) DiffConfig(
+	ctx context.Context,
+	req *pulumirpc.DiffRequest,
+) (*pulumirpc.DiffResponse, error) {
+	panic("DiffConfig panic")
+}
+
+func (s *testRPS) Configure(
+	ctx context.Context,
+	req *pulumirpc.ConfigureRequest,
+) (*pulumirpc.ConfigureResponse, error) {
+	panic("Configure panic")
+}
+
+func (s *testRPS) Invoke(
+	ctx context.Context,
+	req *pulumirpc.InvokeRequest,
+) (*pulumirpc.InvokeResponse, error) {
+	panic("Invoke panic")
+}
+
+func (s *testRPS) StreamInvoke(
+	req *pulumirpc.InvokeRequest,
+	srv pulumirpc.ResourceProvider_StreamInvokeServer,
+) error {
+	panic("StreamInvoke panic")
+}
+
+func (s *testRPS) Call(
+	ctx context.Context,
+	req *pulumirpc.CallRequest,
+) (*pulumirpc.CallResponse, error) {
+	panic("Call panic")
+}
+
+func (s *testRPS) Check(
+	ctx context.Context,
+	req *pulumirpc.CheckRequest,
+) (*pulumirpc.CheckResponse, error) {
+	panic("Check panic")
+}
+
+func (s *testRPS) Diff(
+	ctx context.Context,
+	req *pulumirpc.DiffRequest,
+) (*pulumirpc.DiffResponse, error) {
+	panic("Diff panic")
+}
+
+func (s *testRPS) Create(
+	ctx context.Context,
+	req *pulumirpc.CreateRequest,
+) (*pulumirpc.CreateResponse, error) {
+	panic("Create panic")
+}
+
+func (s *testRPS) Read(
+	ctx context.Context,
+	req *pulumirpc.ReadRequest,
+) (*pulumirpc.ReadResponse, error) {
+	panic("Read panic")
+}
+
+func (s *testRPS) Update(
+	ctx context.Context,
+	req *pulumirpc.UpdateRequest,
+) (*pulumirpc.UpdateResponse, error) {
+	panic("Update panic")
+}
+
+func (s *testRPS) Delete(
+	ctx context.Context,
+	req *pulumirpc.DeleteRequest,
+) (*emptypb.Empty, error) {
+	panic("Delete panic")
+}
+
+func (s *testRPS) Construct(
+	ctx context.Context,
+	req *pulumirpc.ConstructRequest,
+) (resp *pulumirpc.ConstructResponse, finalError error) {
+	panic("Construct panic")
+}
+
+func (s *testRPS) Cancel(ctx context.Context, empty *emptypb.Empty) (*emptypb.Empty, error) {
+	panic("Cancel panic")
+}
+
+func (s *testRPS) GetPluginInfo(
+	ctx context.Context,
+	empty *emptypb.Empty,
+) (*pulumirpc.PluginInfo, error) {
+	panic("GetPluginInfo panic")
+}
+
+func (s *testRPS) Attach(
+	ctx context.Context,
+	attach *pulumirpc.PluginAttach,
+) (*emptypb.Empty, error) {
+	panic("Attach panic")
+}
+
+func (s *testRPS) GetMapping(
+	ctx context.Context,
+	req *pulumirpc.GetMappingRequest,
+) (*pulumirpc.GetMappingResponse, error) {
+	panic("GetMapping panic")
+}
+
+func (s *testRPS) GetMappings(
+	ctx context.Context,
+	req *pulumirpc.GetMappingsRequest,
+) (*pulumirpc.GetMappingsResponse, error) {
+	panic("GetMappings panic")
+}

--- a/pkg/providerserver/panic_recovering_provider_test.go
+++ b/pkg/providerserver/panic_recovering_provider_test.go
@@ -117,14 +117,14 @@ func TestPanicRecoveryByMethod(t *testing.T) {
 			expectURN:     autogold.Expect(urn.URN("")),
 			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 method=Invoke): Invoke panic"),
 		},
-		// {
-		// 	testName: "StreamInvoke",
-		// 	send: func(rps pulumirpc.ResourceProviderServer) {
-		// 		rps.StreamInvoke(&pulumirpc.InvokeRequest{}, nil)
-		// 	},
-		// 	expectURN:     autogold.Expect(urn.URN("")),
-		// 	expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 method=GetSchema): GetSchema panic"),
-		// },
+		{
+			testName: "StreamInvoke",
+			send: func(rps pulumirpc.ResourceProviderServer) {
+				rps.StreamInvoke(&pulumirpc.InvokeRequest{}, nil)
+			},
+			expectURN:     autogold.Expect(urn.URN("")),
+			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 method=StreamInvoke): StreamInvoke panic"),
+		},
 		{
 			testName: "Call",
 			send: func(rps pulumirpc.ResourceProviderServer) {

--- a/pkg/providerserver/panic_recovering_provider_test.go
+++ b/pkg/providerserver/panic_recovering_provider_test.go
@@ -347,6 +347,10 @@ func (log *testLogger) Log(context context.Context, sev diag.Severity, urn resou
 	return nil
 }
 
+func (log *testLogger) LogStatus(context context.Context, sev diag.Severity, urn resource.URN, msg string) error {
+	return log.Log(context, sev, urn, msg)
+}
+
 func expectPanic(t *testing.T, f func()) {
 	defer func() {
 		r := recover()

--- a/pkg/providerserver/panic_recovering_provider_test.go
+++ b/pkg/providerserver/panic_recovering_provider_test.go
@@ -110,11 +110,11 @@ func TestPanicRecoveryByMethod(t *testing.T) {
 			testName:          "Configure",
 			doNotPanicInCheck: true,
 			send: func(rps pulumirpc.ResourceProviderServer) {
-				rps.Check(ctx, &pulumirpc.CheckRequest{Urn: exampleProviderURN()})
+				rps.CheckConfig(ctx, &pulumirpc.CheckRequest{Urn: exampleProviderURN()})
 				rps.Configure(ctx, &pulumirpc.ConfigureRequest{})
 			},
-			expectURN:     autogold.Expect(urn.URN("urn:pulumi:dev::2024-01-27::pulumi:providers:aws::default_6_67_0::600afa97-4e03-40bd-b032-43e524727453")),
-			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 resourceURN=urn:pulumi:dev::2024-01-27::pulumi:providers:aws::default_6_67_0::600afa97-4e03-40bd-b032-43e524727453 method=Check): Check panic"),
+			expectURN:     autogold.Expect(urn.URN("")),
+			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 providerURN=urn:pulumi:dev::2024-01-27::pulumi:providers:aws::default_6_67_0::600afa97-4e03-40bd-b032-43e524727453 method=Configure): Configure panic"),
 		},
 		{
 			testName: "Invoke",

--- a/pkg/providerserver/panic_recovering_provider_test.go
+++ b/pkg/providerserver/panic_recovering_provider_test.go
@@ -69,6 +69,166 @@ func TestPanicRecoveryByMethod(t *testing.T) {
 			expectURN:     autogold.Expect(urn.URN("")),
 			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 method=Handshake): Handshake panic"),
 		},
+		{
+			testName: "Parameterize",
+			send: func(rps pulumirpc.ResourceProviderServer) {
+				rps.Parameterize(ctx, &pulumirpc.ParameterizeRequest{})
+			},
+			expectURN:     autogold.Expect(urn.URN("")),
+			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 method=Parameterize): Parameterize panic"),
+		},
+		{
+			testName: "GetSchema",
+			send: func(rps pulumirpc.ResourceProviderServer) {
+				rps.GetSchema(ctx, &pulumirpc.GetSchemaRequest{})
+			},
+			expectURN:     autogold.Expect(urn.URN("")),
+			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 method=GetSchema): GetSchema panic"),
+		},
+		{
+			testName: "CheckConfig",
+			send: func(rps pulumirpc.ResourceProviderServer) {
+				rps.CheckConfig(ctx, &pulumirpc.CheckRequest{})
+			},
+			expectURN:     autogold.Expect(urn.URN("")),
+			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 method=CheckConfig): CheckConfig panic"),
+		},
+		{
+			testName: "DiffConfig",
+			send: func(rps pulumirpc.ResourceProviderServer) {
+				rps.DiffConfig(ctx, &pulumirpc.DiffRequest{})
+			},
+			expectURN:     autogold.Expect(urn.URN("")),
+			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 method=DiffConfig): DiffConfig panic"),
+		},
+		{
+			testName: "Configure",
+			send: func(rps pulumirpc.ResourceProviderServer) {
+				rps.Configure(ctx, &pulumirpc.ConfigureRequest{})
+			},
+			expectURN:     autogold.Expect(urn.URN("")),
+			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 method=Configure): Configure panic"),
+		},
+		{
+			testName: "Invoke",
+			send: func(rps pulumirpc.ResourceProviderServer) {
+				rps.Invoke(ctx, &pulumirpc.InvokeRequest{})
+			},
+			expectURN:     autogold.Expect(urn.URN("")),
+			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 method=Invoke): Invoke panic"),
+		},
+		// {
+		// 	testName: "StreamInvoke",
+		// 	send: func(rps pulumirpc.ResourceProviderServer) {
+		// 		rps.StreamInvoke(&pulumirpc.InvokeRequest{}, nil)
+		// 	},
+		// 	expectURN:     autogold.Expect(urn.URN("")),
+		// 	expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 method=GetSchema): GetSchema panic"),
+		// },
+		{
+			testName: "Call",
+			send: func(rps pulumirpc.ResourceProviderServer) {
+				rps.Call(ctx, &pulumirpc.CallRequest{})
+			},
+			expectURN:     autogold.Expect(urn.URN("")),
+			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 method=Call): Call panic"),
+		},
+		{
+			testName: "Check",
+			send: func(rps pulumirpc.ResourceProviderServer) {
+				rps.Check(ctx, &pulumirpc.CheckRequest{})
+			},
+			expectURN:     autogold.Expect(urn.URN("")),
+			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 method=Check): Check panic"),
+		},
+		{
+			testName: "Diff",
+			send: func(rps pulumirpc.ResourceProviderServer) {
+				rps.Diff(ctx, &pulumirpc.DiffRequest{})
+			},
+			expectURN:     autogold.Expect(urn.URN("")),
+			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 method=Diff): Diff panic"),
+		},
+		{
+			testName: "Create",
+			send: func(rps pulumirpc.ResourceProviderServer) {
+				rps.Create(ctx, &pulumirpc.CreateRequest{})
+			},
+			expectURN:     autogold.Expect(urn.URN("")),
+			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 method=Create): Create panic"),
+		},
+		{
+			testName: "Read",
+			send: func(rps pulumirpc.ResourceProviderServer) {
+				rps.Read(ctx, &pulumirpc.ReadRequest{})
+			},
+			expectURN:     autogold.Expect(urn.URN("")),
+			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 method=Read): Read panic"),
+		},
+		{
+			testName: "Update",
+			send: func(rps pulumirpc.ResourceProviderServer) {
+				rps.Update(ctx, &pulumirpc.UpdateRequest{})
+			},
+			expectURN:     autogold.Expect(urn.URN("")),
+			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 method=Update): Update panic"),
+		},
+		{
+			testName: "Delete",
+			send: func(rps pulumirpc.ResourceProviderServer) {
+				rps.Delete(ctx, &pulumirpc.DeleteRequest{})
+			},
+			expectURN:     autogold.Expect(urn.URN("")),
+			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 method=Delete): Delete panic"),
+		},
+		{
+			testName: "Construct",
+			send: func(rps pulumirpc.ResourceProviderServer) {
+				rps.Construct(ctx, &pulumirpc.ConstructRequest{})
+			},
+			expectURN:     autogold.Expect(urn.URN("urn:pulumi:::::::")),
+			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 resourceURN=urn:pulumi::::::: method=Construct): Construct panic"),
+		},
+		{
+			testName: "Cancel",
+			send: func(rps pulumirpc.ResourceProviderServer) {
+				rps.Cancel(ctx, &emptypb.Empty{})
+			},
+			expectURN:     autogold.Expect(urn.URN("")),
+			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 method=Cancel): Cancel panic"),
+		},
+		{
+			testName: "GetPluginInfo",
+			send: func(rps pulumirpc.ResourceProviderServer) {
+				rps.GetPluginInfo(ctx, &emptypb.Empty{})
+			},
+			expectURN:     autogold.Expect(urn.URN("")),
+			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 method=GetPluginInfo): GetPluginInfo panic"),
+		},
+		{
+			testName: "Attach",
+			send: func(rps pulumirpc.ResourceProviderServer) {
+				rps.Attach(ctx, &pulumirpc.PluginAttach{})
+			},
+			expectURN:     autogold.Expect(urn.URN("")),
+			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 method=Attach): Attach panic"),
+		},
+		{
+			testName: "GetMapping",
+			send: func(rps pulumirpc.ResourceProviderServer) {
+				rps.GetMapping(ctx, &pulumirpc.GetMappingRequest{})
+			},
+			expectURN:     autogold.Expect(urn.URN("")),
+			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 method=GetMapping): GetMapping panic"),
+		},
+		{
+			testName: "GetMappings",
+			send: func(rps pulumirpc.ResourceProviderServer) {
+				rps.GetMappings(ctx, &pulumirpc.GetMappingsRequest{})
+			},
+			expectURN:     autogold.Expect(urn.URN("")),
+			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 method=GetMappings): GetMappings panic"),
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/providerserver/panic_recovering_provider_test.go
+++ b/pkg/providerserver/panic_recovering_provider_test.go
@@ -67,7 +67,7 @@ func TestPanicRecoveryByMethod(t *testing.T) {
 				rps.Handshake(ctx, &pulumirpc.ProviderHandshakeRequest{EngineAddress: "localhost"})
 			},
 			expectURN:     autogold.Expect(urn.URN("")),
-			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov providerVersion=1.2.3 method=Handshake): Handshake panic"),
+			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 method=Handshake): Handshake panic"),
 		},
 	}
 

--- a/pkg/providerserver/panic_recovering_provider_test.go
+++ b/pkg/providerserver/panic_recovering_provider_test.go
@@ -43,7 +43,7 @@ func TestFormatPanicMessage(t *testing.T) {
 `
 
 	msg := s.formatPanicMessage(panicErr, []byte(exampleStack), &logPanicOptions{resourceURN: exampleResourceURN()})
-	autogold.Expect(`Bridged provider panic (provider=myprov providerVersion=1.2.3): Something went wrong
+	autogold.Expect(`Bridged provider panic (provider=myprov v=1.2.3 resourceURN=urn:pulumi:production::acmecorp-website::custom:resources:Resource$aws:s3/bucketv2:BucketV2::my-bucket): Something went wrong
 
         goroutine 5 [running]:
         runtime/debug.Stack()
@@ -240,7 +240,7 @@ func TestPanicRecoveryByMethod(t *testing.T) {
 				ProviderName:           "myprov",
 				ProviderVersion:        "1.2.3",
 			})
-			s.includeStackTraces = false
+			s.omitStackTraces = true
 
 			expectPanic(t, func() { tc.send(s) })
 

--- a/pkg/providerserver/panic_recovering_provider_test.go
+++ b/pkg/providerserver/panic_recovering_provider_test.go
@@ -186,8 +186,8 @@ func TestPanicRecoveryByMethod(t *testing.T) {
 			send: func(rps pulumirpc.ResourceProviderServer) {
 				rps.Construct(ctx, &pulumirpc.ConstructRequest{})
 			},
-			expectURN:     autogold.Expect(urn.URN("urn:pulumi:::::::")),
-			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 resourceURN=urn:pulumi::::::: method=Construct): Construct panic"),
+			expectURN:     autogold.Expect(urn.URN("")),
+			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 method=Construct): Construct panic"),
 		},
 		{
 			testName: "Cancel",

--- a/pkg/x/muxer/main.go
+++ b/pkg/x/muxer/main.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/providerserver"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -135,7 +136,12 @@ func (m Main) Server(host *provider.HostClient, module, version string) (pulumir
 
 	server := mux(host, dispatchTable, pulumiSchema, m.GetMappingHandler, servers...)
 
-	return server, nil
+	return providerserver.NewPanicRecoveringProviderServer(&providerserver.PanicRecoveringProviderServerOptions{
+		Logger:                 host,
+		ResourceProviderServer: server,
+		ProviderName:           module,
+		ProviderVersion:        version,
+	}), nil
 }
 
 type Endpoint struct {

--- a/pkg/x/muxer/main.go
+++ b/pkg/x/muxer/main.go
@@ -18,11 +18,12 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/providerserver"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/providerserver"
 )
 
 // Mux multiple rpc servers into a single server by routing based on request type and urn.


### PR DESCRIPTION
Recover panics in the bridged providers and emit them as engine error events with sufficient annotations about which provider, provider version, resource and method was responsible for the panic. 

Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/2844

While the bridged providers should never panic, some WIP semantic discrepancy between TF and Pulumi still occasionally results in panics. These changes accomplish two purposes. First, it is easier for maintainers to immediately narrow down a panic to a resource or function involved to attempt a repro. Second, it is easier to scan for panics in internal logs and attribute them to providers unambiguously. 

With these changes, an injected panic in pulumi-random looks as follows. It is unfortunately double-stated but the new error message correctly attributes it to the provider, resource and method:


```
pulumi up --yes                                 ~/code/pulumi-random/examples/simple/ts
Previewing update (anton-test-logging)

View in Browser (Ctrl+O): https://app.pulumi.com/anton-pulumi-corp/simple-random/anton-test-logging/previews/3f77e6b6-287b-4115-8439-8a3e5f328f24

     Type                           Name                              Plan       Info
 +   pulumi:pulumi:Stack            simple-random-anton-test-logging  create     4 errors; 3 warnings
 +   ├─ random:index:RandomInteger  integer                           create     
 +   ├─ random:index:RandomUuid     uuid                              create     
     ├─ random:index:RandomString   string                                       2 errors
 +   └─ random:index:RandomPet      pet                               create     

Diagnostics:
  pulumi:pulumi:Stack (simple-random-anton-test-logging):
    warning: using pulumi-resource-random from $PATH at /Users/anton/code/pulumi-random/bin/pulumi-resource-random
    warning: using pulumi-resource-random from $PATH at /Users/anton/code/pulumi-random/bin/pulumi-resource-random
    warning: resource plugin random is expected to have version >=4.16.8, but has 4.0.0-alpha.0+dev; the wrong version may be on your path, or this may be a bug in the plugin

    error: 
    
             Detected that /Users/anton/code/pulumi-random/bin/pulumi-resource-random exited prematurely.
             This is *always* a bug in the provider. Please report the issue to the provider author as appropriate.
    
    To assist with debugging we have dumped the STDOUT and STDERR streams of the plugin:
    
    panic: FAILUREZ [recovered]
        panic: FAILUREZ
    
    goroutine 27 [running]:
    github.com/pulumi/pulumi-terraform-bridge/v3/pkg/providerserver.(*PanicRecoveringProviderServer).Check.func1()
        /Users/anton/code/pulumi-terraform-bridge/pkg/providerserver/panic_recovering_provider.go:306 +0xc8
    panic({0x1023e15e0?, 0x102779e50?})
        /nix/store/lb8wx7xsk7vryjxbbf9wlj820pdfvnbj-go-1.23.3/share/go/src/runtime/panic.go:785 +0x124
    github.com/pulumi/pulumi-random/provider/v4.Provider.func1({0x14000bbf440?, 0x14000783e00?}, 0x140008bc0c0?, 0x7?)
        /Users/anton/code/pulumi-random/provider/resources.go:69 +0x2c
    github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge.(*provider).CheckWithContext(0x14000a3a388, {0x102799b98?, 0x140007822a0?}, {0x14000720000, 0x5c}, 0x140007822d0, 0x14000782300, 0x0?, {0x140005000c0, 0x20, ...}, ...)
        /Users/anton/code/pulumi-terraform-bridge/pkg/pf/tfbridge/provider_check.go:60 +0x518
    github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/plugin.(*providerServer).Check(0x14000a2bb00, {0x102799b98, 0x140007822a0}, 0x140007a0000)
        /Users/anton/code/pulumi-terraform-bridge/pkg/pf/internal/plugin/provider_server.go:366 +0x20c
    github.com/pulumi/pulumi-terraform-bridge/v3/pkg/providerserver.(*PanicRecoveringProviderServer).Check(0x1035943d0?, {0x102799b98?, 0x140007822a0?}, 0x1024133a0?)
        /Users/anton/code/pulumi-terraform-bridge/pkg/providerserver/panic_recovering_provider.go:309 +0x6c
    github.com/pulumi/pulumi/sdk/v3/proto/go._ResourceProvider_Check_Handler.func1({0x102799b98?, 0x140007822a0?}, {0x1026a33a0?, 0x140007a0000?})
        /Users/anton/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.147.0/proto/go/provider_grpc.pb.go:855 +0xd0
    github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc.OpenTracingServerInterceptor.func1({0x102799b98, 0x140007821b0}, {0x1026a33a0, 0x140007a0000}, 0x1400017c0a0, 0x14000c0a0f0)
        /Users/anton/go/pkg/mod/github.com/grpc-ecosystem/grpc-opentracing@v0.0.0-20180507213350-8e809c8a8645/go/otgrpc/server.go:57 +0x2d4
    github.com/pulumi/pulumi/sdk/v3/proto/go._ResourceProvider_Check_Handler({0x10272b000, 0x14000ba6780}, {0x102799b98, 0x140007821b0}, 0x14000284000, 0x14000a267c0)
        /Users/anton/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.147.0/proto/go/provider_grpc.pb.go:857 +0x148
    google.golang.org/grpc.(*Server).processUnaryRPC(0x14000b9c000, {0x102799b98, 0x14000782120}, {0x1027aabe0, 0x140007b8820}, 0x1400078c000, 0x14000a2bb90, 0x1035c0960, 0x0)
        /Users/anton/go/pkg/mod/google.golang.org/grpc@v1.67.1/server.go:1394 +0xb64
    google.golang.org/grpc.(*Server).handleStream(0x14000b9c000, {0x1027aabe0, 0x140007b8820}, 0x1400078c000)
        /Users/anton/go/pkg/mod/google.golang.org/grpc@v1.67.1/server.go:1805 +0xb20
    google.golang.org/grpc.(*Server).serveStreams.func2.1()
        /Users/anton/go/pkg/mod/google.golang.org/grpc@v1.67.1/server.go:1029 +0x84
    created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 51
        /Users/anton/go/pkg/mod/google.golang.org/grpc@v1.67.1/server.go:1040 +0x13c

  random:index:RandomString (string):
    error: Bridged provider panic (provider=random v=4.0.0-alpha.0+dev resourceURN=urn:pulumi:anton-test-logging::simple-random::random:index/randomString:RandomString::string method=Check): FAILUREZ
    goroutine 27 [running]:
    runtime/debug.Stack()
        /nix/store/lb8wx7xsk7vryjxbbf9wlj820pdfvnbj-go-1.23.3/share/go/src/runtime/debug/stack.go:26 +0x64
    github.com/pulumi/pulumi-terraform-bridge/v3/pkg/providerserver.(*PanicRecoveringProviderServer).Check.func1()
        /Users/anton/code/pulumi-terraform-bridge/pkg/providerserver/panic_recovering_provider.go:303 +0x64
    panic({0x1023e15e0?, 0x102779e50?})
        /nix/store/lb8wx7xsk7vryjxbbf9wlj820pdfvnbj-go-1.23.3/share/go/src/runtime/panic.go:785 +0x124
    github.com/pulumi/pulumi-random/provider/v4.Provider.func1({0x14000bbf440?, 0x14000783e00?}, 0x140008bc0c0?, 0x7?)
        /Users/anton/code/pulumi-random/provider/resources.go:69 +0x2c
    github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge.(*provider).CheckWithContext(0x14000a3a388, {0x102799b98?, 0x140007822a0?}, {0x14000720000, 0x5c}, 0x140007822d0, 0x14000782300, 0x0?, {0x140005000c0, 0x20, ...}, ...)
        /Users/anton/code/pulumi-terraform-bridge/pkg/pf/tfbridge/provider_check.go:60 +0x518
    github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/plugin.(*providerServer).Check(0x14000a2bb00, {0x102799b98, 0x140007822a0}, 0x140007a0000)
        /Users/anton/code/pulumi-terraform-bridge/pkg/pf/internal/plugin/provider_server.go:366 +0x20c
    github.com/pulumi/pulumi-terraform-bridge/v3/pkg/providerserver.(*PanicRecoveringProviderServer).Check(0x1035943d0?, {0x102799b98?, 0x140007822a0?}, 0x1024133a0?)
        /Users/anton/code/pulumi-terraform-bridge/pkg/providerserver/panic_recovering_provider.go:309 +0x6c
    github.com/pulumi/pulumi/sdk/v3/proto/go._ResourceProvider_Check_Handler.func1({0x102799b98?, 0x140007822a0?}, {0x1026a33a0?, 0x140007a0000?})
        /Users/anton/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.147.0/proto/go/provider_grpc.pb.go:855 +0xd0
    github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc.OpenTracingServerInterceptor.func1({0x102799b98, 0x140007821b0}, {0x1026a33a0, 0x140007a0000}, 0x1400017c0a0, 0x14000c0a0f0)
        /Users/anton/go/pkg/mod/github.com/grpc-ecosystem/grpc-opentracing@v0.0.0-20180507213350-8e809c8a8645/go/otgrpc/server.go:57 +0x2d4
    github.com/pulumi/pulumi/sdk/v3/proto/go._ResourceProvider_Check_Handler({0x10272b000, 0x14000ba6780}, {0x102799b98, 0x140007821b0}, 0x14000284000, 0x14000a267c0)
        /Users/anton/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.147.0/proto/go/provider_grpc.pb.go:857 +0x148
    google.golang.org/grpc.(*Server).processUnaryRPC(0x14000b9c000, {0x102799b98, 0x14000782120}, {0x1027aabe0, 0x140007b8820}, 0x1400078c000, 0x14000a2bb90, 0x1035c0960, 0x0)
        /Users/anton/go/pkg/mod/google.golang.org/grpc@v1.67.1/server.go:1394 +0xb64
    google.golang.org/grpc.(*Server).handleStream(0x14000b9c000, {0x1027aabe0, 0x140007b8820}, 0x1400078c000)
        /Users/anton/go/pkg/mod/google.golang.org/grpc@v1.67.1/server.go:1805 +0xb20
    google.golang.org/grpc.(*Server).serveStreams.func2.1()
        /Users/anton/go/pkg/mod/google.golang.org/grpc@v1.67.1/server.go:1029 +0x84
    created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 51
        /Users/anton/go/pkg/mod/google.golang.org/grpc@v1.67.1/server.go:1040 +0x13c
    error: error reading from server: EOF


```