### PR TITLE
Refactor unknown collection supported flag

### DIFF
--- a/pkg/tfbridge/diff_test.go
+++ b/pkg/tfbridge/diff_test.go
@@ -91,7 +91,7 @@ func TestCustomizeDiff(t *testing.T) {
 			Schema: &ResourceInfo{Fields: info},
 		}
 		tfState, err := makeTerraformStateWithOpts(ctx, r, "id", stateMap,
-			makeTerraformStateOptions{defaultZeroSchemaVersion: true, unknownCollectionsSupported: true})
+			makeTerraformStateOptions{defaultZeroSchemaVersion: true})
 		assert.NoError(t, err)
 
 		config, _, err := MakeTerraformConfig(ctx, &Provider{tf: provider}, inputsMap, sch, info)
@@ -135,7 +135,7 @@ func TestCustomizeDiff(t *testing.T) {
 			Schema: &ResourceInfo{Fields: info},
 		}
 		tfState, err := makeTerraformStateWithOpts(ctx, r, "id", stateMap,
-			makeTerraformStateOptions{defaultZeroSchemaVersion: true, unknownCollectionsSupported: true})
+			makeTerraformStateOptions{defaultZeroSchemaVersion: true})
 		assert.NoError(t, err)
 
 		config, _, err := MakeTerraformConfig(ctx, &Provider{tf: provider}, inputsMap, sch, info)
@@ -190,7 +190,7 @@ func TestCustomizeDiff(t *testing.T) {
 					Schema: &ResourceInfo{Fields: info},
 				}
 				tfState, err := makeTerraformStateWithOpts(ctx, r, "id", stateMap,
-					makeTerraformStateOptions{defaultZeroSchemaVersion: true, unknownCollectionsSupported: true})
+					makeTerraformStateOptions{defaultZeroSchemaVersion: true})
 				assert.NoError(t, err)
 
 				config, _, err := MakeTerraformConfig(ctx, &Provider{tf: provider}, inputsMap, sch, info)
@@ -297,9 +297,7 @@ func diffTest(t *testing.T, tfs map[string]*v2Schema.Schema, inputs,
 				sch, r, provider, info := s.setup(tfs)
 
 				tfState, err := makeTerraformStateWithOpts(ctx, r, "id", stateMap,
-					makeTerraformStateOptions{
-						defaultZeroSchemaVersion: true, unknownCollectionsSupported: provider.SupportsUnknownCollections(),
-					})
+					makeTerraformStateOptions{defaultZeroSchemaVersion: true})
 				assert.NoError(t, err)
 
 				config, _, err := MakeTerraformConfig(ctx, &Provider{tf: provider}, inputsMap, sch, info)
@@ -329,9 +327,7 @@ func diffTest(t *testing.T, tfs map[string]*v2Schema.Schema, inputs,
 				t.Parallel()
 				sch, r, provider, info := s.setup(tfs)
 				tfState, err := makeTerraformStateWithOpts(ctx, r, "id", stateMap,
-					makeTerraformStateOptions{
-						defaultZeroSchemaVersion: true, unknownCollectionsSupported: provider.SupportsUnknownCollections(),
-					})
+					makeTerraformStateOptions{defaultZeroSchemaVersion: true})
 				assert.NoError(t, err)
 
 				config, _, err := MakeTerraformConfig(ctx, &Provider{tf: provider}, inputsMap, sch, info)

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -721,7 +721,7 @@ func buildTerraformConfig(ctx context.Context, p *Provider, vars resource.Proper
 	}
 
 	inputs, _, err := makeTerraformInputsWithOptions(ctx, nil, tfVars, nil, tfVars, p.config, p.info.Config,
-		makeTerraformInputsOptions{UnknownCollectionsSupported: p.tf.SupportsUnknownCollections()})
+		makeTerraformInputsOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -1034,7 +1034,7 @@ func (p *Provider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (*pul
 	inputs, _, err := makeTerraformInputsWithOptions(ctx,
 		&PulumiResource{URN: urn, Properties: news, Seed: req.RandomSeed, Autonaming: autonaming},
 		p.configValues, olds, news, schemaMap, res.Schema.Fields,
-		makeTerraformInputsOptions{DisableTFDefaults: true, UnknownCollectionsSupported: p.tf.SupportsUnknownCollections()})
+		makeTerraformInputsOptions{DisableTFDefaults: true})
 	if err != nil {
 		return nil, err
 	}
@@ -1053,7 +1053,7 @@ func (p *Provider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (*pul
 	inputs, assets, err := makeTerraformInputsWithOptions(ctx,
 		&PulumiResource{URN: urn, Properties: news, Seed: req.RandomSeed, Autonaming: autonaming},
 		p.configValues, olds, news, schemaMap, res.Schema.Fields,
-		makeTerraformInputsOptions{UnknownCollectionsSupported: p.tf.SupportsUnknownCollections()})
+		makeTerraformInputsOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -1138,8 +1138,7 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 
 	state, err := makeTerraformStateWithOpts(ctx, res, req.GetId(), olds,
 		makeTerraformStateOptions{
-			defaultZeroSchemaVersion:    opts.defaultZeroSchemaVersion,
-			unknownCollectionsSupported: p.tf.SupportsUnknownCollections(),
+			defaultZeroSchemaVersion: opts.defaultZeroSchemaVersion,
 		},
 	)
 	if err != nil {
@@ -1441,8 +1440,7 @@ func (p *Provider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*pulum
 	}
 	state, err := unmarshalTerraformStateWithOpts(ctx, res, id, req.GetProperties(), fmt.Sprintf("%s.state", label),
 		unmarshalTerraformStateOptions{
-			defaultZeroSchemaVersion:    opts.defaultZeroSchemaVersion,
-			unknownCollectionsSupported: p.tf.SupportsUnknownCollections(),
+			defaultZeroSchemaVersion: opts.defaultZeroSchemaVersion,
 		})
 	if err != nil {
 		return nil, errors.Wrapf(err, "unmarshaling %s's instance state", urn)
@@ -1558,7 +1556,7 @@ func (p *Provider) processImportValidationErrors(
 	tfInputs, _, err := makeTerraformInputsWithOptions(ctx,
 		&PulumiResource{URN: urn, Properties: inputs},
 		p.configValues, inputsWithoutSecrets, inputsWithoutSecrets, schema, schemaInfos,
-		makeTerraformInputsOptions{DisableTFDefaults: true, UnknownCollectionsSupported: p.tf.SupportsUnknownCollections()})
+		makeTerraformInputsOptions{DisableTFDefaults: true})
 	if err != nil {
 		logger.Debug(fmt.Sprintf("Failed to makeTerraformInputsOptions."+
 			" This could lead to validation errors during resource import:\nError: %s", err.Error()))
@@ -1640,8 +1638,7 @@ func (p *Provider) Update(ctx context.Context, req *pulumirpc.UpdateRequest) (*p
 
 	state, err := makeTerraformStateWithOpts(ctx, res, req.GetId(), olds,
 		makeTerraformStateOptions{
-			defaultZeroSchemaVersion:    opts.defaultZeroSchemaVersion,
-			unknownCollectionsSupported: p.tf.SupportsUnknownCollections(),
+			defaultZeroSchemaVersion: opts.defaultZeroSchemaVersion,
 		})
 	if err != nil {
 		return nil, errors.Wrapf(err, "unmarshaling %s's instance state", urn)
@@ -1775,8 +1772,7 @@ func (p *Provider) Delete(ctx context.Context, req *pulumirpc.DeleteRequest) (*p
 	// Fetch the resource attributes since many providers need more than just the ID to perform the delete.
 	state, err := unmarshalTerraformStateWithOpts(ctx, res, req.GetId(), req.GetProperties(), label,
 		unmarshalTerraformStateOptions{
-			defaultZeroSchemaVersion:    opts.defaultZeroSchemaVersion,
-			unknownCollectionsSupported: p.tf.SupportsUnknownCollections(),
+			defaultZeroSchemaVersion: opts.defaultZeroSchemaVersion,
 		})
 	if err != nil {
 		return nil, err
@@ -1838,7 +1834,7 @@ func (p *Provider) Invoke(ctx context.Context, req *pulumirpc.InvokeRequest) (*p
 		nil, args,
 		ds.TF.Schema(),
 		ds.Schema.Fields,
-		makeTerraformInputsOptions{UnknownCollectionsSupported: p.tf.SupportsUnknownCollections()})
+		makeTerraformInputsOptions{})
 	if err != nil {
 		return nil, errors.Wrapf(err, "couldn't prepare resource %v input state", tfname)
 	}

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -293,8 +293,6 @@ type conversionContext struct {
 	ApplyDefaults         bool
 	ApplyTFDefaults       bool
 	Assets                AssetTable
-	// UseTFSetTypes will output TF Set types when converting sets.
-	UseTFSetTypes bool
 }
 
 type makeTerraformInputsOptions struct {
@@ -354,7 +352,6 @@ func makeSingleTerraformInput(
 		ApplyDefaults:         false,
 		ApplyTFDefaults:       false,
 		Assets:                AssetTable{},
-		UseTFSetTypes:         true,
 	}
 
 	return cctx.makeTerraformInput(name, resource.NewNullProperty(), val, tfs, ps)

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -46,14 +46,14 @@ func makeTerraformInputsNoDefaults(olds, news resource.PropertyMap,
 	tfs shim.SchemaMap, ps map[string]*SchemaInfo,
 ) (map[string]interface{}, AssetTable, error) {
 	return makeTerraformInputsWithOptions(context.Background(), nil, nil, olds, news, tfs, ps,
-		makeTerraformInputsOptions{DisableDefaults: true, DisableTFDefaults: true, UnknownCollectionsSupported: true})
+		makeTerraformInputsOptions{DisableDefaults: true, DisableTFDefaults: true})
 }
 
 func makeTerraformInputsForConfig(olds, news resource.PropertyMap,
 	tfs shim.SchemaMap, ps map[string]*SchemaInfo,
 ) (map[string]interface{}, AssetTable, error) {
 	return makeTerraformInputsWithOptions(context.Background(), nil, nil, olds, news, tfs, ps,
-		makeTerraformInputsOptions{UnknownCollectionsSupported: true})
+		makeTerraformInputsOptions{})
 }
 
 func makeTerraformInput(v resource.PropertyValue, tfs shim.Schema, ps *SchemaInfo) (interface{}, error) {
@@ -668,9 +668,7 @@ func TestMetaProperties(t *testing.T) {
 
 			state, err = makeTerraformStateWithOpts(
 				ctx, Resource{TF: res, Schema: &ResourceInfo{}}, state.ID(), props,
-				makeTerraformStateOptions{
-					defaultZeroSchemaVersion: true, unknownCollectionsSupported: prov.SupportsUnknownCollections(),
-				})
+				makeTerraformStateOptions{defaultZeroSchemaVersion: true})
 			assert.NoError(t, err)
 			assert.NotNil(t, state)
 
@@ -686,9 +684,7 @@ func TestMetaProperties(t *testing.T) {
 
 			state, err = makeTerraformStateWithOpts(
 				ctx, Resource{TF: res, Schema: &ResourceInfo{}}, state.ID(), props,
-				makeTerraformStateOptions{
-					defaultZeroSchemaVersion: true, unknownCollectionsSupported: prov.SupportsUnknownCollections(),
-				})
+				makeTerraformStateOptions{defaultZeroSchemaVersion: true})
 			assert.NoError(t, err)
 			assert.NotNil(t, state)
 
@@ -718,9 +714,7 @@ func TestMetaProperties(t *testing.T) {
 
 			state, err = makeTerraformStateWithOpts(
 				ctx, Resource{TF: res, Schema: &ResourceInfo{}}, state.ID(), props,
-				makeTerraformStateOptions{
-					defaultZeroSchemaVersion: true, unknownCollectionsSupported: prov.SupportsUnknownCollections(),
-				})
+				makeTerraformStateOptions{defaultZeroSchemaVersion: true})
 			assert.NoError(t, err)
 			assert.NotNil(t, state)
 
@@ -751,9 +745,7 @@ func TestInjectingCustomTimeouts(t *testing.T) {
 
 			state, err = makeTerraformStateWithOpts(
 				ctx, Resource{TF: res, Schema: &ResourceInfo{}}, state.ID(), props,
-				makeTerraformStateOptions{
-					defaultZeroSchemaVersion: true, unknownCollectionsSupported: prov.SupportsUnknownCollections(),
-				})
+				makeTerraformStateOptions{defaultZeroSchemaVersion: true})
 			assert.NoError(t, err)
 			assert.NotNil(t, state)
 
@@ -769,9 +761,7 @@ func TestInjectingCustomTimeouts(t *testing.T) {
 
 			state, err = makeTerraformStateWithOpts(
 				ctx, Resource{TF: res, Schema: &ResourceInfo{}}, state.ID(), props,
-				makeTerraformStateOptions{
-					defaultZeroSchemaVersion: true, unknownCollectionsSupported: prov.SupportsUnknownCollections(),
-				})
+				makeTerraformStateOptions{defaultZeroSchemaVersion: true})
 			assert.NoError(t, err)
 			assert.NotNil(t, state)
 
@@ -804,9 +794,7 @@ func TestInjectingCustomTimeouts(t *testing.T) {
 
 			state, err = makeTerraformStateWithOpts(
 				ctx, Resource{TF: res, Schema: &ResourceInfo{}}, state.ID(), props,
-				makeTerraformStateOptions{
-					defaultZeroSchemaVersion: true, unknownCollectionsSupported: prov.SupportsUnknownCollections(),
-				})
+				makeTerraformStateOptions{defaultZeroSchemaVersion: true})
 			assert.NoError(t, err)
 			assert.NotNil(t, state)
 
@@ -854,9 +842,7 @@ func TestResultAttributesRoundTrip(t *testing.T) {
 
 		state, err = makeTerraformStateWithOpts(
 			ctx, Resource{TF: res, Schema: &ResourceInfo{}}, state.ID(), props,
-			makeTerraformStateOptions{
-				defaultZeroSchemaVersion: true, unknownCollectionsSupported: prov.SupportsUnknownCollections(),
-			})
+			makeTerraformStateOptions{defaultZeroSchemaVersion: true})
 		assert.NoError(t, err)
 		assert.NotNil(t, state)
 

--- a/pkg/tfshim/sdk-v2/schema.go
+++ b/pkg/tfshim/sdk-v2/schema.go
@@ -9,6 +9,7 @@ import (
 
 var (
 	_ = shim.Schema(v2Schema{})
+	_ = shim.SchemaWithUnknownCollectionSupported(v2Schema{})
 	_ = shim.SchemaMap(v2SchemaMap{})
 )
 
@@ -180,3 +181,5 @@ func (m v2SchemaMap) Range(each func(key string, value shim.Schema) bool) {
 		}
 	}
 }
+
+func (s v2Schema) SupportsUnknownCollections() {}

--- a/pkg/tfshim/shim.go
+++ b/pkg/tfshim/shim.go
@@ -185,6 +185,11 @@ type Schema interface {
 	SetHash(v interface{}) int
 }
 
+type SchemaWithUnknownCollectionSupported interface {
+	Schema
+	SupportsUnknownCollections()
+}
+
 type SchemaMap interface {
 	Len() int
 	Get(key string) Schema
@@ -292,6 +297,7 @@ type Provider interface {
 	// Checks if a value is representing a Set, and unpacks its elements on success.
 	IsSet(ctx context.Context, v interface{}) ([]interface{}, bool)
 
+	// Deprecated: use SchemaWithUnknownCollectionSupported instead.
 	// SupportsUnknownCollections returns false if the provider needs special handling of unknown collections.
 	// False for the sdkv1 provider.
 	SupportsUnknownCollections() bool

--- a/pkg/tfshim/util/filter.go
+++ b/pkg/tfshim/util/filter.go
@@ -148,7 +148,7 @@ func (p *FilteringProvider) IsSet(ctx context.Context, v interface{}) ([]interfa
 }
 
 func (p *FilteringProvider) SupportsUnknownCollections() bool {
-	return p.Provider.SupportsUnknownCollections()
+	return p.Provider.SupportsUnknownCollections() //nolint:staticcheck
 }
 
 type filteringMap struct {


### PR DESCRIPTION
### Context
We have a mechanism for distinguishing between the SDKv1 and the SDKv2 on if they support unknowns for collections. The SDKv1 fails when one is presented while the SDKv2 works fine

This is `unknownCollectionsSupported` and was introduced in https://github.com/pulumi/pulumi-terraform-bridge/pull/2061

### Change
This PR is a pure refactor. The flag was introduced on the provider object but is actually a property of the Schema. This PR changes the mechanism to be a new shim.Schema interface - `SchemaWithUnknownCollectionSupported`. The SDKv2 Schema implements this and the interface implementation can be used directly to infer support for unknown collections.

This allows us to delete a bunch of code and simplify the implementation. It also simplifies the implementation in https://github.com/pulumi/pulumi-terraform-bridge/pull/2891 which is stacked on top of this.