### PR TITLE
Allow providers to publish versions without a leading `v`

### DIFF
--- a/dynamic/provider_test.go
+++ b/dynamic/provider_test.go
@@ -466,39 +466,49 @@ func TestSchemaGenerationFullDocs(t *testing.T) { //nolint:paralleltest
 		fullDocs string
 	}
 
-	tc := testCase{
-		name:     "hashicorp/random",
-		version:  "3.6.3",
-		fullDocs: "--fullDocs",
+	tests := []testCase{
+		{
+			name:     "hashicorp/random",
+			version:  "3.6.3",
+			fullDocs: "--fullDocs",
+		},
+		{
+			name:     "fortinetdev/fortimanager",
+			version:  "1.13.0",
+			fullDocs: "--fullDocs",
+		},
 	}
 
-	t.Run(strings.Join([]string{tc.name, tc.version}, "-"), func(t *testing.T) {
-		helper.Integration(t)
-		ctx := context.Background()
+	for _, tc := range tests {
+		tc := tc
+		t.Run(strings.Join([]string{tc.name, tc.version}, "-"), func(t *testing.T) {
+			helper.Integration(t)
+			ctx := context.Background()
 
-		server := grpcTestServer(ctx, t)
+			server := grpcTestServer(ctx, t)
 
-		result, err := server.Parameterize(ctx, &pulumirpc.ParameterizeRequest{
-			Parameters: &pulumirpc.ParameterizeRequest_Args{
-				Args: &pulumirpc.ParameterizeRequest_ParametersArgs{
-					Args: []string{tc.name, tc.version, tc.fullDocs},
+			result, err := server.Parameterize(ctx, &pulumirpc.ParameterizeRequest{
+				Parameters: &pulumirpc.ParameterizeRequest_Args{
+					Args: &pulumirpc.ParameterizeRequest_ParametersArgs{
+						Args: []string{tc.name, tc.version, tc.fullDocs},
+					},
 				},
-			},
+			})
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.version, result.Version)
+
+			schema, err := server.GetSchema(ctx, &pulumirpc.GetSchemaRequest{
+				SubpackageName:    result.Name,
+				SubpackageVersion: result.Version,
+			})
+
+			require.NoError(t, err)
+			var fmtSchema bytes.Buffer
+			require.NoError(t, json.Indent(&fmtSchema, []byte(schema.Schema), "", "    "))
+			autogold.ExpectFile(t, autogold.Raw(fmtSchema.String()))
 		})
-		require.NoError(t, err)
-
-		assert.Equal(t, tc.version, result.Version)
-
-		schema, err := server.GetSchema(ctx, &pulumirpc.GetSchemaRequest{
-			SubpackageName:    result.Name,
-			SubpackageVersion: result.Version,
-		})
-
-		require.NoError(t, err)
-		var fmtSchema bytes.Buffer
-		require.NoError(t, json.Indent(&fmtSchema, []byte(schema.Schema), "", "    "))
-		autogold.ExpectFile(t, autogold.Raw(fmtSchema.String()))
-	})
+	}
 }
 
 func TestSchemaGenerationIndexDocOutDir(t *testing.T) { //nolint:paralleltest


### PR DESCRIPTION
For example: `registry.opentofu.org/fortinetdev/fortimanager 1.13.0` publishes tags at `1.13.0` instead of `v1.13.0`. This PR catches missing versions attempts without the leading `v`.