### PR TITLE
 Required properties with default will now project as optional for SDKv1 providers

### DIFF
--- a/pkg/pf/internal/schemashim/attr_schema.go
+++ b/pkg/pf/internal/schemashim/attr_schema.go
@@ -36,10 +36,6 @@ func newAttrSchema(key string, attr pfutils.Attr) *attrSchema {
 
 var _ shim.Schema = (*attrSchema)(nil)
 
-var _ shim.SchemaWithWriteOnly = (*attrSchema)(nil)
-
-var _ shim.SchemaWithHasDefault = (*attrSchema)(nil)
-
 func (s *attrSchema) Type() shim.ValueType {
 	ty := s.attr.GetType()
 	vt, err := convertType(ty)
@@ -163,4 +159,12 @@ func (*attrSchema) SetElement(config interface{}) (interface{}, error) {
 
 func (*attrSchema) SetHash(v interface{}) int {
 	panic("SetHash() should not be called during schema generation")
+}
+
+func (*attrSchema) SetElementHash(v interface{}) (int, error) {
+	panic("SetElementHash() should not be called during schema generation")
+}
+
+func (*attrSchema) NewSet(v []interface{}) interface{} {
+	panic("NewSet() should not be called during schema generation")
 }

--- a/pkg/pf/internal/schemashim/block_schema.go
+++ b/pkg/pf/internal/schemashim/block_schema.go
@@ -136,6 +136,10 @@ func (*blockSchema) DefaultValue() (interface{}, error) {
 	return nil, bridge.ErrSchemaDefaultValue
 }
 
+func (s *blockSchema) HasDefault() bool {
+	return false
+}
+
 func (*blockSchema) ExactlyOneOf() []string {
 	panic("ExactlyOneOf() should not be called during schema generation")
 }
@@ -148,6 +152,18 @@ func (*blockSchema) SetHash(v interface{}) int {
 	panic("SetHash() should not be called during schema generation")
 }
 
+func (*blockSchema) SetElementHash(v interface{}) (int, error) {
+	panic("SetElementHash() should not be called during schema generation")
+}
+
+func (*blockSchema) NewSet(v []interface{}) interface{} {
+	panic("NewSet() should not be called during schema generation")
+}
+
 func (*blockSchema) StateFunc() shim.SchemaStateFunc {
 	panic("StateFunc() should not be called during schema generation")
+}
+
+func (*blockSchema) WriteOnly() bool {
+	return false
 }

--- a/pkg/pf/internal/schemashim/type_schema.go
+++ b/pkg/pf/internal/schemashim/type_schema.go
@@ -94,6 +94,10 @@ func (*typeSchema) DefaultValue() (interface{}, error) {
 	return nil, bridge.ErrSchemaDefaultValue
 }
 
+func (*typeSchema) HasDefault() bool {
+	return false
+}
+
 func (*typeSchema) Description() string {
 	return ""
 }
@@ -119,4 +123,16 @@ func (*typeSchema) SetElement(config interface{}) (interface{}, error) {
 
 func (*typeSchema) SetHash(v interface{}) int {
 	panic("SetHash() should not be called during schema generation")
+}
+
+func (*typeSchema) SetElementHash(v interface{}) (int, error) {
+	panic("SetElementHash() should not be called during schema generation")
+}
+
+func (*typeSchema) NewSet(v []interface{}) interface{} {
+	panic("NewSet() should not be called during schema generation")
+}
+
+func (*typeSchema) WriteOnly() bool {
+	return false
 }

--- a/pkg/pf/proto/attribute.go
+++ b/pkg/pf/proto/attribute.go
@@ -22,10 +22,7 @@ import (
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
-var (
-	_ = shim.Schema(attribute{})
-	_ = shim.SchemaWithWriteOnly(attribute{})
-)
+var _ = shim.Schema(attribute{})
 
 type attribute struct {
 	attr tfprotov6.SchemaAttribute
@@ -101,6 +98,7 @@ func (a attribute) Elem() interface{} {
 func (a attribute) Default() interface{}                { return nil }
 func (a attribute) DefaultFunc() shim.SchemaDefaultFunc { return nil }
 func (a attribute) DefaultValue() (interface{}, error)  { return nil, nil }
+func (a attribute) HasDefault() bool                    { return false }
 
 func (a attribute) StateFunc() shim.SchemaStateFunc { return nil }
 func (a attribute) ConflictsWith() []string         { return nil }
@@ -110,4 +108,6 @@ func (a attribute) SetElement(config interface{}) (interface{}, error) {
 	panic("UNIMPLIMENTED")
 }
 
-func (a attribute) SetHash(v interface{}) int { panic("UNIMPLIMENTED") }
+func (a attribute) SetHash(v interface{}) int                 { panic("UNIMPLIMENTED") }
+func (a attribute) SetElementHash(v interface{}) (int, error) { panic("UNIMPLIMENTED") }
+func (a attribute) NewSet(v []interface{}) interface{}        { panic("UNIMPLIMENTED") }

--- a/pkg/pf/proto/attribute.go
+++ b/pkg/pf/proto/attribute.go
@@ -104,10 +104,8 @@ func (a attribute) StateFunc() shim.SchemaStateFunc { return nil }
 func (a attribute) ConflictsWith() []string         { return nil }
 func (a attribute) ExactlyOneOf() []string          { return nil }
 
-func (a attribute) SetElement(config interface{}) (interface{}, error) {
-	panic("UNIMPLIMENTED")
-}
-
-func (a attribute) SetHash(v interface{}) int                 { panic("UNIMPLIMENTED") }
-func (a attribute) SetElementHash(v interface{}) (int, error) { panic("UNIMPLIMENTED") }
-func (a attribute) NewSet(v []interface{}) interface{}        { panic("UNIMPLIMENTED") }
+// Set functions are unused for PF - could be needed if PF opts into detailed diffs
+func (a attribute) SetElement(config interface{}) (interface{}, error) { panic("UNIMPLIMENTED") }
+func (a attribute) SetHash(v interface{}) int                          { panic("UNIMPLIMENTED") }
+func (a attribute) SetElementHash(v interface{}) (int, error)          { panic("UNIMPLIMENTED") }
+func (a attribute) NewSet(v []interface{}) interface{}                 { panic("UNIMPLIMENTED") }

--- a/pkg/pf/proto/block.go
+++ b/pkg/pf/proto/block.go
@@ -134,6 +134,7 @@ func (m blockSchema) Required() bool {
 func (m blockSchema) Default() interface{}                { return nil }
 func (m blockSchema) DefaultFunc() shim.SchemaDefaultFunc { return nil }
 func (m blockSchema) DefaultValue() (interface{}, error)  { return nil, nil }
+func (m blockSchema) HasDefault() bool                    { return false }
 func (m blockSchema) Description() string                 { return m.block.Block.Description }
 func (m blockSchema) Computed() bool                      { return false }
 func (m blockSchema) ForceNew() bool                      { return false }
@@ -150,3 +151,12 @@ func (m blockSchema) SetElement(config interface{}) (interface{}, error) {
 	panic("Cannot set a an element for a map type")
 }
 func (m blockSchema) SetHash(v interface{}) int { panic("Cannot set an hash for an object type") }
+func (m blockSchema) SetElementHash(v interface{}) (int, error) {
+	panic("UNIMPLIMENTED")
+}
+
+func (m blockSchema) NewSet(v []interface{}) interface{} {
+	panic("UNIMPLIMENTED")
+}
+
+func (m blockSchema) WriteOnly() bool { return false }

--- a/pkg/pf/proto/element.go
+++ b/pkg/pf/proto/element.go
@@ -90,6 +90,7 @@ func (e element) Required() bool                              { return false }
 func (e element) Default() interface{}                        { return nil }
 func (e element) DefaultFunc() shim.SchemaDefaultFunc         { return nil }
 func (e element) DefaultValue() (interface{}, error)          { return nil, nil }
+func (e element) HasDefault() bool                            { return false }
 func (e element) Description() string                         { return "" }
 func (e element) Computed() bool                              { return false }
 func (e element) ForceNew() bool                              { return false }
@@ -103,6 +104,9 @@ func (e element) Removed() string                             { return "" }
 func (e element) Sensitive() bool                             { return false }
 func (e element) SetElement(interface{}) (interface{}, error) { return nil, nil }
 func (e element) SetHash(interface{}) int                     { return 0 }
+func (e element) SetElementHash(interface{}) (int, error)     { return 0, nil }
+func (e element) NewSet([]interface{}) interface{}            { return nil }
+func (e element) WriteOnly() bool                             { return false }
 
 func (o elementObject) DeprecationMessage() string { return "" }
 func (o elementObject) Schema() shim.SchemaMap {

--- a/pkg/tfbridge/detailed_diff.go
+++ b/pkg/tfbridge/detailed_diff.go
@@ -363,9 +363,6 @@ func (differ detailedDiffer) calculateSetHashIndexMap(
 		convertedElements = append(convertedElements, convertedElem)
 	}
 
-	tfsh, ok := tfs.(shim.SchemaWithSetElementHash)
-	contract.Assertf(ok, "expected SchemaWithSetElementHash")
-
 	// Calculate the identity of each element. Note that the SetHash function can panic
 	// in the case of custom SetHash functions which get unexpected inputs.
 	for i, newElem := range convertedElements {
@@ -377,7 +374,7 @@ func (differ detailedDiffer) calculateSetHashIndexMap(
 						path.String(), r))
 				}
 			}()
-			setHash, err := tfsh.SetElementHash(newElem)
+			setHash, err := tfs.SetElementHash(newElem)
 			contract.AssertNoErrorf(
 				err, "Failed to calculate preview for element in %s: Failed to convert set element", path.String())
 			return setHash

--- a/pkg/tfbridge/diff.go
+++ b/pkg/tfbridge/diff.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
@@ -109,9 +108,6 @@ func visitPropertyValue(
 				}
 
 				if !e.IsComputed() && !e.IsOutput() {
-					tfs, ok := tfs.(shim.SchemaWithSetElementHash)
-					contract.Assertf(ok, "expected SchemaWithSetElementHash")
-
 					// We cannot compute the hash for computed values because they are represented by the UnknownVariableValue
 					// sentinel string, which may not be a legal value of the corresponding schema type, and SetHash does not
 					// account for computed values. Skipping this for unknown values will result in computing a diff only on the

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -291,7 +291,6 @@ type conversionContext struct {
 	// UseTFSetTypes will output TF Set types when converting sets.
 	// For example, if called on []string{"val1", "val2"}, it will output a TF Set with
 	// the same values: schema.NewSet([]interface{}{"val1", "val2"}).
-	// Note that this only works for schemas which implement shim.SchemaWithNewSet.
 	UseTFSetTypes bool
 	// DropUnknowns will drop unknown values from the input.
 	DropUnknowns bool
@@ -471,9 +470,8 @@ func (ctx *conversionContext) makeTerraformInput(
 			}
 		}
 
-		newSetSchema, ok := tfs.(shim.SchemaWithNewSet)
-		if ok && tfs.Type() == shim.TypeSet && ctx.UseTFSetTypes {
-			return newSetSchema.NewSet(arr), nil
+		if tfs.Type() == shim.TypeSet && ctx.UseTFSetTypes {
+			return tfs.NewSet(arr), nil
 		}
 
 		return arr, nil

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -1876,18 +1876,16 @@ func (g *Generator) propertyVariable(parentPath paths.TypePath, key string,
 		}
 		// Suppress write-only attributes via SchemaInfo.Omit
 		// TODO[pulumi/pulumi-terraform-bridge#2938] remove when the bridge fully supports write-only fields.
-		schemaWithWriteOnly, ok := shimSchema.(shim.SchemaWithWriteOnly)
-		if ok {
-			if schemaWithWriteOnly.WriteOnly() {
-				if info == nil {
-					info = make(map[string]*tfbridge.SchemaInfo)
-				}
-				if val, ok := info[key]; ok {
-					val.Omit = true
-				} else {
-					info[key] = &tfbridge.SchemaInfo{
-						Omit: true,
-					}
+
+		if shimSchema.WriteOnly() {
+			if info == nil {
+				info = make(map[string]*tfbridge.SchemaInfo)
+			}
+			if val, ok := info[key]; ok {
+				val.Omit = true
+			} else {
+				info[key] = &tfbridge.SchemaInfo{
+					Omit: true,
 				}
 			}
 		}

--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -44,7 +44,6 @@ import (
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen/internal/paths"
-	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/x/muxer"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/metadata"
 )
@@ -867,8 +866,8 @@ func (g *schemaGenerator) genResourceType(mod tokens.Module, res *resourceType) 
 		spec.InputProperties[prop.name] = g.genProperty(prop)
 
 		hasDefault := false
-		if s, ok := prop.schema.(shim.SchemaWithHasDefault); ok && !g.info.DisableRequiredWithDefaultTurningOptional {
-			hasDefault = s.HasDefault()
+		if !g.info.DisableRequiredWithDefaultTurningOptional {
+			hasDefault = prop.schema.HasDefault()
 		}
 
 		if !prop.optional() && !hasDefault {

--- a/pkg/tfshim/schema/schema.go
+++ b/pkg/tfshim/schema/schema.go
@@ -1,6 +1,8 @@
 package schema
 
 import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/internalinter"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
@@ -74,6 +76,10 @@ func (s SchemaShim) DefaultValue() (interface{}, error) {
 	return nil, nil
 }
 
+func (s SchemaShim) HasDefault() bool {
+	return s.V.Default != nil || s.V.DefaultFunc != nil
+}
+
 func (s SchemaShim) Description() string {
 	return s.V.Description
 }
@@ -132,6 +138,18 @@ func (s SchemaShim) SetElement(v interface{}) (interface{}, error) {
 
 func (s SchemaShim) SetHash(v interface{}) int {
 	return 0
+}
+
+func (s SchemaShim) NewSet(v []interface{}) interface{} {
+	return schema.NewSet(s.SetHash, v)
+}
+
+func (s SchemaShim) SetElementHash(v interface{}) (int, error) {
+	v, err := s.SetElement(v)
+	if err != nil {
+		return 0, err
+	}
+	return s.SetHash(v), nil
 }
 
 //nolint:revive

--- a/pkg/tfshim/sdk-v1/schema.go
+++ b/pkg/tfshim/sdk-v1/schema.go
@@ -10,8 +10,6 @@ import (
 
 var (
 	_ = shim.Schema(v1Schema{})
-	_ = shim.SchemaWithNewSet(v1Schema{})
-	_ = shim.SchemaWithSetElementHash(v1Schema{})
 	_ = shim.SchemaMap(v1SchemaMap{})
 )
 
@@ -69,6 +67,10 @@ func (s v1Schema) DefaultFunc() shim.SchemaDefaultFunc {
 
 func (s v1Schema) DefaultValue() (interface{}, error) {
 	return s.tf.DefaultValue()
+}
+
+func (s v1Schema) HasDefault() bool {
+	return s.tf.Default != nil || s.tf.DefaultFunc != nil
 }
 
 func (s v1Schema) Description() string {
@@ -157,6 +159,10 @@ func (s v1Schema) SetElementHash(v interface{}) (int, error) {
 
 func (s v1Schema) NewSet(v []interface{}) interface{} {
 	return schema.NewSet(s.SetHash, v)
+}
+
+func (s v1Schema) WriteOnly() bool {
+	return false
 }
 
 type v1SchemaMap map[string]*schema.Schema

--- a/pkg/tfshim/sdk-v2/schema.go
+++ b/pkg/tfshim/sdk-v2/schema.go
@@ -9,12 +9,8 @@ import (
 
 var (
 	_ = shim.Schema(v2Schema{})
-	_ = shim.SchemaWithNewSet(v2Schema{})
 	_ = shim.SchemaWithUnknownCollectionSupported(v2Schema{})
 	_ = shim.SchemaMap(v2SchemaMap{})
-	_ = shim.SchemaWithWriteOnly(v2Schema{})
-	_ = shim.SchemaWithSetElementHash(v2Schema{})
-	_ = shim.SchemaWithHasDefault(v2Schema{})
 )
 
 // UnknownVariableValue is the sentinal defined in github.com/hashicorp/terraform/configs/hcl2shim,

--- a/pkg/tfshim/shim.go
+++ b/pkg/tfshim/shim.go
@@ -209,34 +209,19 @@ type Schema interface {
 	SetElement(config interface{}) (interface{}, error)
 	// Deprecated: use [SchemaWithSetElementHash] and [SetElementHash] instead.
 	SetHash(v interface{}) int
+	NewSet(v []interface{}) interface{}
+	// SetElementHash returns a hash of the given set element.
+	// Note that it expects a set element without any unknown values.
+	SetElementHash(v interface{}) (int, error)
+	WriteOnly() bool
+	HasDefault() bool
 	// This is a no-op internal interface to prevent external users from implementing the interface.
 	internalinter.InternalInterface
 }
 
-type SchemaWithWriteOnly interface {
-	Schema
-	WriteOnly() bool
-}
-
-type SchemaWithNewSet interface {
-	Schema
-	NewSet(v []interface{}) interface{}
-}
 type SchemaWithUnknownCollectionSupported interface {
 	Schema
 	SupportsUnknownCollections()
-}
-
-type SchemaWithSetElementHash interface {
-	Schema
-	// SetElementHash returns a hash of the given set element.
-	// Note that it expects a set element without any unknown values.
-	SetElementHash(v interface{}) (int, error)
-}
-
-type SchemaWithHasDefault interface {
-	Schema
-	HasDefault() bool
 }
 
 type SchemaMap interface {


### PR DESCRIPTION
~Pure refactor.~ Now that adding methods to the `shim` interfaces is no longer breaking we can remove some of the unnecessary interface clutter.

The only effective change here is that the SDKv1 now implements `HasDefault`, which means https://github.com/pulumi/pulumi-terraform-bridge/pull/3035 will apply to it as well. This is unlikely to have a meaningful impact.