### PR TITLE
Expose TF schema versions for PF during tfgen

### DIFF
--- a/pkg/pf/internal/schemashim/datasource.go
+++ b/pkg/pf/internal/schemashim/datasource.go
@@ -29,8 +29,8 @@ func (r *schemaOnlyDataSource) Schema() shim.SchemaMap {
 	return r.tf.Shim()
 }
 
-func (*schemaOnlyDataSource) SchemaVersion() int {
-	panic("DataSource SchemaVersion() should not be called during schema generation")
+func (r *schemaOnlyDataSource) SchemaVersion() int {
+	return int(r.tf.ResourceSchemaVersion())
 }
 
 func (r *schemaOnlyDataSource) DeprecationMessage() string {

--- a/pkg/pf/internal/schemashim/datasource.go
+++ b/pkg/pf/internal/schemashim/datasource.go
@@ -30,7 +30,7 @@ func (r *schemaOnlyDataSource) Schema() shim.SchemaMap {
 }
 
 func (r *schemaOnlyDataSource) SchemaVersion() int {
-	return int(r.tf.ResourceSchemaVersion())
+	panic("datasources do not have schema versions")
 }
 
 func (r *schemaOnlyDataSource) DeprecationMessage() string {

--- a/pkg/pf/internal/schemashim/resource.go
+++ b/pkg/pf/internal/schemashim/resource.go
@@ -29,8 +29,8 @@ func (r *schemaOnlyResource) Schema() shim.SchemaMap {
 	return r.tf.Shim()
 }
 
-func (*schemaOnlyResource) SchemaVersion() int {
-	panic("SchemaVersion() should not be called on a Resource during schema generation")
+func (r *schemaOnlyResource) SchemaVersion() int {
+	return int(r.tf.ResourceSchemaVersion())
 }
 
 func (r *schemaOnlyResource) DeprecationMessage() string {

--- a/pkg/pf/tests/schemashim_test.go
+++ b/pkg/pf/tests/schemashim_test.go
@@ -1157,3 +1157,21 @@ func stdProvider(resourceSchema schema.Schema) *pb.Provider {
 		}},
 	}
 }
+
+func TestSchemaVersionAccessible(t *testing.T) {
+	t.Parallel()
+
+	provider := stdProvider(schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"a1": schema.StringAttribute{
+				Required: true,
+			},
+		},
+		Version: 2,
+	})
+
+	shimmedProvider := schemashim.ShimSchemaOnlyProvider(context.Background(), provider)
+
+	schemaVersion := shimmedProvider.ResourcesMap().Get("testprov_r1").SchemaVersion()
+	require.Equal(t, 2, schemaVersion)
+}

--- a/pkg/pf/tests/schemashim_test.go
+++ b/pkg/pf/tests/schemashim_test.go
@@ -1161,13 +1161,16 @@ func stdProvider(resourceSchema schema.Schema) *pb.Provider {
 func TestSchemaVersionAccessible(t *testing.T) {
 	t.Parallel()
 
-	provider := stdProvider(schema.Schema{
-		Attributes: map[string]schema.Attribute{
-			"a1": schema.StringAttribute{
-				Required: true,
-			},
+	res := pb.NewResource(pb.NewResourceArgs{
+		Name: "r1",
+		ResourceSchema: schema.Schema{
+			Version: 2,
 		},
-		Version: 2,
+	})
+
+	provider := pb.NewProvider(pb.NewProviderArgs{
+		TypeName:     "testprov",
+		AllResources: []pb.Resource{res},
 	})
 
 	shimmedProvider := schemashim.ShimSchemaOnlyProvider(context.Background(), provider)


### PR DESCRIPTION
This PR exposes the TF schema versions to PF during tfgen.

This allows us to implement tfgen-time checks for downgrades.

related to https://github.com/pulumi/pulumi-terraform-bridge/issues/3037
related to https://github.com/pulumi/pulumi-cloudflare/issues/1156