### PR TITLE
Fix PF dynamic type diff error

### DIFF
--- a/pkg/pf/tests/diff_test/diff_test.go
+++ b/pkg/pf/tests/diff_test/diff_test.go
@@ -3,6 +3,7 @@ package tfbridgetests
 import (
 	"context"
 	"math/big"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -10,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hexops/autogold/v2"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/zclconf/go-cty/cty"
 
 	pb "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/providerbuilder"
@@ -182,6 +184,10 @@ func TestPFDetailedDiffStringAttribute(t *testing.T) {
 
 func TestPFDetailedDiffDynamicType(t *testing.T) {
 	t.Parallel()
+	if d, ok := os.LookupEnv("PULUMI_RAW_STATE_DELTA_ENABLED"); ok && cmdutil.IsTruthy(d) {
+		// TODO[pulumi/pulumi-terraform-bridge#3078]
+		t.Skip("Does not work with PULUMI_RAW_STATE_DELTA_ENABLED=true")
+	}
 
 	attributeSchema := rschema.Schema{
 		Attributes: map[string]rschema.Attribute{

--- a/pkg/pf/tests/diff_test/diff_test.go
+++ b/pkg/pf/tests/diff_test/diff_test.go
@@ -206,10 +206,4 @@ func TestPFDetailedDiffDynamicType(t *testing.T) {
 			ResourceSchema: attributeSchema,
 		}), map[string]cty.Value{"key": cty.NumberVal(big.NewFloat(1))}, map[string]cty.Value{"key": cty.NumberVal(big.NewFloat(1))})
 	})
-
-	t.Run("type change", func(t *testing.T) {
-		crosstests.Diff(t, pb.NewResource(pb.NewResourceArgs{
-			ResourceSchema: attributeSchema,
-		}), map[string]cty.Value{"key": cty.StringVal("value")}, map[string]cty.Value{"key": cty.NumberVal(big.NewFloat(1))})
-	})
 }

--- a/pkg/pf/tests/diff_test/diff_test.go
+++ b/pkg/pf/tests/diff_test/diff_test.go
@@ -1,6 +1,7 @@
 package tfbridgetests
 
 import (
+	"math/big"
 	"testing"
 
 	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -175,4 +176,40 @@ func TestPFDetailedDiffStringAttribute(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPFDetailedDiffDynamicType(t *testing.T) {
+	t.Parallel()
+
+	attributeSchema := rschema.Schema{
+		Attributes: map[string]rschema.Attribute{
+			"key": rschema.DynamicAttribute{
+				Optional: true,
+			},
+		},
+	}
+
+	t.Run("no change", func(t *testing.T) {
+		crosstests.Diff(t, pb.NewResource(pb.NewResourceArgs{
+			ResourceSchema: attributeSchema,
+		}), map[string]cty.Value{"key": cty.StringVal("value")}, map[string]cty.Value{"key": cty.StringVal("value")})
+	})
+
+	t.Run("change", func(t *testing.T) {
+		crosstests.Diff(t, pb.NewResource(pb.NewResourceArgs{
+			ResourceSchema: attributeSchema,
+		}), map[string]cty.Value{"key": cty.StringVal("value")}, map[string]cty.Value{"key": cty.StringVal("value1")})
+	})
+
+	t.Run("int no change", func(t *testing.T) {
+		crosstests.Diff(t, pb.NewResource(pb.NewResourceArgs{
+			ResourceSchema: attributeSchema,
+		}), map[string]cty.Value{"key": cty.NumberVal(big.NewFloat(1))}, map[string]cty.Value{"key": cty.NumberVal(big.NewFloat(1))})
+	})
+
+	t.Run("type change", func(t *testing.T) {
+		crosstests.Diff(t, pb.NewResource(pb.NewResourceArgs{
+			ResourceSchema: attributeSchema,
+		}), map[string]cty.Value{"key": cty.StringVal("value")}, map[string]cty.Value{"key": cty.NumberVal(big.NewFloat(1))})
+	})
 }

--- a/pkg/pf/tests/diff_test/diff_test.go
+++ b/pkg/pf/tests/diff_test/diff_test.go
@@ -1,9 +1,11 @@
 package tfbridgetests
 
 import (
+	"context"
 	"math/big"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/resource"
 	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -188,22 +190,96 @@ func TestPFDetailedDiffDynamicType(t *testing.T) {
 			},
 		},
 	}
+	res := pb.NewResource(pb.NewResourceArgs{
+		ResourceSchema: attributeSchema,
+	})
 
 	t.Run("no change", func(t *testing.T) {
-		crosstests.Diff(t, pb.NewResource(pb.NewResourceArgs{
-			ResourceSchema: attributeSchema,
-		}), map[string]cty.Value{"key": cty.StringVal("value")}, map[string]cty.Value{"key": cty.StringVal("value")})
+		crosstests.Diff(t, res,
+			map[string]cty.Value{"key": cty.StringVal("value")},
+			map[string]cty.Value{"key": cty.StringVal("value")},
+		)
 	})
 
 	t.Run("change", func(t *testing.T) {
-		crosstests.Diff(t, pb.NewResource(pb.NewResourceArgs{
-			ResourceSchema: attributeSchema,
-		}), map[string]cty.Value{"key": cty.StringVal("value")}, map[string]cty.Value{"key": cty.StringVal("value1")})
+		crosstests.Diff(t, res,
+			map[string]cty.Value{"key": cty.StringVal("value")},
+			map[string]cty.Value{"key": cty.StringVal("value1")},
+		)
 	})
 
 	t.Run("int no change", func(t *testing.T) {
-		crosstests.Diff(t, pb.NewResource(pb.NewResourceArgs{
-			ResourceSchema: attributeSchema,
-		}), map[string]cty.Value{"key": cty.NumberVal(big.NewFloat(1))}, map[string]cty.Value{"key": cty.NumberVal(big.NewFloat(1))})
+		crosstests.Diff(t, res,
+			map[string]cty.Value{"key": cty.NumberVal(big.NewFloat(1))},
+			map[string]cty.Value{"key": cty.NumberVal(big.NewFloat(1))},
+		)
+	})
+
+	t.Run("type change", func(t *testing.T) {
+		// TODO[pulumi/pulumi-terraform-bridge#3078]
+		t.Skip(`Error converting tftypes.Number<"1"> (value2) at "AttributeName(\"key\")": can't unmarshal tftypes.Number into *string, expected string`)
+		crosstests.Diff(t, res,
+			map[string]cty.Value{"key": cty.StringVal("value")},
+			map[string]cty.Value{"key": cty.NumberVal(big.NewFloat(1))},
+		)
+	})
+}
+
+func TestPFDetailedDiffDynamicTypeWithMigration(t *testing.T) {
+	t.Parallel()
+	// TODO[pulumi/pulumi-terraform-bridge#3078]
+	t.Skip("DynamicPseudoType is not supported")
+
+	attributeSchema := rschema.Schema{
+		Attributes: map[string]rschema.Attribute{
+			"key": rschema.DynamicAttribute{
+				Optional: true,
+			},
+		},
+	}
+	res1 := pb.NewResource(pb.NewResourceArgs{
+		ResourceSchema: attributeSchema,
+	})
+
+	schema2 := rschema.Schema{
+		Attributes: map[string]rschema.Attribute{
+			"key": rschema.DynamicAttribute{
+				Optional: true,
+			},
+		},
+		Version: 1,
+	}
+	res2 := pb.NewResource(pb.NewResourceArgs{
+		ResourceSchema: schema2,
+		UpgradeStateFunc: func(ctx context.Context) map[int64]resource.StateUpgrader {
+			return map[int64]resource.StateUpgrader{
+				0: {
+					PriorSchema: &res1.ResourceSchema,
+					StateUpgrader: func(ctx context.Context, usr1 resource.UpgradeStateRequest, usr2 *resource.UpgradeStateResponse) {
+						usr2.State = *usr1.State
+					},
+				},
+			}
+		},
+	})
+
+	t.Run("no change", func(t *testing.T) {
+		crosstests.Diff(t, res1,
+			map[string]cty.Value{"key": cty.StringVal("value")},
+			map[string]cty.Value{"key": cty.StringVal("value")},
+			crosstests.DiffProviderUpgradedSchema(
+				res2,
+			),
+		)
+	})
+
+	t.Run("change", func(t *testing.T) {
+		crosstests.Diff(t, res1,
+			map[string]cty.Value{"key": cty.StringVal("value")},
+			map[string]cty.Value{"key": cty.StringVal("value1")},
+			crosstests.DiffProviderUpgradedSchema(
+				res2,
+			),
+		)
 	})
 }

--- a/pkg/pf/tfbridge/resource_state.go
+++ b/pkg/pf/tfbridge/resource_state.go
@@ -251,14 +251,9 @@ func (p *provider) parseAndUpgradeResourceState(
 	}
 
 	// Otherwise fallback to imprecise legacy parsing.
-	tfType := rh.schema.Type(ctx).(tftypes.Object)
 	value, err := convert.EncodePropertyMap(rh.encoder, props)
 	if err != nil {
 		return nil, fmt.Errorf("[pf/tfbridge] Error calling EncodePropertyMap: %w", err)
-	}
-	rawState, err := pfutils.NewRawState(tfType, value)
-	if err != nil {
-		return nil, fmt.Errorf("[pf/tfbridge] Error calling NewRawState: %w", err)
 	}
 
 	// Before EnableRawStateDelta rollout, the behavior used to be to skip the upgrade method in case of an exact
@@ -271,6 +266,13 @@ func (p *provider) parseAndUpgradeResourceState(
 			Value:           value,
 		}, nil
 	}
+
+	tfType := rh.schema.Type(ctx).(tftypes.Object)
+	rawState, err := pfutils.NewRawState(tfType, value)
+	if err != nil {
+		return nil, fmt.Errorf("[pf/tfbridge] Error calling NewRawState: %w", err)
+	}
+
 
 	return p.upgradeResourceState(ctx, rh, rawState, parsedMeta.PrivateState, stateVersion)
 }

--- a/pkg/pf/tfbridge/resource_state.go
+++ b/pkg/pf/tfbridge/resource_state.go
@@ -273,7 +273,6 @@ func (p *provider) parseAndUpgradeResourceState(
 		return nil, fmt.Errorf("[pf/tfbridge] Error calling NewRawState: %w", err)
 	}
 
-
 	return p.upgradeResourceState(ctx, rh, rawState, parsedMeta.PrivateState, stateVersion)
 }
 


### PR DESCRIPTION
In https://github.com/pulumi/pulumi-terraform-bridge/pull/2945/ we accidentally changed the behaviour for providers where RawStateDeltas were not enabled. After 2945 we would unconditionally produce the JSON serialization of the state even if it isn't used.

It is only used for upgrading state and for RawStateDeltas. The unintended effect here is that we exposed https://github.com/pulumi/pulumi-terraform-bridge/issues/3078 to all users of attributes of DynamicType even if no upgrades or RawStateDeltas are used.

This PR changes that to not produce the JSON serialization if not necessary. I've also added some tests for both the behaviour fixed here and the behaviour which needs https://github.com/pulumi/pulumi-terraform-bridge/issues/3078

fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/3095