### PR TITLE
Fix convertExamplesInObjectSpec to avoid in-place modification

### DIFF
--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -1106,9 +1106,12 @@ func (g *Generator) convertExamplesInPropertySpec(path examplePath, spec pschema
 
 func (g *Generator) convertExamplesInObjectSpec(path examplePath, spec pschema.ObjectTypeSpec) pschema.ObjectTypeSpec {
 	spec.Description = g.convertExamples(spec.Description, path)
+
+	newProperties := map[string]pschema.PropertySpec{}
 	for name, prop := range spec.Properties {
-		spec.Properties[name] = g.convertExamplesInPropertySpec(path.Property(name), prop)
+		newProperties[name] = g.convertExamplesInPropertySpec(path.Property(name), prop)
 	}
+	spec.Properties = newProperties
 	return spec
 }
 


### PR DESCRIPTION
Due to an unfortunate interaction, pulumi/pulumi-aws on commit 7c14e422b23f9fbb34e37e381adb9d9ee4da49b4 started generating `{convertExamples:123}` markers into the schema. These markers are an artifact of convert_cli.go implementation and should not leak.

The root cause is subtle, with type reuse introduced in pulumi-aws, convertExamplesInObjectSpec gets to repeatedly traverse the same in-memory location, which causes cliConverter.StartConvertingExamples() to call itself:

    docs = StartConvertingExamples(StartConvertingExamples(docs, p), p)

Which breaks the assumptions, as it now assumes `{convertExamples:%d}` is an HCL snippet.

The simple fix here is to avoid self-modifying the schema during convertExamplesInObjectSpec. This is the expected behavior with the signature:

```
    func (g *Generator) convertExamplesInObjectSpec(path examplePath, spec pschema.ObjectTypeSpec) pschema.ObjectTypeSpec {
```

If later this changes to in-place traversal for efficiency, the signature should also change to not return ObjectTypeSpec.