### PR TITLE
Tolerate Configure panics if one provider errors out

### DIFF
--- a/pkg/x/muxer/muxer.go
+++ b/pkg/x/muxer/muxer.go
@@ -308,7 +308,7 @@ func (m *muxer) Configure(ctx context.Context, req *pulumirpc.ConfigureRequest) 
 
 		if errs.Len() > 0 {
 			var panicked bool
-			r, err, panicked = panicRecoveringConfigure(ctx, s, req)
+			r, panicked, err = panicRecoveringConfigure(ctx, s, req)
 			if panicked {
 				continue
 			}
@@ -334,14 +334,14 @@ func panicRecoveringConfigure(
 	ctx context.Context,
 	s server,
 	req *pulumirpc.ConfigureRequest,
-) (response *pulumirpc.ConfigureResponse, finalError error, panicked bool) {
+) (response *pulumirpc.ConfigureResponse, panicked bool, finalError error) {
 	defer func() {
 		if p := recover(); p != nil {
 			panicked = true
 		}
 	}()
 	r, err := s.Configure(ctx, req)
-	return r, err, false
+	return r, false, err
 }
 
 type resourceRequest interface {

--- a/pkg/x/muxer/muxer_test.go
+++ b/pkg/x/muxer/muxer_test.go
@@ -227,7 +227,7 @@ func TestConfigureInSequence(t *testing.T) {
 // Some providers such as pulumi-gcp will panic in PluginFramework Configure if SDKv2 Configure has
 // produced errors. That is they do not expect both being called in the error case. This test checks
 // that such panics are ignored and processed as expected.
-func TestConfigureIngorePanics(t *testing.T) {
+func TestConfigureIgnorePanics(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 

--- a/pkg/x/muxer/muxer_test.go
+++ b/pkg/x/muxer/muxer_test.go
@@ -224,6 +224,46 @@ func TestConfigureInSequence(t *testing.T) {
 	}
 }
 
+// Some providers such as pulumi-gcp will panic in PluginFramework Configure if SDKv2 Configure has
+// produced errors. That is they do not expect both being called in the error case. This test checks
+// that such panics are ignored and processed as expected.
+func TestConfigureIngorePanics(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	m := &muxer{
+		host: &host{},
+		servers: []server{
+			configureReturnsErrors{},
+			configurePanics{},
+		},
+	}
+	_, err := m.Configure(ctx, &pulumirpc.ConfigureRequest{})
+	require.Error(t, err)
+}
+
+type configureReturnsErrors struct {
+	pulumirpc.UnimplementedResourceProviderServer
+}
+
+func (x configureReturnsErrors) Configure(
+	ctx context.Context,
+	req *pulumirpc.ConfigureRequest,
+) (*pulumirpc.ConfigureResponse, error) {
+	return nil, fmt.Errorf("Required configuration values have not been set")
+}
+
+type configurePanics struct {
+	pulumirpc.UnimplementedResourceProviderServer
+}
+
+func (x configurePanics) Configure(
+	ctx context.Context,
+	req *pulumirpc.ConfigureRequest,
+) (*pulumirpc.ConfigureResponse, error) {
+	panic("Configure panics unexpectedly")
+}
+
 type configure struct {
 	pulumirpc.UnimplementedResourceProviderServer
 	t       *testing.T


### PR DESCRIPTION
Minimally scoped panic recovery to address the scenario found in https://github.com/pulumi/pulumi-gcp/issues/3007

GCP expects failure in Configure for SDKv2 to be final. When our code attempts to call Configure for PF after that failure, it results in a panic. 

I do not know if fail-on-first-error is the desired behavior as it seems preferable to collect all the errors to show to the user if possible. Therefore this PR is scoped to tolerate panics if there have been preceding errors. 
