### PR TITLE
Fix PF Dynamic types

### DIFF
--- a/pkg/convert/dynamic.go
+++ b/pkg/convert/dynamic.go
@@ -35,7 +35,7 @@ func (enc *dynamicEncoder) fromPropertyValue(p resource.PropertyValue) (tftypes.
 	case propertyValueIsUnknown(p):
 		return tftypes.NewValue(tftypes.Object{} /* arbitrary type */, tftypes.UnknownValue), nil
 	case p.IsNull():
-		return tftypes.NewValue(tftypes.Object{} /* arbitrary type */, nil), nil
+		return tftypes.NewValue(tftypes.DynamicPseudoType, nil), nil
 	case p.IsBool():
 		return tftypes.NewValue(tftypes.Bool, p.BoolValue()), nil
 	case p.IsNumber():

--- a/pkg/convert/infer_object.go
+++ b/pkg/convert/infer_object.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
 type InferObjectTypeOptions struct{}
@@ -93,6 +93,8 @@ func InferType(s shim.Schema, opts *InferObjectTypeOptions) tftypes.Type {
 			contract.Failf("unexpected Elem(): %#T", elem)
 			return nil
 		}
+	case shim.TypeDynamic:
+		return tftypes.DynamicPseudoType
 	default:
 		contract.Failf("unexpected schema type %v", s.Type())
 		return nil

--- a/pkg/pf/tests/provider_create_test.go
+++ b/pkg/pf/tests/provider_create_test.go
@@ -334,3 +334,26 @@ func TestPFCrossTestCreateBasic(t *testing.T) {
 		"hello": cty.StringVal("world"),
 	})
 }
+
+func TestPFCreateDynamicAttribute(t *testing.T) {
+	t.Parallel()
+
+	res := pb.NewResource(
+		pb.NewResourceArgs{
+			ResourceSchema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"hello": schema.StringAttribute{
+						Optional: true,
+					},
+					"dynamic": schema.DynamicAttribute{
+						Optional: true,
+					},
+				},
+			},
+		},
+	)
+
+	crosstests.Create(t, res, map[string]cty.Value{
+		"hello": cty.StringVal("world"),
+	})
+}


### PR DESCRIPTION
This PR fixes the PF bridge support for dynamic types when the attribute is not specified. Specifically, previously it'd default to an empty object and now the default is a nil PseudoDynamicType.

This is supported by a cross-tests which compares against TF behaviour which does the same.

fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/3067