### PR TITLE
chore: improve test isolation

### DIFF
--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -402,6 +402,8 @@ func TestDiffConfig(t *testing.T) {
 
 func TestBuildConfig(t *testing.T) {
 	t.Parallel()
+
+	testTFProvider := testprovider.ProviderV1()
 	provider := &Provider{
 		tf:     shimv1.NewProvider(testTFProvider),
 		config: shimv1.NewSchemaMap(testTFProvider.Schema),
@@ -508,6 +510,8 @@ func testIgnoreChanges(t *testing.T, provider *Provider) {
 
 func TestIgnoreChanges(t *testing.T) {
 	t.Parallel()
+	testTFProvider := testprovider.ProviderV1()
+
 	provider := &Provider{
 		tf:     shimv1.NewProvider(testTFProvider),
 		config: shimv1.NewSchemaMap(testTFProvider.Schema),
@@ -524,10 +528,12 @@ func TestIgnoreChanges(t *testing.T) {
 
 func TestIgnoreChangesV2(t *testing.T) {
 	t.Parallel()
+	testTFProviderV2 := testprovider.ProviderV2()
 	testIgnoreChangesV2(t, shimv2.NewProvider(testTFProviderV2))
 }
 
 func testIgnoreChangesV2(t *testing.T, prov shim.Provider) {
+	testTFProviderV2 := testprovider.ProviderV2()
 	provider := &Provider{
 		tf:     prov,
 		config: shimv2.NewSchemaMap(testTFProviderV2.Schema),
@@ -546,6 +552,7 @@ func testIgnoreChangesV2(t *testing.T, prov shim.Provider) {
 
 func TestProviderPreview(t *testing.T) {
 	t.Parallel()
+	testTFProvider := testprovider.ProviderV1()
 	provider := &Provider{
 		tf:     shimv1.NewProvider(testTFProvider),
 		config: shimv1.NewSchemaMap(testTFProvider.Schema),
@@ -667,6 +674,7 @@ func TestProviderPreview(t *testing.T) {
 
 func TestProviderPreviewV2(t *testing.T) {
 	t.Parallel()
+	testTFProviderV2 := testprovider.ProviderV2()
 	shimProvider := shimv2.NewProvider(testTFProviderV2)
 	provider := &Provider{
 		tf:     shimProvider,
@@ -802,6 +810,8 @@ func TestProviderPreviewV2(t *testing.T) {
 
 func TestProviderCheckWithAutonaming(t *testing.T) {
 	t.Parallel()
+	testTFProvider := testprovider.ProviderV1()
+	testTFProviderV2 := testprovider.ProviderV2()
 	provider := &Provider{
 		tf:     shimv2.NewProvider(testTFProviderV2),
 		config: shimv2.NewSchemaMap(testTFProviderV2.Schema),
@@ -1091,6 +1101,8 @@ func testProviderRead(t *testing.T, provider *Provider, typeName tokens.Type, ch
 
 func TestProviderReadV1(t *testing.T) {
 	t.Parallel()
+	testTFProvider := testprovider.ProviderV1()
+
 	provider := &Provider{
 		tf:     shimv1.NewProvider(testTFProvider),
 		config: shimv1.NewSchemaMap(testTFProvider.Schema),
@@ -1109,6 +1121,8 @@ func TestProviderReadV1(t *testing.T) {
 
 func TestProviderReadV2(t *testing.T) {
 	t.Parallel()
+
+	testTFProviderV2 := testprovider.ProviderV2()
 	shimProvider := shimv2.NewProvider(testTFProviderV2)
 	provider := &Provider{
 		tf:     shimProvider,
@@ -1174,6 +1188,9 @@ func testProviderReadNestedSecret(t *testing.T, provider *Provider, typeName tok
 
 func TestProviderReadNestedSecretV1(t *testing.T) {
 	t.Parallel()
+
+	testTFProvider := testprovider.ProviderV1()
+
 	provider := &Provider{
 		tf:     shimv1.NewProvider(testTFProvider),
 		config: shimv1.NewSchemaMap(testTFProvider.Schema),
@@ -1192,6 +1209,9 @@ func TestProviderReadNestedSecretV1(t *testing.T) {
 
 func TestProviderReadNestedSecretV2(t *testing.T) {
 	t.Parallel()
+
+	testTFProviderV2 := testprovider.ProviderV2()
+
 	shimProvider := shimv2.NewProvider(testTFProviderV2)
 	provider := &Provider{
 		tf:     shimProvider,
@@ -1211,6 +1231,8 @@ func TestProviderReadNestedSecretV2(t *testing.T) {
 func TestCheck(t *testing.T) {
 	t.Parallel()
 	t.Run("Default application can consult prior state in Check", func(t *testing.T) {
+		testTFProviderV2 := testprovider.ProviderV2()
+
 		shimProvider := shimv2.NewProvider(testTFProviderV2)
 		provider := &Provider{
 			tf:     shimProvider,
@@ -1486,6 +1508,8 @@ This will become a hard error in the future.
 func TestCheckConfig(t *testing.T) {
 	t.Parallel()
 	t.Run("minimal", func(t *testing.T) {
+		testTFProviderV2 := testprovider.ProviderV2()
+
 		// Ensure the method is minimally implemented. Pulumi will be passing a provider version. Make sure it
 		// is mirrored back.
 		provider := &Provider{
@@ -1511,6 +1535,8 @@ func TestCheckConfig(t *testing.T) {
 	})
 
 	t.Run("config_value", func(t *testing.T) {
+		testTFProviderV2 := testprovider.ProviderV2()
+
 		provider := &Provider{
 			tf:     shimv2.NewProvider(testTFProviderV2),
 			config: shimv2.NewSchemaMap(testTFProviderV2.Schema),
@@ -1581,6 +1607,8 @@ func TestCheckConfig(t *testing.T) {
 	})
 
 	t.Run("config_changed", func(t *testing.T) {
+		testTFProviderV2 := testprovider.ProviderV2()
+
 		provider := &Provider{
 			tf:     shimv2.NewProvider(testTFProviderV2),
 			config: shimv2.NewSchemaMap(testTFProviderV2.Schema),
@@ -2090,6 +2118,8 @@ func TestConfigureContextCapture(t *testing.T) {
 func TestPreConfigureCallback(t *testing.T) {
 	t.Parallel()
 	t.Run("PreConfigureCallback called by CheckConfig", func(t *testing.T) {
+		testTFProviderV2 := testprovider.ProviderV2()
+
 		callCounter := 0
 		provider := &Provider{
 			tf:     shimv2.NewProvider(testTFProviderV2),
@@ -2125,6 +2155,8 @@ func TestPreConfigureCallback(t *testing.T) {
 		require.Equalf(t, 1, callCounter, "PreConfigureCallback should be called once")
 	})
 	t.Run("PreConfigureCallbackWithLoggger called by CheckConfig", func(t *testing.T) {
+		testTFProviderV2 := testprovider.ProviderV2()
+
 		callCounter := 0
 		provider := &Provider{
 			tf:     shimv2.NewProvider(testTFProviderV2),
@@ -2165,6 +2197,8 @@ func TestPreConfigureCallback(t *testing.T) {
 		require.Equalf(t, 1, callCounter, "PreConfigureCallbackWithLogger should be called once")
 	})
 	t.Run("PreConfigureCallback can modify config values", func(t *testing.T) {
+		testTFProviderV2 := testprovider.ProviderV2()
+
 		provider := &Provider{
 			tf:     shimv2.NewProvider(testTFProviderV2),
 			config: shimv2.NewSchemaMap(testTFProviderV2.Schema),
@@ -2194,6 +2228,8 @@ func TestPreConfigureCallback(t *testing.T) {
 		}`)
 	})
 	t.Run("PreConfigureCallbackWithLogger can modify config values", func(t *testing.T) {
+		testTFProviderV2 := testprovider.ProviderV2()
+
 		provider := &Provider{
 			tf:     shimv2.NewProvider(testTFProviderV2),
 			config: shimv2.NewSchemaMap(testTFProviderV2.Schema),
@@ -2228,6 +2264,8 @@ func TestPreConfigureCallback(t *testing.T) {
 		}`)
 	})
 	t.Run("PreConfigureCallback not called at preview with unknown values", func(t *testing.T) {
+		testTFProviderV2 := testprovider.ProviderV2()
+
 		provider := &Provider{
 			tf:     shimv2.NewProvider(testTFProviderV2),
 			config: shimv2.NewSchemaMap(testTFProviderV2.Schema),
@@ -2275,6 +2313,8 @@ func TestPreConfigureCallback(t *testing.T) {
 func TestInvoke(t *testing.T) {
 	t.Parallel()
 	t.Run("preserve_program_secrets", func(t *testing.T) {
+		testTFProviderV2 := testprovider.ProviderV2()
+
 		// Currently the provider is unable to preserve secret-ness of values marked as secrets. Returning
 		// secrets makes SDKs unable to consume the provider. Therefore currently the secrets are stripped.
 		//
@@ -2341,6 +2381,9 @@ func TestInvoke(t *testing.T) {
 
 func TestTransformOutputs(t *testing.T) {
 	t.Parallel()
+
+	testTFProviderV2 := testprovider.ProviderV2()
+
 	shimProvider := shimv2.NewProvider(testTFProviderV2)
 	provider := &Provider{
 		tf:     shimProvider,

--- a/pkg/tfbridge/schema_provider_test.go
+++ b/pkg/tfbridge/schema_provider_test.go
@@ -21,10 +21,10 @@ func schemaMap(m map[string]*schema.Schema) shim.SchemaMap {
 	return mm
 }
 
-var (
-	testTFProvider   = testprovider.ProviderV1()
-	testTFProviderV2 = testprovider.ProviderV2()
-)
+// var (
+// 	testTFProvider   = testprovider.ProviderV1()
+// 	testTFProviderV2 = testprovider.ProviderV2()
+// )
 
 type shimFactory interface {
 	SDKVersion() string
@@ -141,6 +141,7 @@ func (f shimv1Factory) NewInstanceState(id string) shim.InstanceState {
 }
 
 func (f shimv1Factory) NewTestProvider() shim.Provider {
+	testTFProvider := testprovider.ProviderV1()
 	return shimv1.NewProvider(testTFProvider)
 }
 
@@ -253,6 +254,7 @@ func (f shimv2Factory) NewInstanceState(id string) shim.InstanceState {
 }
 
 func (f shimv2Factory) NewTestProvider() shim.Provider {
+	testTFProviderV2 := testprovider.ProviderV2()
 	return shimv2.NewProvider(testTFProviderV2)
 }
 

--- a/pkg/tfbridge/schema_provider_test.go
+++ b/pkg/tfbridge/schema_provider_test.go
@@ -21,11 +21,6 @@ func schemaMap(m map[string]*schema.Schema) shim.SchemaMap {
 	return mm
 }
 
-// var (
-// 	testTFProvider   = testprovider.ProviderV1()
-// 	testTFProviderV2 = testprovider.ProviderV2()
-// )
-
 type shimFactory interface {
 	SDKVersion() string
 	NewSchema(s *schema.Schema) shim.Schema

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -1184,6 +1184,7 @@ func TestComputedAsset(t *testing.T) {
 	}
 	inputs, assets, err := makeTerraformInputsNoDefaults(olds, props, tfs, ps)
 	assert.NoError(t, err)
+	testTFProvider := testprovider.ProviderV1()
 	outputs := MakeTerraformOutputs(ctx, shimv1.NewProvider(testTFProvider), inputs, tfs, ps, assets, true)
 	assert.Equal(t, resource.PropertyMap{
 		"zzz": resource.PropertyValue{V: resource.Computed{Element: resource.PropertyValue{V: ""}}},
@@ -1192,6 +1193,8 @@ func TestComputedAsset(t *testing.T) {
 
 func TestInvalidAsset(t *testing.T) {
 	t.Parallel()
+	testTFProvider := testprovider.ProviderV1()
+
 	ctx := context.Background()
 	tfs := shimv1.NewSchemaMap(map[string]*schemav1.Schema{
 		"zzz": {Type: schemav1.TypeString},
@@ -1327,6 +1330,7 @@ func TestOverridingTFSchema(t *testing.T) {
 			t.Run("MakeTerraformOutputs", func(t *testing.T) {
 				t.Parallel()
 
+				testTFProvider := testprovider.ProviderV1()
 				ctx := context.Background()
 				result := MakeTerraformOutputs(
 					ctx,
@@ -1408,6 +1412,7 @@ func TestArchiveAsAsset(t *testing.T) {
 	}
 	inputs, assets, err := makeTerraformInputsNoDefaults(olds, props, tfs, ps)
 	assert.NoError(t, err)
+	testTFProvider := testprovider.ProviderV1()
 	outputs := MakeTerraformOutputs(ctx, shimv1.NewProvider(testTFProvider), inputs, tfs, ps, assets, true)
 	assert.True(t, arch.DeepEquals(outputs["zzz"]))
 }
@@ -1764,6 +1769,7 @@ func makeTestTFProviderV2(
 func TestStringOutputsWithSchema(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
+	testTFProvider := testprovider.ProviderV1()
 	result := MakeTerraformOutputs(
 		ctx,
 		shimv1.NewProvider(testTFProvider),
@@ -3002,6 +3008,7 @@ func TestOutputNumberTypes(t *testing.T) {
 		"fff": float32(50),
 		"ggg": float64(50),
 	}
+	testTFProvider := testprovider.ProviderV1()
 	outputs := MakeTerraformOutputs(
 		ctx,
 		shimv1.NewProvider(testTFProvider),

--- a/pkg/tfbridge/walk_test.go
+++ b/pkg/tfbridge/walk_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/internal/testprovider"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
 	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
@@ -285,6 +286,8 @@ func TestLookupSchemaInfoMapPath(t *testing.T) {
 
 func TestTraverseProperties(t *testing.T) {
 	t.Parallel()
+	testTFProviderV2 := testprovider.ProviderV2()
+
 	prov := &ProviderInfo{
 		P:              shimv2.NewProvider(testTFProviderV2),
 		IgnoreMappings: []string{"nested_secret_resource"},
@@ -405,6 +408,8 @@ func TestTraverseProperties(t *testing.T) {
 func TestTraversePropertiesSchemaInfo(t *testing.T) {
 	t.Parallel()
 	md := NewProviderMetadata(nil)
+	testTFProviderV2 := testprovider.ProviderV2()
+
 	prov := &ProviderInfo{
 		P:            shimv2.NewProvider(testTFProviderV2),
 		MetadataInfo: md,


### PR DESCRIPTION
Refusing to share global test provider values as individual tests are suspected of mutating those.