### PR TITLE
[WIP] Attempt to repro behaviour of getting an update diff due to usage of unicode

### DIFF
--- a/pkg/tfbridge/diff_test.go
+++ b/pkg/tfbridge/diff_test.go
@@ -479,6 +479,31 @@ func TestSimpleUpdate(t *testing.T) {
 		pulumirpc.DiffResponse_DIFF_SOME)
 }
 
+func TestSimpleUpdateWithUnicode(t *testing.T) {
+	t.Parallel()
+	diffTest(t,
+		map[string]*v2Schema.Schema{
+			"jsonRule": {Type: v2Schema.TypeMap},
+			"outp":     {Type: v2Schema.TypeString, Computed: true},
+		},
+		// inputs
+		map[string]interface{}{
+			"jsonRule": map[string]interface{}{
+				"condition": "{\"property\": \"sum\", \"operator\": \">\", \"value\": 2}",
+			},
+		},
+		// state
+		map[string]interface{}{
+			"jsonRule": map[string]interface{}{
+				"condition": "{\"property\": \"sum\", \"operator\": \"\u003e\", \"value\": 2}",
+			},
+			"outp": "bar",
+		},
+		// expected diff kind per property
+		map[string]DiffKind{},
+		pulumirpc.DiffResponse_DIFF_SOME)
+}
+
 func TestSimpleUpdateReplace(t *testing.T) {
 	t.Parallel()
 	diffTest(t,

--- a/pkg/tfbridge/diff_test.go
+++ b/pkg/tfbridge/diff_test.go
@@ -479,12 +479,15 @@ func TestSimpleUpdate(t *testing.T) {
 		pulumirpc.DiffResponse_DIFF_SOME)
 }
 
-func TestSimpleUpdateWithUnicode(t *testing.T) {
+func TestNestedPropertyUpdateWithUnicode(t *testing.T) {
 	t.Parallel()
 	diffTest(t,
 		map[string]*v2Schema.Schema{
-			"jsonRule": {Type: v2Schema.TypeMap},
-			"outp":     {Type: v2Schema.TypeString, Computed: true},
+			"jsonRule": {
+				Type: v2Schema.TypeMap,
+				Elem: &v2Schema.Schema{Type: v2Schema.TypeString},
+			},
+			"outp": {Type: v2Schema.TypeString, Computed: true},
 		},
 		// inputs
 		map[string]interface{}{
@@ -501,7 +504,7 @@ func TestSimpleUpdateWithUnicode(t *testing.T) {
 		},
 		// expected diff kind per property
 		map[string]DiffKind{},
-		pulumirpc.DiffResponse_DIFF_SOME)
+		pulumirpc.DiffResponse_DIFF_NONE)
 }
 
 func TestSimpleUpdateReplace(t *testing.T) {


### PR DESCRIPTION
Trying to repro the behaviour of #2898 where we are getting an update diff without any change to the program. 

I expected the added test to fail based on my assumption that resolved state used explicit unicode characters which differed from the program inputs but the test actually passes. investigating this further