### PR TITLE
Fix RawStateDelta computation for overflowing big ints and floats

### DIFF
--- a/pkg/tfbridge/rawstate.go
+++ b/pkg/tfbridge/rawstate.go
@@ -657,7 +657,7 @@ func (ih *rawStateDeltaHelper) computeDeltaAt(
 	case v.Type().IsBooleanType() && pv.IsBool() && pv.BoolValue() == v.BoolValue():
 		return RawStateDelta{}, nil
 
-	case v.Type().IsNumberType() && pv.IsNumber() && pv.NumberValue() == v.NumberValue():
+	case v.Type().IsNumberType() && pv.IsNumber() && isFloatExactlyEqual(pv.NumberValue(), v.BigFloatValue()):
 		return RawStateDelta{}, nil
 
 	case v.Type().IsNumberType() && pv.IsString():
@@ -838,4 +838,9 @@ func newRawStateFromValue(v valueshim.Value) rawstate.RawState {
 	raw, err := v.Marshal()
 	contract.AssertNoErrorf(err, "v.Marshal() failed")
 	return rawstate.RawState(raw)
+}
+
+// Check if the float64 value fully represents the big.Float; if there is any rounding involved, return false.
+func isFloatExactlyEqual(expected float64, got *big.Float) bool {
+	return new(big.Float).SetFloat64(expected).Cmp(got) == 0
 }

--- a/pkg/tfbridge/rawstate_test.go
+++ b/pkg/tfbridge/rawstate_test.go
@@ -1284,57 +1284,66 @@ func Test_isSimilarNumber(t *testing.T) {
 	t.Parallel()
 
 	type testCase struct {
-		f64     float64
-		bigNum  string
-		similar bool
+		f64       float64
+		bigNum    string
+		bigNumStr autogold.Value
+		similar   bool
 	}
 
 	testCases := []testCase{
 		{
-			f64:     0,
-			bigNum:  "0",
-			similar: true,
+			f64:       0,
+			bigNum:    "0",
+			similar:   true,
+			bigNumStr: autogold.Expect("0"),
 		},
 		{
-			f64:     0.5,
-			bigNum:  "0.5",
-			similar: true,
+			f64:       0.5,
+			bigNum:    "0.5",
+			similar:   true,
+			bigNumStr: autogold.Expect("0.5"),
 		},
 		{
-			f64:     3.14,
-			bigNum:  "3.14",
-			similar: true,
+			f64:       3.14,
+			bigNum:    "3.14",
+			similar:   true,
+			bigNumStr: autogold.Expect("3.14"),
 		},
 		{
-			f64:     2495055709147741000,
-			bigNum:  "2495055709147741000",
-			similar: true,
+			f64:       2495055709147741000,
+			bigNum:    "2495055709147741000",
+			similar:   true,
+			bigNumStr: autogold.Expect("2495055709147741000"),
 		},
 		{
 			f64:    2495055709147741000,
 			bigNum: "2495055709147741188",
 			// Rounding occurred on something that could be an ID; must mark as similar: false.
-			similar: false,
+			similar:   false,
+			bigNumStr: autogold.Expect("2495055709147741188"),
 		},
 		{
 			f64:    2495055709147741188,
 			bigNum: "2495055709147741188",
 			// Rounding occurs here as well as the literal does not represent cleanly in float64.
-			similar: false,
+			similar:   false,
+			bigNumStr: autogold.Expect("2495055709147741188"),
 		},
 		{
 			f64:    2495055709147741000.32,
 			bigNum: "2495055709147741000.32",
 			// There is rounding here but the literal is not an integer and unlikely an ID; either value of
 			// similar: false or similar: true may be acceptable.
-			similar: false,
+			similar:   false,
+			bigNumStr: autogold.Expect("2495055709147741000.2"),
 		},
 		{
 			f64: 2495055709147741000.123456,
 			// This accidentally parses as an integer in big.Float;
 			// Can remove this test case or can decide similar=false - not essential.
-			bigNum:  "2495055709147741000.123456",
-			similar: true,
+			bigNum:    "2495055709147741000.123456",
+			similar:   true,
+			bigNumStr: autogold.Expect("2495055709147741000"),
 		},
 	}
 
@@ -1343,6 +1352,7 @@ func Test_isSimilarNumber(t *testing.T) {
 			bn, _, err := new(big.Float).Parse(tc.bigNum, 10)
 			require.NoError(t, err)
 			t.Logf("Parsed as %q", bn.Text('f', -1))
+			tc.bigNumStr.Equal(t, bn.Text('f', -1))
 			assert.Equal(t, tc.similar, isSimilarNumber(tc.f64, bn))
 		})
 	}

--- a/pkg/valueshim/cty.go
+++ b/pkg/valueshim/cty.go
@@ -16,6 +16,7 @@ package valueshim
 
 import (
 	"encoding/json"
+	"math/big"
 
 	"github.com/hashicorp/go-cty/cty"
 	ctyjson "github.com/hashicorp/go-cty/cty/json"
@@ -60,8 +61,13 @@ func (v ctyValueShim) BoolValue() bool {
 }
 
 func (v ctyValueShim) NumberValue() float64 {
-	f, _ := v.val().AsBigFloat().Float64()
+	bf := v.BigFloatValue()
+	f, _ := bf.Float64()
 	return f
+}
+
+func (v ctyValueShim) BigFloatValue() *big.Float {
+	return v.val().AsBigFloat()
 }
 
 func (v ctyValueShim) AsValueSlice() []Value {

--- a/pkg/valueshim/shim.go
+++ b/pkg/valueshim/shim.go
@@ -16,6 +16,7 @@ package valueshim
 
 import (
 	"encoding/json"
+	"math/big"
 )
 
 // Allows abstracting over cty.Value and tftypes.Value for purposes of computing raw state deltas. In particular for
@@ -35,6 +36,7 @@ type Value interface {
 
 	StringValue() string
 	NumberValue() float64
+	BigFloatValue() *big.Float
 	BoolValue() bool
 }
 

--- a/pkg/valueshim/tfvalue.go
+++ b/pkg/valueshim/tfvalue.go
@@ -125,11 +125,16 @@ func (v tValueShim) BoolValue() bool {
 }
 
 func (v tValueShim) NumberValue() float64 {
+	result := v.BigFloatValue()
+	f, _ := result.Float64()
+	return f
+}
+
+func (v tValueShim) BigFloatValue() *big.Float {
 	var result big.Float
 	err := v.val().As(&result)
 	contract.AssertNoErrorf(err, "Cannot cast value as NumberValue")
-	f, _ := result.Float64()
-	return f
+	return &result
 }
 
 func (v tValueShim) StringValue() string {


### PR DESCRIPTION
The test suite in pulumi-gcp points out a corner case that was not handled previously and may lead to:

    error: recovered raw state does not byte-for-byte match the original raw state

This is the case of overflowing numbers (ints and floats) that cannot fit precisely in the float64 representation used by Pulumi. If the bridged provider maintainer overrides the bridge metadata to project these numbers as strings in the SDKs, everything works as expected. However there are practical cases where this maintainer action has not been taken yet; one reason to defer it is that changing the type from Number to String is a breaking change on the SDKs and may need to await a major version.

The change tightens equality to be stricter than equal-up-to-float64 precision, and if Pulumi representation does not equal the TF representation exactly, the provider will now backtrack and write the exact TF representation into the Raw State Delta, instructing the reader to replace the Pulumi representation with the TF representation.

See also: https://github.com/pulumi/pulumi-gcp/pull/3212