### PR TITLE
Create default tests

### DIFF
--- a/pkg/tests/schema_pulumi_test.go
+++ b/pkg/tests/schema_pulumi_test.go
@@ -618,3 +618,35 @@ func TestDiffSetHashFailsOnNil(t *testing.T) {
 	},
 	)
 }
+
+func TestDefaultApplication(t *testing.T) {
+	t.Parallel()
+
+	t.Run("non-empty default", func(t *testing.T) {
+		t.Parallel()
+
+		res := map[string]*schema.Schema{
+			"test": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "hello",
+			},
+		}
+
+		crosstests.Create(t, res, cty.ObjectVal(map[string]cty.Value{}))
+	})
+
+	t.Run("empty default", func(t *testing.T) {
+		t.Parallel()
+
+		res := map[string]*schema.Schema{
+			"test": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+		}
+
+		crosstests.Create(t, res, cty.ObjectVal(map[string]cty.Value{}))
+	})
+}


### PR DESCRIPTION
Repro for https://github.com/pulumi/pulumi-terraform-bridge/issues/2618
Note the issue is unrelated to `ConflictsWith`.

Our behaviour around defaults in create is not consistent with TF. This means the provider will see different values when run through pulumi and TF.