### PR TITLE
Refactor shim interfaces to not be implementable externally

### DIFF
--- a/pkg/internal/internalinter/internalinter.go
+++ b/pkg/internal/internalinter/internalinter.go
@@ -1,0 +1,9 @@
+package internalinter
+
+type InternalInterface interface {
+	noimplement()
+}
+
+type Internal struct{}
+
+func (s Internal) noimplement() {}

--- a/pkg/pf/internal/schemashim/attr_schema.go
+++ b/pkg/pf/internal/schemashim/attr_schema.go
@@ -18,6 +18,7 @@ import (
 	pfattr "github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/internalinter"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/pfutils"
 	bridge "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
@@ -26,6 +27,11 @@ import (
 type attrSchema struct {
 	key  string
 	attr pfutils.Attr
+	internalinter.Internal
+}
+
+func newAttrSchema(key string, attr pfutils.Attr) *attrSchema {
+	return &attrSchema{key, attr, internalinter.Internal{}}
 }
 
 var _ shim.Schema = (*attrSchema)(nil)

--- a/pkg/pf/internal/schemashim/block_schema.go
+++ b/pkg/pf/internal/schemashim/block_schema.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/internalinter"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/pfutils"
 	bridge "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
@@ -28,10 +29,11 @@ import (
 type blockSchema struct {
 	key   string
 	block pfutils.Block
+	internalinter.Internal
 }
 
 func newBlockSchema(key string, block pfutils.Block) *blockSchema {
-	return &blockSchema{key, block}
+	return &blockSchema{key, block, internalinter.Internal{}}
 }
 
 var _ shim.Schema = (*blockSchema)(nil)

--- a/pkg/pf/internal/schemashim/custom_type_test.go
+++ b/pkg/pf/internal/schemashim/custom_type_test.go
@@ -51,7 +51,7 @@ func TestCustomTypeEmbeddingObjectType(t *testing.T) {
 		},
 	}
 
-	shimmed := &blockSchema{"key", pfutils.FromBlockLike(raw)}
+	shimmed := newBlockSchema("key", pfutils.FromBlockLike(raw))
 	assert.Equal(t, shim.TypeMap, shimmed.Type())
 	assert.NotNil(t, shimmed.Elem())
 	_, isPseudoResource := shimmed.Elem().(shim.Resource)
@@ -80,7 +80,7 @@ func TestCustomListType(t *testing.T) {
 		},
 	}
 
-	shimmed := &blockSchema{"key", pfutils.FromBlockLike(raw)}
+	shimmed := newBlockSchema("key", pfutils.FromBlockLike(raw))
 	assert.Equal(t, shim.TypeList, shimmed.Type())
 	assert.NotNil(t, shimmed.Elem())
 	_, isPseudoResource := shimmed.Elem().(shim.Resource)
@@ -109,7 +109,7 @@ func TestCustomListAttribute(t *testing.T) {
 		},
 	}
 
-	shimmed := &attrSchema{"key", pfutils.FromAttrLike(raw)}
+	shimmed := newAttrSchema("key", pfutils.FromAttrLike(raw))
 	assert.Equal(t, shim.TypeList, shimmed.Type())
 	assert.NotNil(t, shimmed.Elem())
 	_, isPseudoResource := shimmed.Elem().(shim.Schema)
@@ -138,7 +138,7 @@ func TestCustomSetType(t *testing.T) {
 		},
 	}
 
-	shimmed := &blockSchema{"key", pfutils.FromBlockLike(raw)}
+	shimmed := newBlockSchema("key", pfutils.FromBlockLike(raw))
 	assert.Equal(t, shim.TypeSet, shimmed.Type())
 	assert.NotNil(t, shimmed.Elem())
 	_, isPseudoResource := shimmed.Elem().(shim.Resource)

--- a/pkg/pf/internal/schemashim/datasource.go
+++ b/pkg/pf/internal/schemashim/datasource.go
@@ -15,12 +15,14 @@
 package schemashim
 
 import (
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/internalinter"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/runtypes"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
 type schemaOnlyDataSource struct {
 	tf runtypes.Schema
+	internalinter.Internal
 }
 
 var _ shim.Resource = (*schemaOnlyDataSource)(nil)

--- a/pkg/pf/internal/schemashim/datasource_map.go
+++ b/pkg/pf/internal/schemashim/datasource_map.go
@@ -17,6 +17,7 @@ package schemashim
 import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/internalinter"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/runtypes"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
@@ -27,7 +28,7 @@ func newSchemaOnlyDataSourceMap(dataSources runtypes.DataSources) schemaOnlyData
 	for _, name := range dataSources.All() {
 		key := string(name)
 		v := dataSources.Schema(name)
-		m[key] = &schemaOnlyDataSource{v}
+		m[key] = &schemaOnlyDataSource{v, internalinter.Internal{}}
 	}
 	return m
 }

--- a/pkg/pf/internal/schemashim/object_pseudoresource.go
+++ b/pkg/pf/internal/schemashim/object_pseudoresource.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/internalinter"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/pfutils"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
@@ -38,6 +39,7 @@ type objectPseudoResource struct {
 	nestedAttrs  map[string]pfutils.Attr
 	nestedBlocks map[string]pfutils.Block // should have disjoint keys from nestedAttrs
 	allAttrNames []string
+	internalinter.Internal
 }
 
 func newObjectPseudoResource(t basetypes.ObjectTypable,
@@ -127,7 +129,7 @@ func (r *objectPseudoResource) GetOk(key string) (shim.Schema, bool) {
 	// and recurse using attrSchema. This information may be coming out of band from the ObjectTypeable value itself
 	// when using blocks, see TestCustomTypeEmbeddingObjectType.
 	if attr, ok := r.nestedAttrs[key]; ok {
-		return &attrSchema{key, attr}, true
+		return newAttrSchema(key, attr), true
 	}
 
 	// Nested blocks are similar to attributes:
@@ -169,6 +171,7 @@ type tuplePseudoResource struct {
 	schemaOnly
 	attrs map[string]pfutils.Attr
 	tuple attr.TypeWithElementTypes
+	internalinter.Internal
 }
 
 type tupElementAttr struct{ e attr.Type }

--- a/pkg/pf/internal/schemashim/object_type_test.go
+++ b/pkg/pf/internal/schemashim/object_type_test.go
@@ -37,7 +37,7 @@ func TestObjectAttribute(t *testing.T) {
 			"s": basetypes.StringType{},
 		},
 	}
-	shimmed := &attrSchema{"key", pfutils.FromAttrLike(objectAttr)}
+	shimmed := newAttrSchema("key", pfutils.FromAttrLike(objectAttr))
 	assertIsObjectType(t, shimmed)
 	s := shimmed.Elem().(shim.Resource).Schema().Get("s")
 	assert.Equal(t, shim.TypeString, s.Type())
@@ -57,7 +57,7 @@ func TestSingleNestedBlock(t *testing.T) {
 	b := schema.SingleNestedBlock{
 		Attributes: simpleObjectAttributes(),
 	}
-	shimmed := &blockSchema{"key", pfutils.FromResourceBlock(b)}
+	shimmed := newBlockSchema("key", pfutils.FromResourceBlock(b))
 	assertIsObjectType(t, shimmed)
 	assert.Equal(t, "obj[c=str,co=str,desc=str,o=str,r=str]", schemaLogicalType(shimmed).String())
 	r, ok := shimmed.Elem().(shim.Resource)
@@ -72,7 +72,7 @@ func TestListNestedBlock(t *testing.T) {
 			Attributes: simpleObjectAttributes(),
 		},
 	}
-	shimmed := &blockSchema{"key", pfutils.FromResourceBlock(b)}
+	shimmed := newBlockSchema("key", pfutils.FromResourceBlock(b))
 	assert.Equal(t, "list[obj[c=str,co=str,desc=str,o=str,r=str]]", schemaLogicalType(shimmed).String())
 	r, ok := shimmed.Elem().(shim.Resource)
 	require.True(t, ok, "List-nested TF blocks should be represented as Elem() shim.Resource")
@@ -86,7 +86,7 @@ func TestSetNestedBlock(t *testing.T) {
 			Attributes: simpleObjectAttributes(),
 		},
 	}
-	shimmed := &blockSchema{"key", pfutils.FromResourceBlock(b)}
+	shimmed := newBlockSchema("key", pfutils.FromResourceBlock(b))
 	assert.Equal(t, "set[obj[c=str,co=str,desc=str,o=str,r=str]]", schemaLogicalType(shimmed).String())
 	r, ok := shimmed.Elem().(shim.Resource)
 	require.True(t, ok, "Set-nested TF blocks should be represented as Elem() shim.Resource")

--- a/pkg/pf/internal/schemashim/provider.go
+++ b/pkg/pf/internal/schemashim/provider.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/internalinter"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/pfutils"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/runtypes"
@@ -36,6 +37,7 @@ type SchemaOnlyProvider struct {
 	tf            pfprovider.Provider
 	resourceMap   schemaOnlyResourceMap
 	dataSourceMap schemaOnlyDataSourceMap
+	internalinter.Internal
 }
 
 func (p *SchemaOnlyProvider) Server(ctx context.Context) (tfprotov6.ProviderServer, error) {

--- a/pkg/pf/internal/schemashim/resource.go
+++ b/pkg/pf/internal/schemashim/resource.go
@@ -15,12 +15,18 @@
 package schemashim
 
 import (
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/internalinter"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/runtypes"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
 type schemaOnlyResource struct {
 	tf runtypes.Schema
+	internalinter.Internal
+}
+
+func newSchemaOnlyResource(tf runtypes.Schema) *schemaOnlyResource {
+	return &schemaOnlyResource{tf, internalinter.Internal{}}
 }
 
 var _ shim.Resource = (*schemaOnlyResource)(nil)

--- a/pkg/pf/internal/schemashim/type_schema.go
+++ b/pkg/pf/internal/schemashim/type_schema.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/internalinter"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/pfutils"
 	bridge "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
@@ -29,6 +30,7 @@ type typeSchema struct {
 
 	// Object types record attr metadata for each field here, if available.
 	nested map[string]pfutils.Attr
+	internalinter.Internal
 }
 
 var _ shim.Schema = (*typeSchema)(nil)

--- a/pkg/pf/internal/schemashim/type_schema_test.go
+++ b/pkg/pf/internal/schemashim/type_schema_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/internalinter"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
@@ -16,7 +17,7 @@ func TestMapAttribute(t *testing.T) {
 		Optional:    true,
 		ElementType: basetypes.StringType{},
 	}
-	shimmed := &typeSchema{mapAttr.GetType(), nil}
+	shimmed := &typeSchema{mapAttr.GetType(), nil, internalinter.Internal{}}
 	assertIsMapType(t, shimmed)
 	s := shimmed.Elem().(*typeSchema)
 	assert.Equal(t, shim.TypeString, s.Type())
@@ -31,18 +32,18 @@ func assertIsMapType(t *testing.T, shimmed shim.Schema) {
 
 func TestInt32Type(t *testing.T) {
 	t.Parallel()
-	shimmed := &typeSchema{basetypes.Int32Type{}, nil}
+	shimmed := &typeSchema{basetypes.Int32Type{}, nil, internalinter.Internal{}}
 	assert.Equal(t, shim.TypeInt, shimmed.Type())
 }
 
 func TestInt64Type(t *testing.T) {
 	t.Parallel()
-	shimmed := &typeSchema{basetypes.Int64Type{}, nil}
+	shimmed := &typeSchema{basetypes.Int64Type{}, nil, internalinter.Internal{}}
 	assert.Equal(t, shim.TypeInt, shimmed.Type())
 }
 
 func TestNumberType(t *testing.T) {
 	t.Parallel()
-	shimmed := &typeSchema{basetypes.NumberType{}, nil}
+	shimmed := &typeSchema{basetypes.NumberType{}, nil, internalinter.Internal{}}
 	assert.Equal(t, shim.TypeFloat, shimmed.Type())
 }

--- a/pkg/pf/proto/attribute.go
+++ b/pkg/pf/proto/attribute.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/internalinter"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
@@ -26,7 +27,14 @@ var (
 	_ = shim.SchemaWithWriteOnly(attribute{})
 )
 
-type attribute struct{ attr tfprotov6.SchemaAttribute }
+type attribute struct {
+	attr tfprotov6.SchemaAttribute
+	internalinter.Internal
+}
+
+func newAttribute(attr tfprotov6.SchemaAttribute) *attribute {
+	return &attribute{attr, internalinter.Internal{}}
+}
 
 // Simple schema options
 
@@ -85,7 +93,7 @@ func (a attribute) Elem() interface{} {
 			contract.Failf("Invalid attribute nesting: %s", a.attr.NestedType.Nesting)
 		}
 	}
-	return element{a.attr.ValueType(), a.Optional()}.Elem()
+	return newElement(a.attr.ValueType(), a.Optional()).Elem()
 }
 
 // Defaults are applied in the provider binary, not here

--- a/pkg/pf/proto/element.go
+++ b/pkg/pf/proto/element.go
@@ -17,6 +17,7 @@ package proto
 import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/internalinter"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
@@ -28,10 +29,17 @@ var (
 type element struct {
 	typ      tftypes.Type
 	optional bool
+	internalinter.Internal
 }
+
+func newElement(typ tftypes.Type, optional bool) *element {
+	return &element{typ, optional, internalinter.Internal{}}
+}
+
 type elementObject struct {
 	pseudoResource
 	typ tftypes.Object
+	internalinter.Internal
 }
 
 type elementObjectMap tftypes.Object
@@ -111,13 +119,13 @@ func (m elementObjectMap) GetOk(key string) (shim.Schema, bool) {
 		return nil, false
 	}
 	_, optional := m.OptionalAttributes[key]
-	return element{v, optional}, true
+	return newElement(v, optional), true
 }
 
 func (m elementObjectMap) Range(each func(key string, value shim.Schema) bool) {
 	for k, v := range m.AttributeTypes {
 		_, optional := m.OptionalAttributes[k]
-		if !each(k, element{v, optional}) {
+		if !each(k, newElement(v, optional)) {
 			return
 		}
 	}

--- a/pkg/pf/proto/object.go
+++ b/pkg/pf/proto/object.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/internalinter"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
@@ -29,6 +30,7 @@ var (
 type object struct {
 	pseudoResource
 	obj tfprotov6.SchemaObject
+	internalinter.Internal
 }
 
 func (o object) Schema() shim.SchemaMap {
@@ -54,12 +56,12 @@ func (m attrMap) GetOk(key string) (shim.Schema, bool) {
 	if !ok {
 		return nil, false
 	}
-	return attribute{*v}, true
+	return newAttribute(*v), true
 }
 
 func (m attrMap) Range(each func(key string, value shim.Schema) bool) {
 	for k, v := range m {
-		if !each(k, attribute{*v}) {
+		if !each(k, newAttribute(*v)) {
 			return
 		}
 	}

--- a/pkg/pf/proto/protov6.go
+++ b/pkg/pf/proto/protov6.go
@@ -27,6 +27,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/internalinter"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
@@ -67,6 +68,7 @@ type Provider struct {
 	//
 	// Used during Replace.
 	ctx context.Context
+	internalinter.Internal
 }
 
 // Get access to the underlying sever used in Provide

--- a/pkg/pf/proto/resource.go
+++ b/pkg/pf/proto/resource.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/internalinter"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
@@ -43,12 +44,12 @@ func (m resourceMap) GetOk(key string) (shim.Resource, bool) {
 	if !ok {
 		return nil, false
 	}
-	return resource{v}, true
+	return newResource(v), true
 }
 
 func (m resourceMap) Range(each func(key string, value shim.Resource) bool) {
 	for k, v := range m {
-		if !each(k, resource{v}) {
+		if !each(k, newResource(v)) {
 			return
 		}
 	}
@@ -60,7 +61,14 @@ func (m resourceMap) Set(key string, value shim.Resource) {
 	m[key] = v.r
 }
 
-type resource struct{ r *tfprotov6.Schema }
+type resource struct {
+	r *tfprotov6.Schema
+	internalinter.Internal
+}
+
+func newResource(r *tfprotov6.Schema) *resource {
+	return &resource{r, internalinter.Internal{}}
+}
 
 func (r resource) Schema() shim.SchemaMap {
 	return blockMap{r.r.Block}

--- a/pkg/tfshim/schema/provider.go
+++ b/pkg/tfshim/schema/provider.go
@@ -3,6 +3,7 @@ package schema
 import (
 	"context"
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/internalinter"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
@@ -10,6 +11,7 @@ type Provider struct {
 	Schema         shim.SchemaMap
 	ResourcesMap   shim.ResourceMap
 	DataSourcesMap shim.ResourceMap
+	internalinter.Internal
 }
 
 func (p *Provider) Shim() shim.Provider {
@@ -23,11 +25,16 @@ func (p *Provider) Shim() shim.Provider {
 	if c.DataSourcesMap == nil {
 		c.DataSourcesMap = ResourceMap{}
 	}
-	return ProviderShim{c}
+	return newProviderShim(c)
 }
 
 type ProviderShim struct {
 	V *Provider
+	internalinter.Internal
+}
+
+func newProviderShim(p *Provider) *ProviderShim {
+	return &ProviderShim{p, internalinter.Internal{}}
 }
 
 func (s ProviderShim) Schema() shim.SchemaMap {

--- a/pkg/tfshim/schema/resource.go
+++ b/pkg/tfshim/schema/resource.go
@@ -3,6 +3,7 @@ package schema
 import (
 	"fmt"
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/internalinter"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
@@ -22,6 +23,7 @@ func (r *Resource) Shim() shim.Resource {
 
 type ResourceShim struct {
 	V *Resource
+	internalinter.Internal
 }
 
 func (r ResourceShim) Schema() shim.SchemaMap {

--- a/pkg/tfshim/schema/schema.go
+++ b/pkg/tfshim/schema/schema.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/internalinter"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
@@ -28,12 +29,13 @@ type Schema struct {
 }
 
 func (s *Schema) Shim() shim.Schema {
-	return SchemaShim{s}
+	return SchemaShim{s, internalinter.Internal{}}
 }
 
 //nolint:revive
 type SchemaShim struct {
 	V *Schema
+	internalinter.Internal
 }
 
 func (s SchemaShim) Type() shim.ValueType {

--- a/pkg/tfshim/sdk-v1/instance_diff.go
+++ b/pkg/tfshim/sdk-v1/instance_diff.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/internalinter"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
@@ -42,6 +43,7 @@ func resourceAttrDiffToShim(d *terraform.ResourceAttrDiff) *shim.ResourceAttrDif
 
 type v1InstanceDiff struct {
 	tf *terraform.InstanceDiff
+	internalinter.Internal
 }
 
 func (d v1InstanceDiff) DiffEqualDecisionOverride() shim.DiffOverride {

--- a/pkg/tfshim/sdk-v1/instance_state.go
+++ b/pkg/tfshim/sdk-v1/instance_state.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	diff_reader "github.com/pulumi/terraform-diff-reader/sdk-v1"
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/internalinter"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
@@ -15,10 +16,11 @@ var _ = shim.InstanceState(v1InstanceState{})
 type v1InstanceState struct {
 	tf   *terraform.InstanceState
 	diff *terraform.InstanceDiff
+	internalinter.Internal
 }
 
 func NewInstanceState(s *terraform.InstanceState) shim.InstanceState {
-	return v1InstanceState{s, nil}
+	return v1InstanceState{tf: s}
 }
 
 func IsInstanceState(s shim.InstanceState) (*terraform.InstanceState, bool) {

--- a/pkg/tfshim/sdk-v1/provider.go
+++ b/pkg/tfshim/sdk-v1/provider.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/internalinter"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
@@ -34,7 +35,7 @@ func stateToShim(s *terraform.InstanceState) shim.InstanceState {
 	if s == nil {
 		return nil
 	}
-	return v1InstanceState{s, nil}
+	return v1InstanceState{tf: s}
 }
 
 func diffFromShim(d shim.InstanceDiff) *terraform.InstanceDiff {
@@ -48,15 +49,16 @@ func diffToShim(d *terraform.InstanceDiff) shim.InstanceDiff {
 	if d == nil {
 		return nil
 	}
-	return v1InstanceDiff{d}
+	return v1InstanceDiff{tf: d}
 }
 
 type v1Provider struct {
 	tf *schema.Provider
+	internalinter.Internal
 }
 
 func NewProvider(p *schema.Provider) shim.Provider {
-	return v1Provider{p}
+	return v1Provider{tf: p}
 }
 
 func (p v1Provider) Schema() shim.SchemaMap {
@@ -157,7 +159,7 @@ func (p v1Provider) InitLogging(_ context.Context) {
 }
 
 func (p v1Provider) NewDestroyDiff(_ context.Context, t string, opts shim.TimeoutOptions) shim.InstanceDiff {
-	d := v1InstanceDiff{&terraform.InstanceDiff{Destroy: true}}
+	d := v1InstanceDiff{tf: &terraform.InstanceDiff{Destroy: true}}
 	d.applyTimeoutOptions(opts)
 	return d
 }

--- a/pkg/tfshim/sdk-v1/schema.go
+++ b/pkg/tfshim/sdk-v1/schema.go
@@ -4,6 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/internalinter"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
@@ -22,10 +23,11 @@ const UnknownVariableValue = "74D93920-ED26-11E3-AC10-0800200C9A66"
 
 type v1Schema struct {
 	tf *schema.Schema
+	internalinter.Internal
 }
 
 func NewSchema(s *schema.Schema) shim.Schema {
-	return v1Schema{s}
+	return v1Schema{tf: s}
 }
 
 func (s v1Schema) Type() shim.ValueType {
@@ -88,9 +90,9 @@ func (s v1Schema) StateFunc() shim.SchemaStateFunc {
 func (s v1Schema) Elem() interface{} {
 	switch e := s.tf.Elem.(type) {
 	case *schema.Resource:
-		return v1Resource{e}
+		return v1Resource{tf: e}
 	case *schema.Schema:
-		return v1Schema{e}
+		return v1Schema{tf: e}
 	default:
 		return nil
 	}
@@ -182,14 +184,14 @@ func (m v1SchemaMap) Get(key string) shim.Schema {
 
 func (m v1SchemaMap) GetOk(key string) (shim.Schema, bool) {
 	if s, ok := m[key]; ok {
-		return v1Schema{s}, true
+		return v1Schema{tf: s}, true
 	}
 	return nil, false
 }
 
 func (m v1SchemaMap) Range(each func(key string, value shim.Schema) bool) {
 	for key, value := range m {
-		if !each(key, v1Schema{value}) {
+		if !each(key, v1Schema{tf: value}) {
 			return
 		}
 	}

--- a/pkg/tfshim/sdk-v2/instance_diff.go
+++ b/pkg/tfshim/sdk-v2/instance_diff.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/internalinter"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
@@ -32,6 +33,7 @@ func resourceAttrDiffToShim(d *terraform.ResourceAttrDiff) *shim.ResourceAttrDif
 
 type v2InstanceDiff struct {
 	tf *terraform.InstanceDiff
+	internalinter.Internal
 }
 
 func (d v2InstanceDiff) DiffEqualDecisionOverride() shim.DiffOverride {

--- a/pkg/tfshim/sdk-v2/instance_state.go
+++ b/pkg/tfshim/sdk-v2/instance_state.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	diff_reader "github.com/pulumi/terraform-diff-reader/sdk-v2"
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/internalinter"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
@@ -34,6 +35,7 @@ type v2InstanceState struct {
 	resource *schema.Resource
 	tf       *terraform.InstanceState
 	diff     *terraform.InstanceDiff
+	internalinter.Internal
 }
 
 func NewInstanceState(s *terraform.InstanceState) shim.InstanceState {

--- a/pkg/tfshim/sdk-v2/provider.go
+++ b/pkg/tfshim/sdk-v2/provider.go
@@ -11,6 +11,7 @@ import (
 	testing "github.com/mitchellh/go-testing-interface"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/internalinter"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
@@ -41,7 +42,7 @@ func diffToShim(d *terraform.InstanceDiff) shim.InstanceDiff {
 	if d == nil {
 		return nil
 	}
-	return v2InstanceDiff{d}
+	return v2InstanceDiff{tf: d}
 }
 
 type v2Provider struct {
@@ -50,6 +51,7 @@ type v2Provider struct {
 
 	server       *grpcServer
 	planEditFunc PlanStateEditFunc
+	internalinter.Internal
 }
 
 var (

--- a/pkg/tfshim/sdk-v2/schema.go
+++ b/pkg/tfshim/sdk-v2/schema.go
@@ -3,6 +3,7 @@ package sdkv2
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/internalinter"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
@@ -24,10 +25,11 @@ const UnknownVariableValue = "74D93920-ED26-11E3-AC10-0800200C9A66"
 
 type v2Schema struct {
 	tf *schema.Schema
+	internalinter.Internal
 }
 
 func NewSchema(s *schema.Schema) shim.Schema {
-	return v2Schema{s}
+	return v2Schema{tf: s}
 }
 
 func (s v2Schema) Type() shim.ValueType {
@@ -95,9 +97,9 @@ func (s v2Schema) StateFunc() shim.SchemaStateFunc {
 func (s v2Schema) Elem() interface{} {
 	switch e := s.tf.Elem.(type) {
 	case *schema.Resource:
-		return v2Resource{e}
+		return v2Resource{tf: e}
 	case *schema.Schema:
-		return v2Schema{e}
+		return v2Schema{tf: e}
 	default:
 		return nil
 	}
@@ -212,14 +214,14 @@ func (m v2SchemaMap) Get(key string) shim.Schema {
 
 func (m v2SchemaMap) GetOk(key string) (shim.Schema, bool) {
 	if s, ok := m[key]; ok {
-		return v2Schema{s}, true
+		return v2Schema{tf: s}, true
 	}
 	return nil, false
 }
 
 func (m v2SchemaMap) Range(each func(key string, value shim.Schema) bool) {
 	for key, value := range m {
-		if !each(key, v2Schema{value}) {
+		if !each(key, v2Schema{tf: value}) {
 			return
 		}
 	}

--- a/pkg/tfshim/shim.go
+++ b/pkg/tfshim/shim.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/internalinter"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/rawstate"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/valueshim"
 )
@@ -31,11 +32,17 @@ type InstanceState interface {
 
 	Object(sch SchemaMap) (map[string]interface{}, error)
 	Meta() map[string]interface{}
+
+	// This is a no-op internal interface to prevent external users from implementing the interface.
+	internalinter.InternalInterface
 }
 
 // Newer versions of the bridge want to interact with a typed representation of the state.
 type InstanceStateWithTypedValue interface {
 	Value() valueshim.Value
+
+	// This is a no-op internal interface to prevent external users from implementing the interface.
+	internalinter.InternalInterface
 }
 
 type DiffAttrType byte
@@ -81,6 +88,8 @@ type InstanceDiff interface {
 	DiffEqualDecisionOverride() DiffOverride
 	// Required if DiffEqualDecisionOverride is enabled.
 	PriorState() (InstanceState, error)
+	// This is a no-op internal interface to prevent external users from implementing the interface.
+	internalinter.InternalInterface
 }
 
 type ValueType int
@@ -200,6 +209,8 @@ type Schema interface {
 	SetElement(config interface{}) (interface{}, error)
 	// Deprecated: use [SchemaWithSetElementHash] and [SetElementHash] instead.
 	SetHash(v interface{}) int
+	// This is a no-op internal interface to prevent external users from implementing the interface.
+	internalinter.InternalInterface
 }
 
 type SchemaWithWriteOnly interface {
@@ -266,6 +277,9 @@ type Resource interface {
 	InstanceState(id string, object, meta map[string]interface{}) (InstanceState, error)
 
 	DecodeTimeouts(config ResourceConfig) (*ResourceTimeout, error)
+
+	// This is a no-op internal interface to prevent external users from implementing the interface.
+	internalinter.InternalInterface
 }
 
 type ResourceMap interface {
@@ -343,6 +357,8 @@ type Provider interface {
 	// SupportsUnknownCollections returns false if the provider needs special handling of unknown collections.
 	// False for the sdkv1 provider.
 	SupportsUnknownCollections() bool
+	// This is a no-op internal interface to prevent external users from implementing the interface.
+	internalinter.InternalInterface
 }
 
 type TimeoutOptions struct {

--- a/pkg/tfshim/util/filter.go
+++ b/pkg/tfshim/util/filter.go
@@ -17,6 +17,7 @@ package util
 import (
 	"context"
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/internalinter"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
@@ -43,6 +44,7 @@ type FilteringProvider struct {
 	Provider         shim.Provider
 	ResourceFilter   func(token string) bool
 	DataSourceFilter func(token string) bool
+	internalinter.Internal
 }
 
 var _ = (shim.Provider)((*FilteringProvider)(nil))

--- a/pkg/tfshim/util/util.go
+++ b/pkg/tfshim/util/util.go
@@ -17,13 +17,16 @@ package util
 import (
 	"context"
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/internalinter"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
 var _ = (shim.Provider)((*UnimplementedProvider)(nil))
 
 // An embed-able unimplemented Provider for use in testing.
-type UnimplementedProvider struct{}
+type UnimplementedProvider struct {
+	internalinter.Internal
+}
 
 func (UnimplementedProvider) Schema() shim.SchemaMap           { panic("unimplemented") }
 func (UnimplementedProvider) ResourcesMap() shim.ResourceMap   { panic("unimplemented") }


### PR DESCRIPTION
This PR is a pure refactor. The `shim` interfaces are not intended to be implemented externally. They change often and due to the fact they are public we have kept accruing new variants to keep the public interface backwards compatible which add unnecessary complexity.

This PR adds `InternalInterface` interface with a private method which is only implemented by `internalinter.Internal`. This can be embedded in interfaces which are not intended to be implemented outside of the bridge. Implementers in the bridge can embed the implementation of `InternalInterface` but external users can not.

This means that we are free to add methods to interfaces which are not intended to be implemented externally. This will in turn allow us to delete some of the `Schema` and `Resource` variants under `shim`.
