### PR TITLE
Fix Replace handling in PF Diff

### DIFF
--- a/pkg/pf/tests/schema_and_program_test.go
+++ b/pkg/pf/tests/schema_and_program_test.go
@@ -787,7 +787,7 @@ resources:
 	require.Zero(t, res.ChangeSummary["replace"])
 }
 
-func TestCrossTestRequiresReplaceAndUseStateForUnknown(t *testing.T) {
+func TestCrossTestRequiresReplaceAndUseStateForUnknownBasic(t *testing.T) {
 	t.Parallel()
 
 	res := providerbuilder.NewResource(providerbuilder.NewResourceArgs{

--- a/pkg/pf/tests/schema_and_program_test.go
+++ b/pkg/pf/tests/schema_and_program_test.go
@@ -29,9 +29,11 @@ import (
 	presource "github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/providerbuilder"
 	pb "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/providerbuilder"
+	crosstests "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/cross-tests"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/pulcheck"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
@@ -725,4 +727,98 @@ func TestPFResourceWithNullId(t *testing.T) {
 	pt, err := pulcheck.PulCheck(t, prov, program)
 	require.NoError(t, err)
 	pt.Up(t)
+}
+
+func TestRequiresReplaceAndUseStateForUnknown(t *testing.T) {
+	t.Parallel()
+
+	provBuilder := providerbuilder.NewProvider(providerbuilder.NewProviderArgs{
+		AllResources: []providerbuilder.Resource{
+			providerbuilder.NewResource(providerbuilder.NewResourceArgs{
+				ResourceSchema: rschema.Schema{
+					Attributes: map[string]rschema.Attribute{
+						"test": rschema.StringAttribute{
+							Optional: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.RequiresReplace(),
+								stringplanmodifier.UseStateForUnknown(),
+							},
+							Computed: true,
+						},
+						"other": rschema.StringAttribute{
+							Optional: true,
+						},
+					},
+				},
+				CreateFunc: func(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+					resp.State = tfsdk.State(req.Plan)
+					resp.State.SetAttribute(ctx, path.Root("id"), "test-id")
+					resp.State.SetAttribute(ctx, path.Root("test"), "computed-value")
+				},
+			}),
+		},
+	})
+
+	prov := provBuilder.ToProviderInfo()
+
+	program := `
+name: test
+runtime: yaml
+resources:
+    mainRes:
+        type: testprovider:index/test:Test
+        properties:
+            other: "hello"`
+
+	pt, err := pulcheck.PulCheck(t, prov, program)
+	require.NoError(t, err)
+	pt.Up(t)
+
+	pt.WritePulumiYaml(t, `
+name: test
+runtime: yaml
+resources:
+    mainRes:
+        type: testprovider:index/test:Test
+        properties:
+            other: "world"`)
+
+	res := pt.Preview(t, optpreview.Diff())
+	require.Zero(t, res.ChangeSummary["replace"])
+}
+
+func TestCrossTestRequiresReplaceAndUseStateForUnknown(t *testing.T) {
+	t.Parallel()
+
+	res := providerbuilder.NewResource(providerbuilder.NewResourceArgs{
+		ResourceSchema: rschema.Schema{
+			Attributes: map[string]rschema.Attribute{
+				"test": rschema.StringAttribute{
+					Optional: true,
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.RequiresReplace(),
+						stringplanmodifier.UseStateForUnknown(),
+					},
+					Computed: true,
+				},
+				"other": rschema.StringAttribute{
+					Optional: true,
+				},
+			},
+		},
+		CreateFunc: func(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+			resp.State = tfsdk.State(req.Plan)
+			resp.State.SetAttribute(ctx, path.Root("id"), "test-id")
+			resp.State.SetAttribute(ctx, path.Root("test"), "computed-value")
+		},
+	})
+
+	crosstests.Diff(t, res,
+		map[string]cty.Value{
+			"other": cty.StringVal("hello"),
+		},
+		map[string]cty.Value{
+			"other": cty.StringVal("world"),
+		},
+	)
 }

--- a/pkg/pf/tfbridge/provider_diff.go
+++ b/pkg/pf/tfbridge/provider_diff.go
@@ -217,20 +217,12 @@ func trimElementKeyValueFromTFPath(path *tftypes.AttributePath) *tftypes.Attribu
 	// trims everything after an ElementKeyValue path step from the replaceKeys paths
 	//nolint:lll
 	// see `convert.AttributePathToPath` used here: https://github.com/opentofu/opentofu/blob/5968e195b0f6e1ecb4381afa26abb95c636fe755/internal/plugin6/grpc_provider.go#L503
-	trimmedPath := tftypes.NewAttributePath()
-	for _, step := range path.Steps() {
-		switch s := step.(type) {
-		case tftypes.AttributeName:
-			trimmedPath = trimmedPath.WithAttributeName(string(s))
-		case tftypes.ElementKeyString:
-			trimmedPath = trimmedPath.WithElementKeyString(string(s))
-		case tftypes.ElementKeyInt:
-			trimmedPath = trimmedPath.WithElementKeyInt(int(s))
-		default:
-			return trimmedPath
+	for i, step := range path.Steps() {
+		if _, ok := step.(tftypes.ElementKeyValue); ok {
+			return tftypes.NewAttributePathWithSteps(path.Steps()[:i])
 		}
 	}
-	return trimmedPath
+	return path
 }
 
 // checkRequiresReplace checks if the planned state is different from the prior state for the given attribute paths.

--- a/pkg/pf/tfbridge/provider_diff.go
+++ b/pkg/pf/tfbridge/provider_diff.go
@@ -254,14 +254,27 @@ func checkRequiresReplace(
 		if priorErr != nil && plannedErr != nil {
 			return nil, fmt.Errorf("failed to walk attribute path: %s, %w, %w", replace.String(), priorErr, plannedErr)
 		}
-		priorVal, ok := priorValAny.(tftypes.Value)
-		if !ok {
-			return nil, fmt.Errorf("failed to convert priorVal to tftypes.Value")
+
+		var priorVal tftypes.Value
+		if priorErr != nil {
+			priorVal = tftypes.NewValue(priorState.Value.Type(), nil)
+		} else {
+			var ok bool
+			priorVal, ok = priorValAny.(tftypes.Value)
+			if !ok {
+				return nil, fmt.Errorf("failed to convert priorVal to tftypes.Value")
+			}
 		}
 
-		plannedVal, ok := plannedValAny.(tftypes.Value)
-		if !ok {
-			return nil, fmt.Errorf("failed to convert plannedVal to tftypes.Value")
+		var plannedVal tftypes.Value
+		if plannedErr != nil {
+			plannedVal = tftypes.NewValue(plannedState.Type(), nil)
+		} else {
+			var ok bool
+			plannedVal, ok = plannedValAny.(tftypes.Value)
+			if !ok {
+				return nil, fmt.Errorf("failed to convert plannedVal to tftypes.Value")
+			}
 		}
 
 		if !plannedVal.IsKnown() || !priorVal.Equal(plannedVal) {

--- a/pkg/pf/tfbridge/provider_diff.go
+++ b/pkg/pf/tfbridge/provider_diff.go
@@ -215,8 +215,7 @@ func diffAttributePaths(tfDiff []tftypes.ValueDiff) []*tftypes.AttributePath {
 
 func trimElementKeyValueFromTFPath(path *tftypes.AttributePath) *tftypes.AttributePath {
 	// trims everything after an ElementKeyValue path step from the replaceKeys paths
-	//nolint:lll
-	// see `convert.AttributePathToPath` used here: https://github.com/opentofu/opentofu/blob/5968e195b0f6e1ecb4381afa26abb95c636fe755/internal/plugin6/grpc_provider.go#L503
+	// see https://github.com/hashicorp/terraform-plugin-go/blob/main/tfprotov6/internal/toproto/attribute_path.go
 	for i, step := range path.Steps() {
 		if _, ok := step.(tftypes.ElementKeyValue); ok {
 			return tftypes.NewAttributePathWithSteps(path.Steps()[:i])

--- a/pkg/pf/tfbridge/provider_diff_test.go
+++ b/pkg/pf/tfbridge/provider_diff_test.go
@@ -85,3 +85,131 @@ func TestTopLevelPropertyKeySet(t *testing.T) {
 		})
 	}
 }
+
+func TestTrimElementKeyValueFromTFPath(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name   string
+		input  *tftypes.AttributePath
+		expect *tftypes.AttributePath
+	}{
+		{
+			name:   "single attribute name",
+			input:  tftypes.NewAttributePath().WithAttributeName("foo"),
+			expect: tftypes.NewAttributePath().WithAttributeName("foo"),
+		},
+		{
+			name:   "attribute name and string key",
+			input:  tftypes.NewAttributePath().WithAttributeName("foo").WithElementKeyString("bar"),
+			expect: tftypes.NewAttributePath().WithAttributeName("foo").WithElementKeyString("bar"),
+		},
+		{
+			name:   "attribute name and int key",
+			input:  tftypes.NewAttributePath().WithAttributeName("foo").WithElementKeyInt(42),
+			expect: tftypes.NewAttributePath().WithAttributeName("foo").WithElementKeyInt(42),
+		},
+		{
+			name: "stops at unknown step (ElementKeyValue)",
+			input: func() *tftypes.AttributePath {
+				steps := []tftypes.AttributePathStep{
+					tftypes.AttributeName("foo"),
+					tftypes.ElementKeyValue(tftypes.NewValue(tftypes.String, "bar")),
+				}
+				return tftypes.NewAttributePathWithSteps(steps)
+			}(),
+			expect: tftypes.NewAttributePath().WithAttributeName("foo"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := trimElementKeyValueFromTFPath(tc.input)
+			require.Equal(t, tc.expect.String(), actual.String())
+		})
+	}
+}
+
+func TestCheckRequiresReplace(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		name           string
+		priorVal       interface{}
+		plannedVal     interface{}
+		replacePaths   []*tftypes.AttributePath
+		expectPaths    []*tftypes.AttributePath
+		plannedIsKnown bool
+	}
+
+	objectType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{"attr": tftypes.String}}
+
+	makeValue := func(typ tftypes.Type, val interface{}, isKnown bool) tftypes.Value {
+		v := tftypes.NewValue(typ, val)
+		if !isKnown {
+			return tftypes.NewValue(typ, tftypes.UnknownValue)
+		}
+		return v
+	}
+
+	testCases := []testCase{
+		{
+			name:         "null prior state returns empty",
+			priorVal:     nil,
+			plannedVal:   map[string]tftypes.Value{"attr": tftypes.NewValue(tftypes.String, "foo")},
+			replacePaths: []*tftypes.AttributePath{tftypes.NewAttributePath().WithAttributeName("attr")},
+			expectPaths:  []*tftypes.AttributePath{},
+		},
+		{
+			name:         "empty replace keys returns empty",
+			priorVal:     map[string]tftypes.Value{"attr": tftypes.NewValue(tftypes.String, "foo")},
+			plannedVal:   map[string]tftypes.Value{"attr": tftypes.NewValue(tftypes.String, "bar")},
+			replacePaths: []*tftypes.AttributePath{},
+			expectPaths:  []*tftypes.AttributePath{},
+		},
+		{
+			name:         "value differs triggers replace",
+			priorVal:     map[string]tftypes.Value{"attr": tftypes.NewValue(tftypes.String, "foo")},
+			plannedVal:   map[string]tftypes.Value{"attr": tftypes.NewValue(tftypes.String, "bar")},
+			replacePaths: []*tftypes.AttributePath{tftypes.NewAttributePath().WithAttributeName("attr")},
+			expectPaths:  []*tftypes.AttributePath{tftypes.NewAttributePath().WithAttributeName("attr")},
+		},
+		{
+			name:         "value equal does not trigger replace",
+			priorVal:     map[string]tftypes.Value{"attr": tftypes.NewValue(tftypes.String, "foo")},
+			plannedVal:   map[string]tftypes.Value{"attr": tftypes.NewValue(tftypes.String, "foo")},
+			replacePaths: []*tftypes.AttributePath{tftypes.NewAttributePath().WithAttributeName("attr")},
+			expectPaths:  []*tftypes.AttributePath{},
+		},
+		{
+			name:           "planned value unknown triggers replace",
+			priorVal:       map[string]tftypes.Value{"attr": tftypes.NewValue(tftypes.String, "foo")},
+			plannedVal:     nil,
+			replacePaths:   []*tftypes.AttributePath{tftypes.NewAttributePath().WithAttributeName("attr")},
+			expectPaths:    []*tftypes.AttributePath{tftypes.NewAttributePath().WithAttributeName("attr")},
+			plannedIsKnown: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			priorVal := makeValue(objectType, tc.priorVal, true)
+			if tc.priorVal == nil {
+				priorVal = tftypes.NewValue(objectType, nil)
+			}
+			plannedVal := makeValue(objectType, tc.plannedVal, tc.plannedIsKnown || tc.plannedVal != nil)
+			priorState := &upgradedResourceState{Value: priorVal}
+			paths, err := checkRequiresReplace(priorState, plannedVal, tc.replacePaths)
+			require.NoError(t, err)
+			require.ElementsMatch(t, tc.expectPaths, paths)
+		})
+	}
+
+	t.Run("error walking attribute path", func(t *testing.T) {
+		priorVal := tftypes.NewValue(objectType, map[string]tftypes.Value{"attr": tftypes.NewValue(tftypes.String, "foo")})
+		plannedVal := tftypes.NewValue(objectType, map[string]tftypes.Value{"attr": tftypes.NewValue(tftypes.String, "bar")})
+		priorState := &upgradedResourceState{Value: priorVal}
+		badPath := tftypes.NewAttributePath().WithAttributeName("doesnotexist")
+		_, err := checkRequiresReplace(priorState, plannedVal, []*tftypes.AttributePath{badPath})
+		require.Error(t, err)
+	})
+}

--- a/pkg/pf/tfbridge/provider_diff_test.go
+++ b/pkg/pf/tfbridge/provider_diff_test.go
@@ -109,7 +109,7 @@ func TestTrimElementKeyValueFromTFPath(t *testing.T) {
 			expect: tftypes.NewAttributePath().WithAttributeName("foo").WithElementKeyInt(42),
 		},
 		{
-			name: "stops at unknown step (ElementKeyValue)",
+			name: "path with ElementKeyValue truncated",
 			input: func() *tftypes.AttributePath {
 				steps := []tftypes.AttributePathStep{
 					tftypes.AttributeName("foo"),


### PR DESCRIPTION
The PF bridge does not match the TF handling of RequiresReplace output by plan. This causes issues incorrect replacement plans in some cases.

This adapts the opentofu code for use in the PF bridge.

Opentofu reference: https://github.com/opentofu/opentofu/blob/76d388b34051b2dcf7b21d2d6d15e0c4dcb48734/internal/tofu/node_resource_abstract_instance.go#L1116-L1165

fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/3050