### PR TITLE
chore: shim over cty.Value and tftypes.Value representations

### DIFF
--- a/pkg/valueshim/cty.go
+++ b/pkg/valueshim/cty.go
@@ -1,0 +1,134 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package valueshim
+
+import (
+	"encoding/json"
+
+	"github.com/hashicorp/go-cty/cty"
+	ctyjson "github.com/hashicorp/go-cty/cty/json"
+)
+
+// Wrap a cty.Value as Value.
+func FromHCtyValue(v cty.Value) Value {
+	return ctyValueShim(v)
+}
+
+// Wrap a cty.Type as Type.
+func FromHCtyType(v cty.Type) Type {
+	return ctyTypeShim(v)
+}
+
+type ctyValueShim cty.Value
+
+var _ Value = (*ctyValueShim)(nil)
+
+func (v ctyValueShim) val() cty.Value {
+	return cty.Value(v)
+}
+
+func (v ctyValueShim) IsNull() bool {
+	return v.val().IsNull()
+}
+
+func (v ctyValueShim) GoString() string {
+	return v.val().GoString()
+}
+
+func (v ctyValueShim) Type() Type {
+	return FromHCtyType(v.val().Type())
+}
+
+func (v ctyValueShim) AsValueSlice() []Value {
+	s := v.val().AsValueSlice()
+	res := make([]Value, len(s))
+	for i, v := range s {
+		res[i] = ctyValueShim(v)
+	}
+	return res
+}
+
+func (v ctyValueShim) AsValueMap() map[string]Value {
+	m := v.val().AsValueMap()
+	res := make(map[string]Value, len(m))
+
+	for k, v := range m {
+		res[k] = ctyValueShim(v)
+	}
+	return res
+}
+
+func (v ctyValueShim) Remove(key string) Value {
+	switch {
+	case v.val().Type().IsObjectType():
+		m := v.val().AsValueMap()
+		delete(m, key)
+		if len(m) == 0 {
+			return ctyValueShim(cty.EmptyObjectVal)
+		}
+		return ctyValueShim(cty.ObjectVal(m))
+	default:
+		return v
+	}
+}
+
+func (v ctyValueShim) Marshal() (json.RawMessage, error) {
+	vv := v.val()
+	raw, err := ctyjson.Marshal(vv, vv.Type())
+	if err != nil {
+		return nil, err
+	}
+	return json.RawMessage(raw), nil
+}
+
+type ctyTypeShim cty.Type
+
+var _ Type = (*ctyTypeShim)(nil)
+
+func (t ctyTypeShim) ty() cty.Type {
+	return cty.Type(t)
+}
+
+func (t ctyTypeShim) IsNumberType() bool {
+	return t.ty().Equals(cty.Number)
+}
+
+func (t ctyTypeShim) IsBooleanType() bool {
+	return t.ty().Equals(cty.Bool)
+}
+
+func (t ctyTypeShim) IsStringType() bool {
+	return t.ty().Equals(cty.String)
+}
+
+func (t ctyTypeShim) IsListType() bool {
+	return t.ty().IsListType()
+}
+
+func (t ctyTypeShim) IsMapType() bool {
+	return t.ty().IsMapType()
+}
+
+func (t ctyTypeShim) IsSetType() bool {
+	return t.ty().IsSetType()
+}
+
+func (t ctyTypeShim) IsObjectType() bool {
+	return t.ty().IsObjectType()
+}
+
+func (t ctyTypeShim) GoString() string {
+	return t.ty().GoString()
+}

--- a/pkg/valueshim/cty_test.go
+++ b/pkg/valueshim/cty_test.go
@@ -1,0 +1,262 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package valueshim_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hexops/autogold/v2"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/valueshim"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_HCtyValue_IsNull(t *testing.T) {
+	t.Parallel()
+	assert.True(t, valueshim.FromHCtyValue(cty.NullVal(cty.String)).IsNull())
+	assert.False(t, valueshim.FromHCtyValue(cty.StringVal("OK")).IsNull())
+}
+
+func Test_HCtyValue_GoString(t *testing.T) {
+	t.Parallel()
+	v := valueshim.FromHCtyValue(cty.StringVal("OK"))
+	assert.Equal(t, `cty.StringVal("OK")`, v.GoString())
+}
+
+func Test_HCtyValue_Type(t *testing.T) {
+	t.Parallel()
+	v := valueshim.FromHCtyValue(cty.StringVal("OK"))
+	assert.True(t, v.Type().IsStringType())
+}
+
+func Test_HCtyValue_AsValueSlice(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, 0, len(valueshim.FromHCtyValue(cty.ListValEmpty(cty.String)).AsValueSlice()))
+	assert.Equal(t, 0, len(valueshim.FromHCtyValue(cty.SetValEmpty(cty.String)).AsValueSlice()))
+
+	abc := []cty.Value{
+		cty.StringVal("a"),
+		cty.StringVal("b"),
+		cty.StringVal("c"),
+	}
+
+	actualList := valueshim.FromHCtyValue(cty.ListVal(abc)).AsValueSlice()
+	assert.Equal(t, len(abc), len(actualList))
+	for i := 0; i < len(abc); i++ {
+		assert.Equal(t, abc[i].GoString(), actualList[i].GoString())
+	}
+
+	// cty.SetVal may reorder elements so this test may be overly strict.
+	actualSet := valueshim.FromHCtyValue(cty.SetVal(abc)).AsValueSlice()
+	assert.Equal(t, len(abc), len(actualSet))
+	for i := 0; i < len(abc); i++ {
+		assert.Equal(t, abc[i].GoString(), actualSet[i].GoString())
+	}
+}
+
+func Test_HCtyValue_AsValueMap(t *testing.T) {
+	t.Parallel()
+	for _, mk := range []func(map[string]cty.Value) cty.Value{
+		cty.ObjectVal,
+		cty.MapVal,
+	} {
+		example := map[string]cty.Value{
+			"x": cty.StringVal("a"),
+			"y": cty.StringVal("b"),
+		}
+		actual := valueshim.FromHCtyValue(mk(example)).AsValueMap()
+		assert.Equal(t, len(example), len(actual))
+		for k, v := range example {
+			assert.Equal(t, v.GoString(), actual[k].GoString())
+		}
+	}
+}
+
+func Test_HCtyValue_Marshal(t *testing.T) {
+	t.Parallel()
+
+	ok := cty.StringVal("OK")
+	ok2 := cty.StringVal("OK2")
+	n42 := cty.NumberIntVal(42)
+
+	xyType := cty.Object(map[string]cty.Type{
+		"x": cty.String,
+		"y": cty.Number,
+	})
+
+	bigI, _, err := big.ParseFloat("12345678901234567890", 0, 512, big.ToNearestEven)
+	require.NoError(t, err)
+
+	bigF, _, err := big.ParseFloat("1234567890.123456789", 0, 512, big.ToNearestEven)
+	require.NoError(t, err)
+
+	tupType := cty.Tuple([]cty.Type{cty.String, cty.Number})
+
+	type testCase struct {
+		v      cty.Value
+		expect autogold.Value
+	}
+
+	testCases := []testCase{
+		{
+			v:      cty.NullVal(cty.String),
+			expect: autogold.Expect("null"),
+		},
+		{
+			v:      cty.StringVal("OK"),
+			expect: autogold.Expect(`"OK"`),
+		},
+		{
+			v:      cty.NullVal(cty.Number),
+			expect: autogold.Expect("null"),
+		},
+		{
+			v:      cty.NumberIntVal(42),
+			expect: autogold.Expect("42"),
+		},
+		{
+			v:      cty.NumberVal(bigI),
+			expect: autogold.Expect("12345678901234567890"),
+		},
+		{
+			v:      cty.NumberVal(bigF),
+			expect: autogold.Expect("1234567890.123456789"),
+		},
+		{
+			v:      cty.NullVal(cty.Bool),
+			expect: autogold.Expect("null"),
+		},
+		{
+			v:      cty.BoolVal(true),
+			expect: autogold.Expect("true"),
+		},
+		{
+			v:      cty.NullVal(cty.List(cty.String)),
+			expect: autogold.Expect("null"),
+		},
+		{
+			v:      cty.ListValEmpty(cty.String),
+			expect: autogold.Expect("[]"),
+		},
+		{
+			v:      cty.ListVal([]cty.Value{ok}),
+			expect: autogold.Expect(`["OK"]`),
+		},
+		{
+			v:      cty.ListVal([]cty.Value{ok, ok2}),
+			expect: autogold.Expect(`["OK","OK2"]`),
+		},
+		{
+			v:      cty.NullVal(cty.Set(cty.String)),
+			expect: autogold.Expect("null"),
+		},
+		{
+			v:      cty.SetValEmpty(cty.String),
+			expect: autogold.Expect("[]"),
+		},
+		{
+			v:      cty.SetVal([]cty.Value{ok}),
+			expect: autogold.Expect(`["OK"]`),
+		},
+		{
+			v:      cty.SetVal([]cty.Value{ok, ok2}),
+			expect: autogold.Expect(`["OK","OK2"]`),
+		},
+		{
+			v:      cty.NullVal(cty.Map(cty.String)),
+			expect: autogold.Expect("null"),
+		},
+		{
+			v:      cty.MapValEmpty(cty.String),
+			expect: autogold.Expect("{}"),
+		},
+		{
+			v:      cty.MapVal(map[string]cty.Value{"x": ok}),
+			expect: autogold.Expect(`{"x":"OK"}`),
+		},
+		{
+			v:      cty.MapVal(map[string]cty.Value{"x": ok, "y": ok2}),
+			expect: autogold.Expect(`{"x":"OK","y":"OK2"}`),
+		},
+		{
+			v:      cty.NullVal(xyType),
+			expect: autogold.Expect("null"),
+		},
+		{
+			v:      cty.ObjectVal(map[string]cty.Value{"x": ok, "y": n42}),
+			expect: autogold.Expect(`{"x":"OK","y":42}`),
+		},
+		{
+			v:      cty.NullVal(tupType),
+			expect: autogold.Expect("null"),
+		},
+		{
+			v:      cty.TupleVal([]cty.Value{ok, n42}),
+			expect: autogold.Expect(`["OK",42]`),
+		},
+	}
+
+	for _, tc := range testCases {
+		raw, err := valueshim.FromHCtyValue(tc.v).Marshal()
+		require.NoError(t, err)
+		tc.expect.Equal(t, string(raw))
+	}
+}
+
+func Test_HCtyValue_Remove(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		v   cty.Value
+		exp autogold.Value
+	}
+
+	x := cty.ObjectVal(map[string]cty.Value{"x": cty.NumberIntVal(42)})
+	xy := cty.ObjectVal(map[string]cty.Value{"x": cty.NumberIntVal(42), "y": cty.StringVal("OK")})
+
+	testCases := []testCase{
+		{
+			v:   cty.EmptyObjectVal,
+			exp: autogold.Expect("cty.EmptyObjectVal"),
+		},
+		{
+			v:   x,
+			exp: autogold.Expect("cty.EmptyObjectVal"),
+		},
+		{
+			v:   xy,
+			exp: autogold.Expect(`cty.ObjectVal(map[string]cty.Value{"y":cty.StringVal("OK")})`),
+		},
+	}
+
+	for _, tc := range testCases {
+		tc.exp.Equal(t, valueshim.FromHCtyValue(tc.v).Remove("x").GoString())
+	}
+}
+
+func Test_HCtyType(t *testing.T) {
+	assert.True(t, valueshim.FromHCtyType(cty.Bool).IsBooleanType())
+	assert.True(t, valueshim.FromHCtyType(cty.String).IsStringType())
+	assert.True(t, valueshim.FromHCtyType(cty.Number).IsNumberType())
+	assert.True(t, valueshim.FromHCtyType(cty.List(cty.Number)).IsListType())
+	assert.True(t, valueshim.FromHCtyType(cty.Set(cty.Number)).IsSetType())
+	assert.True(t, valueshim.FromHCtyType(cty.Map(cty.Number)).IsMapType())
+	x := cty.Object(map[string]cty.Type{"x": cty.Number})
+	assert.True(t, valueshim.FromHCtyType(x).IsObjectType())
+	assert.Equal(t, `cty.Object(map[string]cty.Type{"x":cty.Number})`, valueshim.FromHCtyType(x).GoString())
+}

--- a/pkg/valueshim/cty_test.go
+++ b/pkg/valueshim/cty_test.go
@@ -20,9 +20,10 @@ import (
 
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hexops/autogold/v2"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/valueshim"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/valueshim"
 )
 
 func Test_HCtyValue_IsNull(t *testing.T) {
@@ -250,6 +251,8 @@ func Test_HCtyValue_Remove(t *testing.T) {
 }
 
 func Test_HCtyType(t *testing.T) {
+	t.Parallel()
+
 	assert.True(t, valueshim.FromHCtyType(cty.Bool).IsBooleanType())
 	assert.True(t, valueshim.FromHCtyType(cty.String).IsStringType())
 	assert.True(t, valueshim.FromHCtyType(cty.Number).IsNumberType())

--- a/pkg/valueshim/package.go
+++ b/pkg/valueshim/package.go
@@ -1,0 +1,16 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Provides wrappers with a uniform representation over cty.Value and tftypes.Value.
+package valueshim

--- a/pkg/valueshim/shim.go
+++ b/pkg/valueshim/shim.go
@@ -1,0 +1,46 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package valueshim
+
+import (
+	"encoding/json"
+)
+
+// Allows abstracting over cty.Value and tftypes.Value for purposes of computing raw state deltas. In particular for
+// Plugin Framework based providers this helps avoid implicit set element reordering that cty.Value brings.
+type Value interface {
+	IsNull() bool
+	GoString() string
+	Type() Type
+	AsValueSlice() []Value
+	AsValueMap() map[string]Value
+
+	// Marshals into the "raw state" JSON representation.
+	Marshal() (json.RawMessage, error)
+
+	// Removes a top-level property from an Object.
+	Remove(key string) Value
+}
+
+type Type interface {
+	IsNumberType() bool
+	IsStringType() bool
+	IsBooleanType() bool
+	IsListType() bool
+	IsMapType() bool
+	IsSetType() bool
+	IsObjectType() bool
+	GoString() string
+}

--- a/pkg/valueshim/tfvalue.go
+++ b/pkg/valueshim/tfvalue.go
@@ -1,0 +1,308 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package valueshim
+
+import (
+	"encoding/json"
+	"math/big"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+// Wrap a tftypes.Value as Value.
+func FromTValue(v tftypes.Value) Value {
+	return tValueShim(v)
+}
+
+// Wrap a tftypes.Type as Type.
+func FromTType(t tftypes.Type) Type {
+	return tTypeShim{t: t}
+}
+
+type tValueShim tftypes.Value
+
+var _ Value = (*tValueShim)(nil)
+
+func (v tValueShim) val() tftypes.Value {
+	return tftypes.Value(v)
+}
+
+func (v tValueShim) IsNull() bool {
+	return v.val().IsNull()
+}
+
+func (v tValueShim) GoString() string {
+	return v.val().String()
+}
+
+func (v tValueShim) Type() Type {
+	return FromTType(v.val().Type())
+}
+
+func (v tValueShim) AsValueSlice() []Value {
+	var s []tftypes.Value
+	err := v.val().As(&s)
+	contract.AssertNoErrorf(err, "AsValueSlice failed")
+	res := make([]Value, len(s))
+	for i, v := range s {
+		res[i] = tValueShim(v)
+	}
+	return res
+}
+
+func (v tValueShim) AsValueMap() map[string]Value {
+	var m map[string]tftypes.Value
+	err := v.val().As(&m)
+	contract.AssertNoErrorf(err, "AsValueMap failed")
+	res := make(map[string]Value, len(m))
+	for k, v := range m {
+		res[k] = tValueShim(v)
+	}
+	return res
+}
+
+func (v tValueShim) Marshal() (json.RawMessage, error) {
+	inmem, err := jsonMarshal(v.val(), tftypes.NewAttributePath())
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(inmem)
+}
+
+func (v tValueShim) Remove(prop string) Value {
+	if !v.Type().IsObjectType() {
+		return v
+	}
+
+	var m map[string]tftypes.Value
+	err := v.val().As(&m)
+	contract.AssertNoErrorf(err, "AsValueMap failed")
+
+	delete(m, prop)
+
+	t1 := tftypes.Object{}
+	t0 := v.val().Type().(tftypes.Object)
+
+	for k, v := range t0.AttributeTypes {
+		if k == prop {
+			continue
+		}
+		if t1.AttributeTypes == nil {
+			t1.AttributeTypes = make(map[string]tftypes.Type)
+		}
+		t1.AttributeTypes[k] = v
+	}
+	for k, v := range t0.OptionalAttributes {
+		if k == prop {
+			continue
+		}
+		if t1.OptionalAttributes == nil {
+			t1.OptionalAttributes = make(map[string]struct{})
+		}
+		t1.OptionalAttributes[k] = v
+	}
+	return tValueShim(tftypes.NewValue(t1, m))
+}
+
+func jsonMarshal(v tftypes.Value, p *tftypes.AttributePath) (interface{}, error) {
+	if v.IsNull() {
+		return nil, nil
+	}
+	if !v.IsKnown() {
+		return nil, p.NewErrorf("unknown values cannot be serialized to JSON")
+	}
+	typ := v.Type()
+	switch {
+	case typ.Is(tftypes.String):
+		return jsonMarshalString(v, p)
+	case typ.Is(tftypes.Number):
+		return jsonMarshalNumber(v, p)
+	case typ.Is(tftypes.Bool):
+		return jsonMarshalBool(v, p)
+	case typ.Is(tftypes.List{}):
+		return jsonMarshalList(v, p)
+	case typ.Is(tftypes.Set{}):
+		return jsonMarshalSet(v, p)
+	case typ.Is(tftypes.Map{}):
+		return jsonMarshalMap(v, p)
+	case typ.Is(tftypes.Tuple{}):
+		return jsonMarshalTuple(v, p)
+	case typ.Is(tftypes.Object{}):
+		return jsonMarshalObject(v, p)
+	}
+
+	return nil, p.NewErrorf("unknown type %s", typ)
+}
+
+func jsonMarshalString(v tftypes.Value, p *tftypes.AttributePath) (interface{}, error) {
+	var stringValue string
+	err := v.As(&stringValue)
+	if err != nil {
+		return nil, p.NewError(err)
+	}
+	return stringValue, nil
+}
+
+func jsonMarshalNumber(v tftypes.Value, p *tftypes.AttributePath) (interface{}, error) {
+	var n big.Float
+	err := v.As(&n)
+	if err != nil {
+		return nil, p.NewError(err)
+	}
+	return json.Number(n.Text('f', -1)), nil
+}
+
+func jsonMarshalBool(v tftypes.Value, p *tftypes.AttributePath) (interface{}, error) {
+	var b bool
+	err := v.As(&b)
+	if err != nil {
+		return nil, p.NewError(err)
+	}
+	return b, nil
+}
+
+func jsonMarshalList(v tftypes.Value, p *tftypes.AttributePath) (interface{}, error) {
+	var vs []tftypes.Value
+	err := v.As(&vs)
+	if err != nil {
+		return nil, p.NewError(err)
+	}
+	res := make([]any, len(vs))
+	for i, v := range vs {
+		ep := p.WithElementKeyInt(i)
+		e, err := jsonMarshal(v, ep)
+		if err != nil {
+			return nil, ep.NewError(err)
+		}
+		res[i] = e
+	}
+	return res, nil
+}
+
+// Important to preserve original order of tftypes.Value here.
+func jsonMarshalSet(v tftypes.Value, p *tftypes.AttributePath) (interface{}, error) {
+	var vs []tftypes.Value
+	err := v.As(&vs)
+	if err != nil {
+		return nil, p.NewError(err)
+	}
+	res := make([]any, len(vs))
+	for i, v := range vs {
+		ep := p.WithElementKeyValue(v)
+		e, err := jsonMarshal(v, ep)
+		if err != nil {
+			return nil, ep.NewError(err)
+		}
+		res[i] = e
+	}
+	return res, nil
+}
+
+func jsonMarshalMap(v tftypes.Value, p *tftypes.AttributePath) (interface{}, error) {
+	var vs map[string]tftypes.Value
+	err := v.As(&vs)
+	if err != nil {
+		return nil, p.NewError(err)
+	}
+	res := make(map[string]any, len(vs))
+	for k, v := range vs {
+		ep := p.WithElementKeyValue(v)
+		e, err := jsonMarshal(v, ep)
+		if err != nil {
+			return nil, ep.NewError(err)
+		}
+		res[k] = e
+	}
+	return res, nil
+}
+
+func jsonMarshalTuple(v tftypes.Value, p *tftypes.AttributePath) (interface{}, error) {
+	var vs []tftypes.Value
+	err := v.As(&vs)
+	if err != nil {
+		return nil, p.NewError(err)
+	}
+	res := make([]any, len(vs))
+	for i, v := range vs {
+		ep := p.WithElementKeyInt(i)
+		e, err := jsonMarshal(v, ep)
+		if err != nil {
+			return nil, ep.NewError(err)
+		}
+		res[i] = e
+	}
+	return res, nil
+}
+
+func jsonMarshalObject(v tftypes.Value, p *tftypes.AttributePath) (interface{}, error) {
+	var vs map[string]tftypes.Value
+	err := v.As(&vs)
+	if err != nil {
+		return nil, p.NewError(err)
+	}
+	res := make(map[string]any, len(vs))
+	for k, v := range vs {
+		ep := p.WithAttributeName(k)
+		e, err := jsonMarshal(v, ep)
+		if err != nil {
+			return nil, ep.NewError(err)
+		}
+		res[k] = e
+	}
+	return res, nil
+}
+
+type tTypeShim struct {
+	t tftypes.Type
+}
+
+var _ Type = (*tTypeShim)(nil)
+
+func (t tTypeShim) ty() tftypes.Type {
+	return t.t
+}
+
+func (t tTypeShim) IsNumberType() bool {
+	return t.ty().Is(tftypes.Number)
+}
+
+func (t tTypeShim) IsBooleanType() bool {
+	return t.ty().Is(tftypes.Bool)
+}
+
+func (t tTypeShim) IsStringType() bool {
+	return t.ty().Is(tftypes.String)
+}
+
+func (t tTypeShim) IsListType() bool {
+	return t.ty().Is(tftypes.List{})
+}
+
+func (t tTypeShim) IsMapType() bool {
+	return t.ty().Is(tftypes.Map{})
+}
+
+func (t tTypeShim) IsSetType() bool {
+	return t.ty().Is(tftypes.Set{})
+}
+
+func (t tTypeShim) IsObjectType() bool {
+	return t.ty().Is(tftypes.Object{})
+}
+
+func (t tTypeShim) GoString() string {
+	return t.ty().String()
+}

--- a/pkg/valueshim/tfvalue_test.go
+++ b/pkg/valueshim/tfvalue_test.go
@@ -1,0 +1,266 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package valueshim_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hexops/autogold/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/valueshim"
+)
+
+func Test_TValue_IsNull(t *testing.T) {
+	t.Parallel()
+	assert.True(t, valueshim.FromTValue(tftypes.NewValue(tftypes.String, nil)).IsNull())
+	assert.False(t, valueshim.FromTValue(tftypes.NewValue(tftypes.String, "OK")).IsNull())
+}
+
+func Test_TValue_GoString(t *testing.T) {
+	t.Parallel()
+	v := valueshim.FromTValue(tftypes.NewValue(tftypes.String, "OK"))
+	assert.Equal(t, `tftypes.String<"OK">`, v.GoString())
+}
+
+func Test_TValue_Type(t *testing.T) {
+	t.Parallel()
+	v := valueshim.FromTValue(tftypes.NewValue(tftypes.String, "OK"))
+	assert.True(t, v.Type().IsStringType())
+}
+
+func Test_TValue_AsValueSlice(t *testing.T) {
+	t.Parallel()
+	for _, ls := range []tftypes.Type{
+		tftypes.List{ElementType: tftypes.String},
+		tftypes.Set{ElementType: tftypes.String},
+	} {
+		abc := []tftypes.Value{
+			tftypes.NewValue(tftypes.String, "a"),
+			tftypes.NewValue(tftypes.String, "b"),
+			tftypes.NewValue(tftypes.String, "c"),
+		}
+		actual := valueshim.FromTValue(tftypes.NewValue(ls, abc)).AsValueSlice()
+		assert.Equal(t, len(abc), len(actual))
+		for i := 0; i < len(abc); i++ {
+			assert.Equal(t, abc[i].String(), actual[i].GoString())
+		}
+	}
+}
+
+func Test_TValue_AsValueMap(t *testing.T) {
+	t.Parallel()
+	for _, ls := range []tftypes.Type{
+		tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+			"x": tftypes.String,
+			"y": tftypes.String,
+		}},
+		tftypes.Map{ElementType: tftypes.String},
+	} {
+		example := map[string]tftypes.Value{
+			"x": tftypes.NewValue(tftypes.String, "a"),
+			"y": tftypes.NewValue(tftypes.String, "b"),
+		}
+		actual := valueshim.FromTValue(tftypes.NewValue(ls, example)).AsValueMap()
+		assert.Equal(t, len(example), len(actual))
+		for k, v := range example {
+			assert.Equal(t, v.String(), actual[k].GoString())
+		}
+	}
+}
+
+func Test_TValue_Marshal(t *testing.T) {
+	t.Parallel()
+
+	ok := tftypes.NewValue(tftypes.String, "OK")
+	ok2 := tftypes.NewValue(tftypes.String, "OK2")
+	n42 := tftypes.NewValue(tftypes.Number, 42)
+	xyType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"x": tftypes.String,
+		"y": tftypes.Number,
+	}}
+
+	bigI, _, err := big.ParseFloat("12345678901234567890", 0, 512, big.ToNearestEven)
+	require.NoError(t, err)
+
+	bigF, _, err := big.ParseFloat("1234567890.123456789", 0, 512, big.ToNearestEven)
+	require.NoError(t, err)
+
+	tupType := tftypes.Tuple{ElementTypes: []tftypes.Type{tftypes.String, tftypes.Number}}
+
+	type testCase struct {
+		v      tftypes.Value
+		expect autogold.Value
+	}
+
+	testCases := []testCase{
+		{
+			v:      tftypes.NewValue(tftypes.String, nil),
+			expect: autogold.Expect("null"),
+		},
+		{
+			v:      tftypes.NewValue(tftypes.String, "OK"),
+			expect: autogold.Expect(`"OK"`),
+		},
+		{
+			v:      tftypes.NewValue(tftypes.Number, nil),
+			expect: autogold.Expect("null"),
+		},
+		{
+			v:      tftypes.NewValue(tftypes.Number, 42),
+			expect: autogold.Expect("42"),
+		},
+		{
+			v:      tftypes.NewValue(tftypes.Number, bigI),
+			expect: autogold.Expect("12345678901234567890"),
+		},
+		{
+			v:      tftypes.NewValue(tftypes.Number, bigF),
+			expect: autogold.Expect("1234567890.123456789"),
+		},
+		{
+			v:      tftypes.NewValue(tftypes.Bool, nil),
+			expect: autogold.Expect("null"),
+		},
+		{
+			v:      tftypes.NewValue(tftypes.Bool, true),
+			expect: autogold.Expect("true"),
+		},
+		{
+			v:      tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, nil),
+			expect: autogold.Expect("null"),
+		},
+		{
+			v:      tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{}),
+			expect: autogold.Expect("[]"),
+		},
+		{
+			v:      tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{ok}),
+			expect: autogold.Expect(`["OK"]`),
+		},
+		{
+			v:      tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{ok, ok2}),
+			expect: autogold.Expect(`["OK","OK2"]`),
+		},
+		{
+			v:      tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, nil),
+			expect: autogold.Expect("null"),
+		},
+		{
+			v:      tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, []tftypes.Value{}),
+			expect: autogold.Expect("[]"),
+		},
+		{
+			v:      tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, []tftypes.Value{ok}),
+			expect: autogold.Expect(`["OK"]`),
+		},
+		{
+			v:      tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, []tftypes.Value{ok, ok2}),
+			expect: autogold.Expect(`["OK","OK2"]`),
+		},
+		{
+			v:      tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, nil),
+			expect: autogold.Expect("null"),
+		},
+		{
+			v:      tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, map[string]tftypes.Value{}),
+			expect: autogold.Expect("{}"),
+		},
+		{
+			v: tftypes.NewValue(tftypes.Map{ElementType: tftypes.String},
+				map[string]tftypes.Value{"x": ok}),
+			expect: autogold.Expect(`{"x":"OK"}`),
+		},
+		{
+			v: tftypes.NewValue(tftypes.Map{ElementType: tftypes.String},
+				map[string]tftypes.Value{"x": ok, "y": ok2}),
+			expect: autogold.Expect(`{"x":"OK","y":"OK2"}`),
+		},
+		{
+			v:      tftypes.NewValue(xyType, nil),
+			expect: autogold.Expect("null"),
+		},
+		{
+			v:      tftypes.NewValue(xyType, map[string]tftypes.Value{"x": ok, "y": n42}),
+			expect: autogold.Expect(`{"x":"OK","y":42}`),
+		},
+		{
+			v:      tftypes.NewValue(tupType, nil),
+			expect: autogold.Expect("null"),
+		},
+		{
+			v:      tftypes.NewValue(tupType, []tftypes.Value{ok, n42}),
+			expect: autogold.Expect(`["OK",42]`),
+		},
+	}
+
+	for _, tc := range testCases {
+		raw, err := valueshim.FromTValue(tc.v).Marshal()
+		require.NoError(t, err)
+		tc.expect.Equal(t, string(raw))
+	}
+}
+
+func Test_TValue_Remove(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		v   tftypes.Value
+		exp autogold.Value
+	}
+
+	testCases := []testCase{
+		{
+			v:   tftypes.NewValue(tftypes.Object{}, map[string]tftypes.Value{}),
+			exp: autogold.Expect("tftypes.Object[]<>"),
+		},
+		{
+			v: tftypes.NewValue(tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{"x": tftypes.String},
+			}, map[string]tftypes.Value{"x": tftypes.NewValue(tftypes.String, "OK")}),
+			exp: autogold.Expect("tftypes.Object[]<>"),
+		},
+		{
+			v: tftypes.NewValue(tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"x": tftypes.String,
+					"y": tftypes.Number,
+				},
+			}, map[string]tftypes.Value{
+				"x": tftypes.NewValue(tftypes.String, "OK"),
+				"y": tftypes.NewValue(tftypes.Number, 42),
+			}),
+			exp: autogold.Expect(`tftypes.Object["y":tftypes.Number]<"y":tftypes.Number<"42">>`),
+		},
+	}
+
+	for _, tc := range testCases {
+		tc.exp.Equal(t, valueshim.FromTValue(tc.v).Remove("x").GoString())
+	}
+}
+
+func Test_TType(t *testing.T) {
+	assert.True(t, valueshim.FromTType(tftypes.Bool).IsBooleanType())
+	assert.True(t, valueshim.FromTType(tftypes.String).IsStringType())
+	assert.True(t, valueshim.FromTType(tftypes.Number).IsNumberType())
+	assert.True(t, valueshim.FromTType(tftypes.List{ElementType: tftypes.Number}).IsListType())
+	assert.True(t, valueshim.FromTType(tftypes.Set{ElementType: tftypes.Number}).IsSetType())
+	assert.True(t, valueshim.FromTType(tftypes.Map{ElementType: tftypes.Number}).IsMapType())
+	assert.True(t, valueshim.FromTType(tftypes.Object{}).IsObjectType())
+	assert.Equal(t, "tftypes.Object[]", valueshim.FromTType(tftypes.Object{}).GoString())
+}

--- a/pkg/valueshim/tfvalue_test.go
+++ b/pkg/valueshim/tfvalue_test.go
@@ -255,6 +255,8 @@ func Test_TValue_Remove(t *testing.T) {
 }
 
 func Test_TType(t *testing.T) {
+	t.Parallel()
+
 	assert.True(t, valueshim.FromTType(tftypes.Bool).IsBooleanType())
 	assert.True(t, valueshim.FromTType(tftypes.String).IsStringType())
 	assert.True(t, valueshim.FromTType(tftypes.Number).IsNumberType())


### PR DESCRIPTION
As part of work on #1667 it is helpful to write code that can operate on both cty.Value native to SDKv2 solutions and tftypes.Value native to the Plugin Framework and dynamic bridge solutions. One helpful invariant is that tftypes.Value does not reorder Set elements like cty.Value does (canonicalizing the order), and for #1667 it is essential that the order of set elements is preserved as much as possible. Doing so via a shim layer makes it easier to accomplish by avoiding intermediate cty.Value to tftypes.Value conversions. This PR simply adds the new package without linking it in, for easier review.