### PR TITLE
Add deprecation note to provider landing page for recently deprecated providers"

### DIFF
--- a/pkg/tfgen/installation_docs.go
+++ b/pkg/tfgen/installation_docs.go
@@ -156,10 +156,29 @@ func writeInstallationInstructions(goImportBasePath, displayName, pkgName, ghOrg
 		pkgName,
 	)
 
+	deprecatedNote := fmt.Sprintf("~> **NOTE:** This provider has recently been deprecated by Pulumi.\n"+
+		"Going forward, it is available as a [Local Package](https://www.pulumi.com/blog/any-terraform-provider/)"+
+		" instead.\n"+
+		"Please see the [provider's repository](https://github.com/pulumi/pulumi-%s) for details.\n\n", pkgName)
+
 	if strings.Contains(sourceRepo, "pulumi") {
 		return installInstructions
 	}
+	for _, provider := range getDeprecatedProviderNames() {
+		if provider == pkgName {
+			// prepend the deprecation note
+			generateInstructions = deprecatedNote + generateInstructions
+		}
+	}
 	return generateInstructions
+}
+
+// TODO: remove this note after 90 days TODO: make and link issue
+func getDeprecatedProviderNames() []string {
+	providerNames := []string{
+		"civo",
+	}
+	return providerNames
 }
 
 func getOverviewHeader(content []byte) string {

--- a/pkg/tfgen/installation_docs.go
+++ b/pkg/tfgen/installation_docs.go
@@ -156,24 +156,25 @@ func writeInstallationInstructions(goImportBasePath, displayName, pkgName, ghOrg
 		pkgName,
 	)
 
-	deprecatedNote := fmt.Sprintf("~> **NOTE:** This provider has recently been deprecated by Pulumi.\n"+
+	deprecatedNote := fmt.Sprintf("~> **NOTE:** This provider was previously published as @pulumi/%[1]s.\n"+
+		"However, that package is no longer being updated."+
 		"Going forward, it is available as a [Local Package](https://www.pulumi.com/blog/any-terraform-provider/)"+
 		" instead.\n"+
-		"Please see the [provider's repository](https://github.com/pulumi/pulumi-%s) for details.\n\n", pkgName)
+		"Please see the [provider's repository](https://github.com/pulumi/pulumi-%[1]s) for details.\n\n", pkgName)
 
 	if strings.Contains(sourceRepo, "pulumi") {
 		return installInstructions
 	}
 	for _, provider := range getDeprecatedProviderNames() {
 		if provider == pkgName {
-			// prepend the deprecation note
-			generateInstructions = deprecatedNote + generateInstructions
+			// append the deprecation note
+			generateInstructions = generateInstructions + deprecatedNote
 		}
 	}
 	return generateInstructions
 }
 
-// TODO: remove this note after 90 days TODO: make and link issue
+// TODO: remove this note after 90 days: https://github.com/pulumi/pulumi-terraform-bridge/issues/2885
 func getDeprecatedProviderNames() []string {
 	providerNames := []string{
 		"civo",

--- a/pkg/tfgen/installation_docs_test.go
+++ b/pkg/tfgen/installation_docs_test.go
@@ -306,14 +306,16 @@ func TestWriteInstallationInstructions(t *testing.T) {
 		},
 		{
 			name: "Generates Deprecation Note If Provider on Deprecated List",
-			expected: autogold.Expect("~> **NOTE:** This provider has recently been deprecated by Pulumi.\n" +
-				"Going forward, it is available as a [Local Package](https://www.pulumi.com/blog/any-terraform-provider/) " +
-				"instead.\n" +
-				"Please see the [provider's repository](https://github.com/pulumi/pulumi-civo) for details.\n\n" +
+			expected: autogold.Expect(
 				"## Generate Provider\n\n" +
-				"The Civo provider must be installed as a Local Package by following the " +
-				"[instructions for Any Terraform Provider](https://www.pulumi.com/registry/packages/terraform-provider/):\n\n" +
-				"```bash\npulumi package add terraform-provider civo/civo\n```\n"),
+					"The Civo provider must be installed as a Local Package by following the " +
+					"[instructions for Any Terraform Provider](https://www.pulumi.com/registry/packages/terraform-provider/):\n\n" +
+					"```bash\npulumi package add terraform-provider civo/civo\n```\n" +
+					"~> **NOTE:** This provider was previously published as @pulumi/civo.\n" +
+					"However, that package is no longer being updated." +
+					"Going forward, it is available as a [Local Package](https://www.pulumi.com/blog/any-terraform-provider/) " +
+					"instead.\n" +
+					"Please see the [provider's repository](https://github.com/pulumi/pulumi-civo) for details.\n\n"),
 			goImportBasePath: "github.com/pulumi/pulumi-testcase/sdk/v3/go/pulumi-testcase",
 			displayName:      "Civo",
 			packageName:      "civo",

--- a/pkg/tfgen/installation_docs_test.go
+++ b/pkg/tfgen/installation_docs_test.go
@@ -304,6 +304,22 @@ func TestWriteInstallationInstructions(t *testing.T) {
 			repository:       "terraform-provider-testcase",
 			ghOrg:            "unicorncorp",
 		},
+		{
+			name: "Generates Deprecation Note If Provider on Deprecated List",
+			expected: autogold.Expect("~> **NOTE:** This provider has recently been deprecated by Pulumi.\n" +
+				"Going forward, it is available as a [Local Package](https://www.pulumi.com/blog/any-terraform-provider/) " +
+				"instead.\n" +
+				"Please see the [provider's repository](https://github.com/pulumi/pulumi-civo) for details.\n\n" +
+				"## Generate Provider\n\n" +
+				"The Civo provider must be installed as a Local Package by following the " +
+				"[instructions for Any Terraform Provider](https://www.pulumi.com/registry/packages/terraform-provider/):\n\n" +
+				"```bash\npulumi package add terraform-provider civo/civo\n```\n"),
+			goImportBasePath: "github.com/pulumi/pulumi-testcase/sdk/v3/go/pulumi-testcase",
+			displayName:      "Civo",
+			packageName:      "civo",
+			repository:       "terraform-provider-civo",
+			ghOrg:            "civo",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This pull request adds a list of deprecated providers to the landing page docsgen so that the page can display a deprecation warning with relevant links.

Currently, the list only contains pulumi-civo; we will add to it as we deprecate.

Part of https://github.com/pulumi/pulumi-civo/issues/696.

Screenshot of expected landing page as soon as we add Civo to the list of dynamically bridged providers:

<img width="826" alt="Screenshot 2025-02-03 at 1 58 31 PM" src="https://github.com/user-attachments/assets/b574aafe-e4e2-4f95-b06d-88cb84bf7cda" />


- **Add deprecation note to installation instructions and add Civo to a hardcoded list of recently-deprecated**
- **Add test to show that a provider returned by getDeprecateProviderNames contains a deprecation note**
