### PR TITLE
Add docs about input ID field

### DIFF
--- a/docs/guides/resource-ids.md
+++ b/docs/guides/resource-ids.md
@@ -85,7 +85,7 @@ func(ctx context.Context, state resource.PropertyMap) (resource.ID, error)
 ### ID field is of input type
 
 ```
-error: Resource my_resource has a problem: an "id" input attribute is not allowed. To map this resource specify SchemaInfo.Name and ResourceInfo.ComputeID
+error: Resource test_res has a problem: an "id" input attribute is not allowed. To map this resource specify SchemaInfo.Name and ResourceInfo.ComputeID
 ```
 
 If the resource has an `"id"` attribute but it is Optional or Required on the TF side, that makes it invalid for use in Pulumi. This can be worked around by renaming the field and specifying the `ResourceInfo.ComputeID` field for the resource:


### PR DESCRIPTION
This adds a section in the docs on fixing ID issues about this tfgen error:

```
error: Resource my_resource has a problem: an "id" input attribute is not allowed. To map this resource specify SchemaInfo.Name and ResourceInfo.ComputeID
```

It happens for PF resources with input ID fields.