### PR TITLE
Default to failing build on extra mapping error

### DIFF
--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -1393,7 +1393,7 @@ func (g *Generator) gatherResources() (moduleMap, error) {
 			if !skipFailBuildOnExtraMapError {
 				resourceMappingErrors = multierror.Append(resourceMappingErrors,
 					fmt.Errorf("Pulumi token %q is mapped to TF provider resource %q, but no such "+
-						"resource found. The mapping will be ignored in the generated provider",
+						"resource found. Remove the mapping and try again",
 						g.info.Resources[name].Tok, name))
 			} else {
 				g.warn("Pulumi token %q is mapped to TF provider resource %q, but no such "+
@@ -1532,20 +1532,13 @@ func (g *Generator) gatherResource(rawname string,
 		properties: res.inprops,
 	}
 
-	// Determine if we should error on extraneous mappings
-	failBuildOnExtraMapError := cmdutil.IsTruthy(os.Getenv("PULUMI_EXTRA_MAPPING_ERROR"))
-	// For pulumi-owned providers, we always want to fail on extraneous mappings. They should be removed.
-	if isOwnedByPulumi(g.info.Repository) {
-		failBuildOnExtraMapError = true
-	}
-
 	// Ensure there weren't any custom fields that were unrecognized.
 	var errs []error
 	for key := range info.Fields {
 		if _, has := schema.Schema().GetOk(key); !has {
 			msg := fmt.Sprintf("there is a custom mapping on resource '%s' for field '%s', but the field was not "+
 				"found in the Terraform metadata and will be ignored. To fix, remove the mapping.", rawname, key)
-			if failBuildOnExtraMapError {
+			if !cmdutil.IsTruthy(os.Getenv("PULUMI_SKIP_EXTRA_MAPPING_ERROR")) {
 				errs = append(errs, errors.New(msg))
 			} else {
 				g.warn(msg)
@@ -1566,12 +1559,7 @@ func (g *Generator) gatherDataSources() (moduleMap, error) {
 
 	skipFailBuildOnMissingMapError := cmdutil.IsTruthy(os.Getenv("PULUMI_SKIP_MISSING_MAPPING_ERROR")) ||
 		cmdutil.IsTruthy(os.Getenv("PULUMI_SKIP_PROVIDER_MAP_ERROR"))
-
-	failBuildOnExtraMapError := cmdutil.IsTruthy(os.Getenv("PULUMI_EXTRA_MAPPING_ERROR"))
-	// For pulumi-owned providers, we always want to fail on extraneous mappings. They should be removed.
-	if isOwnedByPulumi(g.info.GitHubOrg) {
-		failBuildOnExtraMapError = true
-	}
+	skipFailBuildOnExtraMapError := cmdutil.IsTruthy(os.Getenv("PULUMI_SKIP_EXTRA_MAPPING_ERROR"))
 
 	// let's keep a list of TF mapping errors that we can present to the user
 	var dataSourceMappingErrors error
@@ -1618,7 +1606,7 @@ func (g *Generator) gatherDataSources() (moduleMap, error) {
 	sort.Strings(names)
 	for _, name := range names {
 		if !seen[name] {
-			if failBuildOnExtraMapError {
+			if !skipFailBuildOnExtraMapError {
 				dataSourceMappingErrors = multierror.Append(dataSourceMappingErrors,
 					fmt.Errorf("Pulumi token %q is mapped to TF provider data source %q, but no such "+
 						"data source found. Remove the mapping and try again",
@@ -2234,16 +2222,6 @@ func sliceContains[T comparable](slice []T, target T) bool {
 		if v == target {
 			return true
 		}
-	}
-	return false
-}
-
-func isOwnedByPulumi(repo string) bool {
-	// g.info.Repository is the full GH repo name that contains the github org that maintains this provider
-	// For example: https://github.com/pulumi/pulumi-vsphere
-	after, found := strings.CutPrefix(repo, "https://github.com/")
-	if found && strings.HasPrefix(after, "pulumi") {
-		return true
 	}
 	return false
 }

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -1532,21 +1532,7 @@ func (g *Generator) gatherResource(rawname string,
 		properties: res.inprops,
 	}
 
-	// Ensure there weren't any custom fields that were unrecognized.
-	var errs []error
-	for key := range info.Fields {
-		if _, has := schema.Schema().GetOk(key); !has {
-			msg := fmt.Sprintf("there is a custom mapping on resource '%s' for field '%s', but the field was not "+
-				"found in the Terraform metadata and will be ignored. To fix, remove the mapping.", rawname, key)
-			if !cmdutil.IsTruthy(os.Getenv("PULUMI_SKIP_EXTRA_MAPPING_ERROR")) {
-				errs = append(errs, errors.New(msg))
-			} else {
-				g.warn(msg)
-			}
-		}
-	}
-
-	return res, errors.Join(errs...)
+	return res, nil
 }
 
 func (g *Generator) gatherDataSources() (moduleMap, error) {

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -1535,7 +1535,7 @@ func (g *Generator) gatherResource(rawname string,
 	// Determine if we should error on extraneous mappings
 	failBuildOnExtraMapError := cmdutil.IsTruthy(os.Getenv("PULUMI_EXTRA_MAPPING_ERROR"))
 	// For pulumi-owned providers, we always want to fail on extraneous mappings. They should be removed.
-	if g.info.GitHubOrg == "pulumi" {
+	if isOwnedByPulumi(g.info.Repository) {
 		failBuildOnExtraMapError = true
 	}
 
@@ -1569,7 +1569,7 @@ func (g *Generator) gatherDataSources() (moduleMap, error) {
 
 	failBuildOnExtraMapError := cmdutil.IsTruthy(os.Getenv("PULUMI_EXTRA_MAPPING_ERROR"))
 	// For pulumi-owned providers, we always want to fail on extraneous mappings. They should be removed.
-	if g.info.GitHubOrg == "pulumi" {
+	if isOwnedByPulumi(g.info.GitHubOrg) {
 		failBuildOnExtraMapError = true
 	}
 
@@ -2234,6 +2234,16 @@ func sliceContains[T comparable](slice []T, target T) bool {
 		if v == target {
 			return true
 		}
+	}
+	return false
+}
+
+func isOwnedByPulumi(repo string) bool {
+	// g.info.Repository is the full GH repo name that contains the github org that maintains this provider
+	// For example: https://github.com/pulumi/pulumi-vsphere
+	after, found := strings.CutPrefix(repo, "https://github.com/")
+	if found && strings.HasPrefix(after, "pulumi") {
+		return true
 	}
 	return false
 }

--- a/pkg/tfgen/generate_test.go
+++ b/pkg/tfgen/generate_test.go
@@ -809,6 +809,23 @@ func TestExtraMappingError(t *testing.T) {
 		P: mockProvider,
 	}
 
+	// Create provider info with extra field mappings that don't exist in the schema
+	infoWithExtraFields := tfbridge.ProviderInfo{
+		Name:    "test",
+		Version: "1.0.0",
+		Resources: map[string]*tfbridge.ResourceInfo{
+			"existing_resource": {
+				Tok: tokens.Type("test:index:ExistingResource"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"unmapped_field": {
+						Name: "unmappedField",
+					},
+				},
+			},
+		},
+		P: mockProvider,
+	}
+
 	testCases := []struct {
 		name           string
 		envVars        map[string]string
@@ -849,6 +866,14 @@ func TestExtraMappingError(t *testing.T) {
 			},
 			expectError: false,
 			info:        infoWithDataSources,
+		},
+		{
+			name:        "Pulumi providers should error on extra field mapping during validation, not during generation",
+			expectError: true,
+			expectedErrors: []string{
+				"existing_resource: [{unmapped_field}]: overriding non-existent field",
+			},
+			info: infoWithExtraFields,
 		},
 	}
 


### PR DESCRIPTION
This pull request removes the `PULUMI_EXTRA_MAPPING_ERROR` environment variable from the pulumi-terraform-bridge.

Of note: an "extra mapping" is when the Pulumi provider info attempts to map a resource or data source that does not exist in the upstream provider. A "missing mapping" is when a TF resource is not mapped to a Pulumi resource. This pull request ONLY deals with the former.

Previous work on this was partially implemented this https://github.com/pulumi/pulumi-terraform-bridge/pull/616/files only set this error by default in resource generation, but not data source generation. This pull request fixes that.

Additionally, missing field mappings are [now caught in Validate](https://github.com/pulumi/pulumi-terraform-bridge/blob/e774624b0fd4804dcfce8ba37debbba1bcdad16d/pkg/tfbridge/info/validate.go#L85) so we no longer need to check for them during generation.

This pull request adds tests to verify each scenario - extra mappings should trigger errors.

It is my opinion that this is a safe clean up - as stated, this has been the default for Resources for a few years now, and we have [been setting PULUMI_EXTRA_MAPPING_ERROR to `true` in upgrade-provider](https://github.com/pulumi/upgrade-provider/blob/main/upgrade/upgrade_provider.go#L50) so we should see no churn.


