### PR TITLE
Add NoDanglingReferences option

### DIFF
--- a/pkg/tfbridge/info/info.go
+++ b/pkg/tfbridge/info/info.go
@@ -186,6 +186,9 @@ type Provider struct {
 
 	// DisableRequiredWithDefaultTurningOptional disables making required properties optional if they have a default value.
 	DisableRequiredWithDefaultTurningOptional bool
+
+	// Check generated schema for dangling references. Newer providers should opt into this.
+	NoDanglingReferences bool
 }
 
 // HclExampler represents a supplemental HCL example for a given resource or function.

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -1140,8 +1140,15 @@ func (g *Generator) UnstableGenerateFromSchema(genSchemaResult *GenerateSchemaRe
 			files[path] = code
 		}
 	default:
+		allowDanglingRefernces := true
+		if g.info.NoDanglingReferences {
+			allowDanglingRefernces = false
+		}
 		pulumiPackage, diags, err := pschema.BindSpec(
-			pulumiPackageSpec, nil, pschema.ValidationOptions{AllowDanglingReferences: true})
+			pulumiPackageSpec, nil, pschema.ValidationOptions{
+				AllowDanglingReferences: allowDanglingRefernces,
+			},
+		)
 		if err != nil {
 			return nil, pkgerrors.Wrapf(err, "failed to import Pulumi schema")
 		}

--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -442,7 +442,14 @@ func (g *schemaGenerator) genPackageSpec(pack *pkg, sink diag.Sink) (pschema.Pac
 	}
 
 	// Validate the schema.
-	_, diags, err := pschema.BindSpec(spec, nil, pschema.ValidationOptions{AllowDanglingReferences: true})
+
+	allowDanglingReferences := true
+	if g.info.NoDanglingReferences {
+		allowDanglingReferences = false
+	}
+	_, diags, err := pschema.BindSpec(spec, nil, pschema.ValidationOptions{
+		AllowDanglingReferences: allowDanglingReferences,
+	})
 	if err != nil {
 		return pschema.PackageSpec{}, err
 	}


### PR DESCRIPTION
Historically providers such as pulumi-aws generated schemata that had type references that cannot resolve, and relied
on the quirks of the Node SDK generator to make use of these references to link in overlay types.

This is going away in upcoming major release of pulumi-aws, and newer providers should be strict about generating the
schema.

When the new flag NoDanglingReferences is set to `true`, bridge will perform strict schema validity checks before
emitting a schema during `make tfgen`.

Fixes #3116
