### PR TITLE
Allow releasing providers with bridge release

### DIFF
--- a/.github/workflows/update-providers-auto.yml
+++ b/.github/workflows/update-providers-auto.yml
@@ -36,6 +36,8 @@ jobs:
             echo "has_hotfix=false" >> $GITHUB_OUTPUT
             echo "No provider hotfix found. Will not trigger provider releases"
           fi
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Trigger upgrade
         uses: peter-evans/repository-dispatch@v3

--- a/.github/workflows/update-providers-auto.yml
+++ b/.github/workflows/update-providers-auto.yml
@@ -22,6 +22,21 @@ jobs:
     runs-on: ubuntu-latest
     name: Upgrade ${{ matrix.provider }} to pulumi-terraform-bridge to the latest version automatically
     steps:
+      - name: Check for provider hotfixes
+        id: hotfix_check
+        run: |
+          # Get the latest release notes using gh CLI
+          RELEASE_NOTES=$(gh release view --repo pulumi/pulumi-terraform-bridge --json body --jq '.body')
+          
+          # Check for [PROVIDER HOTFIX] in release notes
+          if echo "$RELEASE_NOTES" | grep -q "\[PROVIDER HOTFIX\]"; then
+            echo "has_hotfix=true" >> $GITHUB_OUTPUT
+            echo "Found provider hotfix in release notes. Will trigger provider releases"
+          else
+            echo "has_hotfix=false" >> $GITHUB_OUTPUT
+            echo "No provider hotfix found. Will not trigger provider releases"
+          fi
+
       - name: Trigger upgrade
         uses: peter-evans/repository-dispatch@v3
         with:
@@ -32,7 +47,8 @@ jobs:
           client-payload: |-
             {
                "pr-reviewers": ${{ toJSON( github.actor ) == 'pulumi-bot' && 'VenelinMartinov' || toJSON( github.actor || 'VenelinMartinov' ) }},
-               "automerge": true
+               "automerge": true,
+               "patch-release": ${{ steps.hotfix_check.outputs.has_hotfix }}
             }
     needs: generate-providers-list
     strategy:

--- a/.github/workflows/update-providers-test.yml
+++ b/.github/workflows/update-providers-test.yml
@@ -42,23 +42,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Test upgrading ${{ matrix.provider }} to pulumi-terraform-bridge ${{ github.sha }}
     steps:
-      - name: Check for provider hotfixes
-        id: hotfix_check
-        run: |
-          # Get the latest release notes using gh CLI
-          RELEASE_NOTES=$(gh release view --repo pulumi/pulumi-terraform-bridge --json body --jq '.body')
-          
-          # Check for [PROVIDER HOTFIX] in release notes
-          if echo "$RELEASE_NOTES" | grep -q "\[PROVIDER HOTFIX\]"; then
-            echo "has_hotfix=true" >> $GITHUB_OUTPUT
-            echo "Found provider hotfix in release notes. Will trigger provider releases"
-          else
-            echo "has_hotfix=false" >> $GITHUB_OUTPUT
-            echo "No provider hotfix found. Will not trigger provider releases"
-          fi
-        env:
-          GH_TOKEN: ${{ github.token }}
-
       - name: Trigger upgrade
         uses: peter-evans/repository-dispatch@v3
         with:
@@ -72,8 +55,7 @@ jobs:
                "pr-reviewers": ${{ toJSON( github.triggering_actor || 't0yv0' ) }},
                "pr-description": "This PR was created to test a pulumi/pulumi-terraform-bridge feature.\n\n- pulumi/pulumi-terraform-bridge#${{ github.event.number }}\n\n- https://github.com/pulumi/pulumi-terraform-bridge/commit/${{github.sha}}\n\nDO NOT MERGE.",
                "automerge": false,
-               "pr-title-prefix": "[DOWNSTREAM TEST][BRIDGE]",
-               "patch-release": ${{ steps.hotfix_check.outputs.has_hotfix }}
+               "pr-title-prefix": "[DOWNSTREAM TEST][BRIDGE]"
             }
     needs: generate-providers-list
     strategy:

--- a/.github/workflows/update-providers-test.yml
+++ b/.github/workflows/update-providers-test.yml
@@ -42,6 +42,21 @@ jobs:
     runs-on: ubuntu-latest
     name: Test upgrading ${{ matrix.provider }} to pulumi-terraform-bridge ${{ github.sha }}
     steps:
+      - name: Check for provider hotfixes
+        id: hotfix_check
+        run: |
+          # Get the latest release notes using gh CLI
+          RELEASE_NOTES=$(gh release view --repo pulumi/pulumi-terraform-bridge --json body --jq '.body')
+          
+          # Check for [PROVIDER HOTFIX] in release notes
+          if echo "$RELEASE_NOTES" | grep -q "\[PROVIDER HOTFIX\]"; then
+            echo "has_hotfix=true" >> $GITHUB_OUTPUT
+            echo "Found provider hotfix in release notes. Will trigger provider releases"
+          else
+            echo "has_hotfix=false" >> $GITHUB_OUTPUT
+            echo "No provider hotfix found. Will not trigger provider releases"
+          fi
+
       - name: Trigger upgrade
         uses: peter-evans/repository-dispatch@v3
         with:
@@ -55,7 +70,8 @@ jobs:
                "pr-reviewers": ${{ toJSON( github.triggering_actor || 't0yv0' ) }},
                "pr-description": "This PR was created to test a pulumi/pulumi-terraform-bridge feature.\n\n- pulumi/pulumi-terraform-bridge#${{ github.event.number }}\n\n- https://github.com/pulumi/pulumi-terraform-bridge/commit/${{github.sha}}\n\nDO NOT MERGE.",
                "automerge": false,
-               "pr-title-prefix": "[DOWNSTREAM TEST][BRIDGE]"
+               "pr-title-prefix": "[DOWNSTREAM TEST][BRIDGE]",
+               "patch-release": ${{ steps.hotfix_check.outputs.has_hotfix }}
             }
     needs: generate-providers-list
     strategy:

--- a/.github/workflows/update-providers-test.yml
+++ b/.github/workflows/update-providers-test.yml
@@ -56,6 +56,8 @@ jobs:
             echo "has_hotfix=false" >> $GITHUB_OUTPUT
             echo "No provider hotfix found. Will not trigger provider releases"
           fi
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Trigger upgrade
         uses: peter-evans/repository-dispatch@v3


### PR DESCRIPTION
This adds a mechanism for triggering provider releases from a bridge release. Currently this is adding a comment to the release notes like:

```
<!---
[PROVIDER HOTFIX]
-->
```

This will in turn get picked up by the upgrade-provider-action and will trigger all bridge upgrade PRs to have `needs-release/patch` on providers which will trigger a patch release.

Example PR: https://github.com/pulumi/pulumi-aiven/pull/913

fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/2267