### PR TITLE
Enable accurate bridge previews by default in the bridge

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,15 +23,10 @@ jobs:
         # go version in our go.mod files.
         go-version: [1.22.x, 1.23.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        feature-flags: ["DEFAULT", "PULUMI_TF_BRIDGE_ACCURATE_BRIDGE_PREVIEW"]
+        feature-flags: ["DEFAULT"]
         # Needs to match TOTAL_SHARDS
         shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
         exclude:
-          # We do not run non-default feature flags on non-ubuntu. 
-          - platform: windows-latest
-            feature-flags: "PULUMI_TF_BRIDGE_ACCURATE_BRIDGE_PREVIEW"
-          - platform: macos-latest
-            feature-flags: "PULUMI_TF_BRIDGE_ACCURATE_BRIDGE_PREVIEW"
           # Windows and mac test runs do not need to be sharded as they are fast enough.
           # In order to do that we will skip all except the 0-th shard.
           - platform: windows-latest

--- a/pkg/internal/tests/cross-tests/diff.go
+++ b/pkg/internal/tests/cross-tests/diff.go
@@ -8,10 +8,9 @@ import (
 )
 
 type diffOpts struct {
-	deleteBeforeReplace           bool
-	disableAccurateBridgePreviews bool
-	resource2                     *schema.Resource
-	skipDiffEquivalenceCheck      bool
+	deleteBeforeReplace      bool
+	resource2                *schema.Resource
+	skipDiffEquivalenceCheck bool
 }
 
 // An option that can be used to customize [Diff].
@@ -20,11 +19,6 @@ type DiffOption func(*diffOpts)
 // DiffDeleteBeforeReplace specifies whether to delete the resource before replacing it.
 func DiffDeleteBeforeReplace(deleteBeforeReplace bool) DiffOption {
 	return func(o *diffOpts) { o.deleteBeforeReplace = deleteBeforeReplace }
-}
-
-// DiffDisableAccurateBridgePreviews specifies whether to disable accurate bridge previews.
-func DiffDisableAccurateBridgePreviews() DiffOption {
-	return func(o *diffOpts) { o.disableAccurateBridgePreviews = true }
 }
 
 // DiffProviderUpgradedSchema specifies the second provider schema to use for the diff.
@@ -49,12 +43,11 @@ func Diff(
 	config2Cty := cty.ObjectVal(config2)
 
 	return runDiffCheck(t, diffTestCase{
-		Resource:                      resource,
-		Config1:                       config1Cty,
-		Config2:                       config2Cty,
-		DeleteBeforeReplace:           o.deleteBeforeReplace,
-		DisableAccurateBridgePreviews: o.disableAccurateBridgePreviews,
-		Resource2:                     o.resource2,
-		SkipDiffEquivalenceCheck:      o.skipDiffEquivalenceCheck,
+		Resource:                 resource,
+		Config1:                  config1Cty,
+		Config2:                  config2Cty,
+		DeleteBeforeReplace:      o.deleteBeforeReplace,
+		Resource2:                o.resource2,
+		SkipDiffEquivalenceCheck: o.skipDiffEquivalenceCheck,
 	})
 }

--- a/pkg/internal/tests/cross-tests/diff_check.go
+++ b/pkg/internal/tests/cross-tests/diff_check.go
@@ -44,9 +44,8 @@ type diffTestCase struct {
 	Config1, Config2 any
 
 	// Optional object type for the resource. If left nil will be inferred from Resource schema.
-	ObjectType                    *tftypes.Object
-	DeleteBeforeReplace           bool
-	DisableAccurateBridgePreviews bool
+	ObjectType          *tftypes.Object
+	DeleteBeforeReplace bool
 
 	// Optional second schema to use as an upgrade test with a different schema.
 	Resource2 *schema.Resource
@@ -77,13 +76,8 @@ func runDiffCheck(t T, tc diffTestCase) crosstestsimpl.DiffResult {
 	tfp1 := &schema.Provider{ResourcesMap: map[string]*schema.Resource{defRtype: resource1}}
 	tfp2 := &schema.Provider{ResourcesMap: map[string]*schema.Resource{defRtype: resource2}}
 
-	opts := []pulcheck.BridgedProviderOpt{}
-	if !tc.DisableAccurateBridgePreviews {
-		opts = append(opts, pulcheck.EnableAccurateBridgePreviews())
-	}
-
-	bridgedProvider1 := pulcheck.BridgedProvider(t, defProviderShortName, tfp1, opts...)
-	bridgedProvider2 := pulcheck.BridgedProvider(t, defProviderShortName, tfp2, opts...)
+	bridgedProvider1 := pulcheck.BridgedProvider(t, defProviderShortName, tfp1)
+	bridgedProvider2 := pulcheck.BridgedProvider(t, defProviderShortName, tfp2)
 	if tc.DeleteBeforeReplace {
 		bridgedProvider1.Resources[defRtype].DeleteBeforeReplace = true
 		bridgedProvider2.Resources[defRtype].DeleteBeforeReplace = true

--- a/pkg/internal/tests/pulcheck/pulcheck.go
+++ b/pkg/internal/tests/pulcheck/pulcheck.go
@@ -195,20 +195,13 @@ type T interface {
 }
 
 type bridgedProviderOpts struct {
-	StateEdit                    shimv2.PlanStateEditFunc
-	resourceInfo                 map[string]*info.Resource
-	configInfo                   map[string]*info.Schema
-	EnableAccurateBridgePreviews bool
+	StateEdit    shimv2.PlanStateEditFunc
+	resourceInfo map[string]*info.Resource
+	configInfo   map[string]*info.Schema
 }
 
 // BridgedProviderOpts
 type BridgedProviderOpt func(*bridgedProviderOpts)
-
-func EnableAccurateBridgePreviews() BridgedProviderOpt {
-	return func(o *bridgedProviderOpts) {
-		o.EnableAccurateBridgePreviews = true
-	}
-}
 
 func WithStateEdit(f shimv2.PlanStateEditFunc) BridgedProviderOpt {
 	return func(o *bridgedProviderOpts) {
@@ -241,14 +234,6 @@ func BridgedProvider(t T, providerName string, tfp *schema.Provider, opts ...Bri
 
 	tfp = WithValidProvider(t, tfp)
 
-	// If the PULUMI_ACCURATE_BRIDGE_PREVIEWS environment variable is set, use it to enable
-	// accurate bridge previews.
-	accurateBridgePreviews := os.Getenv("PULUMI_ACCURATE_BRIDGE_PREVIEWS") == "true"
-	// Otherwise, use the value of the EnableAccurateBridgePreviews option.
-	if !accurateBridgePreviews {
-		accurateBridgePreviews = options.EnableAccurateBridgePreviews
-	}
-
 	shimProvider := shimv2.NewProvider(tfp,
 		shimv2.WithPlanStateEdit(options.StateEdit),
 	)
@@ -260,7 +245,6 @@ func BridgedProvider(t T, providerName string, tfp *schema.Provider, opts ...Bri
 		MetadataInfo:                   &tfbridge.MetadataInfo{},
 		EnableZeroDefaultSchemaVersion: true,
 		Resources:                      options.resourceInfo,
-		EnableAccurateBridgePreview:    accurateBridgePreviews,
 		Config:                         options.configInfo,
 	}
 	provider.MustComputeTokens(tokens.SingleModule(providerName,

--- a/pkg/pf/internal/providerbuilder/build_provider.go
+++ b/pkg/pf/internal/providerbuilder/build_provider.go
@@ -89,11 +89,10 @@ func (impl *Provider) ToProviderInfo() tfbridge0.ProviderInfo {
 	shimProvider := tfbridge.ShimProvider(impl)
 
 	provider := tfbridge0.ProviderInfo{
-		P:                           shimProvider,
-		Name:                        impl.TypeName,
-		Version:                     "0.0.1",
-		MetadataInfo:                &tfbridge0.MetadataInfo{},
-		EnableAccurateBridgePreview: true,
+		P:            shimProvider,
+		Name:         impl.TypeName,
+		Version:      "0.0.1",
+		MetadataInfo: &tfbridge0.MetadataInfo{},
 	}
 
 	provider.MustComputeTokens(tokens.SingleModule(impl.TypeName, "index", tokens.MakeStandard(impl.TypeName)))

--- a/pkg/pf/tests/provider_diff_test.go
+++ b/pkg/pf/tests/provider_diff_test.go
@@ -57,7 +57,6 @@ func TestEmptyTestresDiff(t *testing.T) {
 func TestOptionRemovalTestresDiff(t *testing.T) {
 	t.Parallel()
 	info := testprovider.SyntheticTestBridgeProvider()
-	info.EnableAccurateBridgePreview = false
 	server, err := newProviderServer(t, info)
 	require.NoError(t, err)
 	testCase := `
@@ -264,7 +263,6 @@ func TestSetNestedObjectAdded(t *testing.T) {
 func TestSetNestedObjectAddedOtherDiff(t *testing.T) {
 	t.Parallel()
 	info := testprovider.SyntheticTestBridgeProvider()
-	info.EnableAccurateBridgePreview = false
 	server, err := newProviderServer(t, info)
 	require.NoError(t, err)
 	testCase := `

--- a/pkg/tests/diff_test/detailed_diff_set_test.go
+++ b/pkg/tests/diff_test/detailed_diff_set_test.go
@@ -710,7 +710,7 @@ func TestSDKv2DetailedDiffRegressGCP2953(t *testing.T) {
 	tfp := &schema.Provider{ResourcesMap: map[string]*schema.Resource{
 		"prov_test": &res,
 	}}
-	bridgedProvider := pulcheck.BridgedProvider(t, "prov", tfp, pulcheck.EnableAccurateBridgePreviews())
+	bridgedProvider := pulcheck.BridgedProvider(t, "prov", tfp)
 
 	program := `
 name: test

--- a/pkg/tests/diff_test/detailed_diff_unknown_test.go
+++ b/pkg/tests/diff_test/detailed_diff_unknown_test.go
@@ -812,7 +812,7 @@ func TestUnknownCollectionForceNewDetailedDiff(t *testing.T) {
 		}
 
 		tfp := &schema.Provider{ResourcesMap: resMap}
-		bridgedProvider := pulcheck.BridgedProvider(t, "prov", tfp, pulcheck.EnableAccurateBridgePreviews())
+		bridgedProvider := pulcheck.BridgedProvider(t, "prov", tfp)
 		runTest := func(t *testing.T, program2 string, expectedOutput autogold.Value) {
 			runTest(t, program2, bridgedProvider, expectedOutput)
 		}
@@ -875,7 +875,7 @@ func TestUnknownCollectionForceNewDetailedDiff(t *testing.T) {
 		}
 
 		tfp := &schema.Provider{ResourcesMap: resMap}
-		bridgedProvider := pulcheck.BridgedProvider(t, "prov", tfp, pulcheck.EnableAccurateBridgePreviews())
+		bridgedProvider := pulcheck.BridgedProvider(t, "prov", tfp)
 		runTest := func(t *testing.T, program2 string, expectedOutput autogold.Value) {
 			runTest(t, program2, bridgedProvider, expectedOutput)
 		}
@@ -938,7 +938,7 @@ func TestUnknownCollectionForceNewDetailedDiff(t *testing.T) {
 		}
 
 		tfp := &schema.Provider{ResourcesMap: resMap}
-		bridgedProvider := pulcheck.BridgedProvider(t, "prov", tfp, pulcheck.EnableAccurateBridgePreviews())
+		bridgedProvider := pulcheck.BridgedProvider(t, "prov", tfp)
 		runTest := func(t *testing.T, program2 string, expectedOutput autogold.Value) {
 			runTest(t, program2, bridgedProvider, expectedOutput)
 		}
@@ -1001,7 +1001,7 @@ func TestUnknownCollectionForceNewDetailedDiff(t *testing.T) {
 		}
 
 		tfp := &schema.Provider{ResourcesMap: resMap}
-		bridgedProvider := pulcheck.BridgedProvider(t, "prov", tfp, pulcheck.EnableAccurateBridgePreviews())
+		bridgedProvider := pulcheck.BridgedProvider(t, "prov", tfp)
 		runTest := func(t *testing.T, program2 string, expectedOutput autogold.Value) {
 			runTest(t, program2, bridgedProvider, expectedOutput)
 		}
@@ -1062,7 +1062,7 @@ func runDetailedDiffTest(
 	t *testing.T, resMap map[string]*schema.Resource, program1, program2 string,
 ) (string, map[string]interface{}) {
 	tfp := &schema.Provider{ResourcesMap: resMap}
-	bridgedProvider := pulcheck.BridgedProvider(t, "prov", tfp, pulcheck.EnableAccurateBridgePreviews())
+	bridgedProvider := pulcheck.BridgedProvider(t, "prov", tfp)
 	pt := pulcheck.PulCheck(t, bridgedProvider, program1)
 	pt.Up(t)
 	pulumiYamlPath := filepath.Join(pt.CurrentStack().Workspace().WorkDir(), "Pulumi.yaml")

--- a/pkg/tfbridge/diff_test.go
+++ b/pkg/tfbridge/diff_test.go
@@ -2265,9 +2265,7 @@ func TestChangingMaxItems1FilterProperty(t *testing.T) {
 		},
 		expectedDiffChanges: pulumirpc.DiffResponse_DIFF_SOME,
 		expected: map[string]*pulumirpc.PropertyDiff{
-			"rules[0].filter": {
-				Kind: pulumirpc.PropertyDiff_UPDATE,
-			},
+			"rules[0].filter": {},
 		},
 	})
 }

--- a/pkg/tfbridge/info/info.go
+++ b/pkg/tfbridge/info/info.go
@@ -170,6 +170,7 @@ type Provider struct {
 	// EnableZeroDefaultSchemaVersion makes the provider default
 	// to version 0 when no version is specified in the state of a resource.
 	EnableZeroDefaultSchemaVersion bool
+	// Deprecated: This flag is enabled by default and will be removed in a future release.
 	// EnableAccurateBridgePreview makes the SDKv2 bridge use an experimental feature
 	// to generate more accurate diffs and previews for resources
 	EnableAccurateBridgePreview bool

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -57,8 +57,7 @@ import (
 )
 
 type providerOptions struct {
-	defaultZeroSchemaVersion    bool
-	enableAccurateBridgePreview bool
+	defaultZeroSchemaVersion bool
 }
 
 type providerOption func(providerOptions) (providerOptions, error)
@@ -66,13 +65,6 @@ type providerOption func(providerOptions) (providerOptions, error)
 func WithDefaultZeroSchemaVersion() providerOption { //nolint:revive
 	return func(opts providerOptions) (providerOptions, error) {
 		opts.defaultZeroSchemaVersion = true
-		return opts, nil
-	}
-}
-
-func withAccurateBridgePreview() providerOption {
-	return func(opts providerOptions) (providerOptions, error) {
-		opts.enableAccurateBridgePreview = true
 		return opts, nil
 	}
 }
@@ -276,10 +268,6 @@ func newProvider(ctx context.Context, host *provider.HostClient,
 	opts := []providerOption{}
 	if info.EnableZeroDefaultSchemaVersion {
 		opts = append(opts, WithDefaultZeroSchemaVersion())
-	}
-
-	if info.EnableAccurateBridgePreview || cmdutil.IsTruthy(os.Getenv("PULUMI_TF_BRIDGE_ACCURATE_BRIDGE_PREVIEW")) {
-		opts = append(opts, withAccurateBridgePreview())
 	}
 
 	p := &Provider{
@@ -1137,9 +1125,7 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 	}
 
 	state, err := makeTerraformStateWithOpts(ctx, res, req.GetId(), olds,
-		makeTerraformStateOptions{
-			defaultZeroSchemaVersion: opts.defaultZeroSchemaVersion,
-		},
+		makeTerraformStateOptions(opts),
 	)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unmarshaling %s's instance state", urn)
@@ -1175,7 +1161,7 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 	var changes pulumirpc.DiffResponse_DiffChanges
 
 	decisionOverride := diff.DiffEqualDecisionOverride()
-	if opts.enableAccurateBridgePreview && decisionOverride != shim.DiffNoOverride {
+	if decisionOverride != shim.DiffNoOverride {
 		if decisionOverride == shim.DiffOverrideNoUpdate {
 			changes = pulumirpc.DiffResponse_DIFF_NONE
 		} else {
@@ -1251,23 +1237,6 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 
 	deleteBeforeReplace := len(replaces) > 0 &&
 		(res.Schema.DeleteBeforeReplace || nameRequiresDeleteBeforeReplace(news, olds, schema, res.Schema))
-
-	if !opts.enableAccurateBridgePreview {
-		// If the upstream diff object indicates a replace is necessary and we have not
-		// recorded any replaces, that means that `makeDetailedDiff` failed to translate a
-		// property. This is known to happen for computed input properties:
-		//
-		// https://github.com/pulumi/pulumi-aws/issues/2971
-		if (diff.RequiresNew() || diff.Destroy()) &&
-			// In theory, we should be safe to set __meta as replaces whenever
-			// `diff.RequiresNew() || diff.Destroy()` but by checking replaces we
-			// limit the blast radius of this change to diffs that we know will panic
-			// later on.
-			len(replaces) == 0 {
-			replaces = append(replaces, "__meta")
-			changes = pulumirpc.DiffResponse_DIFF_SOME
-		}
-	}
 
 	if changes == pulumirpc.DiffResponse_DIFF_NONE &&
 		markWronglyTypedMaxItemsOneStateDiff(schema, fields, olds) {
@@ -1439,9 +1408,8 @@ func (p *Provider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*pulum
 		return nil, err
 	}
 	state, err := unmarshalTerraformStateWithOpts(ctx, res, id, req.GetProperties(), fmt.Sprintf("%s.state", label),
-		unmarshalTerraformStateOptions{
-			defaultZeroSchemaVersion: opts.defaultZeroSchemaVersion,
-		})
+		unmarshalTerraformStateOptions(opts),
+	)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unmarshaling %s's instance state", urn)
 	}
@@ -1637,9 +1605,8 @@ func (p *Provider) Update(ctx context.Context, req *pulumirpc.UpdateRequest) (*p
 	}
 
 	state, err := makeTerraformStateWithOpts(ctx, res, req.GetId(), olds,
-		makeTerraformStateOptions{
-			defaultZeroSchemaVersion: opts.defaultZeroSchemaVersion,
-		})
+		makeTerraformStateOptions(opts),
+	)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unmarshaling %s's instance state", urn)
 	}
@@ -1771,9 +1738,8 @@ func (p *Provider) Delete(ctx context.Context, req *pulumirpc.DeleteRequest) (*p
 	}
 	// Fetch the resource attributes since many providers need more than just the ID to perform the delete.
 	state, err := unmarshalTerraformStateWithOpts(ctx, res, req.GetId(), req.GetProperties(), label,
-		unmarshalTerraformStateOptions{
-			defaultZeroSchemaVersion: opts.defaultZeroSchemaVersion,
-		})
+		unmarshalTerraformStateOptions(opts),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -2530,7 +2530,7 @@ func TestTransformOutputs(t *testing.T) {
 
 func TestSkipDetailedDiff(t *testing.T) {
 	t.Parallel()
-	provider := func(t *testing.T, skipDetailedDiffForChanges bool) *Provider {
+	provider := func() *Provider {
 		p := testprovider.CustomizedDiffProvider(func(data *schema.ResourceData) {})
 		shimProvider := shimv2.NewProvider(p)
 		return &Provider{
@@ -2551,7 +2551,7 @@ func TestSkipDetailedDiff(t *testing.T) {
 		}
 	}
 	t.Run("Diff", func(t *testing.T) {
-		testutils.Replay(t, provider(t, true), `
+		testutils.Replay(t, provider(), `
                 {
 		  "method": "/pulumirpc.ResourceProvider/Diff",
 		  "request": {
@@ -2562,21 +2562,17 @@ func TestSkipDetailedDiff(t *testing.T) {
 		  },
 		  "response": {
 		    "changes": "DIFF_SOME",
-		    "hasDetailedDiff": true
+		    "hasDetailedDiff": true,
+			"detailedDiff": {
+				"labels": {}
+			},
+			"diffs": ["labels"]
 		  }
 		}`)
 	})
 
-	// This test checks that we will flag some meta field (`__meta`) as a replace if
-	// the upstream diff indicates a replace but there is no field associated with the
-	// replace.
-	//
-	// We do this since Pulumi's gRPC protocol doesn't have direct support for
-	// declaring a replace on a resource without an associated property.
 	t.Run("EmptyDiffWithReplace", func(t *testing.T) {
-		test := func(skipDetailedDiffForChanges bool) func(t *testing.T) {
-			return func(t *testing.T) {
-				testutils.Replay(t, provider(t, skipDetailedDiffForChanges), `
+		testutils.Replay(t, provider(), `
                 {
 		  "method": "/pulumirpc.ResourceProvider/Diff",
 		  "request": {
@@ -2588,21 +2584,18 @@ func TestSkipDetailedDiff(t *testing.T) {
 		  "response": {
 		    "changes": "DIFF_SOME",
 		    "replaces": ["__meta"],
-		    "hasDetailedDiff": true
+		    "hasDetailedDiff": true,
+			"detailedDiff": {
+				"__meta": {"kind": "UPDATE_REPLACE"},
+				"labels": {}
+			},
+			"diffs": ["__meta", "labels"]
 		  }
 		}`)
-			}
-		}
-		t.Run("withDetailedDiff", test(false))
-		t.Run("skipDetailedDiff", test(true))
 	})
 
-	// This test checks that we don't insert extraneous replaces when there is an
-	// existing field that holds a replace.
 	t.Run("FullDiffWithReplace", func(t *testing.T) {
-		test := func(skipDetailedDiffForChanges bool) func(t *testing.T) {
-			return func(t *testing.T) {
-				testutils.Replay(t, provider(t, skipDetailedDiffForChanges), `
+		testutils.Replay(t, provider(), `
                 {
 		  "method": "/pulumirpc.ResourceProvider/Diff",
 		  "request": {
@@ -2613,16 +2606,15 @@ func TestSkipDetailedDiff(t *testing.T) {
 		  },
 		  "response": {
 		    "changes": "DIFF_SOME",
-		    "replaces": ["labels"],
+		    "replaces": ["__meta"],
 		    "hasDetailedDiff": true,
-		    "detailedDiff": { "labels": { "kind": "UPDATE_REPLACE" } },
-		    "diffs": ["labels"]
+		    "detailedDiff": {
+				"__meta": {"kind": "UPDATE_REPLACE"},
+				"labels": {"kind": "UPDATE"}
+			},
+		    "diffs": ["__meta", "labels"]
 		  }
 		}`)
-			}
-		}
-		t.Run("withDetailedDiff", test(false))
-		t.Run("skipDetailedDiff", test(true))
 	})
 }
 
@@ -2855,11 +2847,10 @@ func TestMaxItemOneWrongStateDiff(t *testing.T) {
 				"changes": "DIFF_SOME",
 				"hasDetailedDiff": true,
 				"detailedDiff": {
-					"nested_str": {
-						"kind": "UPDATE"
+					"nestedStr": {
 					}
 				},
-				"diffs": ["nested_str"]
+				"diffs": ["nestedStr"]
 			}
 		}`)
 	})
@@ -5452,9 +5443,6 @@ func TestSetDuplicatedDiffEntries(t *testing.T) {
             "privileges"
         ],
         "detailedDiff": {
-            "privileges": {
-                "kind": "UPDATE"
-            },
             "privileges[0]": {
                 "kind": "DELETE"
             },


### PR DESCRIPTION
This enables the accurate bridge previews feature for the SDKv2 bridge by default and cleans up all the related code for the flag.

fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/2598