### PR TITLE
Rename all clashing tests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -162,7 +162,7 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           skip-cache: true
-          version: v1.64.2
+          version: v1.64.7
       - name: Lint
         run: make lint
   version-check:

--- a/dynamic/provider_test.go
+++ b/dynamic/provider_test.go
@@ -215,7 +215,7 @@ func skipUnlessDeltasEnabled(t *testing.T) {
 	}
 }
 
-func TestConfigure(t *testing.T) {
+func TestDynamicConfigure(t *testing.T) {
 	t.Parallel()
 	skipWindows(t)
 
@@ -255,7 +255,7 @@ func TestConfigure(t *testing.T) {
 }`)))(t)
 }
 
-func TestCheckConfig(t *testing.T) {
+func TestDynamicCheckConfig(t *testing.T) {
 	t.Parallel()
 	skipWindows(t)
 

--- a/pkg/pf/tests/autonaming_test.go
+++ b/pkg/pf/tests/autonaming_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 )
 
-func TestAutonaming(t *testing.T) {
+func TestPFAutonaming(t *testing.T) {
 	t.Parallel()
 	provBuilder := providerbuilder.NewProvider(
 		providerbuilder.NewProviderArgs{

--- a/pkg/pf/tests/integration/attach_test.go
+++ b/pkg/pf/tests/integration/attach_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAttach(t *testing.T) {
+func TestPFAttach(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {
 		t.Skip()
@@ -41,7 +41,7 @@ func TestAttach(t *testing.T) {
 	pt.Preview(t)
 }
 
-func TestAttachMuxed(t *testing.T) {
+func TestPFAttachMuxed(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {
 		t.Skip()

--- a/pkg/pf/tests/internal/pftfcheck/pftf_test.go
+++ b/pkg/pf/tests/internal/pftfcheck/pftf_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/tfcheck"
 )
 
-func TestBasic(t *testing.T) {
+func TestTFBasic(t *testing.T) {
 	t.Parallel()
 	prov := pb.NewProvider(pb.NewProviderArgs{
 		AllResources: []pb.Resource{
@@ -47,7 +47,7 @@ output "s_val" {
 	require.Equal(t, "hello", driver.GetOutput(t, "s_val"))
 }
 
-func TestDefaults(t *testing.T) {
+func TestTFDefaults(t *testing.T) {
 	t.Parallel()
 	prov := pb.NewProvider(pb.NewProviderArgs{
 		AllResources: []pb.Resource{

--- a/pkg/pf/tests/provider_check_test.go
+++ b/pkg/pf/tests/provider_check_test.go
@@ -35,7 +35,7 @@ import (
 	tfbridge0 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 )
 
-func TestCheck(t *testing.T) {
+func TestPFCheck(t *testing.T) {
 	t.Parallel()
 	type testCase struct {
 		name        string

--- a/pkg/pf/tests/provider_checkconfig_test.go
+++ b/pkg/pf/tests/provider_checkconfig_test.go
@@ -45,7 +45,7 @@ import (
 	shimschema "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
 )
 
-func TestCheckConfig(t *testing.T) {
+func TestPFCheckConfig(t *testing.T) {
 	t.Parallel()
 	t.Run("minimal", func(t *testing.T) {
 		schema := schema.Schema{}
@@ -471,7 +471,7 @@ func TestCheckConfig(t *testing.T) {
 	})
 }
 
-func TestPreConfigureCallback(t *testing.T) {
+func TestPFPreConfigureCallback(t *testing.T) {
 	t.Parallel()
 	t.Run("PreConfigureCallback called by CheckConfig", func(t *testing.T) {
 		schema := schema.Schema{

--- a/pkg/pf/tests/provider_configure_test.go
+++ b/pkg/pf/tests/provider_configure_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
 )
 
-func TestConfigure(t *testing.T) {
+func TestPFConfigure(t *testing.T) {
 	t.Parallel()
 
 	t.Run("string", testConfigurePrimitive{
@@ -535,7 +535,7 @@ func TestConfigureBooleans(t *testing.T) {
 	}`)
 }
 
-func TestConfigureErrorReplacement(t *testing.T) {
+func TestPFConfigureErrorReplacement(t *testing.T) {
 	t.Parallel()
 	t.Run("replace_config_properties", func(t *testing.T) {
 		errString := `some error with "config_property" and "config" but not config`

--- a/pkg/pf/tests/provider_get_mapping_test.go
+++ b/pkg/pf/tests/provider_get_mapping_test.go
@@ -29,7 +29,7 @@ import (
 	tfbridge0 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 )
 
-func TestGetMapping(t *testing.T) {
+func TestPFGetMapping(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	info := testprovider.RandomProvider()

--- a/pkg/pf/tests/provider_transform_outputs_test.go
+++ b/pkg/pf/tests/provider_transform_outputs_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 )
 
-func TestTransformOutputs(t *testing.T) {
+func TestPFTransformOutputs(t *testing.T) {
 	t.Parallel()
 	p := testprovider.SyntheticTestBridgeProvider()
 
@@ -155,7 +155,7 @@ func TestTransformOutputs(t *testing.T) {
 	})
 }
 
-func TestTransformFromState(t *testing.T) {
+func TestPFTransformFromState(t *testing.T) {
 	t.Parallel()
 	provider := func(t *testing.T) pulumirpc.ResourceProviderServer {
 		p := testprovider.AssertProvider(func(config tfsdk.Config, old, new *tfsdk.State) {

--- a/pkg/pf/tests/schema_and_program_test.go
+++ b/pkg/pf/tests/schema_and_program_test.go
@@ -43,7 +43,7 @@ func ref[T any](t T) *T {
 	return &t
 }
 
-func TestBasic(t *testing.T) {
+func TestPFBasic(t *testing.T) {
 	t.Parallel()
 	provBuilder := providerbuilder.NewProvider(
 		providerbuilder.NewProviderArgs{
@@ -322,7 +322,7 @@ resources:
 	}
 }
 
-func TestDefaults(t *testing.T) {
+func TestPFDefaults(t *testing.T) {
 	t.Parallel()
 	provBuilder := pb.NewProvider(pb.NewProviderArgs{
 		AllResources: []providerbuilder.Resource{

--- a/pkg/tests/autonaming_test.go
+++ b/pkg/tests/autonaming_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 )
 
-func TestAutonaming(t *testing.T) {
+func TestSDKv2Autonaming(t *testing.T) {
 	t.Parallel()
 	resMap := map[string]*schema.Resource{
 		"prov_test": {

--- a/pkg/tests/schema_pulumi_test.go
+++ b/pkg/tests/schema_pulumi_test.go
@@ -26,7 +26,7 @@ func ref[T any](t T) *T {
 	return &t
 }
 
-func TestBasic(t *testing.T) {
+func TestSDKv2Basic(t *testing.T) {
 	t.Parallel()
 	resMap := map[string]*schema.Resource{
 		"prov_test": {

--- a/pkg/tf2pulumi/il/graph_test.go
+++ b/pkg/tf2pulumi/il/graph_test.go
@@ -56,7 +56,7 @@ func TestLocalForwardReferences(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestMetaProperties(t *testing.T) {
+func TestTF2PulumiMetaProperties(t *testing.T) {
 	t.Parallel()
 	info := test.NewProviderInfoSource("../testdata/providers")
 

--- a/pkg/tfbridge/assets_test.go
+++ b/pkg/tfbridge/assets_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBasic(t *testing.T) {
+func TestAssetsBasic(t *testing.T) {
 	t.Parallel()
 	t1 := &AssetTranslation{Kind: FileAsset}
 	assert.True(t, t1.IsAsset())

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -188,7 +188,7 @@ func TestCamelPascalPulumiName(t *testing.T) {
 	})
 }
 
-func TestDiffConfig(t *testing.T) {
+func TestSDKv2DiffConfig(t *testing.T) {
 	t.Parallel()
 	yes := true
 	tfProvider := shimv2.NewProvider(&schema.Provider{
@@ -508,7 +508,7 @@ func testIgnoreChanges(t *testing.T, provider *Provider) {
 	}).DeepEquals(outs["setPropertyValues"]))
 }
 
-func TestIgnoreChanges(t *testing.T) {
+func TestSDKv2IgnoreChanges(t *testing.T) {
 	t.Parallel()
 	testTFProvider := testprovider.ProviderV1()
 
@@ -1233,7 +1233,7 @@ func TestProviderReadNestedSecretV2(t *testing.T) {
 	testProviderReadNestedSecret(t, provider, "NestedSecretResource")
 }
 
-func TestCheck(t *testing.T) {
+func TestSDKv2Check(t *testing.T) {
 	t.Parallel()
 	t.Run("Default application can consult prior state in Check", func(t *testing.T) {
 		testTFProviderV2 := testprovider.ProviderV2()
@@ -1510,7 +1510,7 @@ This will become a hard error in the future.
 `).Equal(t, logs.String())
 }
 
-func TestCheckConfig(t *testing.T) {
+func TestSDKv2CheckConfig(t *testing.T) {
 	t.Parallel()
 	t.Run("minimal", func(t *testing.T) {
 		testTFProviderV2 := testprovider.ProviderV2()
@@ -1949,7 +1949,7 @@ func TestCheckConfig(t *testing.T) {
 	})
 }
 
-func TestConfigure(t *testing.T) {
+func TestSDKv2Configure(t *testing.T) {
 	t.Parallel()
 	t.Run("handle_secret_nested_objects", func(t *testing.T) {
 		p := testprovider.ProviderV2()
@@ -2022,7 +2022,7 @@ func TestConfigure(t *testing.T) {
 	})
 }
 
-func TestConfigureErrorReplacement(t *testing.T) {
+func TestSDKv2ConfigureErrorReplacement(t *testing.T) {
 	t.Parallel()
 	t.Run("replace_config_properties", func(t *testing.T) {
 		p := testprovider.ProviderV2()
@@ -2120,7 +2120,7 @@ func TestConfigureContextCapture(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestPreConfigureCallback(t *testing.T) {
+func TestSDKv2PreConfigureCallback(t *testing.T) {
 	t.Parallel()
 	t.Run("PreConfigureCallback called by CheckConfig", func(t *testing.T) {
 		testTFProviderV2 := testprovider.ProviderV2()
@@ -2384,7 +2384,7 @@ func TestInvoke(t *testing.T) {
 	})
 }
 
-func TestTransformOutputs(t *testing.T) {
+func TestSDKv2TransformOutputs(t *testing.T) {
 	t.Parallel()
 
 	testTFProviderV2 := testprovider.ProviderV2()
@@ -2672,7 +2672,7 @@ func TestSkipDetailedDiff(t *testing.T) {
 	})
 }
 
-func TestTransformFromState(t *testing.T) {
+func TestSDKv2TransformFromState(t *testing.T) {
 	t.Parallel()
 	provider := func(t *testing.T) *Provider {
 		p := testprovider.AssertProvider(func(data *schema.ResourceData) {

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -648,7 +648,7 @@ func TestTerraformOutputsWithSecretsUnsupported(t *testing.T) {
 }
 
 // Test that meta-properties are correctly produced.
-func TestMetaProperties(t *testing.T) {
+func TestSDKv2MetaProperties(t *testing.T) {
 	t.Parallel()
 	for _, f := range factories {
 		t.Run(f.SDKVersion(), func(t *testing.T) {
@@ -917,7 +917,7 @@ func fixedDefault(value interface{}) func() (interface{}, error) {
 	return func() (interface{}, error) { return value, nil }
 }
 
-func TestDefaults(t *testing.T) {
+func TestSDKv2Defaults(t *testing.T) {
 	ctx := context.Background()
 	for _, f := range factories {
 		t.Run(f.SDKVersion(), func(t *testing.T) {

--- a/pkg/tfshim/sdk-v1/instance_state_test.go
+++ b/pkg/tfshim/sdk-v1/instance_state_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestToInstanceState(t *testing.T) {
+func TestSDKv1ToInstanceState(t *testing.T) {
 	t.Parallel()
 	res := NewResource(&schema.Resource{
 		Schema: map[string]*schema.Schema{
@@ -169,7 +169,7 @@ func TestToInstanceState(t *testing.T) {
 }
 
 // Test that an unset list still generates a length attribute.
-func TestEmptyListAttribute(t *testing.T) {
+func TestSDKv1EmptyListAttribute(t *testing.T) {
 	t.Parallel()
 	res := NewResource(&schema.Resource{
 		Schema: map[string]*schema.Schema{
@@ -184,7 +184,7 @@ func TestEmptyListAttribute(t *testing.T) {
 	})
 }
 
-func TestObjectFromInstanceDiff(t *testing.T) {
+func TestSDKv1ObjectFromInstanceDiff(t *testing.T) {
 	t.Parallel()
 	res := NewResource(&schema.Resource{
 		Schema: map[string]*schema.Schema{

--- a/pkg/tfshim/sdk-v2/instance_state_test.go
+++ b/pkg/tfshim/sdk-v2/instance_state_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestToInstanceState(t *testing.T) {
+func TestSDKv2ToInstanceState(t *testing.T) {
 	t.Parallel()
 	res := NewResource(&schema.Resource{
 		Schema: map[string]*schema.Schema{
@@ -163,7 +163,7 @@ func TestToInstanceState(t *testing.T) {
 }
 
 // Test that an unset list still generates a length attribute.
-func TestEmptyListAttribute(t *testing.T) {
+func TestSDKv2EmptyListAttribute(t *testing.T) {
 	t.Parallel()
 	res := NewResource(&schema.Resource{
 		Schema: map[string]*schema.Schema{
@@ -178,7 +178,7 @@ func TestEmptyListAttribute(t *testing.T) {
 	})
 }
 
-func TestObjectFromInstanceDiff(t *testing.T) {
+func TestSDKv2ObjectFromInstanceDiff(t *testing.T) {
 	t.Parallel()
 	res := NewResource(&schema.Resource{
 		Schema: map[string]*schema.Schema{

--- a/pkg/x/muxer/muxer_test.go
+++ b/pkg/x/muxer/muxer_test.go
@@ -29,7 +29,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-func TestAttach(t *testing.T) {
+func TestMuxerAttach(t *testing.T) {
 	t.Parallel()
 	req := &pulumirpc.PluginAttach{Address: "test"}
 	ctx := context.Background()
@@ -93,7 +93,7 @@ func (h *host) Log(context.Context, diag.Severity, urn.URN, string) error {
 	return nil
 }
 
-func TestDiffConfig(t *testing.T) {
+func TestMuxerDiffConfig(t *testing.T) {
 	t.Parallel()
 	type testCase struct {
 		name           string

--- a/pkg/x/muxer/tests/muxer_test.go
+++ b/pkg/x/muxer/tests/muxer_test.go
@@ -204,7 +204,7 @@ func TestDivergentCheckConfig(t *testing.T) {
 	mux(t, m).replay(e)
 }
 
-func TestGetMapping(t *testing.T) {
+func TestMuxerGetMapping(t *testing.T) {
 	t.Parallel()
 	t.Run("single-responding-server", func(t *testing.T) {
 		var m muxer.DispatchTable

--- a/unstable/propertyvalue/ignore_changes_test.go
+++ b/unstable/propertyvalue/ignore_changes_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestIgnoreChanges(t *testing.T) {
+func TestPVIgnoreChanges(t *testing.T) {
 	t.Parallel()
 	old := func() resource.PropertyMap {
 		return resource.PropertyMap{


### PR DESCRIPTION
Rename all clashing tests so that sharding can run effectively without running the same tests in multiple jobs.

fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/2993