### PR TITLE
Fix diffing assets and archives

### DIFF
--- a/pkg/tests/schema_pulumi_test.go
+++ b/pkg/tests/schema_pulumi_test.go
@@ -837,7 +837,7 @@ func TestAssetDiff(t *testing.T) {
 		prev := pt.Preview(t, optpreview.Diff())
 
 		require.Contains(t, prev.StdOut, "- testPath: asset(file:2cf24db)")
-		require.Contains(t, prev.StdOut, "+ testPath: asset(file:486ea46)(file:")
+		require.Contains(t, prev.StdOut, "+ testPath: asset(file:486ea46)")
 		require.Contains(t, prev.StdOut, "~ 1 to update")
 
 		pt.Up(t)

--- a/pkg/tests/schema_pulumi_test.go
+++ b/pkg/tests/schema_pulumi_test.go
@@ -836,6 +836,8 @@ func TestAssetDiff(t *testing.T) {
 
 		prev := pt.Preview(t, optpreview.Diff())
 
+		require.Contains(t, prev.StdOut, "- testPath: asset(file:2cf24db)")
+		require.Contains(t, prev.StdOut, "+ testPath: asset(file:486ea46)(file:")
 		require.Contains(t, prev.StdOut, "~ 1 to update")
 
 		pt.Up(t)
@@ -875,7 +877,10 @@ func TestAssetDiff(t *testing.T) {
     ~ prov:index/test:Test: (update)
         [id=newid]
         [urn=urn:pulumi:test::test::prov:index/test:Test::mainRes]
-        testPath  : asset(text:2cf24db) {
+      - testPath: asset(text:2cf24db) {
+            <contents elided>
+        }
+      + testPath: asset(text:486ea46) {
             <contents elided>
         }
 Resources:
@@ -950,6 +955,7 @@ func TestArchiveDiff(t *testing.T) {
 
 		prev := pt.Preview(t, optpreview.Diff())
 
+		require.Contains(t, prev.StdOut, "~ testPath: archive(file:8933f25->e22d32b)")
 		require.Contains(t, prev.StdOut, "~ 1 to update")
 
 		pt.Up(t)
@@ -997,12 +1003,10 @@ func TestArchiveDiff(t *testing.T) {
     ~ prov:index/test:Test: (update)
         [id=newid]
         [urn=urn:pulumi:test::test::prov:index/test:Test::mainRes]
-        testPath  : archive(assets:2a03253) {
-            "file1": asset(text:2cf24db) {
-                <contents elided>
+      ~ testPath: archive(assets:2a03253->4c74cbf) {
+          ~ "file1": asset(text:2cf24db->91e9240) {"<contents elided>" => "<contents elided>"
             }
-            "file2": asset(text:486ea46) {
-                <contents elided>
+          ~ "file2": asset(text:486ea46->da4c6d4) {"<contents elided>" => "<contents elided>"
             }
         }
 Resources:

--- a/pkg/tfbridge/detailed_diff.go
+++ b/pkg/tfbridge/detailed_diff.go
@@ -829,6 +829,7 @@ func makeDetailedDiffV2(
 	state shim.InstanceState,
 	diff shim.InstanceDiff,
 	assets AssetTable,
+	oldAssets AssetTable,
 	supportsSecrets bool,
 	newInputs resource.PropertyMap,
 	replaceOverride *bool,
@@ -848,7 +849,7 @@ func makeDetailedDiffV2(
 	if err != nil {
 		return nil, err
 	}
-	priorProps, err := MakeTerraformResult(ctx, prov, prior, tfs, ps, assets, supportsSecrets)
+	priorProps, err := MakeTerraformResult(ctx, prov, prior, tfs, ps, oldAssets, supportsSecrets)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tfbridge/property_path.go
+++ b/pkg/tfbridge/property_path.go
@@ -1,8 +1,6 @@
 package tfbridge
 
 import (
-	"fmt"
-
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -61,40 +59,6 @@ func (k propertyPath) IsReservedKey() bool {
 func (k propertyPath) GetFromMap(v resource.PropertyMap) (resource.PropertyValue, bool) {
 	path := resource.PropertyPath(k)
 	return path.Get(resource.NewProperty(v))
-}
-
-// GetFromSchemaInfo looks up the schema info for the given path.
-// It returns nil if the path is not found in the schema info map.
-// It returns an error if the path is not a valid property path.
-func (k propertyPath) GetFromSchemaInfo(ps map[string]*info.Schema) (*info.Schema, error) {
-	var info *info.Schema
-	top := k[0]
-	stringTop, ok := top.(string)
-	if !ok {
-		return nil, fmt.Errorf("expected path to start with a string, got %T, %v", top, top)
-	}
-
-	info = ps[stringTop]
-	for _, p := range k[1:] {
-		if info == nil {
-			return nil, nil
-		}
-		if stringP, ok := p.(string); ok {
-			if info.Fields == nil {
-				return nil, nil
-			}
-			info = info.Fields[stringP]
-		} else if _, ok := p.(int); ok {
-			if info.Elem == nil {
-				return nil, nil
-			}
-			info = info.Elem
-		} else {
-			return nil, fmt.Errorf("unexpected path element %T, %v", p, p)
-		}
-	}
-
-	return info, nil
 }
 
 func lookupSchemas(

--- a/pkg/tfbridge/property_path.go
+++ b/pkg/tfbridge/property_path.go
@@ -1,6 +1,8 @@
 package tfbridge
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -11,6 +13,8 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/propertyvalue"
 )
 
+// propertyPath is a wrapper around resource.PropertyPath that adds some convenience methods.
+// If the path is constructed using the propertyPath methods, it will only have string and int elements.
 type propertyPath resource.PropertyPath
 
 func isForceNew(tfs shim.Schema, ps *SchemaInfo) bool {
@@ -57,6 +61,40 @@ func (k propertyPath) IsReservedKey() bool {
 func (k propertyPath) GetFromMap(v resource.PropertyMap) (resource.PropertyValue, bool) {
 	path := resource.PropertyPath(k)
 	return path.Get(resource.NewProperty(v))
+}
+
+// GetFromSchemaInfo looks up the schema info for the given path.
+// It returns nil if the path is not found in the schema info map.
+// It returns an error if the path is not a valid property path.
+func (k propertyPath) GetFromSchemaInfo(ps map[string]*info.Schema) (*info.Schema, error) {
+	var info *info.Schema
+	top := k[0]
+	stringTop, ok := top.(string)
+	if !ok {
+		return nil, fmt.Errorf("expected path to start with a string, got %T, %v", top, top)
+	}
+
+	info = ps[stringTop]
+	for _, p := range k[1:] {
+		if info == nil {
+			return nil, nil
+		}
+		if stringP, ok := p.(string); ok {
+			if info.Fields == nil {
+				return nil, nil
+			}
+			info = info.Fields[stringP]
+		} else if _, ok := p.(int); ok {
+			if info.Elem == nil {
+				return nil, nil
+			}
+			info = info.Elem
+		} else {
+			return nil, fmt.Errorf("unexpected path element %T, %v", p, p)
+		}
+	}
+
+	return info, nil
 }
 
 func lookupSchemas(

--- a/pkg/tfbridge/property_path_test.go
+++ b/pkg/tfbridge/property_path_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/require"
 
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
 )
@@ -312,101 +311,6 @@ func TestWalkTwoPropertyValues(t *testing.T) {
 func TestPropertyPath(t *testing.T) {
 	t.Parallel()
 	require.Equal(t, newPropertyPath("foo").Subpath("bar").Key(), detailedDiffKey("foo.bar"))
-}
-
-func TestGetFromSchemaInfo(t *testing.T) {
-	t.Parallel()
-
-	t.Run("top-level string property", func(t *testing.T) {
-		ps := map[string]*info.Schema{
-			"foo": {Name: "foo"},
-		}
-		path := newPropertyPath("foo")
-		sch, err := path.GetFromSchemaInfo(ps)
-		require.NoError(t, err)
-		require.NotNil(t, sch)
-		require.Equal(t, "foo", sch.Name)
-	})
-
-	t.Run("nested property", func(t *testing.T) {
-		ps := map[string]*info.Schema{
-			"parent": {
-				Name: "parent",
-				Fields: map[string]*info.Schema{
-					"child": {Name: "child"},
-				},
-			},
-		}
-		path := newPropertyPath("parent").Subpath("child")
-		sch, err := path.GetFromSchemaInfo(ps)
-		require.NoError(t, err)
-		require.NotNil(t, sch)
-		require.Equal(t, "child", sch.Name)
-	})
-
-	t.Run("list element property", func(t *testing.T) {
-		ps := map[string]*info.Schema{
-			"list": {
-				Name: "list",
-				Elem: &info.Schema{
-					Name: "elem",
-				},
-			},
-		}
-		path := newPropertyPath("list").Index(0)
-		sch, err := path.GetFromSchemaInfo(ps)
-		require.NoError(t, err)
-		require.NotNil(t, sch)
-		require.Equal(t, "elem", sch.Name)
-	})
-
-	t.Run("nested list element property", func(t *testing.T) {
-		ps := map[string]*info.Schema{
-			"list": {
-				Name: "list",
-				Elem: &info.Schema{
-					Fields: map[string]*info.Schema{
-						"foo": {Name: "foo"},
-					},
-				},
-			},
-		}
-		path := newPropertyPath("list").Index(0).Subpath("foo")
-		sch, err := path.GetFromSchemaInfo(ps)
-		require.NoError(t, err)
-		require.NotNil(t, sch)
-		require.Equal(t, "foo", sch.Name)
-	})
-
-	t.Run("returns nil for missing property", func(t *testing.T) {
-		ps := map[string]*info.Schema{
-			"foo": {Name: "foo"},
-		}
-		path := newPropertyPath("bar")
-		sch, err := path.GetFromSchemaInfo(ps)
-		require.NoError(t, err)
-		require.Nil(t, sch)
-	})
-
-	t.Run("returns error for non-string top element", func(t *testing.T) {
-		ps := map[string]*info.Schema{
-			"foo": {Name: "foo"},
-		}
-		path := propertyPath{123}
-		sch, err := path.GetFromSchemaInfo(ps)
-		require.Error(t, err)
-		require.Nil(t, sch)
-	})
-
-	t.Run("returns error for unexpected path element type", func(t *testing.T) {
-		ps := map[string]*info.Schema{
-			"foo": {Name: "foo"},
-		}
-		path := propertyPath{"foo", 1.23}
-		sch, err := path.GetFromSchemaInfo(ps)
-		require.Error(t, err)
-		require.Nil(t, sch)
-	})
 }
 
 func TestLookupSchemasPropertyPath(t *testing.T) {

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -1133,10 +1133,7 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 		}
 
 		if res.Schema != nil {
-			oldAssets, err = getAssetTable(olds, res.Schema.Fields, res.TF.Schema())
-			if err != nil {
-				return nil, err
-			}
+			oldAssets = getAssetTable(olds, res.Schema.Fields, res.TF.Schema())
 		}
 	} else {
 		state, oldAssets, err = makeTerraformStateWithAssetsWithOpts(

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -1133,7 +1133,7 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 		}
 
 		if res.Schema != nil {
-			oldAssets, err = getAssetTable(olds, res.Schema.Fields)
+			oldAssets, err = getAssetTable(olds, res.Schema.Fields, res.TF.Schema())
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -1125,13 +1125,22 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 	}
 
 	var state shim.InstanceState
+	var oldAssets AssetTable
 	if pNew, enabled := makeTerraformStateViaUpgradeEnabled(p.info, p.tf, olds); enabled {
 		state, err = makeTerraformStateViaUpgrade(ctx, pNew, res, olds)
 		if err != nil {
 			return nil, errors.Wrapf(err, "unmarshaling %s's instance state via upgrade", urn)
 		}
+
+		if res.Schema != nil {
+			oldAssets, err = getAssetTable(olds, res.Schema.Fields)
+			if err != nil {
+				return nil, err
+			}
+		}
 	} else {
-		state, err = makeTerraformStateWithOpts(ctx, res, req.GetId(), olds, makeTerraformStateOptions(opts))
+		state, oldAssets, err = makeTerraformStateWithAssetsWithOpts(
+			ctx, res, req.GetId(), olds, makeTerraformStateOptions(opts))
 		if err != nil {
 			return nil, errors.Wrapf(err, "unmarshaling %s's instance state", urn)
 		}
@@ -1176,7 +1185,7 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 
 		replaceDecision := diff.RequiresNew()
 		detailedDiff, err = makeDetailedDiffV2(
-			ctx, schema, fields, res.TF, p.tf, state, diff, assets, p.supportsSecrets, news, &replaceDecision)
+			ctx, schema, fields, res.TF, p.tf, state, diff, assets, oldAssets, p.supportsSecrets, news, &replaceDecision)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -1884,7 +1884,7 @@ func ExtractInputsFromOutputs(oldInputs, outs resource.PropertyMap,
 	return extractSchemaInputsObject(outs, tfs, ps), nil
 }
 
-func getAssetTable(m resource.PropertyMap, ps map[string]*SchemaInfo, tfs shim.SchemaMap) (AssetTable, error) {
+func getAssetTable(m resource.PropertyMap, ps map[string]*SchemaInfo, tfs shim.SchemaMap) AssetTable {
 	assets := AssetTable{}
 	val := resource.NewObjectProperty(m)
 	_, err := propertyvalue.TransformPropertyValue(
@@ -1893,14 +1893,13 @@ func getAssetTable(m resource.PropertyMap, ps map[string]*SchemaInfo, tfs shim.S
 			if v.IsAsset() || v.IsArchive() {
 				schPath := PropertyPathToSchemaPath(p, tfs, ps)
 				info := LookupSchemaInfoMapPath(schPath, ps)
-				if info == nil {
-					return v, fmt.Errorf("unexpected asset %s", p.String())
-				}
+				contract.Assertf(info != nil, "unexpected asset %s", p.String())
 				assets[info] = v
 			}
 			return v, nil
 		},
 		val,
 	)
-	return assets, err
+	contract.AssertNoErrorf(err, "failed to transform property value")
+	return assets
 }

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -1893,6 +1893,9 @@ func getAssetTable(m resource.PropertyMap, ps map[string]*SchemaInfo, tfs shim.S
 			if v.IsAsset() || v.IsArchive() {
 				schPath := PropertyPathToSchemaPath(p, tfs, ps)
 				info := LookupSchemaInfoMapPath(schPath, ps)
+				if info == nil {
+					return v, fmt.Errorf("unexpected asset %s", p.String())
+				}
 				assets[info] = v
 			}
 			return v, nil

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -1884,20 +1884,15 @@ func ExtractInputsFromOutputs(oldInputs, outs resource.PropertyMap,
 	return extractSchemaInputsObject(outs, tfs, ps), nil
 }
 
-func getAssetTable(m resource.PropertyMap, ps map[string]*SchemaInfo) (AssetTable, error) {
+func getAssetTable(m resource.PropertyMap, ps map[string]*SchemaInfo, tfs shim.SchemaMap) (AssetTable, error) {
 	assets := AssetTable{}
 	val := resource.NewObjectProperty(m)
 	_, err := propertyvalue.TransformPropertyValue(
 		resource.PropertyPath{},
 		func(p resource.PropertyPath, v resource.PropertyValue) (resource.PropertyValue, error) {
 			if v.IsAsset() || v.IsArchive() {
-				info, err := propertyPath(p).GetFromSchemaInfo(ps)
-				if err != nil {
-					return v, err
-				}
-				if info == nil {
-					return v, fmt.Errorf("unexpected archive %s", p.String())
-				}
+				schPath := PropertyPathToSchemaPath(p, tfs, ps)
+				info := LookupSchemaInfoMapPath(schPath, ps)
 				assets[info] = v
 			}
 			return v, nil

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -35,6 +35,7 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/log"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/propertyvalue"
 )
 
 // This file deals with translating between the Pulumi representations of a resource's configuration and state and the
@@ -1345,6 +1346,33 @@ func makeTerraformStateViaUpgradeEnabled(
 	return pp, true
 }
 
+// makeTerraformStateWithAssetsWithOpts is used in Diff when [makeTerraformStateViaUpgrade] is not available.
+func makeTerraformStateWithAssetsWithOpts(
+	ctx context.Context,
+	res Resource,
+	id string,
+	m resource.PropertyMap,
+	opts makeTerraformStateOptions,
+) (shim.InstanceState, AssetTable, error) {
+	// Turn the resource properties into a map. For the most part, this is a straight
+	// Mappable, but we use MapReplace because we use float64s and Terraform uses
+	// ints, to represent numbers.
+	inputs, assets, err := makeTerraformInputsWithOptions(ctx, nil, nil, nil, m, res.TF.Schema(), res.Schema.Fields,
+		makeTerraformInputsOptions{DisableDefaults: true, DisableTFDefaults: true})
+	if err != nil {
+		return nil, nil, err
+	}
+	meta, err := parseMeta(m, res, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	instanceState, err := res.TF.InstanceState(id, inputs, meta)
+	if err != nil {
+		return nil, nil, err
+	}
+	return instanceState, assets, nil
+}
+
 // The old method used when [makeTerraformStateViaUpgrade] is not available.
 func makeTerraformStateWithOpts(
 	ctx context.Context,
@@ -1353,19 +1381,8 @@ func makeTerraformStateWithOpts(
 	m resource.PropertyMap,
 	opts makeTerraformStateOptions,
 ) (shim.InstanceState, error) {
-	// Turn the resource properties into a map. For the most part, this is a straight
-	// Mappable, but we use MapReplace because we use float64s and Terraform uses
-	// ints, to represent numbers.
-	inputs, _, err := makeTerraformInputsWithOptions(ctx, nil, nil, nil, m, res.TF.Schema(), res.Schema.Fields,
-		makeTerraformInputsOptions{DisableDefaults: true, DisableTFDefaults: true})
-	if err != nil {
-		return nil, err
-	}
-	meta, err := parseMeta(m, res, opts)
-	if err != nil {
-		return nil, err
-	}
-	return res.TF.InstanceState(id, inputs, meta)
+	state, _, err := makeTerraformStateWithAssetsWithOpts(ctx, res, id, m, opts)
+	return state, err
 }
 
 // The preferred method for recreating TF state that is used when the Pulumi state was written with a recent enough
@@ -1865,4 +1882,27 @@ func ExtractInputsFromOutputs(oldInputs, outs resource.PropertyMap,
 	}
 	// Otherwise, take a schema-directed approach that fills out all input-only properties.
 	return extractSchemaInputsObject(outs, tfs, ps), nil
+}
+
+func getAssetTable(m resource.PropertyMap, ps map[string]*SchemaInfo) (AssetTable, error) {
+	assets := AssetTable{}
+	val := resource.NewObjectProperty(m)
+	_, err := propertyvalue.TransformPropertyValue(
+		resource.PropertyPath{},
+		func(p resource.PropertyPath, v resource.PropertyValue) (resource.PropertyValue, error) {
+			if v.IsAsset() || v.IsArchive() {
+				info, err := propertyPath(p).GetFromSchemaInfo(ps)
+				if err != nil {
+					return v, err
+				}
+				if info == nil {
+					return v, fmt.Errorf("unexpected archive %s", p.String())
+				}
+				assets[info] = v
+			}
+			return v, nil
+		},
+		val,
+	)
+	return assets, err
 }

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -4232,7 +4232,7 @@ func TestGetAssetTable(t *testing.T) {
 		assetProp := resource.NewAssetProperty(asset)
 		props := resource.PropertyMap{"foo": assetProp}
 		ps := map[string]*SchemaInfo{"foo": {Asset: &AssetTranslation{Kind: FileAsset}}}
-		assets, err := getAssetTable(props, ps)
+		assets, err := getAssetTable(props, ps, nil)
 		assert.NoError(t, err)
 		require.Len(t, assets, 1)
 		for info, v := range assets {
@@ -4244,7 +4244,7 @@ func TestGetAssetTable(t *testing.T) {
 	t.Run("no assets present", func(t *testing.T) {
 		props := resource.PropertyMap{"bar": resource.NewStringProperty("baz")}
 		ps := map[string]*SchemaInfo{"bar": {}}
-		assets, err := getAssetTable(props, ps)
+		assets, err := getAssetTable(props, ps, nil)
 		assert.NoError(t, err)
 		assert.Empty(t, assets)
 	})
@@ -4257,7 +4257,7 @@ func TestGetAssetTable(t *testing.T) {
 		archiveProp := resource.NewArchiveProperty(archive)
 		props := resource.PropertyMap{"arch": archiveProp}
 		ps := map[string]*SchemaInfo{"arch": {Asset: &AssetTranslation{Kind: FileArchive}}}
-		assets, err := getAssetTable(props, ps)
+		assets, err := getAssetTable(props, ps, nil)
 		assert.NoError(t, err)
 		require.Len(t, assets, 1)
 		for info, v := range assets {
@@ -4272,7 +4272,7 @@ func TestGetAssetTable(t *testing.T) {
 		assetProp := resource.NewAssetProperty(asset)
 		props := resource.PropertyMap{"missing": assetProp}
 		ps := map[string]*SchemaInfo{}
-		_, err = getAssetTable(props, ps)
+		_, err = getAssetTable(props, ps, nil)
 		assert.Error(t, err)
 	})
 
@@ -4284,7 +4284,7 @@ func TestGetAssetTable(t *testing.T) {
 		nestedPS := map[string]*SchemaInfo{
 			"outer": {Fields: map[string]*SchemaInfo{"inner": {Asset: &AssetTranslation{Kind: FileAsset}}}},
 		}
-		assets, err := getAssetTable(nestedProps, nestedPS)
+		assets, err := getAssetTable(nestedProps, nestedPS, nil)
 		assert.NoError(t, err)
 		found := false
 		for info, v := range assets {
@@ -4307,7 +4307,7 @@ func TestGetAssetTable(t *testing.T) {
 			"foo": {Asset: &AssetTranslation{Kind: FileAsset}},
 			"bar": {Asset: &AssetTranslation{Kind: FileAsset}},
 		}
-		assets, err := getAssetTable(props, ps)
+		assets, err := getAssetTable(props, ps, nil)
 		assert.NoError(t, err)
 		assert.Len(t, assets, 2)
 		assert.Contains(t, assets, ps["foo"])
@@ -4322,14 +4322,14 @@ func TestGetAssetTable(t *testing.T) {
 		assetProp := resource.NewAssetProperty(asset)
 		props := resource.PropertyMap{"foo": assetProp}
 		ps := map[string]*SchemaInfo{"foo": nil}
-		_, err = getAssetTable(props, ps)
+		_, err = getAssetTable(props, ps, nil)
 		assert.Error(t, err)
 	})
 
 	t.Run("non-asset value with asset SchemaInfo", func(t *testing.T) {
 		props := resource.PropertyMap{"foo": resource.NewStringProperty("not an asset")}
 		ps := map[string]*SchemaInfo{"foo": {Asset: &AssetTranslation{Kind: FileAsset}}}
-		assets, err := getAssetTable(props, ps)
+		assets, err := getAssetTable(props, ps, nil)
 		assert.NoError(t, err)
 		assert.Empty(t, assets)
 	})

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -4239,8 +4239,7 @@ func TestGetAssetTable(t *testing.T) {
 				Optional: true,
 			},
 		})
-		assets, err := getAssetTable(props, ps, tfs)
-		assert.NoError(t, err)
+		assets := getAssetTable(props, ps, tfs)
 		require.Len(t, assets, 1)
 		for info, v := range assets {
 			assert.Same(t, ps["foo"], info)
@@ -4257,8 +4256,7 @@ func TestGetAssetTable(t *testing.T) {
 				Optional: true,
 			},
 		})
-		assets, err := getAssetTable(props, ps, tfs)
-		assert.NoError(t, err)
+		assets := getAssetTable(props, ps, tfs)
 		assert.Empty(t, assets)
 	})
 
@@ -4276,8 +4274,7 @@ func TestGetAssetTable(t *testing.T) {
 				Optional: true,
 			},
 		})
-		assets, err := getAssetTable(props, ps, tfs)
-		assert.NoError(t, err)
+		assets := getAssetTable(props, ps, tfs)
 		require.Len(t, assets, 1)
 		for info, v := range assets {
 			assert.Same(t, ps["arch"], info)
@@ -4297,8 +4294,12 @@ func TestGetAssetTable(t *testing.T) {
 				Optional: true,
 			},
 		})
-		_, err = getAssetTable(props, ps, tfs)
-		assert.Error(t, err)
+		defer func() {
+			if r := recover(); r == nil {
+				assert.Fail(t, "panic did not occur", r)
+			}
+		}()
+		getAssetTable(props, ps, tfs)
 	})
 
 	t.Run("nested asset", func(t *testing.T) {
@@ -4325,8 +4326,7 @@ func TestGetAssetTable(t *testing.T) {
 				},
 			},
 		})
-		assets, err := getAssetTable(nestedProps, nestedPS, tfs)
-		assert.NoError(t, err)
+		assets := getAssetTable(nestedProps, nestedPS, tfs)
 		found := false
 		for info, v := range assets {
 			if info == nestedPS["outer"].Elem.Fields["inner"] && v.DeepEquals(nestedAsset) {
@@ -4352,8 +4352,7 @@ func TestGetAssetTable(t *testing.T) {
 			"foo": {Type: schemav2.TypeString, Optional: true},
 			"bar": {Type: schemav2.TypeString, Optional: true},
 		})
-		assets, err := getAssetTable(props, ps, tfs)
-		assert.NoError(t, err)
+		assets := getAssetTable(props, ps, tfs)
 		assert.Len(t, assets, 2)
 		assert.Contains(t, assets, ps["foo"])
 		assert.Contains(t, assets, ps["bar"])
@@ -4370,8 +4369,12 @@ func TestGetAssetTable(t *testing.T) {
 		tfs := shimv2.NewSchemaMap(map[string]*schemav2.Schema{
 			"foo": {Type: schemav2.TypeString, Optional: true},
 		})
-		_, err = getAssetTable(props, ps, tfs)
-		assert.Error(t, err)
+		defer func() {
+			if r := recover(); r == nil {
+				assert.Fail(t, "panic did not occur", r)
+			}
+		}()
+		getAssetTable(props, ps, tfs)
 	})
 
 	t.Run("non-asset value with asset SchemaInfo", func(t *testing.T) {
@@ -4380,8 +4383,7 @@ func TestGetAssetTable(t *testing.T) {
 		tfs := shimv2.NewSchemaMap(map[string]*schemav2.Schema{
 			"foo": {Type: schemav2.TypeString, Optional: true},
 		})
-		assets, err := getAssetTable(props, ps, tfs)
-		assert.NoError(t, err)
+		assets := getAssetTable(props, ps, tfs)
 		assert.Empty(t, assets)
 	})
 }


### PR DESCRIPTION
This PR fixes the diffing of resource properties which contain Pulumi Assets or Archives. We were not correctly handling the assets coming from the old properties both for with RawStateDeltas enabled and without. Instead we were using the new property assets in place of the old ones and that produced no diff for these properties.

This fixes both:
- Without raw state deltas, the asset table is parsed as part of transforming the property values to the TF domain - we can use these in the diff algorithm.
- With raw state deltas, we now add a recursive pass over the old property values, which produces an asset table.

fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/3102