### PR TITLE
Improve test isolation for TestTranslateCodeBlocks

### DIFF
--- a/pkg/tfgen/installation_docs_test.go
+++ b/pkg/tfgen/installation_docs_test.go
@@ -425,7 +425,7 @@ func TestTranslateCodeBlocks(t *testing.T) {
 		contentStr string
 		g          *Generator
 	}
-	p := tfbridge.ProviderInfo{
+	providerInfo := tfbridge.ProviderInfo{
 		Name: "simple",
 		P: sdkv2.NewProvider(&schema.Provider{
 			ResourcesMap: map[string]*schema.Resource{
@@ -464,60 +464,37 @@ func TestTranslateCodeBlocks(t *testing.T) {
 			},
 		},
 	}
-	pclsMap := make(map[string]translatedExample)
+	generator, err := NewGenerator(GeneratorOptions{
+		Language:     RegistryDocs,
+		PluginHost:   &testPluginHost{},
+		ProviderInfo: providerInfo,
+	})
+	assert.NoError(t, err)
 
 	testCases := []testCase{
 		{
 			name:       "configuration",
 			desc:       "Translates HCL from examples ",
 			contentStr: readfile(t, "test_data/installation-docs/configuration.md"),
-			g: &Generator{
-				sink: mockSink{},
-				cliConverterState: &cliConverter{
-					info: p,
-					pcls: pclsMap,
-				},
-				language: RegistryDocs,
-			},
+			g:          generator,
 		},
 		{
 			name:       "invalid-example",
 			desc:       "Does not translate an invalid example and leaves example block blank",
 			contentStr: readfile(t, "test_data/installation-docs/invalid-example.md"),
-			g: &Generator{
-				sink: mockSink{},
-				cliConverterState: &cliConverter{
-					info: p,
-					pcls: pclsMap,
-				},
-				language: RegistryDocs,
-			},
+			g:          generator,
 		},
 		{
 			name:       "provider-config-only",
 			desc:       "Translates standalone provider config into Pulumi config YAML",
 			contentStr: readfile(t, "test_data/installation-docs/provider-config-only.md"),
-			g: &Generator{
-				sink: mockSink{},
-				cliConverterState: &cliConverter{
-					info: p,
-					pcls: pclsMap,
-				},
-				language: RegistryDocs,
-			},
+			g:          generator,
 		},
 		{
 			name:       "example-only",
 			desc:       "Translates standalone example into languages",
 			contentStr: readfile(t, "test_data/installation-docs/example-only.md"),
-			g: &Generator{
-				sink: mockSink{},
-				cliConverterState: &cliConverter{
-					info: p,
-					pcls: pclsMap,
-				},
-				language: RegistryDocs,
-			},
+			g:          generator,
 		},
 	}
 

--- a/pkg/tfgen/test_data/installation-docs/configuration.md
+++ b/pkg/tfgen/test_data/installation-docs/configuration.md
@@ -3,17 +3,6 @@ Use the navigation to the left to read about the available resources.
 ## Example Usage
 
 ```hcl
-# Define required providers
-terraform {
-  required_version = ">= 0.14.0"
-  required_providers {
-    simple = {
-      source  = "terraform-provider-simple/simple"
-      version = "~> 1.53.0"
-    }
-  }
-}
-
 # Configure the OpenStack Provider
 provider "simple-provider" {
   user_name   = "admin"

--- a/pkg/tfgen/test_data/installation-docs/configuration.md
+++ b/pkg/tfgen/test_data/installation-docs/configuration.md
@@ -3,8 +3,8 @@ Use the navigation to the left to read about the available resources.
 ## Example Usage
 
 ```hcl
-# Configure the OpenStack Provider
-provider "simple-provider" {
+# Configure the Simple Provider
+provider "simple" {
   user_name   = "admin"
   tenant_name = "admin"
   password    = "pwd"

--- a/pkg/tfgen/test_data/installation-docs/provider-config-only.md
+++ b/pkg/tfgen/test_data/installation-docs/provider-config-only.md
@@ -3,8 +3,8 @@ This example should translate at least the Pulumi config
 ## Example Usage
 
 ```hcl
-# Configure the OpenStack Provider
-provider "simple-provider" {
+# Configure the Simple Provider
+provider "simple" {
   user_name   = "admin"
   tenant_name = "admin"
   password    = "pwd"

--- a/pkg/tfgen/testdata/TestTranslateCodeBlocks/configuration.golden
+++ b/pkg/tfgen/testdata/TestTranslateCodeBlocks/configuration.golden
@@ -9,15 +9,15 @@ Use the navigation to the left to read about the available resources.
 name: configuration-example
 runtime: nodejs
 config:
-    simple-provider:authUrl:
+    simple:authUrl:
         value: http://myauthurl:5000/v3
-    simple-provider:password:
+    simple:password:
         value: pwd
-    simple-provider:region:
+    simple:region:
         value: RegionOne
-    simple-provider:tenantName:
+    simple:tenantName:
         value: admin
-    simple-provider:userName:
+    simple:userName:
         value: admin
 
 ```
@@ -39,15 +39,15 @@ export const someOutput = aResource.result;
 name: configuration-example
 runtime: python
 config:
-    simple-provider:authUrl:
+    simple:authUrl:
         value: http://myauthurl:5000/v3
-    simple-provider:password:
+    simple:password:
         value: pwd
-    simple-provider:region:
+    simple:region:
         value: RegionOne
-    simple-provider:tenantName:
+    simple:tenantName:
         value: admin
-    simple-provider:userName:
+    simple:userName:
         value: admin
 
 ```
@@ -68,15 +68,15 @@ pulumi.export("someOutput", a_resource["result"])
 name: configuration-example
 runtime: dotnet
 config:
-    simple-provider:authUrl:
+    simple:authUrl:
         value: http://myauthurl:5000/v3
-    simple-provider:password:
+    simple:password:
         value: pwd
-    simple-provider:region:
+    simple:region:
         value: RegionOne
-    simple-provider:tenantName:
+    simple:tenantName:
         value: admin
-    simple-provider:userName:
+    simple:userName:
         value: admin
 
 ```
@@ -109,15 +109,15 @@ return await Deployment.RunAsync(() =>
 name: configuration-example
 runtime: go
 config:
-    simple-provider:authUrl:
+    simple:authUrl:
         value: http://myauthurl:5000/v3
-    simple-provider:password:
+    simple:password:
         value: pwd
-    simple-provider:region:
+    simple:region:
         value: RegionOne
-    simple-provider:tenantName:
+    simple:tenantName:
         value: admin
-    simple-provider:userName:
+    simple:userName:
         value: admin
 
 ```
@@ -151,15 +151,15 @@ func main() {
 name: configuration-example
 runtime: yaml
 config:
-    simple-provider:authUrl:
+    simple:authUrl:
         value: http://myauthurl:5000/v3
-    simple-provider:password:
+    simple:password:
         value: pwd
-    simple-provider:region:
+    simple:region:
         value: RegionOne
-    simple-provider:tenantName:
+    simple:tenantName:
         value: admin
-    simple-provider:userName:
+    simple:userName:
         value: admin
 
 ```
@@ -182,15 +182,15 @@ outputs:
 name: configuration-example
 runtime: java
 config:
-    simple-provider:authUrl:
+    simple:authUrl:
         value: http://myauthurl:5000/v3
-    simple-provider:password:
+    simple:password:
         value: pwd
-    simple-provider:region:
+    simple:region:
         value: RegionOne
-    simple-provider:tenantName:
+    simple:tenantName:
         value: admin
-    simple-provider:userName:
+    simple:userName:
         value: admin
 
 ```

--- a/pkg/tfgen/testdata/TestTranslateCodeBlocks/provider-config-only.golden
+++ b/pkg/tfgen/testdata/TestTranslateCodeBlocks/provider-config-only.golden
@@ -7,15 +7,15 @@ This example should translate at least the Pulumi config
 name: configuration-example
 runtime: 
 config:
-    simple-provider:authUrl:
+    simple:authUrl:
         value: http://myauthurl:5000/v3
-    simple-provider:password:
+    simple:password:
         value: pwd
-    simple-provider:region:
+    simple:region:
         value: RegionOne
-    simple-provider:tenantName:
+    simple:tenantName:
         value: admin
-    simple-provider:userName:
+    simple:userName:
         value: admin
 
 ```


### PR DESCRIPTION
This pull request fixes up `TestTranslateCodeBlocks`:

- Provides a fully assigned Generator with a mock test host to the test case. This: 
    - prevents the underlying code from attempting to re-create a Generator for each Convert call, resulting in very quick rate limiting
    - additionally prevents the automatic downloading of the terraform converter plugin 
- Ensures the test provider names in the test files match the test provider name in the test (`simple`).
- Removes the `required_providers` section as unnecessary

As a result of https://github.com/pulumi/pulumi-converter-terraform/pull/319, which is now in use by the bridge, we also no longer download the terraform-provider for a nonexisting provider.

Fixes #2974
