### PR TITLE
Fix pu/pu automerge failure when no update is available

### DIFF
--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -77,5 +77,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     - name: "Set PR to auto-merge"
+      if: steps.gomod.outputs.changes != 0
       run: "gh pr merge --auto --squash ${{ steps.create-pr.outputs.pr_url }}"
     name: weekly-pulumi-update


### PR DESCRIPTION
The GH action failed when no update is available. This PR fixes that.

example: https://github.com/pulumi/pulumi-terraform-bridge/actions/runs/13699095131/attempts/1

fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/2934