### PR TITLE
Add skip diff equivalence flag for Diff cross-tests

### DIFF
--- a/pkg/internal/tests/cross-tests/diff.go
+++ b/pkg/internal/tests/cross-tests/diff.go
@@ -11,6 +11,7 @@ type diffOpts struct {
 	deleteBeforeReplace           bool
 	disableAccurateBridgePreviews bool
 	resource2                     *schema.Resource
+	skipDiffEquivalenceCheck      bool
 }
 
 // An option that can be used to customize [Diff].
@@ -31,6 +32,11 @@ func DiffProviderUpgradedSchema(resource2 *schema.Resource) DiffOption {
 	return func(o *diffOpts) { o.resource2 = resource2 }
 }
 
+// DiffSkipDiffEquivalenceCheck specifies whether to skip the diff equivalence check.
+func DiffSkipDiffEquivalenceCheck() DiffOption {
+	return func(o *diffOpts) { o.skipDiffEquivalenceCheck = true }
+}
+
 func Diff(
 	t T, resource *schema.Resource, config1, config2 map[string]cty.Value, opts ...DiffOption,
 ) crosstestsimpl.DiffResult {
@@ -49,5 +55,6 @@ func Diff(
 		DeleteBeforeReplace:           o.deleteBeforeReplace,
 		DisableAccurateBridgePreviews: o.disableAccurateBridgePreviews,
 		Resource2:                     o.resource2,
+		SkipDiffEquivalenceCheck:      o.skipDiffEquivalenceCheck,
 	})
 }

--- a/pkg/internal/tests/cross-tests/diff_check.go
+++ b/pkg/internal/tests/cross-tests/diff_check.go
@@ -50,6 +50,9 @@ type diffTestCase struct {
 
 	// Optional second schema to use as an upgrade test with a different schema.
 	Resource2 *schema.Resource
+
+	// Whether to skip the diff equivalence check.
+	SkipDiffEquivalenceCheck bool
 }
 
 func runDiffCheck(t T, tc diffTestCase) crosstestsimpl.DiffResult {
@@ -125,7 +128,9 @@ func runDiffCheck(t T, tc diffTestCase) crosstestsimpl.DiffResult {
 
 	changes := tfd.driver.ParseChangesFromTFPlan(tfDiffPlan)
 
-	crosstestsimpl.VerifyBasicDiffAgreement(t, changes.Actions, x.Summary, diffResponse)
+	if !tc.SkipDiffEquivalenceCheck {
+		crosstestsimpl.VerifyBasicDiffAgreement(t, changes.Actions, x.Summary, diffResponse)
+	}
 
 	return crosstestsimpl.DiffResult{
 		TFDiff:     changes,


### PR DESCRIPTION
This PR adds a `DiffSkipDiffEquivalenceCheck` for Diff cross-tests which allows a test to skip the check for equivalence between TF and Pulumi. This is useful to mark cases where there are known differences in behaviour.