### PR TITLE
Double number of test shards

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   # Note this needs to match the shard input to the test matrix below as well as pattern in exclude.
   # see jobs.test.strategy.matrix.{shard,exclude}
-  TOTAL_SHARDS: 15
+  TOTAL_SHARDS: 30
   ESC_ACTION_OIDC_AUTH: true
   ESC_ACTION_OIDC_ORGANIZATION: pulumi
   ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
@@ -34,7 +34,7 @@ jobs:
         platform: [ubuntu-latest, macos-latest, windows-latest]
         feature-flags: ["DEFAULT", "PULUMI_RAW_STATE_DELTA_ENABLED"]
         # Needs to match TOTAL_SHARDS
-        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29]
         exclude:
           # Windows and mac test runs do not need to be sharded as they are fast enough.
           # In order to do that we will skip all except the 0-th shard.
@@ -66,6 +66,36 @@ jobs:
             shard: 13
           - platform: windows-latest
             shard: 14
+          - platform: windows-latest
+            shard: 15
+          - platform: windows-latest
+            shard: 16
+          - platform: windows-latest
+            shard: 17
+          - platform: windows-latest
+            shard: 18
+          - platform: windows-latest
+            shard: 19
+          - platform: windows-latest
+            shard: 20
+          - platform: windows-latest
+            shard: 21
+          - platform: windows-latest
+            shard: 22
+          - platform: windows-latest
+            shard: 23
+          - platform: windows-latest
+            shard: 24
+          - platform: windows-latest
+            shard: 25
+          - platform: windows-latest
+            shard: 26
+          - platform: windows-latest
+            shard: 27
+          - platform: windows-latest
+            shard: 28
+          - platform: windows-latest
+            shard: 29
           - platform: macos-latest
             shard: 1
           - platform: macos-latest
@@ -94,6 +124,36 @@ jobs:
             shard: 13
           - platform: macos-latest
             shard: 14
+          - platform: macos-latest
+            shard: 15
+          - platform: macos-latest
+            shard: 16
+          - platform: macos-latest
+            shard: 17
+          - platform: macos-latest
+            shard: 18
+          - platform: macos-latest
+            shard: 19
+          - platform: macos-latest
+            shard: 20
+          - platform: macos-latest
+            shard: 21
+          - platform: macos-latest
+            shard: 22
+          - platform: macos-latest
+            shard: 23
+          - platform: macos-latest
+            shard: 24
+          - platform: macos-latest
+            shard: 25
+          - platform: macos-latest
+            shard: 26
+          - platform: macos-latest
+            shard: 27
+          - platform: macos-latest
+            shard: 28
+          - platform: macos-latest
+            shard: 29
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Fetch secrets from ESC


### PR DESCRIPTION
Double the number of test shards in the bridge. We have quite a few tests here and available concurrent runners, so we can get quicker CI runs with more runners.

fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/2993