### PR TITLE
Fix PF Int32 types being mistranslated to Floats

### DIFF
--- a/pkg/pf/internal/schemashim/convert_type.go
+++ b/pkg/pf/internal/schemashim/convert_type.go
@@ -34,6 +34,8 @@ func convertType(typ pfattr.Type) (shim.ValueType, error) {
 	switch {
 	case is(tftypes.Bool):
 		return shim.TypeBool, nil
+	case typ.Equal(basetypes.Int32Type{}):
+		return shim.TypeInt, nil
 	case typ.Equal(basetypes.Int64Type{}):
 		// We special case int, since it is a stable type but not present on the wire.
 		return shim.TypeInt, nil

--- a/pkg/pf/internal/schemashim/type_schema_test.go
+++ b/pkg/pf/internal/schemashim/type_schema_test.go
@@ -28,3 +28,21 @@ func assertIsMapType(t *testing.T, shimmed shim.Schema) {
 	schema, isTypeSchema := shimmed.Elem().(*typeSchema)
 	assert.Truef(t, isTypeSchema, "expected shim.Elem() to be of type %T", *schema)
 }
+
+func TestInt32Type(t *testing.T) {
+	t.Parallel()
+	shimmed := &typeSchema{basetypes.Int32Type{}, nil}
+	assert.Equal(t, shim.TypeInt, shimmed.Type())
+}
+
+func TestInt64Type(t *testing.T) {
+	t.Parallel()
+	shimmed := &typeSchema{basetypes.Int64Type{}, nil}
+	assert.Equal(t, shim.TypeInt, shimmed.Type())
+}
+
+func TestNumberType(t *testing.T) {
+	t.Parallel()
+	shimmed := &typeSchema{basetypes.NumberType{}, nil}
+	assert.Equal(t, shim.TypeFloat, shimmed.Type())
+}


### PR DESCRIPTION
In the PF bridge, we would previously translate PF Int32 types as Float. This PR adds explicit handling for it as well as tests.

fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/2924