### PR TITLE
PF allow TF name to differ from bridge name

### DIFF
--- a/pkg/pf/internal/pfutils/common.go
+++ b/pkg/pf/internal/pfutils/common.go
@@ -50,13 +50,13 @@ type entry[T any] struct {
 	t      T
 }
 
-type collection[T any] map[runtypes.TypeName]entry[T]
+type collection[T any] map[runtypes.TypeOrRenamedEntityName]entry[T]
 
-func (c collection[T]) All() []runtypes.TypeName {
+func (c collection[T]) All() []runtypes.TypeOrRenamedEntityName {
 	if c == nil {
 		return nil
 	}
-	var names []runtypes.TypeName
+	var names []runtypes.TypeOrRenamedEntityName
 	for name := range c {
 		names = append(names, name)
 	}
@@ -66,11 +66,11 @@ func (c collection[T]) All() []runtypes.TypeName {
 	return names
 }
 
-func (c collection[T]) Has(name runtypes.TypeName) bool {
+func (c collection[T]) Has(name runtypes.TypeOrRenamedEntityName) bool {
 	_, ok := c[name]
 	return ok
 }
 
-func (c collection[T]) Schema(name runtypes.TypeName) Schema {
+func (c collection[T]) Schema(name runtypes.TypeOrRenamedEntityName) Schema {
 	return c[name].schema
 }

--- a/pkg/pf/internal/pfutils/common.go
+++ b/pkg/pf/internal/pfutils/common.go
@@ -46,6 +46,7 @@ func checkDiagsForErrors(diag diag.Diagnostics) error {
 
 type entry[T any] struct {
 	schema Schema
+	tfName runtypes.TypeName
 	t      T
 }
 

--- a/pkg/pf/internal/pfutils/datasources.go
+++ b/pkg/pf/internal/pfutils/datasources.go
@@ -48,11 +48,10 @@ func GatherDatasources[F func(Schema) shim.SchemaMap](
 			return nil, fmt.Errorf("Resource %s GetSchema() error: %w", meta.TypeName, err)
 		}
 
-		typeName := runtypes.TypeName(meta.TypeName)
-		ds[typeName] = entry[func() datasource.DataSource]{
+		ds[runtypes.TypeOrRenamedEntityName(meta.TypeName)] = entry[func() datasource.DataSource]{
 			t:      makeDataSource,
 			schema: FromDataSourceSchema(dataSourceSchema),
-			tfName: typeName,
+			tfName: runtypes.TypeName(meta.TypeName),
 		}
 	}
 
@@ -64,7 +63,7 @@ type dataSources struct {
 	convert func(Schema) shim.SchemaMap
 }
 
-func (r dataSources) Schema(t runtypes.TypeName) runtypes.Schema {
+func (r dataSources) Schema(t runtypes.TypeOrRenamedEntityName) runtypes.Schema {
 	entry := r.collection[t]
 	return runtypesSchemaAdapter{entry.schema, r.convert, entry.tfName}
 }

--- a/pkg/pf/internal/pfutils/datasources.go
+++ b/pkg/pf/internal/pfutils/datasources.go
@@ -48,9 +48,11 @@ func GatherDatasources[F func(Schema) shim.SchemaMap](
 			return nil, fmt.Errorf("Resource %s GetSchema() error: %w", meta.TypeName, err)
 		}
 
-		ds[runtypes.TypeName(meta.TypeName)] = entry[func() datasource.DataSource]{
+		typeName := runtypes.TypeName(meta.TypeName)
+		ds[typeName] = entry[func() datasource.DataSource]{
 			t:      makeDataSource,
 			schema: FromDataSourceSchema(dataSourceSchema),
+			tfName: typeName,
 		}
 	}
 
@@ -63,7 +65,8 @@ type dataSources struct {
 }
 
 func (r dataSources) Schema(t runtypes.TypeName) runtypes.Schema {
-	return runtypesSchemaAdapter{r.collection.Schema(t), r.convert}
+	entry := r.collection[t]
+	return runtypesSchemaAdapter{entry.schema, r.convert, entry.tfName}
 }
 
 func (dataSources) IsDataSources() {}

--- a/pkg/pf/internal/pfutils/proposed_new_test.go
+++ b/pkg/pf/internal/pfutils/proposed_new_test.go
@@ -39,6 +39,8 @@ type runtimeSchemaAdapter struct{ Schema }
 
 func (runtimeSchemaAdapter) Shim() shim.SchemaMap { panic("UNIMPLEMENTED") }
 
+func (runtimeSchemaAdapter) TFName() runtypes.TypeName { panic("UNIMPLEMENTED") }
+
 func TestComputedOptionalBecomingUnknown(t *testing.T) {
 	t.Parallel()
 	schema := rschema.Schema{Attributes: map[string]rschema.Attribute{

--- a/pkg/pf/internal/pfutils/resources.go
+++ b/pkg/pf/internal/pfutils/resources.go
@@ -48,11 +48,10 @@ func GatherResources[F func(Schema) shim.SchemaMap](
 			return nil, fmt.Errorf("Resource %s GetSchema() error: %w", meta.TypeName, err)
 		}
 
-		typeName := runtypes.TypeName(meta.TypeName)
-		rs[typeName] = entry[func() resource.Resource]{
+		rs[runtypes.TypeOrRenamedEntityName(meta.TypeName)] = entry[func() resource.Resource]{
 			t:      makeResource,
 			schema: FromResourceSchema(resSchema),
-			tfName: typeName,
+			tfName: runtypes.TypeName(meta.TypeName),
 		}
 	}
 
@@ -80,7 +79,7 @@ func (r runtypesSchemaAdapter) TFName() runtypes.TypeName {
 	return r.tfName
 }
 
-func (r resources) Schema(t runtypes.TypeName) runtypes.Schema {
+func (r resources) Schema(t runtypes.TypeOrRenamedEntityName) runtypes.Schema {
 	entry := r.collection[t]
 	return runtypesSchemaAdapter{entry.schema, r.convert, entry.tfName}
 }

--- a/pkg/pf/internal/runtypes/types.go
+++ b/pkg/pf/internal/runtypes/types.go
@@ -45,7 +45,8 @@ type Schema interface {
 // examplecloud_thing.
 type TypeName string
 
-// This could be a [TypeName] indicating a real Terraform type or else a TypeName+RenamedEntitySuffix pseudo-type introduced by [info.RenameResourceWithAlias].
+// This could be a [TypeName] indicating a real Terraform type or else a
+// TypeName+RenamedEntitySuffix pseudo-type introduced by [info.RenameResourceWithAlias].
 type TypeOrRenamedEntityName string
 
 type collection interface {

--- a/pkg/pf/internal/runtypes/types.go
+++ b/pkg/pf/internal/runtypes/types.go
@@ -37,6 +37,8 @@ type Schema interface {
 	DeprecationMessage() string
 
 	ResourceProtoSchema(ctx context.Context) (*tfprotov6.Schema, error)
+
+	TFName() TypeName
 }
 
 // Full resource type, including the provider type prefix and an underscore. For example,

--- a/pkg/pf/internal/runtypes/types.go
+++ b/pkg/pf/internal/runtypes/types.go
@@ -45,19 +45,22 @@ type Schema interface {
 // examplecloud_thing.
 type TypeName string
 
+// This could be a [TypeName] indicating a real Terraform type or else a TypeName+RenamedEntitySuffix pseudo-type introduced by [info.RenameResourceWithAlias].
+type TypeOrRenamedEntityName string
+
 type collection interface {
-	All() []TypeName
-	Has(TypeName) bool
-	Schema(TypeName) Schema
+	All() []TypeOrRenamedEntityName
+	Has(TypeOrRenamedEntityName) bool
+	Schema(TypeOrRenamedEntityName) Schema
 }
 
-// Represents all provider's resources pre-indexed by TypeName.
+// Represents all provider's resources pre-indexed by TypeOrRenamedEntityName.
 type Resources interface {
 	collection
 	IsResources()
 }
 
-// Represents all provider's datasources pre-indexed by TypeName.
+// Represents all provider's datasources pre-indexed by TypeOrRenamedEntityName.
 type DataSources interface {
 	collection
 	IsDataSources()

--- a/pkg/pf/internal/schemashim/datasource_map.go
+++ b/pkg/pf/internal/schemashim/datasource_map.go
@@ -66,20 +66,20 @@ func (m schemaOnlyDataSourceMap) Set(key string, value shim.Resource) {
 	m[key] = v
 }
 
-func (m schemaOnlyDataSourceMap) All() []runtypes.TypeName {
-	arr := make([]runtypes.TypeName, 0, len(m))
+func (m schemaOnlyDataSourceMap) All() []runtypes.TypeOrRenamedEntityName {
+	arr := make([]runtypes.TypeOrRenamedEntityName, 0, len(m))
 	for k := range m {
-		arr = append(arr, runtypes.TypeName(k))
+		arr = append(arr, runtypes.TypeOrRenamedEntityName(k))
 	}
 	return arr
 }
 
-func (m schemaOnlyDataSourceMap) Has(key runtypes.TypeName) bool {
+func (m schemaOnlyDataSourceMap) Has(key runtypes.TypeOrRenamedEntityName) bool {
 	_, ok := m[string(key)]
 	return ok
 }
 
-func (m schemaOnlyDataSourceMap) Schema(key runtypes.TypeName) runtypes.Schema {
+func (m schemaOnlyDataSourceMap) Schema(key runtypes.TypeOrRenamedEntityName) runtypes.Schema {
 	return m[string(key)].tf
 }
 

--- a/pkg/pf/internal/schemashim/resource_map.go
+++ b/pkg/pf/internal/schemashim/resource_map.go
@@ -66,20 +66,20 @@ func (m schemaOnlyResourceMap) Set(key string, value shim.Resource) {
 	m[key] = v
 }
 
-func (m schemaOnlyResourceMap) All() []runtypes.TypeName {
-	arr := make([]runtypes.TypeName, 0, len(m))
+func (m schemaOnlyResourceMap) All() []runtypes.TypeOrRenamedEntityName {
+	arr := make([]runtypes.TypeOrRenamedEntityName, 0, len(m))
 	for k := range m {
-		arr = append(arr, runtypes.TypeName(k))
+		arr = append(arr, runtypes.TypeOrRenamedEntityName(k))
 	}
 	return arr
 }
 
-func (m schemaOnlyResourceMap) Has(key runtypes.TypeName) bool {
+func (m schemaOnlyResourceMap) Has(key runtypes.TypeOrRenamedEntityName) bool {
 	_, ok := m[string(key)]
 	return ok
 }
 
-func (m schemaOnlyResourceMap) Schema(key runtypes.TypeName) runtypes.Schema {
+func (m schemaOnlyResourceMap) Schema(key runtypes.TypeOrRenamedEntityName) runtypes.Schema {
 	return m[string(key)].tf
 }
 

--- a/pkg/pf/proto/runtypes.go
+++ b/pkg/pf/proto/runtypes.go
@@ -41,7 +41,10 @@ func (p Provider) DataSources(context.Context) (runtypes.DataSources, error) {
 	return datasources{collection(v.DataSourceSchemas)}, nil
 }
 
-type schema struct{ s *tfprotov6.Schema }
+type schema struct {
+	s      *tfprotov6.Schema
+	tfName runtypes.TypeName
+}
 
 var _ = runtypes.Schema(schema{})
 
@@ -66,11 +69,19 @@ func (s schema) Shim() shim.SchemaMap {
 	return blockMap{s.s.Block}
 }
 
+func (s schema) TFName() runtypes.TypeName {
+	return s.tfName
+}
+
+var _ runtypes.Resources = resources{}
+
 type resources struct{ collection }
 
 func (resources) IsResources() {}
 
 type datasources struct{ collection }
+
+var _ runtypes.DataSources = datasources{}
 
 func (datasources) IsDataSources() {}
 
@@ -93,5 +104,5 @@ func (c collection) Schema(key runtypes.TypeName) runtypes.Schema {
 	s, ok := c[string(key)]
 	contract.Assertf(ok, "called Schema on a resource that does not exist")
 
-	return schema{s}
+	return schema{s, key}
 }

--- a/pkg/pf/proto/runtypes.go
+++ b/pkg/pf/proto/runtypes.go
@@ -87,22 +87,22 @@ func (datasources) IsDataSources() {}
 
 type collection map[string]*tfprotov6.Schema
 
-func (c collection) All() []runtypes.TypeName {
-	arr := make([]runtypes.TypeName, 0, len(c))
+func (c collection) All() []runtypes.TypeOrRenamedEntityName {
+	arr := make([]runtypes.TypeOrRenamedEntityName, 0, len(c))
 	for k := range c {
-		arr = append(arr, runtypes.TypeName(k))
+		arr = append(arr, runtypes.TypeOrRenamedEntityName(k))
 	}
 	return arr
 }
 
-func (c collection) Has(key runtypes.TypeName) bool {
+func (c collection) Has(key runtypes.TypeOrRenamedEntityName) bool {
 	_, ok := c[string(key)]
 	return ok
 }
 
-func (c collection) Schema(key runtypes.TypeName) runtypes.Schema {
+func (c collection) Schema(key runtypes.TypeOrRenamedEntityName) runtypes.Schema {
 	s, ok := c[string(key)]
 	contract.Assertf(ok, "called Schema on a resource that does not exist")
 
-	return schema{s, key}
+	return schema{s, runtypes.TypeName(key)}
 }

--- a/pkg/pf/tests/nested_attr_test.go
+++ b/pkg/pf/tests/nested_attr_test.go
@@ -33,7 +33,7 @@ func TestNestedType(t *testing.T) {
 	info := testprovider.SyntheticTestBridgeProvider()
 	res, err := info.P.(pf.ShimProvider).Resources(ctx)
 	require.NoError(t, err)
-	testresTypeName := runtypes.TypeName("testbridge_testres")
+	testresTypeName := runtypes.TypeOrRenamedEntityName("testbridge_testres")
 	testresType := res.Schema(testresTypeName).Type(ctx)
 
 	obj := testresType.(tftypes.Object).AttributeTypes["services"].(tftypes.List).ElementType.(tftypes.Object)

--- a/pkg/pf/tests/schema_and_program_test.go
+++ b/pkg/pf/tests/schema_and_program_test.go
@@ -626,8 +626,6 @@ func TestPFAliasesSchemaUpgrade(t *testing.T) {
 }
 
 func TestPFAliasesRenameWithAlias(t *testing.T) {
-	// TODO[pulumi/pulumi-terraform-bridge#2992]
-	t.Skip()
 	t.Parallel()
 
 	prov1 := pb.NewProvider(pb.NewProviderArgs{

--- a/pkg/pf/tfbridge/provider.go
+++ b/pkg/pf/tfbridge/provider.go
@@ -298,7 +298,7 @@ func (p *provider) SignalCancellationWithContext(_ context.Context) error {
 	return nil
 }
 
-func (p *provider) terraformResourceName(resourceToken tokens.Type) (string, error) {
+func (p *provider) terraformResourceNameOrRenamedEntity(resourceToken tokens.Type) (string, error) {
 	for tfname, v := range p.info.Resources {
 		if v.Tok == resourceToken {
 			return tfname, nil
@@ -307,7 +307,7 @@ func (p *provider) terraformResourceName(resourceToken tokens.Type) (string, err
 	return "", fmt.Errorf("[pf/tfbridge] unknown resource token: %v", resourceToken)
 }
 
-func (p *provider) terraformDatasourceName(functionToken tokens.ModuleMember) (string, error) {
+func (p *provider) terraformDatasourceNameOrRenamedEntity(functionToken tokens.ModuleMember) (string, error) {
 	for tfname, v := range p.info.DataSources {
 		if v.Tok == functionToken {
 			return tfname, nil

--- a/pkg/pf/tfbridge/provider_datasources.go
+++ b/pkg/pf/tfbridge/provider_datasources.go
@@ -37,7 +37,7 @@ type datasourceHandle struct {
 }
 
 func (p *provider) datasourceHandle(ctx context.Context, token tokens.ModuleMember) (datasourceHandle, error) {
-	dsName, err := p.terraformDatasourceName(token)
+	dsName, err := p.terraformDatasourceNameOrRenamedEntity(token)
 	if err != nil {
 		return datasourceHandle{}, err
 	}

--- a/pkg/pf/tfbridge/provider_datasources.go
+++ b/pkg/pf/tfbridge/provider_datasources.go
@@ -42,8 +42,7 @@ func (p *provider) datasourceHandle(ctx context.Context, token tokens.ModuleMemb
 		return datasourceHandle{}, err
 	}
 
-	typeName := runtypes.TypeName(dsName)
-	schema := p.datasources.Schema(typeName)
+	schema := p.datasources.Schema(runtypes.TypeOrRenamedEntityName(dsName))
 
 	typ := schema.Type(ctx).(tftypes.Object)
 

--- a/pkg/pf/tfbridge/provider_resources.go
+++ b/pkg/pf/tfbridge/provider_resources.go
@@ -44,8 +44,7 @@ func (p *provider) resourceHandle(ctx context.Context, urn pulumiresource.URN) (
 		return resourceHandle{}, err
 	}
 
-	n := runtypes.TypeName(typeName)
-	schema := p.resources.Schema(n)
+	schema := p.resources.Schema(runtypes.TypeOrRenamedEntityName(typeName))
 
 	result := resourceHandle{
 		terraformResourceName: string(schema.TFName()),

--- a/pkg/pf/tfbridge/provider_resources.go
+++ b/pkg/pf/tfbridge/provider_resources.go
@@ -48,7 +48,7 @@ func (p *provider) resourceHandle(ctx context.Context, urn pulumiresource.URN) (
 	schema := p.resources.Schema(n)
 
 	result := resourceHandle{
-		terraformResourceName: typeName,
+		terraformResourceName: string(schema.TFName()),
 		schema:                schema,
 	}
 

--- a/pkg/pf/tfbridge/provider_resources.go
+++ b/pkg/pf/tfbridge/provider_resources.go
@@ -39,19 +39,19 @@ type resourceHandle struct {
 }
 
 func (p *provider) resourceHandle(ctx context.Context, urn pulumiresource.URN) (resourceHandle, error) {
-	typeName, err := p.terraformResourceName(urn.Type())
+	typeOrRenamedEntityName, err := p.terraformResourceNameOrRenamedEntity(urn.Type())
 	if err != nil {
 		return resourceHandle{}, err
 	}
 
-	schema := p.resources.Schema(runtypes.TypeOrRenamedEntityName(typeName))
+	schema := p.resources.Schema(runtypes.TypeOrRenamedEntityName(typeOrRenamedEntityName))
 
 	result := resourceHandle{
 		terraformResourceName: string(schema.TFName()),
 		schema:                schema,
 	}
 
-	if info, ok := p.info.Resources[typeName]; ok {
+	if info, ok := p.info.Resources[typeOrRenamedEntityName]; ok {
 		result.pulumiResourceInfo = info
 	}
 
@@ -62,12 +62,12 @@ func (p *provider) resourceHandle(ctx context.Context, urn pulumiresource.URN) (
 
 	objectType := result.schema.Type(ctx).(tftypes.Object)
 
-	encoder, err := p.encoding.NewResourceEncoder(typeName, objectType)
+	encoder, err := p.encoding.NewResourceEncoder(typeOrRenamedEntityName, objectType)
 	if err != nil {
 		return resourceHandle{}, fmt.Errorf("Failed to prepare a resource encoder: %s", err)
 	}
 
-	outputsDecoder, err := p.encoding.NewResourceDecoder(typeName, objectType)
+	outputsDecoder, err := p.encoding.NewResourceDecoder(typeOrRenamedEntityName, objectType)
 	if err != nil {
 		return resourceHandle{}, fmt.Errorf("Failed to prepare an resoure decoder: %s", err)
 	}
@@ -76,7 +76,7 @@ func (p *provider) resourceHandle(ctx context.Context, urn pulumiresource.URN) (
 	result.decoder = outputsDecoder
 	result.token = token
 
-	result.schemaOnlyShimResource, _ = p.schemaOnlyProvider.ResourcesMap().GetOk(typeName)
+	result.schemaOnlyShimResource, _ = p.schemaOnlyProvider.ResourcesMap().GetOk(typeOrRenamedEntityName)
 	return result, nil
 }
 

--- a/pkg/pf/tfbridge/provider_test.go
+++ b/pkg/pf/tfbridge/provider_test.go
@@ -33,7 +33,7 @@ func TestTerraformResourceName(t *testing.T) {
 			},
 		},
 	}
-	name, err := p.terraformResourceName(urn.Type())
+	name, err := p.terraformResourceNameOrRenamedEntity(urn.Type())
 	assert.NoError(t, err)
 	assert.Equal(t, name, "random_integer")
 }

--- a/pkg/tfbridge/info/info.go
+++ b/pkg/tfbridge/info/info.go
@@ -71,8 +71,8 @@ type Provider struct {
 	Version        string                             // the version of the provider package.
 	Config         map[string]*Schema                 // a map of TF name to config schema overrides.
 	ExtraConfig    map[string]*Config                 // a list of Pulumi-only configuration variables.
-	Resources      map[string]*Resource               // a map of TF name to Pulumi name; standard mangling occurs if no entry.
-	DataSources    map[string]*DataSource             // a map of TF name to Pulumi resource info.
+	Resources      map[string]*Resource               // a map of TF type or renamed entity name to Pulumi resource info.
+	DataSources    map[string]*DataSource             // a map of TF type or renamed entity name to Pulumi resource info.
 	ExtraTypes     map[string]pschema.ComplexTypeSpec // a map of Pulumi token to schema type for extra types.
 	ExtraResources map[string]pschema.ResourceSpec    // a map of Pulumi token to schema type for extra resources.
 	ExtraFunctions map[string]pschema.FunctionSpec    // a map of Pulumi token to schema type for extra functions.


### PR DESCRIPTION
This change enables resource in the PF bridge to have different names to their TF names. This is used for `RenameResourceWithAlias` which allows two resources in the PF bridge to correspond to the same resource in TF.

Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/2992