### PR TITLE
Auto-merge weekly pu/pu upgrade

### DIFF
--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -76,4 +76,6 @@ jobs:
         github_token: ${{ secrets.PULUMI_BOT_TOKEN }}
       env:
         GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+    - name: "Set PR to auto-merge"
+      run: "gh pr merge --auto --squash ${{ steps.create-pr.outputs.pr_url }}"
     name: weekly-pulumi-update


### PR DESCRIPTION
We have automation for standing up a weekly pulumi/pulumi upgrade PR. This change sets it to auto-merge so that we have one less thing to remember on ops.