### PR TITLE
Add check whether a type ref refers to a resource rather than a type

### DIFF
--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -1002,9 +1002,17 @@ func (g *schemaGenerator) schemaType(path paths.TypePath, typ *propertyType, out
 				if tPkg == g.pkg {
 					pkg = ""
 				}
+				refPrefix := "#/types/"
+				// Check if this token is already a resource token.
+				// If yes, we have a resource reference in the schema and want to express that, to avoid dangling refs.
+				for _, resource := range g.info.Resources {
+					if resource.Tok.String() == strings.TrimSuffix(string(t), "[]") {
+						refPrefix = "#/resources/"
+					}
+				}
 				spec := pschema.TypeSpec{
 					Type: defaultType,
-					Ref:  fmt.Sprintf("%s#/types/%s", pkg, strings.TrimSuffix(string(t), "[]")),
+					Ref:  fmt.Sprintf("%s%s%s", pkg, refPrefix, strings.TrimSuffix(string(t), "[]")),
 				}
 				if strings.HasSuffix(string(t), "[]") {
 					items := spec


### PR DESCRIPTION
When a provider [references an AltType that is actually a resource reference](https://github.com/pulumi/pulumi-aws/blob/master/provider/resources.go#L1816), currently the bridge sets this ref in the schema with the `#/types` prefix. This results in dangling type references (the ref exists, but not as a `Type`).

This pull request checks if the generated type token belongs to any of the provider resources and correctly generates the reference using the `#/resources` prefix.

Reasons for this approach:

- Tokens are unique
- Token generation in the provider contains no metadata on whether this is a "resource reference" or a "type reference"
- If the provider uses a resource reference, that resource should exist. In the case that it does not - this is cleanup work to allow us to enable stricter schema checks for dangling resources in the near future.

**Update**
Reverting to draft because converting to `#/resource` references builds a Go SDK that has unnecessary imports, which doesn't compile. This could mean either:
- Codegen doesn't generate the AltTypes properly for Go 
- Codegen erroneously assumes that we need to reference these packages in the generated types for Go.

_With this change_, I see proper types and imports being generated (on p-aws' resource ref types using this change) in the other SDKs:
```python
-    def application(self, value: Optional[pulumi.Input[builtins.str]]):
+    def application(self, value: Optional[pulumi.Input[Union[builtins.str, 'Application']]]):
```

Schema diff snippet:
```
@@ -271362,7 +271362,7 @@
                         },
                         {
                             "type": "string",
-                            "$ref": "#/types/aws:elasticbeanstalk/application:Application"
+                            "$ref": "#/resources/aws:elasticbeanstalk/application:Application"
                         }
                     ],
                     "description": "Name of the application that contains the version\nto be deployed\n"
@@ -271418,7 +271418,7 @@
                 },
                 "version": {
                     "type": "string",
-                    "$ref": "#/types/aws:elasticbeanstalk/applicationVersion:ApplicationVersion",
+                    "$ref": "#/resources/aws:elasticbeanstalk/applicationVersion:ApplicationVersion",
                     "description": "The name of the Elastic Beanstalk Application Version\nto use in deployment.\n"
                 },
                 "waitForReadyTimeout": {
```



The exception is Node: no difference is shown; union types for this already exist even with the incorrect ref token.
p-aws diff for this change: https://github.com/pulumi/pulumi-aws/compare/7.0.0-alpha...gen-with-reference-tokens?expand=1

_Conversely_, when I remove the AltType from p-aws' schema, the only SDKs that show any changes are Go and Node, where we lose the strict type:
Go:
`Application pulumi.Input` => `Application pulumi.StringPtrInput`
Node:
`application: pulumi.Input<string | Application>` =>  `application: pulumi.Input<string>`

Sample schema diff:
```
--- a/provider/cmd/pulumi-resource-aws/schema.json
+++ b/provider/cmd/pulumi-resource-aws/schema.json
@@ -271356,15 +271356,6 @@
             "inputProperties": {
                 "application": {
                     "type": "string",
-                    "oneOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "string",
-                            "$ref": "#/types/aws:elasticbeanstalk/application:Application"
-                        }
-                    ],
                     "description": "Name of the application that contains the version\nto be deployed\n"
                 },
                 "cnamePrefix": {
```

                

The other SDKs are unaffected; continuing to just use the base string type.
Diff that just removes one of these resource refs: https://github.com/pulumi/pulumi-aws/compare/7.0.0-alpha...resource-refs?expand=1

Ideally we'd be able to use the resource reference as suggested here and fix up how Go behaves.

This PR is probably good as-is, but needs work in Go codegen, or we need to decide that we won't have these resource references anymore at all as a breaking change for pulumi-aws and other providers that do this.

Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/3069.

