### PR TITLE
Add DecodeOptions to pkg/convert

### DIFF
--- a/pkg/convert/adapter.go
+++ b/pkg/convert/adapter.go
@@ -45,12 +45,12 @@ type adaptedDecoder[T Decoder] struct {
 	decoder T
 }
 
-func (d adaptedDecoder[T]) toPropertyValue(v tftypes.Value) (resource.PropertyValue, error) {
+func (d adaptedDecoder[T]) toPropertyValue(v tftypes.Value, dopts DecodeOptions) (resource.PropertyValue, error) {
 	adapted, err := d.adapter(v)
 	if err != nil {
 		return resource.PropertyValue{}, fmt.Errorf("failed to adapt for %T: %w", d.decoder, err)
 	}
-	return decode(d.decoder, adapted)
+	return decode(d.decoder, adapted, dopts)
 }
 
 func newIntOverrideStringEncoder() Encoder {

--- a/pkg/convert/bool.go
+++ b/pkg/convert/bool.go
@@ -48,7 +48,7 @@ func (*boolEncoder) fromPropertyValue(p resource.PropertyValue) (tftypes.Value, 
 	return tftypes.NewValue(tftypes.Bool, p.BoolValue()), nil
 }
 
-func (*boolDecoder) toPropertyValue(v tftypes.Value) (resource.PropertyValue, error) {
+func (*boolDecoder) toPropertyValue(v tftypes.Value, _ DecodeOptions) (resource.PropertyValue, error) {
 	if !v.IsKnown() {
 		return unknownProperty(), nil
 	}

--- a/pkg/convert/convert_test.go
+++ b/pkg/convert/convert_test.go
@@ -199,7 +199,7 @@ func TestConvertTurnaround(t *testing.T) {
 		t.Run(testcase.name+"/tf2pu", func(t *testing.T) {
 			t.Parallel()
 
-			actual, err := decode(decoder, testcase.val)
+			actual, err := decode(decoder, testcase.val, DecodeOptions{})
 			require.NoError(t, err)
 
 			if f := testcase.normProp; f != nil {

--- a/pkg/convert/dynamic.go
+++ b/pkg/convert/dynamic.go
@@ -103,7 +103,7 @@ func newDynamicDecoder() Decoder {
 	return &dynamicDecoder{}
 }
 
-func (dec *dynamicDecoder) toPropertyValue(v tftypes.Value) (resource.PropertyValue, error) {
+func (dec *dynamicDecoder) toPropertyValue(v tftypes.Value, dopts DecodeOptions) (resource.PropertyValue, error) {
 	switch {
 	case !v.IsKnown():
 		return unknownProperty(), nil
@@ -139,7 +139,7 @@ func (dec *dynamicDecoder) toPropertyValue(v tftypes.Value) (resource.PropertyVa
 		}
 		var translated []resource.PropertyValue
 		for _, e := range elements {
-			te, err := dec.toPropertyValue(e)
+			te, err := dec.toPropertyValue(e, dopts)
 			if err != nil {
 				return resource.PropertyValue{}, err
 			}
@@ -154,7 +154,7 @@ func (dec *dynamicDecoder) toPropertyValue(v tftypes.Value) (resource.PropertyVa
 		}
 		translated := make(resource.PropertyMap)
 		for k, v := range elements {
-			tv, err := dec.toPropertyValue(v)
+			tv, err := dec.toPropertyValue(v, dopts)
 			if err != nil {
 				return resource.PropertyValue{}, err
 			}
@@ -171,7 +171,7 @@ func (dec *dynamicDecoder) toPropertyValue(v tftypes.Value) (resource.PropertyVa
 		}
 		var result []resource.PropertyValue
 		for _, e := range elements {
-			te, err := dec.toPropertyValue(e)
+			te, err := dec.toPropertyValue(e, dopts)
 			if err != nil {
 				return resource.PropertyValue{}, err
 			}

--- a/pkg/convert/flattened.go
+++ b/pkg/convert/flattened.go
@@ -44,7 +44,7 @@ type flattenedDecoder struct {
 	elementDecoder Decoder
 }
 
-func (dec *flattenedDecoder) toPropertyValue(v tftypes.Value) (resource.PropertyValue, error) {
+func (dec *flattenedDecoder) toPropertyValue(v tftypes.Value, dopts DecodeOptions) (resource.PropertyValue, error) {
 	var list []tftypes.Value
 	if err := v.As(&list); err != nil {
 		return resource.PropertyValue{}, err
@@ -53,7 +53,7 @@ func (dec *flattenedDecoder) toPropertyValue(v tftypes.Value) (resource.Property
 	case 0:
 		return resource.NewNullProperty(), nil
 	case 1:
-		return decode(dec.elementDecoder, list[0])
+		return decode(dec.elementDecoder, list[0], dopts)
 	default:
 		msg := "IsMaxItemsOne list or set has too many (%d) values"
 		err := fmt.Errorf(msg, len(list))

--- a/pkg/convert/flattened_test.go
+++ b/pkg/convert/flattened_test.go
@@ -95,7 +95,7 @@ func TestFlattenedDecoder(t *testing.T) {
 	t.Run("singleton-list", func(t *testing.T) {
 		tfValue := tftypes.NewValue(tftypes.List{ElementType: tftypes.String},
 			[]tftypes.Value{tftypes.NewValue(tftypes.String, "foo")})
-		actual, err := decode(listDecoder, tfValue)
+		actual, err := decode(listDecoder, tfValue, DecodeOptions{})
 		require.NoError(t, err)
 		expected := resource.NewStringProperty("foo")
 		assert.Equal(t, expected, actual)
@@ -103,7 +103,7 @@ func TestFlattenedDecoder(t *testing.T) {
 
 	t.Run("empty-list", func(t *testing.T) {
 		tfValue := tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{})
-		actual, err := decode(listDecoder, tfValue)
+		actual, err := decode(listDecoder, tfValue, DecodeOptions{})
 		require.NoError(t, err)
 		expected := resource.NewNullProperty()
 		assert.Equal(t, expected, actual)
@@ -112,7 +112,7 @@ func TestFlattenedDecoder(t *testing.T) {
 	t.Run("singleton-set", func(t *testing.T) {
 		tfValue := tftypes.NewValue(tftypes.Set{ElementType: tftypes.String},
 			[]tftypes.Value{tftypes.NewValue(tftypes.String, "foo")})
-		actual, err := decode(setDecoder, tfValue)
+		actual, err := decode(setDecoder, tfValue, DecodeOptions{})
 		require.NoError(t, err)
 		expected := resource.NewStringProperty("foo")
 		assert.Equal(t, expected, actual)
@@ -120,7 +120,7 @@ func TestFlattenedDecoder(t *testing.T) {
 
 	t.Run("empty-set", func(t *testing.T) {
 		tfValue := tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, []tftypes.Value{})
-		actual, err := decode(setDecoder, tfValue)
+		actual, err := decode(setDecoder, tfValue, DecodeOptions{})
 		require.NoError(t, err)
 		expected := resource.NewNullProperty()
 		assert.Equal(t, expected, actual)
@@ -128,7 +128,7 @@ func TestFlattenedDecoder(t *testing.T) {
 
 	t.Run("error-propagation", func(t *testing.T) {
 		tfValue := tftypes.NewValue(tftypes.String, "mistyped")
-		_, err := decode(listDecoder, tfValue)
+		_, err := decode(listDecoder, tfValue, DecodeOptions{})
 		require.Error(t, err)
 	})
 
@@ -136,7 +136,7 @@ func TestFlattenedDecoder(t *testing.T) {
 		tfValue := tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{
 			tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
 		})
-		v, err := decode(listDecoder, tfValue)
+		v, err := decode(listDecoder, tfValue, DecodeOptions{})
 		require.NoError(t, err)
 		require.Equal(t, unknownProperty(), v)
 	})
@@ -145,21 +145,21 @@ func TestFlattenedDecoder(t *testing.T) {
 		tfValue := tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, []tftypes.Value{
 			tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
 		})
-		v, err := decode(setDecoder, tfValue)
+		v, err := decode(setDecoder, tfValue, DecodeOptions{})
 		require.NoError(t, err)
 		require.Equal(t, unknownProperty(), v)
 	})
 
 	t.Run("unknown-list", func(t *testing.T) {
 		tfValue := tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, tftypes.UnknownValue)
-		v, err := decode(listDecoder, tfValue)
+		v, err := decode(listDecoder, tfValue, DecodeOptions{})
 		require.NoError(t, err)
 		require.Equal(t, unknownProperty(), v)
 	})
 
 	t.Run("unknown-set", func(t *testing.T) {
 		tfValue := tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, tftypes.UnknownValue)
-		v, err := decode(setDecoder, tfValue)
+		v, err := decode(setDecoder, tfValue, DecodeOptions{})
 		require.NoError(t, err)
 		require.Equal(t, unknownProperty(), v)
 	})

--- a/pkg/convert/list.go
+++ b/pkg/convert/list.go
@@ -69,7 +69,7 @@ func (enc *listEncoder) fromPropertyValue(p resource.PropertyValue) (tftypes.Val
 	return tftypes.NewValue(listTy, values), nil
 }
 
-func (dec *listDecoder) toPropertyValue(v tftypes.Value) (resource.PropertyValue, error) {
+func (dec *listDecoder) toPropertyValue(v tftypes.Value, dopts DecodeOptions) (resource.PropertyValue, error) {
 	var elements []tftypes.Value
 	if err := v.As(&elements); err != nil {
 		return resource.PropertyValue{},
@@ -77,7 +77,7 @@ func (dec *listDecoder) toPropertyValue(v tftypes.Value) (resource.PropertyValue
 	}
 	values := []resource.PropertyValue{}
 	for _, e := range elements {
-		ev, err := decode(dec.elementDecoder, e)
+		ev, err := decode(dec.elementDecoder, e, dopts)
 		if err != nil {
 			return resource.PropertyValue{},
 				fmt.Errorf("decList fails with %s: %w", e.String(), err)

--- a/pkg/convert/map.go
+++ b/pkg/convert/map.go
@@ -67,7 +67,7 @@ func (enc *mapEncoder) fromPropertyValue(p resource.PropertyValue) (tftypes.Valu
 	return tftypes.NewValue(mapTy, values), nil
 }
 
-func (dec *mapDecoder) toPropertyValue(v tftypes.Value) (resource.PropertyValue, error) {
+func (dec *mapDecoder) toPropertyValue(v tftypes.Value, dopts DecodeOptions) (resource.PropertyValue, error) {
 	elements := map[string]tftypes.Value{}
 	if err := v.As(&elements); err != nil {
 		return resource.PropertyValue{},
@@ -76,7 +76,7 @@ func (dec *mapDecoder) toPropertyValue(v tftypes.Value) (resource.PropertyValue,
 
 	values := make(resource.PropertyMap)
 	for k, e := range elements {
-		ev, err := decode(dec.elementDecoder, e)
+		ev, err := decode(dec.elementDecoder, e, dopts)
 		if err != nil {
 			return resource.PropertyValue{},
 				fmt.Errorf("decMap fails with %s: %w", e.String(), err)

--- a/pkg/convert/number.go
+++ b/pkg/convert/number.go
@@ -73,7 +73,7 @@ func (*numberEncoder) tryParseNumber(s string) (any, bool) {
 	return nil, false
 }
 
-func (*numberDecoder) toPropertyValue(v tftypes.Value) (resource.PropertyValue, error) {
+func (*numberDecoder) toPropertyValue(v tftypes.Value, _ DecodeOptions) (resource.PropertyValue, error) {
 	if !v.IsKnown() {
 		return unknownProperty(), nil
 	}

--- a/pkg/convert/object.go
+++ b/pkg/convert/object.go
@@ -88,7 +88,7 @@ func (enc *objectEncoder) fromPropertyValue(p resource.PropertyValue) (tftypes.V
 	return tftypes.NewValue(enc.objectType, values), nil
 }
 
-func (dec *objectDecoder) toPropertyValue(v tftypes.Value) (resource.PropertyValue, error) {
+func (dec *objectDecoder) toPropertyValue(v tftypes.Value, dopts DecodeOptions) (resource.PropertyValue, error) {
 	elements := map[string]tftypes.Value{}
 	if err := v.As(&elements); err != nil {
 		return resource.PropertyValue{},
@@ -100,14 +100,14 @@ func (dec *objectDecoder) toPropertyValue(v tftypes.Value) (resource.PropertyVal
 		attrValue, gotAttrValue := elements[attr]
 		if gotAttrValue {
 			t := dec.objectType.AttributeTypes[attr]
-			pv, err := decode(decoder, attrValue)
+			pv, err := decode(decoder, attrValue, dopts)
 			if err != nil {
 				return resource.PropertyValue{},
 					fmt.Errorf("objectDecoder (%T) fails on property %q (value %s): %w",
 						decoder, attr, attrValue, err)
 			}
 			key := dec.propertyNames.PropertyKey(attr, t)
-			if !pv.IsNull() {
+			if !pv.IsNull() || dopts.PreserveNull {
 				values[key] = pv
 			}
 		}

--- a/pkg/convert/secret.go
+++ b/pkg/convert/secret.go
@@ -31,8 +31,8 @@ func newSecretDecoder(elementDecoder Decoder) (Decoder, error) {
 	}, nil
 }
 
-func (dec *secretDecoder) toPropertyValue(v tftypes.Value) (resource.PropertyValue, error) {
-	encoded, err := decode(dec.elementDecoder, v)
+func (dec *secretDecoder) toPropertyValue(v tftypes.Value, dopts DecodeOptions) (resource.PropertyValue, error) {
+	encoded, err := decode(dec.elementDecoder, v, dopts)
 	if err != nil {
 		return resource.PropertyValue{}, err
 	}

--- a/pkg/convert/set.go
+++ b/pkg/convert/set.go
@@ -73,7 +73,7 @@ func (enc *setEncoder) fromPropertyValue(p resource.PropertyValue) (tftypes.Valu
 	return tftypes.NewValue(setTy, values), nil
 }
 
-func (dec *setDecoder) toPropertyValue(v tftypes.Value) (resource.PropertyValue, error) {
+func (dec *setDecoder) toPropertyValue(v tftypes.Value, dopts DecodeOptions) (resource.PropertyValue, error) {
 	retErr := func(msg string, args ...any) error {
 		return fmt.Errorf("set decoder failed: "+msg, args...)
 	}
@@ -85,7 +85,7 @@ func (dec *setDecoder) toPropertyValue(v tftypes.Value) (resource.PropertyValue,
 	}
 	values := []resource.PropertyValue{}
 	for i, e := range elements {
-		ev, err := decode(dec.elementDecoder, e)
+		ev, err := decode(dec.elementDecoder, e, dopts)
 		if err != nil {
 			return resource.PropertyValue{},
 				retErr("could not decode element %d (%v): %w", i, ev, err)

--- a/pkg/convert/string.go
+++ b/pkg/convert/string.go
@@ -87,7 +87,7 @@ func (*stringEncoder) fromPropertyValue(p resource.PropertyValue) (tftypes.Value
 	}
 }
 
-func (*stringDecoder) toPropertyValue(v tftypes.Value) (resource.PropertyValue, error) {
+func (*stringDecoder) toPropertyValue(v tftypes.Value, _ DecodeOptions) (resource.PropertyValue, error) {
 	if !v.IsKnown() {
 		return unknownProperty(), nil
 	}

--- a/pkg/convert/tuple.go
+++ b/pkg/convert/tuple.go
@@ -79,7 +79,7 @@ func (enc *tupleEncoder) fromPropertyValue(p resource.PropertyValue) (tftypes.Va
 	return tftypes.NewValue(typ, values), nil
 }
 
-func (dec *tupleDecoder) toPropertyValue(v tftypes.Value) (resource.PropertyValue, error) {
+func (dec *tupleDecoder) toPropertyValue(v tftypes.Value, dopts DecodeOptions) (resource.PropertyValue, error) {
 	var elements []tftypes.Value
 	if err := v.As(&elements); err != nil {
 		return resource.PropertyValue{},
@@ -88,7 +88,7 @@ func (dec *tupleDecoder) toPropertyValue(v tftypes.Value) (resource.PropertyValu
 	values := make([]resource.PropertyValue, len(elements))
 	for i, e := range elements {
 		var err error
-		values[i], err = decode(dec.decoders[i], e)
+		values[i], err = decode(dec.decoders[i], e, dopts)
 		if err != nil {
 			return resource.PropertyValue{},
 				fmt.Errorf("failed to decode tuple[%d] (%s): %w", i, v, err)


### PR DESCRIPTION
Adds an ability to preserve object property nulls to pkg/convert. As part of #1667 solution the bridge is adding deltas that encode the difference between TF RawState and Pulumi PropertyMap state so that the TF RawState can be reconstructed byte-for-byte at read time and passed to TF state upgraders as is. The RawState will be passed to UpgradeResourceState request method as in: https://github.com/hashicorp/terraform-plugin-go/blob/v0.26.0/tfprotov6/resource.go#L114

The question here is around object types with missing attributes. In the RawState representation, is there any semantic difference between `"foo": null` and omitting "foo" from the RawState? The change errs on the side that any such nulls may be significant.

The PR does not change behavior but introduces options to be used in the #1667 solution.