### PR TITLE
Rewrite Any TF provider upstream property named `pulumi` to `pulumi_info`

### DIFF
--- a/dynamic/internal/fixup/properties_test.go
+++ b/dynamic/internal/fixup/properties_test.go
@@ -15,6 +15,7 @@
 package fixup_test
 
 import (
+	"fmt"
 	"testing"
 
 	_ "github.com/hexops/autogold/v2" // autogold registers a flag for -update
@@ -307,4 +308,29 @@ func TestFixProviderResourceName(t *testing.T) {
 	err := fixup.Default(&p)
 	require.NoError(t, err)
 	assert.Equal(t, tokens.Type("test:index/testProvider:TestProvider"), p.Resources["test_provider"].Tok)
+}
+
+func TestFixPropertyNamedPulumiRenamedPulumiInfo(t *testing.T) {
+	t.Parallel()
+
+	p := info.Provider{
+		Name: "test",
+		P: (&schema.Provider{
+			ResourcesMap: schema.ResourceMap{
+				"test_res": (&schema.Resource{
+					Schema: schema.SchemaMap{
+						"pulumi": (&schema.Schema{
+							Type: shim.TypeString,
+						}).Shim(),
+					},
+				}).Shim(),
+			},
+		}).Shim(),
+	}
+
+	err := fixup.Default(&p)
+	require.NoError(t, err)
+	fmt.Println(p.Resources["test_res"].Fields["pulumi"].Name)
+	assert.NotNil(t, p.Resources["test_res"])
+	assert.Equal(t, "pulumiInfo", p.Resources["test_res"].Fields["pulumi"].Name)
 }

--- a/pkg/tfbridge/info/validate.go
+++ b/pkg/tfbridge/info/validate.go
@@ -88,6 +88,7 @@ var (
 	errCannotSpecifyNameOnElem         = fmt.Errorf("cannot specify .Name on a List[T], Map[T] or Set[T] type")
 	errCannotSetMaxItemsOne            = fmt.Errorf("can only specify .MaxItemsOne on List[T] or Set[T] type")
 	errFieldsShouldBeOnElem            = fmt.Errorf(".Fields should be .Elem.Fields")
+	errPropertyNameCannotBePulumi      = fmt.Errorf("a property should not be named pulumi")
 )
 
 func (c *infoCheck) checkResource(tfToken string, schema shim.SchemaMap, info map[string]*Schema) {
@@ -104,6 +105,10 @@ func (c *infoCheck) checkProperty(path walk.SchemaPath, tfs shim.Schema, ps *Sch
 	// If there is no override, then there were no mistakes.
 	if ps == nil {
 		return
+	}
+
+	if ps.Name == "pulumi" {
+		c.error(path, errPropertyNameCannotBePulumi)
 	}
 
 	if t := tfs.Type(); t != shim.TypeSet && t != shim.TypeList && ps.MaxItemsOne != nil {

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -1753,6 +1753,12 @@ func propertyName(key string, sch shim.SchemaMap, custom map[string]*tfbridge.Sc
 	// BUGBUG: work around issue in the Elastic Transcoder where a field has a trailing ":".
 	key = strings.TrimSuffix(key, ":")
 
+	// "pulumi" is a reserved word.
+	// Rewrite the supplied upstream key to something compatible when there is an upstream clash.
+	if key == "pulumi" {
+		key = "pulumi_info"
+	}
+
 	return tfbridge.TerraformToPulumiNameV2(key, sch, custom)
 }
 

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -1752,13 +1752,6 @@ func input(sch shim.Schema, info *tfbridge.SchemaInfo) bool {
 func propertyName(key string, sch shim.SchemaMap, custom map[string]*tfbridge.SchemaInfo) string {
 	// BUGBUG: work around issue in the Elastic Transcoder where a field has a trailing ":".
 	key = strings.TrimSuffix(key, ":")
-
-	// "pulumi" is a reserved word.
-	// Rewrite the supplied upstream key to something compatible when there is an upstream clash.
-	if key == "pulumi" {
-		key = "pulumi_info"
-	}
-
 	return tfbridge.TerraformToPulumiNameV2(key, sch, custom)
 }
 


### PR DESCRIPTION
This pull request uses the `dynamic` package's fixup functionality to rename any property key named `pulumi` to `pulumi_info` in the `provider.Info` to avoid runtime errors.

It also adds a validation error in `validate.go` so that any traditionally bridged providers will encounter an error at gen time and then can alias the offending field.

Fix for https://github.com/pulumi/pulumi-terraform-provider/issues/74. See related discussion http://github.com/pulumi/pulumi/issues/18994.
