### PR TITLE
chore: fixup newPulumiTest

### DIFF
--- a/pkg/pf/tests/muxwith_test.go
+++ b/pkg/pf/tests/muxwith_test.go
@@ -54,14 +54,14 @@ func TestNewMuxProvider(t *testing.T) {
 
 	// Providers using newPulumiTest utilize NewMuxProvider and MuxWith to connect up a PF provider.
 	pt := newPulumiTest(t, p, `
-		name: test-program
-		runtime: yaml
-		resources:
-		  my-res:
-		    type: testprovider:index:R
-		    properties:
-		      p: "FOO"
-		`)
+             name: test-program
+             runtime: yaml
+             resources:
+               my-res:
+                 type: testprovider:index:R
+                 properties:
+                   p: "FOO"
+        `)
 
 	pt.Up(t)
 


### PR DESCRIPTION
Per https://github.com/pulumi/pulumi-terraform-bridge/pull/3016#discussion_r2054658146 there is now a capability to start a PF provider directly for testing without calling main functions. Capability is coming from https://github.com/pulumi/pulumi-terraform-bridge/pull/2075 and is only working for PF-based providers at the moment. Still using this capability makes the given test helper code much simpler as muxing need not be involved. 