### PR TITLE
Remove warning about PF not supporting aliases

### DIFF
--- a/pkg/pf/internal/check/not_supported.go
+++ b/pkg/pf/internal/check/not_supported.go
@@ -111,7 +111,6 @@ func (u *notSupportedUtil) resource(path string, res *tfbridge.ResourceInfo) {
 	u.fields(path, res.Fields)
 	u.assertIsZero(path+".UniqueNameFields", res.UniqueNameFields)
 	u.assertIsZero(path+".Docs", res.Docs)
-	u.assertIsZero(path+".Aliases", res.Aliases)
 }
 
 func (u *notSupportedUtil) schema(path string, schema *tfbridge.SchemaInfo) {


### PR DESCRIPTION
Looks like the PF bridge DOES support resource aliases, so the warning is not accurate. This PR removes it.

There's a test for aliases in https://github.com/pulumi/pulumi-terraform-bridge/pull/2970