### PR TITLE
Fix conversion handling of map type resource elems in schema.go

### DIFF
--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -507,6 +507,8 @@ func (ctx *conversionContext) makeTerraformInput(
 		var tfflds shim.SchemaMap
 
 		if tfs != nil {
+			// This case should not happen for normal schemas but can arise as an artifact of some helper functions
+			// in the bridge. See TestMakeSingleTerraformInput/map for more details.
 			if r, ok := tfs.Elem().(shim.Resource); ok {
 				tfflds = r.Schema()
 			}

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -522,15 +522,6 @@ func (ctx *conversionContext) makeTerraformInput(
 				return nil, err
 			}
 
-			if tfs.Type() == shim.TypeMap {
-				// If we have schema information that indicates that this value is being
-				// presented to a map-typed field whose Elem is a shim.Resource, wrap the
-				// value in an array in order to work around a bug in Terraform.
-				//
-				// TODO[pulumi/pulumi-terraform-bridge#1828]: This almost certainly stems from
-				// a bug in the bridge's implementation and not terraform's implementation.
-				return []interface{}{obj}, nil
-			}
 			return obj, nil
 		}
 

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -4008,6 +4008,24 @@ func TestMakeSingleTerraformInput(t *testing.T) {
 				}},
 			}},
 		},
+		{
+			// This schema is invalid in the SDKv2 but is produced as an artifact of some operations in the bridge.
+			// This is a result of the inability to otherwise refer to elements of a set/list with a Resource Elem.
+			name: "map",
+			prop: resource.NewObjectProperty(resource.PropertyMap{
+				"foo": resource.NewStringProperty("bar"),
+			}),
+			schema: &schemav2.Schema{
+				Type:     schemav2.TypeMap,
+				Optional: true,
+				Elem: &schemav2.Resource{
+					Schema: map[string]*schemav2.Schema{
+						"foo": {Type: schemav2.TypeString, Optional: true},
+					},
+				},
+			},
+			expected: map[string]interface{}{"foo": "bar"},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -4011,6 +4011,9 @@ func TestMakeSingleTerraformInput(t *testing.T) {
 		{
 			// This schema is invalid in the SDKv2 but is produced as an artifact of some operations in the bridge.
 			// This is a result of the inability to otherwise refer to elements of a set/list with a Resource Elem.
+			//
+			// The only current use of this combination is walk.LookupSchema returning a Map with a resource Elem for elemenets
+			// of a list/set of objects. See `TestLookupSchemas/resource elem schema lookup` for an example.
 			name: "map",
 			prop: resource.NewObjectProperty(resource.PropertyMap{
 				"foo": resource.NewStringProperty("bar"),

--- a/pkg/tfbridge/walk_test.go
+++ b/pkg/tfbridge/walk_test.go
@@ -503,4 +503,26 @@ func TestLookupSchemas(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, shim.TypeString, sch.Type())
 	})
+
+	t.Run("resource elem schema lookup", func(t *testing.T) {
+		tfs := shimv2.NewSchemaMap(map[string]*sdkv2schema.Schema{
+			"myList": {
+				Type:     sdkv2schema.TypeList,
+				Optional: true,
+				Elem: &sdkv2schema.Resource{
+					Schema: map[string]*sdkv2schema.Schema{
+						"foo": {Type: sdkv2schema.TypeString},
+					},
+				},
+			},
+		})
+
+		sch, _, err := LookupSchemas(walk.NewSchemaPath().GetAttr("myList").Element(), tfs, nil)
+		require.NoError(t, err)
+
+		// Note that the element of a list of resources is returned as a map. This is not technically correct
+		// but is the what we currently do here.
+		// A Map type with a resource element is not a valid schema in the SDKv2, so this is the only use of that combination.
+		require.Equal(t, shim.TypeMap, sch.Type())
+	})
 }


### PR DESCRIPTION
This PR fixes handling of Map-typed Schemas with a Resource Elem in schema.go. This schema combination is invalid in the SDKv2 but is produced by some utilities in the bridge. We incorrectly nesting these values under a list for some reason when converting to the intermediate golang-type layer.

These schemas are produced to refer to the elements of a Resource Elem List or Set-type. There is no valid way to refer to the schemas of these types, so we output a Map-schema with a Resource Elem. I believe this is currently the only way to produce a Map type with a Resource Elem in the SDKv2 bridge.

The reason is an odd workaround which was added in https://github.com/pulumi/pulumi-terraform-bridge/issues/1830 (a refactor?). There isn't much context around it but it's certainly wrong. I suspect it was added to work around another bridge bug which was since fixed and this has remained.

This is part of https://github.com/pulumi/pulumi-terraform-bridge/issues/2920

The only other alternative here was pile on even more workarounds for this behaviour. I opted to clean it up instead.