### PR TITLE
Improve preview for set elements with computed properties

### DIFF
--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/added_end.golden
@@ -51,10 +51,6 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           + [2]: {
                   + nestedProp: "val3"
                 }
@@ -63,9 +59,5 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/added_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/added_end_unordered.golden
@@ -51,10 +51,6 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           + [2]: {
                   + nestedProp: "val1"
                 }
@@ -63,9 +59,5 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/added_front.golden
@@ -51,25 +51,13 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val3" => "val2"
-                }
-          + [2]: {
-                  + nestedProp: "val3"
+          + [0]: {
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/added_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/added_front_unordered.golden
@@ -51,23 +51,13 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
-                }
-          ~ [1]: {
-                }
-          + [2]: {
-                  + nestedProp: "val1"
+          + [0]: {
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/added_middle.golden
@@ -51,23 +51,13 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val3" => "val2"
-                }
-          + [2]: {
-                  + nestedProp: "val3"
+          + [1]: {
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/added_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/added_middle_unordered.golden
@@ -51,25 +51,13 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val3"
-                }
-          + [2]: {
-                  + nestedProp: "val1"
+          + [1]: {
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/removed_end.golden
@@ -51,10 +51,6 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           - [2]: {
                   - computed  : ""
                   - nestedProp: "val3"
@@ -64,9 +60,5 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/removed_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/removed_end_unordered.golden
@@ -51,26 +51,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val3"
-                }
-          - [2]: {
+          - [0]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/removed_front.golden
@@ -51,26 +51,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val3"
-                }
-          - [2]: {
+          - [0]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/removed_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/removed_front_unordered.golden
@@ -51,26 +51,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val3"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
-          - [2]: {
+          - [1]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/removed_middle.golden
@@ -51,24 +51,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val3"
-                }
-          - [2]: {
+          - [1]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/removed_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/removed_middle_unordered.golden
@@ -51,26 +51,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val3"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
-          - [2]: {
+          - [1]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/same_element_updated.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/same_element_updated.golden
@@ -56,12 +56,8 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
           ~ [1]: {
                   ~ nestedProp: "val2" => "val4"
-                }
-          ~ [2]: {
                 }
         ]
 Resources:
@@ -69,9 +65,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
 		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
 		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/same_element_updated_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/same_element_updated_unordered.golden
@@ -56,14 +56,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
+          + [1]: {
+                  + nestedProp: "val4"
                 }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val4"
-                }
-          ~ [2]: {
-                  ~ nestedProp: "val3" => "val1"
+          - [2]: {
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -71,11 +69,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/shuffled_added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/shuffled_added_end.golden
@@ -51,12 +51,6 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
           + [2]: {
                   + nestedProp: "val3"
                 }
@@ -65,11 +59,5 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/shuffled_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/shuffled_added_front.golden
@@ -51,23 +51,13 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
-          ~ [1]: {
-                }
-          + [2]: {
-                  + nestedProp: "val2"
+          + [0]: {
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/shuffled_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/shuffled_added_middle.golden
@@ -51,25 +51,13 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val3"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val3" => "val2"
-                }
-          + [2]: {
-                  + nestedProp: "val1"
+          + [1]: {
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/shuffled_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/shuffled_removed_end.golden
@@ -51,12 +51,6 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
           - [2]: {
                   - computed  : ""
                   - nestedProp: "val3"
@@ -66,11 +60,5 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/shuffled_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/shuffled_removed_front.golden
@@ -51,24 +51,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val3"
-                }
-          ~ [1]: {
-                }
-          - [2]: {
+          - [0]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/shuffled_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/shuffled_removed_middle.golden
@@ -51,26 +51,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val3"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
-          - [2]: {
+          - [1]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/two_added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/two_added.golden
@@ -56,10 +56,6 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           + [2]: {
                   + nestedProp: "val3"
                 }
@@ -72,9 +68,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
-		"props[3]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[3]": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/two_added_and_two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/two_added_and_two_removed.golden
@@ -66,10 +66,6 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           ~ [2]: {
                   ~ nestedProp: "val3" => "val5"
                 }
@@ -82,8 +78,6 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
 		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
 		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
 		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -66,17 +66,19 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val5"
+          + [0]: {
+                  + nestedProp: "val5"
                 }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val6"
+          + [1]: {
+                  + nestedProp: "val6"
                 }
-          ~ [2]: {
-                  ~ nestedProp: "val3" => "val1"
+          - [2]: {
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
-          ~ [3]: {
-                  ~ nestedProp: "val4" => "val2"
+          - [3]: {
+                  - computed  : ""
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -84,13 +86,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -66,16 +66,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val5"
+          + [1]: {
+                  + nestedProp: "val5"
                 }
           ~ [2]: {
                   ~ nestedProp: "val3" => "val6"
                 }
-          ~ [3]: {
-                  ~ nestedProp: "val4" => "val2"
+          - [3]: {
+                  - computed  : ""
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -83,12 +82,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1]":            map[string]interface{}{"kind": "ADD_REPLACE"},
 		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
 		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[3]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -68,16 +68,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val5"
+          + [1]: {
+                  + nestedProp: "val5"
                 }
           ~ [2]: {
                   ~ nestedProp: "val3" => "val6"
                 }
-          ~ [3]: {
-                  ~ nestedProp: "val4" => "val2"
+          - [3]: {
+                  - computed  : ""
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -85,12 +84,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1]":            map[string]interface{}{"kind": "ADD_REPLACE"},
 		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
 		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[3]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_and_nested_force_new/two_removed.golden
@@ -56,10 +56,6 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           - [2]: {
                   - computed  : ""
                   - nestedProp: "val3"
@@ -74,9 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
-		"props[3]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/added_end.golden
@@ -51,10 +51,6 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           + [2]: {
                   + nestedProp: "val3"
                 }
@@ -63,9 +59,5 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/added_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/added_end_unordered.golden
@@ -51,10 +51,6 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           + [2]: {
                   + nestedProp: "val1"
                 }
@@ -63,9 +59,5 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/added_front.golden
@@ -51,25 +51,13 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val3" => "val2"
-                }
-          + [2]: {
-                  + nestedProp: "val3"
+          + [0]: {
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/added_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/added_front_unordered.golden
@@ -51,23 +51,13 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
-                }
-          ~ [1]: {
-                }
-          + [2]: {
-                  + nestedProp: "val1"
+          + [0]: {
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/added_middle.golden
@@ -51,23 +51,13 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val3" => "val2"
-                }
-          + [2]: {
-                  + nestedProp: "val3"
+          + [1]: {
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/added_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/added_middle_unordered.golden
@@ -51,25 +51,13 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val3"
-                }
-          + [2]: {
-                  + nestedProp: "val1"
+          + [1]: {
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/removed_end.golden
@@ -51,10 +51,6 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           - [2]: {
                   - computed  : ""
                   - nestedProp: "val3"
@@ -64,9 +60,5 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/removed_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/removed_end_unordered.golden
@@ -51,26 +51,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val3"
-                }
-          - [2]: {
+          - [0]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/removed_front.golden
@@ -51,26 +51,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val3"
-                }
-          - [2]: {
+          - [0]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/removed_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/removed_front_unordered.golden
@@ -51,26 +51,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val3"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
-          - [2]: {
+          - [1]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/removed_middle.golden
@@ -51,24 +51,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val3"
-                }
-          - [2]: {
+          - [1]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/removed_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/removed_middle_unordered.golden
@@ -51,26 +51,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val3"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
-          - [2]: {
+          - [1]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/same_element_updated.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/same_element_updated.golden
@@ -56,12 +56,8 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
           ~ [1]: {
                   ~ nestedProp: "val2" => "val4"
-                }
-          ~ [2]: {
                 }
         ]
 Resources:
@@ -69,9 +65,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
 		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
 		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/same_element_updated_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/same_element_updated_unordered.golden
@@ -56,14 +56,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
+          + [1]: {
+                  + nestedProp: "val4"
                 }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val4"
-                }
-          ~ [2]: {
-                  ~ nestedProp: "val3" => "val1"
+          - [2]: {
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -71,11 +69,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/shuffled_added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/shuffled_added_end.golden
@@ -51,12 +51,6 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
           + [2]: {
                   + nestedProp: "val3"
                 }
@@ -65,11 +59,5 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/shuffled_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/shuffled_added_front.golden
@@ -51,23 +51,13 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
-          ~ [1]: {
-                }
-          + [2]: {
-                  + nestedProp: "val2"
+          + [0]: {
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/shuffled_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/shuffled_added_middle.golden
@@ -51,25 +51,13 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val3"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val3" => "val2"
-                }
-          + [2]: {
-                  + nestedProp: "val1"
+          + [1]: {
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/shuffled_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/shuffled_removed_end.golden
@@ -51,12 +51,6 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
           - [2]: {
                   - computed  : ""
                   - nestedProp: "val3"
@@ -66,11 +60,5 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/shuffled_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/shuffled_removed_front.golden
@@ -51,24 +51,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val3"
-                }
-          ~ [1]: {
-                }
-          - [2]: {
+          - [0]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/shuffled_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/shuffled_removed_middle.golden
@@ -51,26 +51,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val3"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
-          - [2]: {
+          - [1]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/two_added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/two_added.golden
@@ -56,10 +56,6 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           + [2]: {
                   + nestedProp: "val3"
                 }
@@ -72,9 +68,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
-		"props[3]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[3]": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/two_added_and_two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/two_added_and_two_removed.golden
@@ -66,10 +66,6 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           ~ [2]: {
                   ~ nestedProp: "val3" => "val5"
                 }
@@ -82,8 +78,6 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
 		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
 		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -66,17 +66,19 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val5"
+          + [0]: {
+                  + nestedProp: "val5"
                 }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val6"
+          + [1]: {
+                  + nestedProp: "val6"
                 }
-          ~ [2]: {
-                  ~ nestedProp: "val3" => "val1"
+          - [2]: {
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
-          ~ [3]: {
-                  ~ nestedProp: "val4" => "val2"
+          - [3]: {
+                  - computed  : ""
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -84,13 +86,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[0]": map[string]interface{}{},
+		"props[1]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -66,16 +66,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val5"
+          + [1]: {
+                  + nestedProp: "val5"
                 }
           ~ [2]: {
                   ~ nestedProp: "val3" => "val6"
                 }
-          ~ [3]: {
-                  ~ nestedProp: "val4" => "val2"
+          - [3]: {
+                  - computed  : ""
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -83,12 +82,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1]":            map[string]interface{}{},
 		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
 		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -68,16 +68,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val5"
+          + [1]: {
+                  + nestedProp: "val5"
                 }
           ~ [2]: {
                   ~ nestedProp: "val3" => "val6"
                 }
-          ~ [3]: {
-                  ~ nestedProp: "val4" => "val2"
+          - [3]: {
+                  - computed  : ""
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -85,12 +84,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1]":            map[string]interface{}{},
 		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
 		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_force_new/two_removed.golden
@@ -56,10 +56,6 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           - [2]: {
                   - computed  : ""
                   - nestedProp: "val3"
@@ -74,9 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
-		"props[3]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/added_end.golden
@@ -51,10 +51,6 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           + [2]: {
                   + nestedProp: "val3"
                 }
@@ -63,9 +59,5 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":          map[string]interface{}{},
-	},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/added_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/added_end_unordered.golden
@@ -51,10 +51,6 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           + [2]: {
                   + nestedProp: "val1"
                 }
@@ -63,9 +59,5 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":          map[string]interface{}{},
-	},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/added_front.golden
@@ -51,25 +51,13 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val3" => "val2"
-                }
-          + [2]: {
-                  + nestedProp: "val3"
+          + [0]: {
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/added_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/added_front_unordered.golden
@@ -51,23 +51,13 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
-                }
-          ~ [1]: {
-                }
-          + [2]: {
-                  + nestedProp: "val1"
+          + [0]: {
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/added_middle.golden
@@ -51,23 +51,13 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val3" => "val2"
-                }
-          + [2]: {
-                  + nestedProp: "val3"
+          + [1]: {
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/added_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/added_middle_unordered.golden
@@ -51,25 +51,13 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val3"
-                }
-          + [2]: {
-                  + nestedProp: "val1"
+          + [1]: {
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/removed_end.golden
@@ -51,10 +51,6 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           - [2]: {
                   - computed  : ""
                   - nestedProp: "val3"
@@ -64,9 +60,5 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":          map[string]interface{}{"kind": "DELETE"},
-	},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/removed_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/removed_end_unordered.golden
@@ -51,26 +51,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val3"
-                }
-          - [2]: {
+          - [0]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/removed_front.golden
@@ -51,26 +51,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val3"
-                }
-          - [2]: {
+          - [0]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/removed_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/removed_front_unordered.golden
@@ -51,26 +51,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val3"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
-          - [2]: {
+          - [1]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/removed_middle.golden
@@ -51,24 +51,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val3"
-                }
-          - [2]: {
+          - [1]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/removed_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/removed_middle_unordered.golden
@@ -51,26 +51,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val3"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
-          - [2]: {
+          - [1]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/same_element_updated.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/same_element_updated.golden
@@ -56,12 +56,8 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
           ~ [1]: {
                   ~ nestedProp: "val2" => "val4"
-                }
-          ~ [2]: {
                 }
         ]
 Resources:
@@ -69,9 +65,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
 		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
 		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/same_element_updated_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/same_element_updated_unordered.golden
@@ -56,14 +56,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
+          + [1]: {
+                  + nestedProp: "val4"
                 }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val4"
-                }
-          ~ [2]: {
-                  ~ nestedProp: "val3" => "val1"
+          - [2]: {
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -71,11 +69,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/shuffled_added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/shuffled_added_end.golden
@@ -51,12 +51,6 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
           + [2]: {
                   + nestedProp: "val3"
                 }
@@ -65,11 +59,5 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{},
-	},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/shuffled_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/shuffled_added_front.golden
@@ -51,23 +51,13 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
-          ~ [1]: {
-                }
-          + [2]: {
-                  + nestedProp: "val2"
+          + [0]: {
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/shuffled_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/shuffled_added_middle.golden
@@ -51,25 +51,13 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val3"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val3" => "val2"
-                }
-          + [2]: {
-                  + nestedProp: "val1"
+          + [1]: {
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/shuffled_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/shuffled_removed_end.golden
@@ -51,12 +51,6 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
           - [2]: {
                   - computed  : ""
                   - nestedProp: "val3"
@@ -66,11 +60,5 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE"},
-	},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/shuffled_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/shuffled_removed_front.golden
@@ -51,24 +51,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val3"
-                }
-          ~ [1]: {
-                }
-          - [2]: {
+          - [0]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/shuffled_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/shuffled_removed_middle.golden
@@ -51,26 +51,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val3"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
-          - [2]: {
+          - [1]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/two_added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/two_added.golden
@@ -56,10 +56,6 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           + [2]: {
                   + nestedProp: "val3"
                 }
@@ -72,9 +68,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":          map[string]interface{}{},
-		"props[3]":          map[string]interface{}{},
+		"props[2]": map[string]interface{}{},
+		"props[3]": map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/two_added_and_two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/two_added_and_two_removed.golden
@@ -66,10 +66,6 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           ~ [2]: {
                   ~ nestedProp: "val3" => "val5"
                 }
@@ -82,8 +78,6 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
 		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
 		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -66,17 +66,19 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val5"
+          + [0]: {
+                  + nestedProp: "val5"
                 }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val6"
+          + [1]: {
+                  + nestedProp: "val6"
                 }
-          ~ [2]: {
-                  ~ nestedProp: "val3" => "val1"
+          - [2]: {
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
-          ~ [3]: {
-                  ~ nestedProp: "val4" => "val2"
+          - [3]: {
+                  - computed  : ""
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -84,13 +86,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[0]": map[string]interface{}{},
+		"props[1]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -66,16 +66,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val5"
+          + [1]: {
+                  + nestedProp: "val5"
                 }
           ~ [2]: {
                   ~ nestedProp: "val3" => "val6"
                 }
-          ~ [3]: {
-                  ~ nestedProp: "val4" => "val2"
+          - [3]: {
+                  - computed  : ""
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -83,12 +82,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1]":            map[string]interface{}{},
 		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
 		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -68,16 +68,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val5"
+          + [1]: {
+                  + nestedProp: "val5"
                 }
           ~ [2]: {
                   ~ nestedProp: "val3" => "val6"
                 }
-          ~ [3]: {
-                  ~ nestedProp: "val4" => "val2"
+          - [3]: {
+                  - computed  : ""
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -85,12 +84,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1]":            map[string]interface{}{},
 		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
 		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetComputedBlock/block_with_computed_no_replace/two_removed.golden
@@ -56,10 +56,6 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           - [2]: {
                   - computed  : ""
                   - nestedProp: "val3"
@@ -74,9 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":          map[string]interface{}{"kind": "DELETE"},
-		"props[3]":          map[string]interface{}{"kind": "DELETE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/added_end.golden
@@ -51,10 +51,6 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           + [2]: {
                   + nestedProp: "val3"
                 }
@@ -63,9 +59,5 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/added_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/added_end_unordered.golden
@@ -51,10 +51,6 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           + [2]: {
                   + nestedProp: "val1"
                 }
@@ -63,9 +59,5 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/added_front.golden
@@ -51,25 +51,13 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val3" => "val2"
-                }
-          + [2]: {
-                  + nestedProp: "val3"
+          + [0]: {
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/added_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/added_front_unordered.golden
@@ -51,23 +51,13 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
-                }
-          ~ [1]: {
-                }
-          + [2]: {
-                  + nestedProp: "val1"
+          + [0]: {
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/added_middle.golden
@@ -51,23 +51,13 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val3" => "val2"
-                }
-          + [2]: {
-                  + nestedProp: "val3"
+          + [1]: {
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/added_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/added_middle_unordered.golden
@@ -51,25 +51,13 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val3"
-                }
-          + [2]: {
-                  + nestedProp: "val1"
+          + [1]: {
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/removed_end.golden
@@ -51,10 +51,6 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           - [2]: {
                   - computed  : ""
                   - nestedProp: "val3"
@@ -64,9 +60,5 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/removed_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/removed_end_unordered.golden
@@ -51,26 +51,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val3"
-                }
-          - [2]: {
+          - [0]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/removed_front.golden
@@ -51,26 +51,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val3"
-                }
-          - [2]: {
+          - [0]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/removed_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/removed_front_unordered.golden
@@ -51,26 +51,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val3"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
-          - [2]: {
+          - [1]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/removed_middle.golden
@@ -51,24 +51,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val3"
-                }
-          - [2]: {
+          - [1]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/removed_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/removed_middle_unordered.golden
@@ -51,26 +51,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val3"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
-          - [2]: {
+          - [1]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/same_element_updated.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/same_element_updated.golden
@@ -56,12 +56,8 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
           ~ [1]: {
                   ~ nestedProp: "val2" => "val4"
-                }
-          ~ [2]: {
                 }
         ]
 Resources:
@@ -69,9 +65,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
 		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
 		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/same_element_updated_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/same_element_updated_unordered.golden
@@ -56,14 +56,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
+          + [1]: {
+                  + nestedProp: "val4"
                 }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val4"
-                }
-          ~ [2]: {
-                  ~ nestedProp: "val3" => "val1"
+          - [2]: {
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -71,11 +69,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/shuffled_added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/shuffled_added_end.golden
@@ -51,12 +51,6 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
           + [2]: {
                   + nestedProp: "val3"
                 }
@@ -65,11 +59,5 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/shuffled_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/shuffled_added_front.golden
@@ -51,23 +51,13 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
-          ~ [1]: {
-                }
-          + [2]: {
-                  + nestedProp: "val2"
+          + [0]: {
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/shuffled_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/shuffled_added_middle.golden
@@ -51,25 +51,13 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val3"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val3" => "val2"
-                }
-          + [2]: {
-                  + nestedProp: "val1"
+          + [1]: {
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/shuffled_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/shuffled_removed_end.golden
@@ -51,12 +51,6 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
           - [2]: {
                   - computed  : ""
                   - nestedProp: "val3"
@@ -66,11 +60,5 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/shuffled_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/shuffled_removed_front.golden
@@ -51,24 +51,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val3"
-                }
-          ~ [1]: {
-                }
-          - [2]: {
+          - [0]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/shuffled_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/shuffled_removed_middle.golden
@@ -51,26 +51,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val3"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
-          - [2]: {
+          - [1]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/two_added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/two_added.golden
@@ -56,10 +56,6 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           + [2]: {
                   + nestedProp: "val3"
                 }
@@ -72,9 +68,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
-		"props[3]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[3]": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/two_added_and_two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/two_added_and_two_removed.golden
@@ -66,10 +66,6 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           ~ [2]: {
                   ~ nestedProp: "val3" => "val5"
                 }
@@ -82,8 +78,6 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
 		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
 		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -66,17 +66,19 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val5"
+          + [0]: {
+                  + nestedProp: "val5"
                 }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val6"
+          + [1]: {
+                  + nestedProp: "val6"
                 }
-          ~ [2]: {
-                  ~ nestedProp: "val3" => "val1"
+          - [2]: {
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
-          ~ [3]: {
-                  ~ nestedProp: "val4" => "val2"
+          - [3]: {
+                  - computed  : ""
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -84,13 +86,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[0]": map[string]interface{}{},
+		"props[1]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -66,16 +66,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val5"
+          + [1]: {
+                  + nestedProp: "val5"
                 }
           ~ [2]: {
                   ~ nestedProp: "val3" => "val6"
                 }
-          ~ [3]: {
-                  ~ nestedProp: "val4" => "val2"
+          - [3]: {
+                  - computed  : ""
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -83,12 +82,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1]":            map[string]interface{}{},
 		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
 		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -68,16 +68,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val5"
+          + [1]: {
+                  + nestedProp: "val5"
                 }
           ~ [2]: {
                   ~ nestedProp: "val3" => "val6"
                 }
-          ~ [3]: {
-                  ~ nestedProp: "val4" => "val2"
+          - [3]: {
+                  - computed  : ""
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -85,12 +84,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1]":            map[string]interface{}{},
 		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
 		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_force_new/two_removed.golden
@@ -56,10 +56,6 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           - [2]: {
                   - computed  : ""
                   - nestedProp: "val3"
@@ -74,9 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
-		"props[3]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/added_end.golden
@@ -51,10 +51,6 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           + [2]: {
                   + nestedProp: "val3"
                 }
@@ -63,9 +59,5 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/added_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/added_end_unordered.golden
@@ -51,10 +51,6 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           + [2]: {
                   + nestedProp: "val1"
                 }
@@ -63,9 +59,5 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/added_front.golden
@@ -51,25 +51,13 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val3" => "val2"
-                }
-          + [2]: {
-                  + nestedProp: "val3"
+          + [0]: {
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/added_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/added_front_unordered.golden
@@ -51,23 +51,13 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
-                }
-          ~ [1]: {
-                }
-          + [2]: {
-                  + nestedProp: "val1"
+          + [0]: {
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/added_middle.golden
@@ -51,23 +51,13 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val3" => "val2"
-                }
-          + [2]: {
-                  + nestedProp: "val3"
+          + [1]: {
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/added_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/added_middle_unordered.golden
@@ -51,25 +51,13 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val3"
-                }
-          + [2]: {
-                  + nestedProp: "val1"
+          + [1]: {
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/removed_end.golden
@@ -51,10 +51,6 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           - [2]: {
                   - computed  : ""
                   - nestedProp: "val3"
@@ -64,9 +60,5 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/removed_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/removed_end_unordered.golden
@@ -51,26 +51,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val3"
-                }
-          - [2]: {
+          - [0]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/removed_front.golden
@@ -51,26 +51,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val3"
-                }
-          - [2]: {
+          - [0]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/removed_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/removed_front_unordered.golden
@@ -51,26 +51,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val3"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
-          - [2]: {
+          - [1]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/removed_middle.golden
@@ -51,24 +51,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val3"
-                }
-          - [2]: {
+          - [1]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/removed_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/removed_middle_unordered.golden
@@ -51,26 +51,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val3"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
-          - [2]: {
+          - [1]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/same_element_updated.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/same_element_updated.golden
@@ -56,12 +56,8 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
           ~ [1]: {
                   ~ nestedProp: "val2" => "val4"
-                }
-          ~ [2]: {
                 }
         ]
 Resources:
@@ -69,9 +65,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
 		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
 		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/same_element_updated_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/same_element_updated_unordered.golden
@@ -56,14 +56,12 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
+          + [1]: {
+                  + nestedProp: "val4"
                 }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val4"
-                }
-          ~ [2]: {
-                  ~ nestedProp: "val3" => "val1"
+          - [2]: {
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -71,11 +69,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/shuffled_added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/shuffled_added_end.golden
@@ -51,12 +51,6 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
           + [2]: {
                   + nestedProp: "val3"
                 }
@@ -65,11 +59,5 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/shuffled_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/shuffled_added_front.golden
@@ -51,23 +51,13 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
-          ~ [1]: {
-                }
-          + [2]: {
-                  + nestedProp: "val2"
+          + [0]: {
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/shuffled_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/shuffled_added_middle.golden
@@ -51,25 +51,13 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val3"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val3" => "val2"
-                }
-          + [2]: {
-                  + nestedProp: "val1"
+          + [1]: {
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2]":            map[string]interface{}{"kind": "ADD_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/shuffled_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/shuffled_removed_end.golden
@@ -51,12 +51,6 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
           - [2]: {
                   - computed  : ""
                   - nestedProp: "val3"
@@ -66,11 +60,5 @@ Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/shuffled_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/shuffled_removed_front.golden
@@ -51,24 +51,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val3"
-                }
-          ~ [1]: {
-                }
-          - [2]: {
+          - [0]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/shuffled_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/shuffled_removed_middle.golden
@@ -51,26 +51,14 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val3"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
-          - [2]: {
+          - [1]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     +-1 to replace
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE_REPLACE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/two_added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/two_added.golden
@@ -56,10 +56,6 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           + [2]: {
                   + nestedProp: "val3"
                 }
@@ -72,9 +68,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":          map[string]interface{}{"kind": "ADD_REPLACE"},
-		"props[3]":          map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[3]": map[string]interface{}{"kind": "ADD_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/two_added_and_two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/two_added_and_two_removed.golden
@@ -66,10 +66,6 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           ~ [2]: {
                   ~ nestedProp: "val3" => "val5"
                 }
@@ -82,8 +78,6 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
 		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
 		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
 		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -66,17 +66,19 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val5"
+          + [0]: {
+                  + nestedProp: "val5"
                 }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val6"
+          + [1]: {
+                  + nestedProp: "val6"
                 }
-          ~ [2]: {
-                  ~ nestedProp: "val3" => "val1"
+          - [2]: {
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
-          ~ [3]: {
-                  ~ nestedProp: "val4" => "val2"
+          - [3]: {
+                  - computed  : ""
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -84,13 +86,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[0]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[1]": map[string]interface{}{"kind": "ADD_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -66,16 +66,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val5"
+          + [1]: {
+                  + nestedProp: "val5"
                 }
           ~ [2]: {
                   ~ nestedProp: "val3" => "val6"
                 }
-          ~ [3]: {
-                  ~ nestedProp: "val4" => "val2"
+          - [3]: {
+                  - computed  : ""
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -83,12 +82,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1]":            map[string]interface{}{"kind": "ADD_REPLACE"},
 		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
 		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[3]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -68,16 +68,15 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val5"
+          + [1]: {
+                  + nestedProp: "val5"
                 }
           ~ [2]: {
                   ~ nestedProp: "val3" => "val6"
                 }
-          ~ [3]: {
-                  ~ nestedProp: "val4" => "val2"
+          - [3]: {
+                  - computed  : ""
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -85,12 +84,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[1]":            map[string]interface{}{"kind": "ADD_REPLACE"},
 		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
 		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
-		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE_REPLACE"},
+		"props[3]":            map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_and_nested_force_new/two_removed.golden
@@ -56,10 +56,6 @@ Plan: 1 to add, 0 to change, 1 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           - [2]: {
                   - computed  : ""
                   - nestedProp: "val3"
@@ -74,9 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
-		"props[3]":          map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE_REPLACE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE_REPLACE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/added_end.golden
@@ -51,10 +51,6 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           + [2]: {
                   + nestedProp: "val3"
                 }
@@ -63,9 +59,5 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":          map[string]interface{}{},
-	},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/added_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/added_end_unordered.golden
@@ -51,10 +51,6 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           + [2]: {
                   + nestedProp: "val1"
                 }
@@ -63,9 +59,5 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":          map[string]interface{}{},
-	},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/added_front.golden
@@ -51,25 +51,13 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val3" => "val2"
-                }
-          + [2]: {
-                  + nestedProp: "val3"
+          + [0]: {
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/added_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/added_front_unordered.golden
@@ -51,23 +51,13 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
-                }
-          ~ [1]: {
-                }
-          + [2]: {
-                  + nestedProp: "val1"
+          + [0]: {
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/added_middle.golden
@@ -51,23 +51,13 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val3" => "val2"
-                }
-          + [2]: {
-                  + nestedProp: "val3"
+          + [1]: {
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/added_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/added_middle_unordered.golden
@@ -51,25 +51,13 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val3"
-                }
-          + [2]: {
-                  + nestedProp: "val1"
+          + [1]: {
+                  + nestedProp: "val3"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/removed_end.golden
@@ -51,10 +51,6 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           - [2]: {
                   - computed  : ""
                   - nestedProp: "val3"
@@ -64,9 +60,5 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":          map[string]interface{}{"kind": "DELETE"},
-	},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/removed_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/removed_end_unordered.golden
@@ -51,26 +51,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val3"
-                }
-          - [2]: {
+          - [0]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/removed_front.golden
@@ -51,26 +51,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val3"
-                }
-          - [2]: {
+          - [0]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/removed_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/removed_front_unordered.golden
@@ -51,26 +51,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val3"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
-          - [2]: {
+          - [1]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/removed_middle.golden
@@ -51,24 +51,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val3"
-                }
-          - [2]: {
+          - [1]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/removed_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/removed_middle_unordered.golden
@@ -51,26 +51,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val3"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
-          - [2]: {
+          - [1]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/same_element_updated.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/same_element_updated.golden
@@ -56,12 +56,8 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
           ~ [1]: {
                   ~ nestedProp: "val2" => "val4"
-                }
-          ~ [2]: {
                 }
         ]
 Resources:
@@ -69,9 +65,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
 		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
 		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/same_element_updated_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/same_element_updated_unordered.golden
@@ -56,14 +56,12 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
+          + [1]: {
+                  + nestedProp: "val4"
                 }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val4"
-                }
-          ~ [2]: {
-                  ~ nestedProp: "val3" => "val1"
+          - [2]: {
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
         ]
 Resources:
@@ -71,11 +69,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/shuffled_added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/shuffled_added_end.golden
@@ -51,12 +51,6 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
           + [2]: {
                   + nestedProp: "val3"
                 }
@@ -65,11 +59,5 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{},
-	},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/shuffled_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/shuffled_added_front.golden
@@ -51,23 +51,13 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
-          ~ [1]: {
-                }
-          + [2]: {
-                  + nestedProp: "val2"
+          + [0]: {
+                  + nestedProp: "val1"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/shuffled_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/shuffled_added_middle.golden
@@ -51,25 +51,13 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val3"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val3" => "val2"
-                }
-          + [2]: {
-                  + nestedProp: "val1"
+          + [1]: {
+                  + nestedProp: "val2"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/shuffled_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/shuffled_removed_end.golden
@@ -51,12 +51,6 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val2"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
           - [2]: {
                   - computed  : ""
                   - nestedProp: "val3"
@@ -66,11 +60,5 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE"},
-	},
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/shuffled_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/shuffled_removed_front.golden
@@ -51,24 +51,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val3"
-                }
-          ~ [1]: {
-                }
-          - [2]: {
+          - [0]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val1"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE"},
-	},
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/shuffled_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/shuffled_removed_middle.golden
@@ -51,26 +51,14 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val3"
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val1"
-                }
-          - [2]: {
+          - [1]: {
                   - computed  : ""
-                  - nestedProp: "val3"
+                  - nestedProp: "val2"
                 }
         ]
 Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":            map[string]interface{}{"kind": "DELETE"},
-	},
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/two_added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/two_added.golden
@@ -56,10 +56,6 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           + [2]: {
                   + nestedProp: "val3"
                 }
@@ -72,9 +68,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":          map[string]interface{}{},
-		"props[3]":          map[string]interface{}{},
+		"props[2]": map[string]interface{}{},
+		"props[3]": map[string]interface{}{},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/two_added_and_two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/two_added_and_two_removed.golden
@@ -66,10 +66,6 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           ~ [2]: {
                   ~ nestedProp: "val3" => "val5"
                 }
@@ -82,8 +78,6 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
 		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
 		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
 		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -66,17 +66,19 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                  ~ nestedProp: "val1" => "val5"
+          + [0]: {
+                  + nestedProp: "val5"
                 }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val6"
+          + [1]: {
+                  + nestedProp: "val6"
                 }
-          ~ [2]: {
-                  ~ nestedProp: "val3" => "val1"
+          - [2]: {
+                  - computed  : ""
+                  - nestedProp: "val3"
                 }
-          ~ [3]: {
-                  ~ nestedProp: "val4" => "val2"
+          - [3]: {
+                  - computed  : ""
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -84,13 +86,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[0]": map[string]interface{}{},
+		"props[1]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -66,16 +66,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val5"
+          + [1]: {
+                  + nestedProp: "val5"
                 }
           ~ [2]: {
                   ~ nestedProp: "val3" => "val6"
                 }
-          ~ [3]: {
-                  ~ nestedProp: "val4" => "val2"
+          - [3]: {
+                  - computed  : ""
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -83,12 +82,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1]":            map[string]interface{}{},
 		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
 		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -68,16 +68,15 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                  ~ nestedProp: "val2" => "val5"
+          + [1]: {
+                  + nestedProp: "val5"
                 }
           ~ [2]: {
                   ~ nestedProp: "val3" => "val6"
                 }
-          ~ [3]: {
-                  ~ nestedProp: "val4" => "val2"
+          - [3]: {
+                  - computed  : ""
+                  - nestedProp: "val4"
                 }
         ]
 Resources:
@@ -85,12 +84,9 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[1]":            map[string]interface{}{},
 		"props[2].computed":   map[string]interface{}{"kind": "UPDATE"},
 		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
-		"props[3].computed":   map[string]interface{}{"kind": "UPDATE"},
-		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3]":            map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetNestedComputedBlock/block_with_nested_computed_no_replace/two_removed.golden
@@ -56,10 +56,6 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [id=id]
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
-          ~ [0]: {
-                }
-          ~ [1]: {
-                }
           - [2]: {
                   - computed  : ""
                   - nestedProp: "val3"
@@ -74,9 +70,7 @@ Resources:
     1 unchanged
 `,
 	detailedDiff: map[string]interface{}{
-		"props[0].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[1].computed": map[string]interface{}{"kind": "UPDATE"},
-		"props[2]":          map[string]interface{}{"kind": "DELETE"},
-		"props[3]":          map[string]interface{}{"kind": "DELETE"},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE"},
 	},
 }

--- a/pkg/tests/schema_pulumi_test.go
+++ b/pkg/tests/schema_pulumi_test.go
@@ -580,8 +580,10 @@ func TestDiffSetHashFailsOnNil(t *testing.T) {
 				Optional: true,
 				Elem:     elemSch,
 				Set: func(v interface{}) int {
-					if v == nil {
-						panic("trying to hash nil")
+					for _, subV := range v.(map[string]interface{}) {
+						if subV == nil {
+							panic("nil value in hash func")
+						}
 					}
 					return schema.HashResource(elemSch)(v)
 				},

--- a/pkg/tests/tfcheck/tf_test.go
+++ b/pkg/tests/tfcheck/tf_test.go
@@ -267,7 +267,7 @@ func TestTFSetHashNil(t *testing.T) {
 		},
 	}
 
-	driver := NewTfDriver(t, t.TempDir(), "test", &prov)
+	driver := NewTfDriver(t, t.TempDir(), "test", NewTFDriverOpts{SDKProvider: &prov})
 
 	driver.Write(t, `
 resource "test_resource" "test" {

--- a/pkg/tests/tfcheck/tf_test.go
+++ b/pkg/tests/tfcheck/tf_test.go
@@ -221,3 +221,62 @@ resource "test_resource" "test" {
 	require.NoError(t, err)
 	t.Log(driver.GetState(t))
 }
+
+// TF Never calls the SetHash function with nil values.
+// Instead it assumes zero values for the unknowns and nils in the plan.
+func TestTFSetHashNil(t *testing.T) {
+	t.Parallel()
+
+	resSch := &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"bool": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"computed_bool": {
+				Type:     schema.TypeBool,
+				Computed: true,
+				Optional: true,
+			},
+		},
+	}
+
+	prov := schema.Provider{
+		ResourcesMap: map[string]*schema.Resource{
+			"test_resource": {
+				Schema: map[string]*schema.Schema{
+					"set": {
+						Type:     schema.TypeSet,
+						Optional: true,
+						Elem:     resSch,
+						Set: func(i interface{}) int {
+							for _, v := range i.(map[string]interface{}) {
+								if v == nil {
+									panic("nil value in hash func")
+								}
+							}
+							return schema.HashResource(resSch)(i)
+						},
+					},
+				},
+			},
+		},
+	}
+
+	driver := NewTfDriver(t, t.TempDir(), "test", &prov)
+
+	driver.Write(t, `
+resource "test_resource" "test" {
+	set {
+		name = "foo"
+	}
+}
+	`)
+
+	_, err := driver.Plan(t)
+	require.NoError(t, err)
+}

--- a/pkg/tfbridge/detailed_diff.go
+++ b/pkg/tfbridge/detailed_diff.go
@@ -311,6 +311,7 @@ func makeSingleTerraformInput(
 		ApplyTFDefaults:       false,
 		Assets:                AssetTable{},
 		UseTFSetTypes:         true,
+		DropUnknowns:          true,
 	}
 
 	return cctx.makeTerraformInput(name, resource.NewNullProperty(), val, tfs, ps)

--- a/pkg/tfbridge/detailed_diff.go
+++ b/pkg/tfbridge/detailed_diff.go
@@ -370,7 +370,10 @@ func (differ detailedDiffer) calculateSetHashIndexMap(
 						path.String(), r))
 				}
 			}()
-			return tfs.SetHash(newElem)
+			setConfig, err := tfs.SetElement(newElem)
+			contract.AssertNoErrorf(
+				err, "Failed to calculate preview for element in %s: Failed to convert set element", path.String())
+			return tfs.SetHash(setConfig)
 		}()
 		identities[setHash(elementHash)] = arrayIndex(i)
 	}

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -292,6 +292,8 @@ type conversionContext struct {
 	// the same values: schema.NewSet([]interface{}{"val1", "val2"}).
 	// Note that this only works for schemas which implement shim.SchemaWithNewSet.
 	UseTFSetTypes bool
+	// DropUnknowns will drop unknown values from the input.
+	DropUnknowns bool
 }
 
 type makeTerraformInputsOptions struct {
@@ -533,6 +535,9 @@ func (ctx *conversionContext) makeTerraformInput(
 		// If any variables are unknown, we need to mark them in the inputs so the config map treats it right.  This
 		// requires the use of the special UnknownVariableValue sentinel in Terraform, which is how it internally stores
 		// interpolated variables whose inputs are currently unknown.
+		if ctx.DropUnknowns {
+			return nil, nil
+		}
 		return makeTerraformUnknown(tfs), nil
 	default:
 		contract.Failf("Unexpected value marshaled: %v", v)

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -983,7 +983,7 @@ func makeTerraformUnknownElement(elem interface{}) interface{} {
 // makeTerraformUnknown creates an unknown value with the shape indicated by the given schema.
 //
 // It is important that we use the TF schema (if available) to decide what shape the unknown value should have:
-// e.g. TF does not play nicely with unknown lists, instead expecting a list of unknowns.
+// e.g. the TF plugin SDKv1 does not play nicely with unknown lists, instead expecting a list of unknowns.
 func makeTerraformUnknown(tfs shim.Schema) interface{} {
 	_, unknownCollectionsSupported := tfs.(shim.SchemaWithUnknownCollectionSupported)
 	if unknownCollectionsSupported {
@@ -995,7 +995,8 @@ func makeTerraformUnknown(tfs shim.Schema) interface{} {
 
 	switch tfs.Type() {
 	case shim.TypeList, shim.TypeSet:
-		// TF does not accept unknown lists or sets. Instead, it accepts lists or sets of unknowns.
+		// Schemas without SchemaWithUnknownCollectionSupported do not accept
+		// unknown lists or sets. Instead, it accepts lists or sets of unknowns.
 		count := 1
 		if tfs.MinItems() > 0 {
 			count = tfs.MinItems()

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -4046,7 +4046,7 @@ func TestMakeSingleTerraformInput(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			result, err := makeSingleTerraformInput(
+			result, err := makeSetElementTerraformInput(
 				context.Background(), "name", tc.prop, shimv2.NewSchema(tc.schema), nil)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expected, result)
@@ -4071,7 +4071,7 @@ func TestMakeSingleTerraformInputSets(t *testing.T) {
 		resource.NewStringProperty("baz"),
 	})
 
-	result, err := makeSingleTerraformInput(
+	result, err := makeSetElementTerraformInput(
 		context.Background(), "name", prop, shimv2.NewSchema(sch), nil)
 	require.NoError(t, err)
 	setRes := result.(*schemav2.Set)

--- a/pkg/tfshim/sdk-v1/schema.go
+++ b/pkg/tfshim/sdk-v1/schema.go
@@ -10,6 +10,7 @@ import (
 var (
 	_ = shim.Schema(v1Schema{})
 	_ = shim.SchemaWithNewSet(v1Schema{})
+	_ = shim.SchemaWithSetElementHash(v1Schema{})
 	_ = shim.SchemaMap(v1SchemaMap{})
 )
 
@@ -142,6 +143,14 @@ func (s v1Schema) SetHash(v interface{}) int {
 		return -code
 	}
 	return code
+}
+
+func (s v1Schema) SetElementHash(v interface{}) (int, error) {
+	v, err := s.SetElement(v)
+	if err != nil {
+		return 0, err
+	}
+	return s.SetHash(v), nil
 }
 
 func (s v1Schema) NewSet(v []interface{}) interface{} {

--- a/pkg/tfshim/sdk-v2/schema.go
+++ b/pkg/tfshim/sdk-v2/schema.go
@@ -12,6 +12,7 @@ var (
 	_ = shim.SchemaWithUnknownCollectionSupported(v2Schema{})
 	_ = shim.SchemaMap(v2SchemaMap{})
 	_ = shim.SchemaWithWriteOnly(v2Schema{})
+	_ = shim.SchemaWithSetElementHash(v2Schema{})
 )
 
 // UnknownVariableValue is the sentinal defined in github.com/hashicorp/terraform/configs/hcl2shim,
@@ -164,6 +165,14 @@ func (s v2Schema) SetHash(v interface{}) int {
 		return -code
 	}
 	return code
+}
+
+func (s v2Schema) SetElementHash(v interface{}) (int, error) {
+	v, err := s.SetElement(v)
+	if err != nil {
+		return 0, err
+	}
+	return s.SetHash(v), nil
 }
 
 func (s v2Schema) NewSet(v []interface{}) interface{} {

--- a/pkg/tfshim/sdk-v2/schema.go
+++ b/pkg/tfshim/sdk-v2/schema.go
@@ -129,6 +129,15 @@ func (s v2Schema) WriteOnly() bool {
 }
 
 func (s v2Schema) SetElement(v interface{}) (interface{}, error) {
+	// The plugin-sdk does some pre-processing on the set element values before
+	// calling the hash function on them. Some examples of that are:
+	// - dropping unknowns
+	// - defaulting null values (false for bools, 0 for ints, "" for strings)
+	// Instead of trying to reverse that, we'll just call the plugin-sdk's
+	// code for accessing set elements which handles this pre-processing.
+	// This ensures that the hash functions receives the values it expects.
+	// See [pkg/tests/tfcheck/tf_test.go:TestTFSetHashNil] for an example of
+	// this behaviour in TF.
 	sch := map[string]*schema.Schema{"e": s.tf}
 	setWriter := &schema.MapFieldWriter{Schema: sch}
 	err := setWriter.WriteField([]string{"e"}, []interface{}{v})

--- a/pkg/tfshim/sdk-v2/schema.go
+++ b/pkg/tfshim/sdk-v2/schema.go
@@ -129,6 +129,8 @@ func (s v2Schema) WriteOnly() bool {
 	return s.tf.WriteOnly
 }
 
+// SetElement expects a set element without any unknown values.
+// The value passed here can contain golang types or a plugin-sdk schema.Set.
 func (s v2Schema) SetElement(v interface{}) (interface{}, error) {
 	// The plugin-sdk does some pre-processing on the set element values before
 	// calling the hash function on them. Some examples of that are:

--- a/pkg/tfshim/shim.go
+++ b/pkg/tfshim/shim.go
@@ -202,6 +202,8 @@ type SchemaWithUnknownCollectionSupported interface {
 
 type SchemaWithSetElementHash interface {
 	Schema
+	// SetElementHash returns a hash of the given set element.
+	// Note that it expects a set element without any unknown values.
 	SetElementHash(v interface{}) (int, error)
 }
 

--- a/pkg/tfshim/shim.go
+++ b/pkg/tfshim/shim.go
@@ -180,9 +180,9 @@ type Schema interface {
 	Deprecated() string
 	Removed() string
 	Sensitive() bool
-	// Deprecated: use SchemaWithSetElementHash and SetElementHash instead.
+	// Deprecated: use [SchemaWithSetElementHash] and [SetElementHash] instead.
 	SetElement(config interface{}) (interface{}, error)
-	// Deprecated: use SchemaWithSetElementHash and SetElementHash instead.
+	// Deprecated: use [SchemaWithSetElementHash] and [SetElementHash] instead.
 	SetHash(v interface{}) int
 }
 

--- a/pkg/tfshim/shim.go
+++ b/pkg/tfshim/shim.go
@@ -180,7 +180,9 @@ type Schema interface {
 	Deprecated() string
 	Removed() string
 	Sensitive() bool
+	// Deprecated: use SchemaWithSetElementHash and SetElementHash instead.
 	SetElement(config interface{}) (interface{}, error)
+	// Deprecated: use SchemaWithSetElementHash and SetElementHash instead.
 	SetHash(v interface{}) int
 }
 
@@ -196,6 +198,11 @@ type SchemaWithNewSet interface {
 type SchemaWithUnknownCollectionSupported interface {
 	Schema
 	SupportsUnknownCollections()
+}
+
+type SchemaWithSetElementHash interface {
+	Schema
+	SetElementHash(v interface{}) (int, error)
 }
 
 type SchemaMap interface {


### PR DESCRIPTION
This PR improves the preview displayed for set elements with computed properties in two ways:

1. Fixes hashing of set elements to more closely mimic what TF does - TF never hashes nulls or computed values in set elements, so we adopt their behaviour by using the plugin-sdk `MapFieldReader`.
2. By dropping unknowns when hashing elements we can now correctly match elements from the plan to the state in cases where the resource is replaced.

Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/3018
Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/2779

Related to https://github.com/pulumi/pulumi-aws/issues/5438
Related to https://github.com/pulumi/pulumi-gcp/issues/3142