### PR TITLE
Add sumologic to deprecated provider list

### DIFF
--- a/pkg/tfgen/installation_docs.go
+++ b/pkg/tfgen/installation_docs.go
@@ -180,6 +180,7 @@ func getDeprecatedProviderNames() []string {
 		"civo",
 		"rke",
 		"libvirt",
+		"sumologic",
 	}
 	return providerNames
 }


### PR DESCRIPTION
This pull request allows for the insertion of a deprecation warning in the provider's registry page.

Part of supporting Sumologic as an Any TF provider: https://github.com/pulumi/pulumi-sumologic/issues/653