### PR TITLE
PluginFramework encoders now parse "" as nil numbers

### DIFF
--- a/pkg/convert/number.go
+++ b/pkg/convert/number.go
@@ -42,9 +42,16 @@ func (*numberEncoder) fromPropertyValue(p resource.PropertyValue) (tftypes.Value
 	if p.IsNull() {
 		return tftypes.NewValue(tftypes.Number, nil), nil
 	}
+	// TODO[pulumi/pulumi-terraform-bridge#1667] workaround a problem in
+	// https://github.com/pulumi/pulumi-aws/issues/5222 where SDKv2 TypeNullableInt gets parsed
+	// into a schema that now expects a number. This case interprets an empty string value as a
+	// nil number when parsing numbers.
+	if p.IsString() && p.StringValue() == "" {
+		return tftypes.NewValue(tftypes.Number, nil), nil
+	}
 	if !p.IsNumber() {
 		return tftypes.NewValue(tftypes.Number, nil),
-			fmt.Errorf("Expected a Number")
+			fmt.Errorf("Expected a Number, got %#v %v", p, p.IsString())
 	}
 	return tftypes.NewValue(tftypes.Number, p.NumberValue()), nil
 }

--- a/pkg/convert/number_test.go
+++ b/pkg/convert/number_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func Test_numberEncoder_emptyStringToNull(t *testing.T) {
+	t.Parallel()
 	n := newNumberEncoder()
 	v, err := n.fromPropertyValue(resource.NewStringProperty(""))
 	require.NoError(t, err)

--- a/pkg/convert/number_test.go
+++ b/pkg/convert/number_test.go
@@ -1,0 +1,29 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package convert
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_numberEncoder_emptyStringToNull(t *testing.T) {
+	n := newNumberEncoder()
+	v, err := n.fromPropertyValue(resource.NewStringProperty(""))
+	require.NoError(t, err)
+	require.True(t, v.IsKnown())
+}

--- a/pkg/pf/internal/providerbuilder/build_resource.go
+++ b/pkg/pf/internal/providerbuilder/build_resource.go
@@ -30,11 +30,12 @@ type NewResourceArgs struct {
 	Name           string
 	ResourceSchema schema.Schema
 
-	CreateFunc      func(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse)
-	ReadFunc        func(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse)
-	UpdateFunc      func(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse)
-	DeleteFunc      func(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse)
-	ImportStateFunc func(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse)
+	CreateFunc       func(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse)
+	ReadFunc         func(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse)
+	UpdateFunc       func(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse)
+	DeleteFunc       func(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse)
+	ImportStateFunc  func(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse)
+	UpgradeStateFunc func(context.Context) map[int64]resource.StateUpgrader
 }
 
 // NewResource creates a new Resource with the given parameters, filling reasonable defaults.
@@ -67,6 +68,11 @@ func NewResource(args NewResourceArgs) Resource {
 			resp.State = tfsdk.State(req.Plan)
 		}
 	}
+	if args.UpgradeStateFunc == nil {
+		args.UpgradeStateFunc = func(ctx context.Context) map[int64]resource.StateUpgrader {
+			return nil
+		}
+	}
 
 	return Resource(args)
 }
@@ -76,11 +82,12 @@ type Resource struct {
 	Name           string
 	ResourceSchema schema.Schema
 
-	CreateFunc      func(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse)
-	ReadFunc        func(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse)
-	UpdateFunc      func(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse)
-	DeleteFunc      func(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse)
-	ImportStateFunc func(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse)
+	CreateFunc       func(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse)
+	ReadFunc         func(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse)
+	UpdateFunc       func(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse)
+	DeleteFunc       func(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse)
+	ImportStateFunc  func(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse)
+	UpgradeStateFunc func(context.Context) map[int64]resource.StateUpgrader
 }
 
 func (r *Resource) Metadata(ctx context.Context, req resource.MetadataRequest, re *resource.MetadataResponse) {

--- a/pkg/pf/tests/schema_and_program_test.go
+++ b/pkg/pf/tests/schema_and_program_test.go
@@ -549,5 +549,4 @@ resources:
 	})
 
 	pt.Up(t)
-	assert.Equal(t, 1, 0)
 }


### PR DESCRIPTION
This is a workaround until #1667 can guarantee that RawState is parsed correctly and passed to migration machinery.

Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/2903

In theory there should be no harm to be a little tolerant when parsing incorrectly typed data, but there may be other use cases that do not agree that "" should be interpreted as nil.

For the moment this workaround fixes a popular issue in `pulumi-aws`:

    https://github.com/pulumi/pulumi-aws/issues/5222