### PR TITLE
Fix PF WriteOnly attributes skip

### DIFF
--- a/pkg/pf/internal/pfutils/attr.go
+++ b/pkg/pf/internal/pfutils/attr.go
@@ -45,15 +45,11 @@ type AttrLike interface {
 	IsOptional() bool
 	IsRequired() bool
 	IsSensitive() bool
+	IsWriteOnly() bool
 	GetDeprecationMessage() string
 	GetDescription() string
 	GetMarkdownDescription() string
 	GetType() attr.Type
-}
-
-type AttrLikeWithWriteOnly interface {
-	AttrLike
-	IsWriteOnly() bool
 }
 
 func FromProviderAttribute(x pschema.Attribute) Attr {

--- a/pkg/pf/internal/schemashim/attr_schema.go
+++ b/pkg/pf/internal/schemashim/attr_schema.go
@@ -142,11 +142,7 @@ func (s *attrSchema) Sensitive() bool {
 }
 
 func (s *attrSchema) WriteOnly() bool {
-	schema, ok := s.attr.(pfutils.AttrLikeWithWriteOnly)
-	if ok {
-		return schema.IsWriteOnly()
-	}
-	return false
+	return s.attr.IsWriteOnly()
 }
 
 func (*attrSchema) SetElement(config interface{}) (interface{}, error) {

--- a/pkg/pf/internal/schemashim/object_pseudoresource.go
+++ b/pkg/pf/internal/schemashim/object_pseudoresource.go
@@ -180,6 +180,7 @@ func (tupElementAttr) IsOptional() bool               { return false }
 func (tupElementAttr) IsRequired() bool               { return true }
 func (tupElementAttr) IsSensitive() bool              { return false }
 func (tupElementAttr) IsComputed() bool               { return false }
+func (tupElementAttr) IsWriteOnly() bool              { return false }
 
 func (t tupElementAttr) GetType() attr.Type { return t.e }
 

--- a/pkg/pf/tfgen/testdata/TestWriteOnlyOmit.golden
+++ b/pkg/pf/tfgen/testdata/TestWriteOnlyOmit.golden
@@ -12,23 +12,8 @@
     },
     "resources": {
         "testprovider:index:Res": {
-            "properties": {
-                "a1": {
-                    "type": "string"
-                }
-            },
-            "inputProperties": {
-                "a1": {
-                    "type": "string"
-                }
-            },
             "stateInputs": {
                 "description": "Input properties used for looking up and filtering Res resources.\n",
-                "properties": {
-                    "a1": {
-                        "type": "string"
-                    }
-                },
                 "type": "object"
             }
         }


### PR DESCRIPTION
~This is a pure refactor. It removes a redundant internal interface from the PF bridge.~

This started as a refactor but is actually a bug fix. Looks like we did not implement the PF portion of https://github.com/pulumi/pulumi-terraform-bridge/pull/2933 correctly. We also had a test which asserted on the wrong behaviour.

This PR fixes skipping PF WriteOnly attributes during tfgen. It also simplifies the PF code by removing a redundant interface.

`AttrLike` is a copy of the PF `fwschema..Attribute` which has `WriteOnly` implemented. This makes the method non-optional and adding it to an internal interface is not a breaking change.