### PR TITLE
chore: do not fail-fast when testing

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,6 +26,8 @@ jobs:
         feature-flags: ["DEFAULT"]
         # Needs to match TOTAL_SHARDS
         shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+        # Collect all test failures instead of stopping when only one test is failing.
+        fail-fast: false
         exclude:
           # Windows and mac test runs do not need to be sharded as they are fast enough.
           # In order to do that we will skip all except the 0-th shard.


### PR DESCRIPTION
When making some of the more extensive changes to the bridge, it is helpful to have a list of all failing tests. Running all the tests locally takes a fair bit of time so currently in practice we often rely on CI to identify test failures. It is helpful to identify all of them instead of just the first one.