### PR TITLE
Fix Accurate Previews for set-nested sets

### DIFF
--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/added.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{"value"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/added.golden
@@ -2,15 +2,43 @@ tests.testOutput{
 	initialValue: &[]string{},
 	changeValue:  &[]string{"value"},
 	tfOut: `
-No changes. Your infrastructure matches the configuration.
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
 
-Terraform has compared your real infrastructure against your configuration
-and found no differences, so no changes are needed.
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {}
+      + prop {
+          + nested_prop = [
+              + "value",
+            ]
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  + nestedProps: [
+                  +     [0]: "value"
+                    ]
+                }
+        ]
 Resources:
-    2 unchanged
+    ~ 1 to update
+    1 unchanged
 `,
+	detailedDiff: map[string]interface{}{"props[0].nestedProps": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/added_end.golden
@@ -1,0 +1,23 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/added_end.golden
@@ -9,15 +9,50 @@ tests.testOutput{
 		"val3",
 	},
 	tfOut: `
-No changes. Your infrastructure matches the configuration.
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
 
-Terraform has compared your real infrastructure against your configuration
-and found no differences, so no changes are needed.
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = [
+              - "val1",
+              - "val2",
+            ] -> null
+        }
+      + prop {
+          + nested_prop = [
+              + "val1",
+              + "val2",
+              + "val3",
+            ]
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProps: [
+                      + [2]: "val3"
+                    ]
+                }
+        ]
 Resources:
-    2 unchanged
+    ~ 1 to update
+    1 unchanged
 `,
+	detailedDiff: map[string]interface{}{"props[0].nestedProps[2]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/added_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/added_end_unordered.golden
@@ -1,0 +1,23 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/added_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/added_end_unordered.golden
@@ -9,15 +9,53 @@ tests.testOutput{
 		"val1",
 	},
 	tfOut: `
-No changes. Your infrastructure matches the configuration.
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
 
-Terraform has compared your real infrastructure against your configuration
-and found no differences, so no changes are needed.
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = [
+              - "val2",
+              - "val3",
+            ] -> null
+        }
+      + prop {
+          + nested_prop = [
+              + "val1",
+              + "val2",
+              + "val3",
+            ]
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  + __defaults : []
+                  ~ nestedProps: [
+                        [0]: "val2"
+                        [1]: "val3"
+                      + [2]: "val1"
+                    ]
+                }
+        ]
 Resources:
-    2 unchanged
+    ~ 1 to update
+    1 unchanged
 `,
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/added_front.golden
@@ -9,15 +9,50 @@ tests.testOutput{
 		"val3",
 	},
 	tfOut: `
-No changes. Your infrastructure matches the configuration.
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
 
-Terraform has compared your real infrastructure against your configuration
-and found no differences, so no changes are needed.
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = [
+              - "val2",
+              - "val3",
+            ] -> null
+        }
+      + prop {
+          + nested_prop = [
+              + "val1",
+              + "val2",
+              + "val3",
+            ]
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProps: [
+                      + [0]: "val1"
+                    ]
+                }
+        ]
 Resources:
-    2 unchanged
+    ~ 1 to update
+    1 unchanged
 `,
+	detailedDiff: map[string]interface{}{"props[0].nestedProps[0]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/added_front.golden
@@ -1,0 +1,23 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/added_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/added_front_unordered.golden
@@ -1,0 +1,23 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/added_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/added_front_unordered.golden
@@ -9,15 +9,53 @@ tests.testOutput{
 		"val1",
 	},
 	tfOut: `
-No changes. Your infrastructure matches the configuration.
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
 
-Terraform has compared your real infrastructure against your configuration
-and found no differences, so no changes are needed.
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = [
+              - "val1",
+              - "val3",
+            ] -> null
+        }
+      + prop {
+          + nested_prop = [
+              + "val1",
+              + "val2",
+              + "val3",
+            ]
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  + __defaults : []
+                  ~ nestedProps: [
+                      ~ [0]: "val1" => "val2"
+                        [1]: "val3"
+                      + [2]: "val1"
+                    ]
+                }
+        ]
 Resources:
-    2 unchanged
+    ~ 1 to update
+    1 unchanged
 `,
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/added_middle.golden
@@ -1,0 +1,23 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/added_middle.golden
@@ -9,15 +9,50 @@ tests.testOutput{
 		"val3",
 	},
 	tfOut: `
-No changes. Your infrastructure matches the configuration.
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
 
-Terraform has compared your real infrastructure against your configuration
-and found no differences, so no changes are needed.
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = [
+              - "val1",
+              - "val3",
+            ] -> null
+        }
+      + prop {
+          + nested_prop = [
+              + "val1",
+              + "val2",
+              + "val3",
+            ]
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProps: [
+                      + [1]: "val2"
+                    ]
+                }
+        ]
 Resources:
-    2 unchanged
+    ~ 1 to update
+    1 unchanged
 `,
+	detailedDiff: map[string]interface{}{"props[0].nestedProps[1]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/added_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/added_middle_unordered.golden
@@ -9,15 +9,53 @@ tests.testOutput{
 		"val1",
 	},
 	tfOut: `
-No changes. Your infrastructure matches the configuration.
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
 
-Terraform has compared your real infrastructure against your configuration
-and found no differences, so no changes are needed.
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = [
+              - "val1",
+              - "val2",
+            ] -> null
+        }
+      + prop {
+          + nested_prop = [
+              + "val1",
+              + "val2",
+              + "val3",
+            ]
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  + __defaults : []
+                  ~ nestedProps: [
+                      ~ [0]: "val1" => "val2"
+                      ~ [1]: "val2" => "val3"
+                      + [2]: "val1"
+                    ]
+                }
+        ]
 Resources:
-    2 unchanged
+    ~ 1 to update
+    1 unchanged
 `,
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/added_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/added_middle_unordered.golden
@@ -1,0 +1,23 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/changed_empty_to_null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/changed_empty_to_null.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  nil,
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/changed_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/changed_non-null.golden
@@ -4,15 +4,47 @@ tests.testOutput{
 	},
 	changeValue: &[]string{"value1"},
 	tfOut: `
-No changes. Your infrastructure matches the configuration.
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
 
-Terraform has compared your real infrastructure against your configuration
-and found no differences, so no changes are needed.
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = [
+              - "value",
+            ] -> null
+        }
+      + prop {
+          + nested_prop = [
+              + "value1",
+            ]
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProps: [
+                      ~ [0]: "value" => "value1"
+                    ]
+                }
+        ]
 Resources:
-    2 unchanged
+    ~ 1 to update
+    1 unchanged
 `,
+	detailedDiff: map[string]interface{}{"props[0].nestedProps[0]": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/changed_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/changed_non-null.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value1"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/changed_non-null_to_null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/changed_non-null_to_null.golden
@@ -1,0 +1,45 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: nil,
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = [
+              - "value",
+            ] -> null
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      - props: [
+      -     [0]: {
+              - nestedProps: [
+              -     [0]: "value"
+                ]
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/changed_null_to_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/changed_null_to_empty.golden
@@ -1,0 +1,36 @@
+tests.testOutput{
+	initialValue: nil, changeValue: &[]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + prop {}
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + props: [
+      +     [0]: {
+              + nestedProps: []
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/changed_null_to_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/changed_null_to_non-null.golden
@@ -1,0 +1,44 @@
+tests.testOutput{
+	initialValue: nil, changeValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + prop {
+          + nested_prop = [
+              + "value",
+            ]
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + props: [
+      +     [0]: {
+              + nestedProps: [
+              +     [0]: "value"
+                ]
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/removed.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/removed_end.golden
@@ -1,0 +1,23 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/removed_end.golden
@@ -9,15 +9,50 @@ tests.testOutput{
 		"val2",
 	},
 	tfOut: `
-No changes. Your infrastructure matches the configuration.
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
 
-Terraform has compared your real infrastructure against your configuration
-and found no differences, so no changes are needed.
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = [
+              - "val1",
+              - "val2",
+              - "val3",
+            ] -> null
+        }
+      + prop {
+          + nested_prop = [
+              + "val1",
+              + "val2",
+            ]
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProps: [
+                      - [2]: "val3"
+                    ]
+                }
+        ]
 Resources:
-    2 unchanged
+    ~ 1 to update
+    1 unchanged
 `,
+	detailedDiff: map[string]interface{}{"props[0].nestedProps[2]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/removed_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/removed_end_unordered.golden
@@ -9,15 +9,50 @@ tests.testOutput{
 		"val3",
 	},
 	tfOut: `
-No changes. Your infrastructure matches the configuration.
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
 
-Terraform has compared your real infrastructure against your configuration
-and found no differences, so no changes are needed.
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = [
+              - "val1",
+              - "val2",
+              - "val3",
+            ] -> null
+        }
+      + prop {
+          + nested_prop = [
+              + "val2",
+              + "val3",
+            ]
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProps: [
+                      - [0]: "val1"
+                    ]
+                }
+        ]
 Resources:
-    2 unchanged
+    ~ 1 to update
+    1 unchanged
 `,
+	detailedDiff: map[string]interface{}{"props[0].nestedProps[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/removed_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/removed_end_unordered.golden
@@ -1,0 +1,23 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/removed_front.golden
@@ -9,15 +9,50 @@ tests.testOutput{
 		"val3",
 	},
 	tfOut: `
-No changes. Your infrastructure matches the configuration.
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
 
-Terraform has compared your real infrastructure against your configuration
-and found no differences, so no changes are needed.
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = [
+              - "val1",
+              - "val2",
+              - "val3",
+            ] -> null
+        }
+      + prop {
+          + nested_prop = [
+              + "val2",
+              + "val3",
+            ]
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProps: [
+                      - [0]: "val1"
+                    ]
+                }
+        ]
 Resources:
-    2 unchanged
+    ~ 1 to update
+    1 unchanged
 `,
+	detailedDiff: map[string]interface{}{"props[0].nestedProps[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/removed_front.golden
@@ -1,0 +1,23 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/removed_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/removed_front_unordered.golden
@@ -9,15 +9,53 @@ tests.testOutput{
 		"val1",
 	},
 	tfOut: `
-No changes. Your infrastructure matches the configuration.
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
 
-Terraform has compared your real infrastructure against your configuration
-and found no differences, so no changes are needed.
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = [
+              - "val1",
+              - "val2",
+              - "val3",
+            ] -> null
+        }
+      + prop {
+          + nested_prop = [
+              + "val1",
+              + "val3",
+            ]
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  + __defaults : []
+                  ~ nestedProps: [
+                      ~ [0]: "val1" => "val3"
+                      ~ [1]: "val2" => "val1"
+                      - [2]: "val3"
+                    ]
+                }
+        ]
 Resources:
-    2 unchanged
+    ~ 1 to update
+    1 unchanged
 `,
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/removed_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/removed_front_unordered.golden
@@ -1,0 +1,23 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/removed_middle.golden
@@ -1,0 +1,23 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/removed_middle.golden
@@ -9,15 +9,50 @@ tests.testOutput{
 		"val3",
 	},
 	tfOut: `
-No changes. Your infrastructure matches the configuration.
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
 
-Terraform has compared your real infrastructure against your configuration
-and found no differences, so no changes are needed.
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = [
+              - "val1",
+              - "val2",
+              - "val3",
+            ] -> null
+        }
+      + prop {
+          + nested_prop = [
+              + "val1",
+              + "val3",
+            ]
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProps: [
+                      - [1]: "val2"
+                    ]
+                }
+        ]
 Resources:
-    2 unchanged
+    ~ 1 to update
+    1 unchanged
 `,
+	detailedDiff: map[string]interface{}{"props[0].nestedProps[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/removed_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/removed_middle_unordered.golden
@@ -9,15 +9,53 @@ tests.testOutput{
 		"val1",
 	},
 	tfOut: `
-No changes. Your infrastructure matches the configuration.
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
 
-Terraform has compared your real infrastructure against your configuration
-and found no differences, so no changes are needed.
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = [
+              - "val1",
+              - "val2",
+              - "val3",
+            ] -> null
+        }
+      + prop {
+          + nested_prop = [
+              + "val1",
+              + "val3",
+            ]
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  + __defaults : []
+                  ~ nestedProps: [
+                      ~ [0]: "val1" => "val3"
+                      ~ [1]: "val2" => "val1"
+                      - [2]: "val3"
+                    ]
+                }
+        ]
 Resources:
-    2 unchanged
+    ~ 1 to update
+    1 unchanged
 `,
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/removed_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/removed_middle_unordered.golden
@@ -1,0 +1,23 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/same_element_updated.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/same_element_updated.golden
@@ -10,15 +10,54 @@ tests.testOutput{
 		"val3",
 	},
 	tfOut: `
-No changes. Your infrastructure matches the configuration.
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
 
-Terraform has compared your real infrastructure against your configuration
-and found no differences, so no changes are needed.
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = [
+              - "val1",
+              - "val2",
+              - "val3",
+            ] -> null
+        }
+      + prop {
+          + nested_prop = [
+              + "val1",
+              + "val3",
+              + "val4",
+            ]
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  + __defaults : []
+                  ~ nestedProps: [
+                        [0]: "val1"
+                      ~ [1]: "val2" => "val4"
+                        [2]: "val3"
+                    ]
+                }
+        ]
 Resources:
-    2 unchanged
+    ~ 1 to update
+    1 unchanged
 `,
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/same_element_updated.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/same_element_updated.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val4",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/same_element_updated_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/same_element_updated_unordered.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val4",
+		"val1",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/same_element_updated_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/same_element_updated_unordered.golden
@@ -10,15 +10,54 @@ tests.testOutput{
 		"val1",
 	},
 	tfOut: `
-No changes. Your infrastructure matches the configuration.
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
 
-Terraform has compared your real infrastructure against your configuration
-and found no differences, so no changes are needed.
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = [
+              - "val1",
+              - "val2",
+              - "val3",
+            ] -> null
+        }
+      + prop {
+          + nested_prop = [
+              + "val1",
+              + "val2",
+              + "val4",
+            ]
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  + __defaults : []
+                  ~ nestedProps: [
+                      ~ [0]: "val1" => "val2"
+                      ~ [1]: "val2" => "val4"
+                      ~ [2]: "val3" => "val1"
+                    ]
+                }
+        ]
 Resources:
-    2 unchanged
+    ~ 1 to update
+    1 unchanged
 `,
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_added_end.golden
@@ -9,15 +9,53 @@ tests.testOutput{
 		"val3",
 	},
 	tfOut: `
-No changes. Your infrastructure matches the configuration.
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
 
-Terraform has compared your real infrastructure against your configuration
-and found no differences, so no changes are needed.
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = [
+              - "val1",
+              - "val2",
+            ] -> null
+        }
+      + prop {
+          + nested_prop = [
+              + "val1",
+              + "val2",
+              + "val3",
+            ]
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  + __defaults : []
+                  ~ nestedProps: [
+                      ~ [0]: "val1" => "val2"
+                      ~ [1]: "val2" => "val1"
+                      + [2]: "val3"
+                    ]
+                }
+        ]
 Resources:
-    2 unchanged
+    ~ 1 to update
+    1 unchanged
 `,
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_added_end.golden
@@ -1,0 +1,23 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_added_front.golden
@@ -1,0 +1,23 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_added_front.golden
@@ -9,15 +9,53 @@ tests.testOutput{
 		"val2",
 	},
 	tfOut: `
-No changes. Your infrastructure matches the configuration.
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
 
-Terraform has compared your real infrastructure against your configuration
-and found no differences, so no changes are needed.
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = [
+              - "val2",
+              - "val3",
+            ] -> null
+        }
+      + prop {
+          + nested_prop = [
+              + "val1",
+              + "val2",
+              + "val3",
+            ]
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  + __defaults : []
+                  ~ nestedProps: [
+                      ~ [0]: "val2" => "val1"
+                        [1]: "val3"
+                      + [2]: "val2"
+                    ]
+                }
+        ]
 Resources:
-    2 unchanged
+    ~ 1 to update
+    1 unchanged
 `,
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_added_middle.golden
@@ -1,0 +1,23 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+		"val1",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_added_middle.golden
@@ -9,15 +9,53 @@ tests.testOutput{
 		"val1",
 	},
 	tfOut: `
-No changes. Your infrastructure matches the configuration.
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
 
-Terraform has compared your real infrastructure against your configuration
-and found no differences, so no changes are needed.
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = [
+              - "val1",
+              - "val3",
+            ] -> null
+        }
+      + prop {
+          + nested_prop = [
+              + "val1",
+              + "val2",
+              + "val3",
+            ]
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  + __defaults : []
+                  ~ nestedProps: [
+                      ~ [0]: "val1" => "val3"
+                      ~ [1]: "val3" => "val2"
+                      + [2]: "val1"
+                    ]
+                }
+        ]
 Resources:
-    2 unchanged
+    ~ 1 to update
+    1 unchanged
 `,
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_removed_end.golden
@@ -9,15 +9,53 @@ tests.testOutput{
 		"val1",
 	},
 	tfOut: `
-No changes. Your infrastructure matches the configuration.
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
 
-Terraform has compared your real infrastructure against your configuration
-and found no differences, so no changes are needed.
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = [
+              - "val1",
+              - "val2",
+              - "val3",
+            ] -> null
+        }
+      + prop {
+          + nested_prop = [
+              + "val1",
+              + "val2",
+            ]
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  + __defaults : []
+                  ~ nestedProps: [
+                      ~ [0]: "val1" => "val2"
+                      ~ [1]: "val2" => "val1"
+                      - [2]: "val3"
+                    ]
+                }
+        ]
 Resources:
-    2 unchanged
+    ~ 1 to update
+    1 unchanged
 `,
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_removed_end.golden
@@ -1,0 +1,23 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_removed_front.golden
@@ -1,0 +1,23 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_removed_front.golden
@@ -9,15 +9,53 @@ tests.testOutput{
 		"val2",
 	},
 	tfOut: `
-No changes. Your infrastructure matches the configuration.
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
 
-Terraform has compared your real infrastructure against your configuration
-and found no differences, so no changes are needed.
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = [
+              - "val1",
+              - "val2",
+              - "val3",
+            ] -> null
+        }
+      + prop {
+          + nested_prop = [
+              + "val2",
+              + "val3",
+            ]
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  + __defaults : []
+                  ~ nestedProps: [
+                      ~ [0]: "val1" => "val3"
+                        [1]: "val2"
+                      - [2]: "val3"
+                    ]
+                }
+        ]
 Resources:
-    2 unchanged
+    ~ 1 to update
+    1 unchanged
 `,
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_removed_middle.golden
@@ -1,0 +1,23 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_removed_middle.golden
@@ -9,15 +9,53 @@ tests.testOutput{
 		"val1",
 	},
 	tfOut: `
-No changes. Your infrastructure matches the configuration.
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
 
-Terraform has compared your real infrastructure against your configuration
-and found no differences, so no changes are needed.
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = [
+              - "val1",
+              - "val2",
+              - "val3",
+            ] -> null
+        }
+      + prop {
+          + nested_prop = [
+              + "val1",
+              + "val3",
+            ]
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  + __defaults : []
+                  ~ nestedProps: [
+                      ~ [0]: "val1" => "val3"
+                      ~ [1]: "val2" => "val1"
+                      - [2]: "val3"
+                    ]
+                }
+        ]
 Resources:
-    2 unchanged
+    ~ 1 to update
+    1 unchanged
 `,
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_unordered.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_with_duplicates.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_with_duplicates.golden
@@ -1,0 +1,25 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_with_duplicates_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_with_duplicates_unordered.golden
@@ -1,0 +1,25 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/two_added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/two_added.golden
@@ -10,15 +10,55 @@ tests.testOutput{
 		"val4",
 	},
 	tfOut: `
-No changes. Your infrastructure matches the configuration.
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
 
-Terraform has compared your real infrastructure against your configuration
-and found no differences, so no changes are needed.
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = [
+              - "val1",
+              - "val2",
+            ] -> null
+        }
+      + prop {
+          + nested_prop = [
+              + "val1",
+              + "val2",
+              + "val3",
+              + "val4",
+            ]
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProps: [
+                      + [2]: "val3"
+                      + [3]: "val4"
+                    ]
+                }
+        ]
 Resources:
-    2 unchanged
+    ~ 1 to update
+    1 unchanged
 `,
+	detailedDiff: map[string]interface{}{
+		"props[0].nestedProps[2]": map[string]interface{}{},
+		"props[0].nestedProps[3]": map[string]interface{}{},
+	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/two_added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/two_added.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/two_added_and_two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/two_added_and_two_removed.golden
@@ -12,15 +12,57 @@ tests.testOutput{
 		"val6",
 	},
 	tfOut: `
-No changes. Your infrastructure matches the configuration.
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
 
-Terraform has compared your real infrastructure against your configuration
-and found no differences, so no changes are needed.
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = [
+              - "val1",
+              - "val2",
+              - "val3",
+              - "val4",
+            ] -> null
+        }
+      + prop {
+          + nested_prop = [
+              + "val1",
+              + "val2",
+              + "val5",
+              + "val6",
+            ]
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProps: [
+                      ~ [2]: "val3" => "val5"
+                      ~ [3]: "val4" => "val6"
+                    ]
+                }
+        ]
 Resources:
-    2 unchanged
+    ~ 1 to update
+    1 unchanged
 `,
+	detailedDiff: map[string]interface{}{
+		"props[0].nestedProps[2]": map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProps[3]": map[string]interface{}{"kind": "UPDATE"},
+	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/two_added_and_two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/two_added_and_two_removed.golden
@@ -1,0 +1,26 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val5",
+		"val6",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -1,0 +1,26 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val5",
+		"val6",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -12,15 +12,57 @@ tests.testOutput{
 		"val2",
 	},
 	tfOut: `
-No changes. Your infrastructure matches the configuration.
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
 
-Terraform has compared your real infrastructure against your configuration
-and found no differences, so no changes are needed.
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = [
+              - "val1",
+              - "val2",
+              - "val3",
+              - "val4",
+            ] -> null
+        }
+      + prop {
+          + nested_prop = [
+              + "val1",
+              + "val2",
+              + "val5",
+              + "val6",
+            ]
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  + __defaults : []
+                  ~ nestedProps: [
+                      ~ [0]: "val1" => "val5"
+                      ~ [1]: "val2" => "val6"
+                      ~ [2]: "val3" => "val1"
+                      ~ [3]: "val4" => "val2"
+                    ]
+                }
+        ]
 Resources:
-    2 unchanged
+    ~ 1 to update
+    1 unchanged
 `,
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -1,0 +1,26 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val5",
+		"val6",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -12,15 +12,57 @@ tests.testOutput{
 		"val2",
 	},
 	tfOut: `
-No changes. Your infrastructure matches the configuration.
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
 
-Terraform has compared your real infrastructure against your configuration
-and found no differences, so no changes are needed.
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = [
+              - "val1",
+              - "val2",
+              - "val3",
+              - "val4",
+            ] -> null
+        }
+      + prop {
+          + nested_prop = [
+              + "val1",
+              + "val2",
+              + "val5",
+              + "val6",
+            ]
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  + __defaults : []
+                  ~ nestedProps: [
+                        [0]: "val1"
+                      ~ [1]: "val2" => "val5"
+                      ~ [2]: "val3" => "val6"
+                      ~ [3]: "val4" => "val2"
+                    ]
+                }
+        ]
 Resources:
-    2 unchanged
+    ~ 1 to update
+    1 unchanged
 `,
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -1,0 +1,28 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val5",
+		"val6",
+		"val2",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -14,15 +14,59 @@ tests.testOutput{
 		"val2",
 	},
 	tfOut: `
-No changes. Your infrastructure matches the configuration.
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
 
-Terraform has compared your real infrastructure against your configuration
-and found no differences, so no changes are needed.
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = [
+              - "val1",
+              - "val2",
+              - "val3",
+              - "val4",
+            ] -> null
+        }
+      + prop {
+          + nested_prop = [
+              + "val1",
+              + "val2",
+              + "val5",
+              + "val6",
+            ]
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  + __defaults : []
+                  ~ nestedProps: [
+                        [0]: "val1"
+                      ~ [1]: "val2" => "val5"
+                      ~ [2]: "val3" => "val6"
+                      ~ [3]: "val4" => "val2"
+                      + [4]: "val1"
+                      + [5]: "val2"
+                    ]
+                }
+        ]
 Resources:
-    2 unchanged
+    ~ 1 to update
+    1 unchanged
 `,
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/two_removed.golden
@@ -10,15 +10,55 @@ tests.testOutput{
 		"val2",
 	},
 	tfOut: `
-No changes. Your infrastructure matches the configuration.
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
 
-Terraform has compared your real infrastructure against your configuration
-and found no differences, so no changes are needed.
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = [
+              - "val1",
+              - "val2",
+              - "val3",
+              - "val4",
+            ] -> null
+        }
+      + prop {
+          + nested_prop = [
+              + "val1",
+              + "val2",
+            ]
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
 `,
 	pulumiOut: `Previewing update (test):
   pulumi:pulumi:Stack: (same)
     [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProps: [
+                      - [2]: "val3"
+                      - [3]: "val4"
+                    ]
+                }
+        ]
 Resources:
-    2 unchanged
+    ~ 1 to update
+    1 unchanged
 `,
+	detailedDiff: map[string]interface{}{
+		"props[0].nestedProps[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[0].nestedProps[3]": map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/two_removed.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/unchanged_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/unchanged_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/unchanged_null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/unchanged_null.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: nil, changeValue: nil,
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tfbridge/detailed_diff.go
+++ b/pkg/tfbridge/detailed_diff.go
@@ -313,22 +313,20 @@ func (differ detailedDiffer) calculateSetHashIndexMap(
 		return nil
 	}
 
-	convertedVal, err := makeSingleTerraformInput(
-		differ.ctx, path.String(), resource.NewArrayProperty(listVal), tfs, ps)
-	if err != nil {
-		return nil
-	}
+	convertedElements := []interface{}{}
 
-	if convertedVal == nil {
-		return nil
+	for _, elem := range listVal {
+		convertedElem, err := makeSingleTerraformInputForSetElement(
+			differ.ctx, path.String(), elem, tfs, ps)
+		if err != nil {
+			return nil
+		}
+		convertedElements = append(convertedElements, convertedElem)
 	}
-
-	convertedListVal, ok := convertedVal.([]interface{})
-	contract.Assertf(ok, "converted value should be a list")
 
 	// Calculate the identity of each element. Note that the SetHash function can panic
 	// in the case of custom SetHash functions which get unexpected inputs.
-	for i, newElem := range convertedListVal {
+	for i, newElem := range convertedElements {
 		elementHash := func() int {
 			defer func() {
 				if r := recover(); r != nil {

--- a/pkg/tfbridge/detailed_diff_test.go
+++ b/pkg/tfbridge/detailed_diff_test.go
@@ -605,8 +605,13 @@ func runDetailedDiffTest(
 	expected map[string]*pulumirpc.PropertyDiff,
 ) {
 	t.Helper()
-	actual := MakeDetailedDiffV2(context.Background(), tfs, ps, old, new, new, nil)
-
+	ctx := context.Background()
+	buf := &bytes.Buffer{}
+	ctx = logging.InitLogging(ctx, logging.LogOptions{
+		LogSink: &testLogSink{buf},
+	})
+	actual := MakeDetailedDiffV2(ctx, tfs, ps, old, new, new, nil)
+	require.Empty(t, buf.String())
 	require.Equal(t, expected, actual)
 }
 

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -342,7 +342,7 @@ func MakeTerraformInputs(
 
 // makeSingleTerraformInput converts a single Pulumi property value into a plain go value suitable for use by Terraform.
 // makeSingleTerraformInput does not apply any defaults or other transformations.
-func makeSingleTerraformInput(
+func makeSingleTerraformInputForSetElement(
 	ctx context.Context, name string, val resource.PropertyValue, tfs shim.Schema, ps *SchemaInfo,
 ) (interface{}, error) {
 	cctx := &conversionContext{
@@ -479,6 +479,12 @@ func (ctx *conversionContext) makeTerraformInput(
 				arr = append(arr, e)
 			}
 		}
+
+		newSetSchema, ok := tfs.(shim.SchemaWithNewSet)
+		if ok && tfs.Type() == shim.TypeSet && ctx.UseTFSetTypes {
+			return newSetSchema.NewSet(arr), nil
+		}
+
 		return arr, nil
 	case v.IsAsset():
 		// We require that there be asset information, otherwise an error occurs.

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -294,6 +294,9 @@ type conversionContext struct {
 	ApplyTFDefaults       bool
 	Assets                AssetTable
 	// UseTFSetTypes will output TF Set types when converting sets.
+	// For example, if called on []string{"val1", "val2"}, it will output a TF Set with
+	// the same values: schema.NewSet([]interface{}{"val1", "val2"}).
+	// Note that this only works for schemas which implement shim.SchemaWithNewSet.
 	UseTFSetTypes bool
 }
 
@@ -340,24 +343,6 @@ func MakeTerraformInputs(
 	olds, news resource.PropertyMap, tfs shim.SchemaMap, ps map[string]*SchemaInfo,
 ) (map[string]interface{}, AssetTable, error) {
 	return makeTerraformInputsWithOptions(ctx, instance, config, olds, news, tfs, ps, makeTerraformInputsOptions{})
-}
-
-// makeSingleTerraformInput converts a single Pulumi property value into a plain go value suitable for use by Terraform.
-// makeSingleTerraformInput does not apply any defaults or other transformations.
-func makeSingleTerraformInputForSetElement(
-	ctx context.Context, name string, val resource.PropertyValue, tfs shim.Schema, ps *SchemaInfo,
-) (interface{}, error) {
-	cctx := &conversionContext{
-		Ctx:                   ctx,
-		ComputeDefaultOptions: ComputeDefaultOptions{},
-		ProviderConfig:        nil,
-		ApplyDefaults:         false,
-		ApplyTFDefaults:       false,
-		Assets:                AssetTable{},
-		UseTFSetTypes:         true,
-	}
-
-	return cctx.makeTerraformInput(name, resource.NewNullProperty(), val, tfs, ps)
 }
 
 // makeTerraformInput takes a single property plus custom schema info and does whatever is necessary

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -293,6 +293,8 @@ type conversionContext struct {
 	ApplyDefaults         bool
 	ApplyTFDefaults       bool
 	Assets                AssetTable
+	// UseTFSetTypes will output TF Set types when converting sets.
+	UseTFSetTypes bool
 }
 
 type makeTerraformInputsOptions struct {
@@ -352,6 +354,7 @@ func makeSingleTerraformInputForSetElement(
 		ApplyDefaults:         false,
 		ApplyTFDefaults:       false,
 		Assets:                AssetTable{},
+		UseTFSetTypes:         true,
 	}
 
 	return cctx.makeTerraformInput(name, resource.NewNullProperty(), val, tfs, ps)

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -3897,7 +3897,7 @@ func TestExtractInputsFromOutputsSdkv2(t *testing.T) {
 	}
 }
 
-func TestMakeSingleTerraformInputForSetElement(t *testing.T) {
+func TestMakeSingleTerraformInput(t *testing.T) {
 	t.Parallel()
 
 	type testCase struct {
@@ -4015,7 +4015,7 @@ func TestMakeSingleTerraformInputForSetElement(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			result, err := makeSingleTerraformInputForSetElement(
+			result, err := makeSingleTerraformInput(
 				context.Background(), "name", tc.prop, shimv2.NewSchema(tc.schema), nil)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expected, result)
@@ -4024,7 +4024,7 @@ func TestMakeSingleTerraformInputForSetElement(t *testing.T) {
 }
 
 // Function pointers make asserting equality slightly more involved here
-func TestMakeSingleTerraformInputForSetElementSets(t *testing.T) {
+func TestMakeSingleTerraformInputSets(t *testing.T) {
 	t.Parallel()
 
 	sch := &schemav2.Schema{
@@ -4040,7 +4040,7 @@ func TestMakeSingleTerraformInputForSetElementSets(t *testing.T) {
 		resource.NewStringProperty("baz"),
 	})
 
-	result, err := makeSingleTerraformInputForSetElement(
+	result, err := makeSingleTerraformInput(
 		context.Background(), "name", prop, shimv2.NewSchema(sch), nil)
 	require.NoError(t, err)
 	setRes := result.(*schemav2.Set)

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -3897,7 +3897,7 @@ func TestExtractInputsFromOutputsSdkv2(t *testing.T) {
 	}
 }
 
-func TestMakeSingleTerraformInput(t *testing.T) {
+func TestMakeSingleTerraformInputForSetElement(t *testing.T) {
 	t.Parallel()
 
 	type testCase struct {
@@ -4015,9 +4015,34 @@ func TestMakeSingleTerraformInput(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			result, err := makeSingleTerraformInput(context.Background(), "name", tc.prop, shimv2.NewSchema(tc.schema), nil)
+			result, err := makeSingleTerraformInputForSetElement(
+				context.Background(), "name", tc.prop, shimv2.NewSchema(tc.schema), nil)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expected, result)
 		})
 	}
+}
+
+// Function pointers make asserting equality slightly more involved here
+func TestMakeSingleTerraformInputForSetElementSets(t *testing.T) {
+	t.Parallel()
+
+	sch := &schemav2.Schema{
+		Type:     schemav2.TypeSet,
+		Optional: true,
+		Elem: &schemav2.Schema{
+			Type: schemav2.TypeString,
+		},
+	}
+
+	prop := resource.NewArrayProperty([]resource.PropertyValue{
+		resource.NewStringProperty("bar"),
+		resource.NewStringProperty("baz"),
+	})
+
+	result, err := makeSingleTerraformInputForSetElement(
+		context.Background(), "name", prop, shimv2.NewSchema(sch), nil)
+	require.NoError(t, err)
+	setRes := result.(*schemav2.Set)
+	require.Equal(t, []interface{}{"bar", "baz"}, setRes.List())
 }

--- a/pkg/tfshim/sdk-v1/schema.go
+++ b/pkg/tfshim/sdk-v1/schema.go
@@ -9,6 +9,7 @@ import (
 
 var (
 	_ = shim.Schema(v1Schema{})
+	_ = shim.SchemaWithNewSet(v1Schema{})
 	_ = shim.SchemaMap(v1SchemaMap{})
 )
 
@@ -141,6 +142,10 @@ func (s v1Schema) SetHash(v interface{}) int {
 		return -code
 	}
 	return code
+}
+
+func (s v1Schema) NewSet(v []interface{}) interface{} {
+	return schema.NewSet(s.SetHash, v)
 }
 
 type v1SchemaMap map[string]*schema.Schema

--- a/pkg/tfshim/sdk-v2/schema.go
+++ b/pkg/tfshim/sdk-v2/schema.go
@@ -9,6 +9,7 @@ import (
 
 var (
 	_ = shim.Schema(v2Schema{})
+	_ = shim.SchemaWithNewSet(v2Schema{})
 	_ = shim.SchemaWithUnknownCollectionSupported(v2Schema{})
 	_ = shim.SchemaMap(v2SchemaMap{})
 )
@@ -142,6 +143,10 @@ func (s v2Schema) SetHash(v interface{}) int {
 		return -code
 	}
 	return code
+}
+
+func (s v2Schema) NewSet(v []interface{}) interface{} {
+	return schema.NewSet(s.SetHash, v)
 }
 
 type v2SchemaMap map[string]*schema.Schema

--- a/pkg/tfshim/sdk-v2/schema.go
+++ b/pkg/tfshim/sdk-v2/schema.go
@@ -138,6 +138,8 @@ func (s v2Schema) SetElement(v interface{}) (interface{}, error) {
 }
 
 func (s v2Schema) SetHash(v interface{}) int {
+	//nolint:lll
+	// adapted from https://github.com/pulumi/terraform-plugin-sdk/blob/4f60ee4e2975c25b88b392e69c87551bb0e26dfc/helper/schema/set.go#L220
 	code := s.tf.ZeroValue().(*schema.Set).F(v)
 	if code < 0 {
 		return -code

--- a/pkg/tfshim/shim.go
+++ b/pkg/tfshim/shim.go
@@ -185,6 +185,10 @@ type Schema interface {
 	SetHash(v interface{}) int
 }
 
+type SchemaWithNewSet interface {
+	Schema
+	NewSet(v []interface{}) interface{}
+}
 type SchemaWithUnknownCollectionSupported interface {
 	Schema
 	SupportsUnknownCollections()


### PR DESCRIPTION
The detailed diff v2 code currently fails to calculate previews for set-nested sets. This results in a lack of preview for some resources.

The problem is triggered by a panic which we handle in the set element hashing code. It is caused by a difference in the way we present values for use by the TF hashing code.

TF expects the values to be the golang-equivalent of the `schema` values, except for schema.Set:
- `string` for `schema.String`
- `[]intreface{}` for `schema.List`
- `map[string]interface{}` for `schema.Map`
**However:**
- !**`schema.Set` for `schema.Set`**!

Reference: https://github.com/hashicorp/terraform-plugin-sdk/blob/4d5e3b9a3211f139b41e78ea9ee880c8bf9bb87f/helper/schema/serialize.go#L72

Instead we were using the `makeTerraformInput` code which converts `resource.PropertyValue` to golang `interface{}`.

This PR adds an option in the conversion context `UseTFSetTypes` which is only used by the detailed diff code for converting list types where the TF schema points to a Set into a `shim.Set`. This is only implemented for schemas which implement the `SchemaWithNewSet` interface, which are the SDKv1 and SDKv2.

I've also added additional cross-tests around the problematic schema. Recordings in [d099de2](https://github.com/pulumi/pulumi-terraform-bridge/pull/2891/commits/d099de25774846fa310b2bf6565accdee45db60d)
 
fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/2892