### PR TITLE
chore: ignore direnv .envrc files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ pf/coverage.out
 pf/tests/coverage.out
 
 pulumi-hcl-lint
+
+.envrc


### PR DESCRIPTION
For direnv users - ignore .envrc files that may be setting local custom settings such as the desired feature flag set for testing.