### PR TITLE
Add Libvirt to deprecated provider list

### DIFF
--- a/pkg/tfgen/installation_docs.go
+++ b/pkg/tfgen/installation_docs.go
@@ -179,6 +179,7 @@ func getDeprecatedProviderNames() []string {
 	providerNames := []string{
 		"civo",
 		"rke",
+		"libvirt",
 	}
 	return providerNames
 }


### PR DESCRIPTION
Part of https://github.com/pulumi/home/issues/3879,

When we add Libvirt to our dynamically bridged provider list, a note for the recent change to Any TF Provider will appear on the landing page.


