### PR TITLE
Add RKE to deprecated provider list

### DIFF
--- a/pkg/tfgen/installation_docs.go
+++ b/pkg/tfgen/installation_docs.go
@@ -178,6 +178,7 @@ func writeInstallationInstructions(goImportBasePath, displayName, pkgName, ghOrg
 func getDeprecatedProviderNames() []string {
 	providerNames := []string{
 		"civo",
+		"rke",
 	}
 	return providerNames
 }


### PR DESCRIPTION
What it says on the box.

Part of https://github.com/pulumi/home/issues/3878.
