### PR TITLE
Enforce `pf/tfgen.ProviderMetadata.BridgeMetadata` deprecation

### DIFF
--- a/pkg/pf/tfbridge/metadata.go
+++ b/pkg/pf/tfbridge/metadata.go
@@ -29,7 +29,7 @@ type ProviderMetadata struct {
 	// JSON-serialzed Pulumi Package Schema.
 	PackageSchema []byte
 
-	// Deprecated. This field is no longer in use and will be removed in future versions.
+	// Deprecated: This field is no longer in use and will be removed in future versions.
 	BridgeMetadata []byte
 
 	// XParamaterize overrides the functionality of the Paramaterize call.


### PR DESCRIPTION
The previous syntax is not enforced by Go's language tooling.

Following up on https://github.com/pulumi/pulumi-cloudflare/pull/1057#discussion_r1939403604.