### PR TITLE
Update the `go-version` so we test supported go versions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -30,7 +30,7 @@ jobs:
         #
         # When we decide to bump our minimum go version, we need to remember to bump the
         # go version in our go.mod files.
-        go-version: [1.22.x, 1.23.x]
+        go-version: [1.23.x, 1.24.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
         feature-flags: ["DEFAULT", "PULUMI_RAW_STATE_DELTA_ENABLED"]
         # Needs to match TOTAL_SHARDS


### PR DESCRIPTION
We should test the Go versions we actually support: 1.23 & 1.24.