### PR TITLE
Assert empty stderr in Diff cross-tests

### DIFF
--- a/pkg/internal/tests/cross-tests/diff_check.go
+++ b/pkg/internal/tests/cross-tests/diff_check.go
@@ -88,6 +88,8 @@ func runDiffCheck(t T, tc diffTestCase) crosstestsimpl.DiffResult {
 	require.NoErrorf(t, err, "writing Pulumi.yaml")
 
 	previewRes := pt.Preview(t, optpreview.Diff())
+	require.Empty(t, previewRes.StdErr, "preview should not have errors")
+
 	diffResponse := crosstestsimpl.GetPulumiDiffResponse(t, pt.GrpcLog(t).Entries)
 	x := pt.Up(t)
 


### PR DESCRIPTION
This PR adds an assertion to Diff cross-tests that we haven't emitted anything to stderr. This should catch any warnings emitted during Diff.

Necessary for the tests in https://github.com/pulumi/pulumi-terraform-bridge/pull/2891
Related to https://github.com/pulumi/pulumi-terraform-bridge/issues/2892