### PR TITLE
chore: reduce noise in downstream_checks.py

### DIFF
--- a/scripts/downstream_checks.py
+++ b/scripts/downstream_checks.py
@@ -5,8 +5,16 @@ import requests
 
 NOT_BRIDGED_PROVIDERS = [
     "aws-apigateway",
+    "aws-native",
     "awsx",
+    "command",
+    "docker-build",
     "eks",
+    "kubernetes",
+    "kubernetes-cert-manager",
+    "kubernetes-coredns",
+    "kubernetes-ingress-nginx",
+    "terraform",
     "terraform-module",
 ]
 


### PR DESCRIPTION
Since ci-mgmt was refactored we need to mark more providers explicitly as not pertitent to the bridge.