### PR TITLE
chore: mark (d v2InstanceDiff) ProposedState as dead code

### DIFF
--- a/pkg/tfshim/sdk-v2/instance_diff.go
+++ b/pkg/tfshim/sdk-v2/instance_diff.go
@@ -68,6 +68,7 @@ func (d v2InstanceDiff) Attributes() map[string]shim.ResourceAttrDiff {
 }
 
 func (d v2InstanceDiff) ProposedState(res shim.Resource, priorState shim.InstanceState) (shim.InstanceState, error) {
+	panic("v2InstanceDiff.ProposedState should not be called being overridden buy v2InstanceDiff2.ProposedNewState")
 	var prior *terraform.InstanceState
 	if priorState != nil {
 		prior = priorState.(v2InstanceState).tf

--- a/pkg/tfshim/sdk-v2/instance_diff.go
+++ b/pkg/tfshim/sdk-v2/instance_diff.go
@@ -68,22 +68,14 @@ func (d v2InstanceDiff) Attributes() map[string]shim.ResourceAttrDiff {
 }
 
 func (d v2InstanceDiff) ProposedState(res shim.Resource, priorState shim.InstanceState) (shim.InstanceState, error) {
-	panic("v2InstanceDiff.ProposedState should not be called being overridden buy v2InstanceDiff2.ProposedNewState")
-	var prior *terraform.InstanceState
-	if priorState != nil {
-		prior = priorState.(v2InstanceState).tf
-	} else {
-		prior = &terraform.InstanceState{
-			Attributes: map[string]string{},
-			Meta:       map[string]interface{}{},
-		}
-	}
-
-	return v2InstanceState{
-		resource: res.(v2Resource).tf,
-		tf:       prior,
-		diff:     d.tf,
-	}, nil
+	// In the current bridge versions, v2InstanceDiff is used by itself only when working with data source calls.
+	// For data sources ProposedState is never called. Consider refactoring away from using shim.InstanceState to
+	// represent those.
+	//
+	// When v2InstanceDiff is used as a struct embedded into v2InstanceDiff2, the outer struct re-implements
+	// ProposedState() so again this method does not get called.
+	contract.Failf("v2InstanceDiff().ProposedState() should not be called")
+	return nil, nil
 }
 
 func (d v2InstanceDiff) PriorState() (shim.InstanceState, error) {


### PR DESCRIPTION
There is a lot of dead code cleanup opportunity in this package but it is a bit difficult to reason about. Let us take it step by step. This marks some code as obviously dead before we can refactor further.