### PR TITLE
Add --resources flag to filter dynamic provider resources

### DIFF
--- a/dynamic/info.go
+++ b/dynamic/info.go
@@ -123,20 +123,6 @@ func providerInfo(ctx context.Context, p run.Provider, value parameterize.Value)
 		}
 
 		prov.IgnoreMappings = ignoreMappings
-
-		// Remove ignored resources from the maps (fixup may have pre-populated them)
-		//
-		// TODO: fixup.Default should ignore ignored mappings, so we shouldn't need this.
-		if prov.Resources != nil {
-			for _, ignored := range ignoreMappings {
-				delete(prov.Resources, ignored)
-			}
-		}
-		if prov.DataSources != nil {
-			for _, ignored := range ignoreMappings {
-				delete(prov.DataSources, ignored)
-			}
-		}
 	}
 
 	if err := fixup.Default(&prov); err != nil {

--- a/dynamic/info.go
+++ b/dynamic/info.go
@@ -101,10 +101,10 @@ func providerInfo(ctx context.Context, p run.Provider, value parameterize.Value)
 	}
 
 	// Apply resource filtering if specified
-	if len(value.Resources) > 0 {
+	if len(value.Includes) > 0 {
 		// Create a set of resources to include
 		includeSet := make(map[string]bool)
-		for _, resource := range value.Resources {
+		for _, resource := range value.Includes {
 			includeSet[resource] = true
 		}
 

--- a/dynamic/info_test.go
+++ b/dynamic/info_test.go
@@ -165,7 +165,7 @@ func TestResourceFiltering(t *testing.T) {
 
 	t.Run("filter specific resources", func(t *testing.T) {
 		// Test filtering to include only specific resources
-		info, err := providerInfo(t.Context(), provider, parameterize.Value{
+		info, err := providerInfo(context.Background(), provider, parameterize.Value{
 			Resources: []string{"test_resource_a", "test_data_a"},
 		})
 		require.NoError(t, err)
@@ -188,7 +188,7 @@ func TestResourceFiltering(t *testing.T) {
 
 	t.Run("empty resources includes all", func(t *testing.T) {
 		// Test empty resources (should include all - existing behavior)
-		info, err := providerInfo(t.Context(), provider, parameterize.Value{})
+		info, err := providerInfo(context.Background(), provider, parameterize.Value{})
 		require.NoError(t, err)
 		assert.Empty(t, info.IgnoreMappings)
 
@@ -206,7 +206,7 @@ func TestResourceFiltering(t *testing.T) {
 
 	t.Run("nil resources includes all", func(t *testing.T) {
 		// Test nil resources (should include all - existing behavior)
-		info, err := providerInfo(t.Context(), provider, parameterize.Value{
+		info, err := providerInfo(context.Background(), provider, parameterize.Value{
 			Resources: nil,
 		})
 		require.NoError(t, err)
@@ -226,7 +226,7 @@ func TestResourceFiltering(t *testing.T) {
 
 	t.Run("single resource filter", func(t *testing.T) {
 		// Test filtering to a single resource
-		info, err := providerInfo(t.Context(), provider, parameterize.Value{
+		info, err := providerInfo(context.Background(), provider, parameterize.Value{
 			Resources: []string{"test_resource_b"},
 		})
 		require.NoError(t, err)
@@ -248,7 +248,7 @@ func TestResourceFiltering(t *testing.T) {
 
 	t.Run("non-existent resource", func(t *testing.T) {
 		// Test filtering with non-existent resource (should ignore all actual resources)
-		info, err := providerInfo(t.Context(), provider, parameterize.Value{
+		info, err := providerInfo(context.Background(), provider, parameterize.Value{
 			Resources: []string{"non_existent_resource"},
 		})
 		require.NoError(t, err)

--- a/dynamic/info_test.go
+++ b/dynamic/info_test.go
@@ -144,6 +144,131 @@ func TestFixHyphenToken(t *testing.T) {
 	}, p.Resources)
 }
 
+func TestResourceFiltering(t *testing.T) {
+	t.Parallel()
+
+	provider := schemaOnlyProvider{
+		name:    "test",
+		version: "1.0.0",
+		schema: &tfprotov6.GetProviderSchemaResponse{
+			ResourceSchemas: map[string]*tfprotov6.Schema{
+				"test_resource_a": {Block: &tfprotov6.SchemaBlock{}},
+				"test_resource_b": {Block: &tfprotov6.SchemaBlock{}},
+				"test_resource_c": {Block: &tfprotov6.SchemaBlock{}},
+			},
+			DataSourceSchemas: map[string]*tfprotov6.Schema{
+				"test_data_a": {Block: &tfprotov6.SchemaBlock{}},
+				"test_data_b": {Block: &tfprotov6.SchemaBlock{}},
+			},
+		},
+	}
+
+	t.Run("filter specific resources", func(t *testing.T) {
+		// Test filtering to include only specific resources
+		info, err := providerInfo(t.Context(), provider, parameterize.Value{
+			Resources: []string{"test_resource_a", "test_data_a"},
+		})
+		require.NoError(t, err)
+
+		// Should ignore all resources/datasources NOT in the Resources list
+		expectedIgnored := []string{"test_resource_b", "test_resource_c", "test_data_b"}
+		assert.ElementsMatch(t, expectedIgnored, info.IgnoreMappings)
+
+		// Should only have the specified resources in the Resources map
+		expectedResources := []string{"test_resource_a", "test_data_a"}
+		actualResources := make([]string, 0, len(info.Resources)+len(info.DataSources))
+		for tfName := range info.Resources {
+			actualResources = append(actualResources, tfName)
+		}
+		for tfName := range info.DataSources {
+			actualResources = append(actualResources, tfName)
+		}
+		assert.ElementsMatch(t, expectedResources, actualResources)
+	})
+
+	t.Run("empty resources includes all", func(t *testing.T) {
+		// Test empty resources (should include all - existing behavior)
+		info, err := providerInfo(t.Context(), provider, parameterize.Value{})
+		require.NoError(t, err)
+		assert.Empty(t, info.IgnoreMappings)
+
+		// Should have all resources in the Resources and DataSources maps
+		expectedResources := []string{"test_resource_a", "test_resource_b", "test_resource_c", "test_data_a", "test_data_b"}
+		actualResources := make([]string, 0, len(info.Resources)+len(info.DataSources))
+		for tfName := range info.Resources {
+			actualResources = append(actualResources, tfName)
+		}
+		for tfName := range info.DataSources {
+			actualResources = append(actualResources, tfName)
+		}
+		assert.ElementsMatch(t, expectedResources, actualResources)
+	})
+
+	t.Run("nil resources includes all", func(t *testing.T) {
+		// Test nil resources (should include all - existing behavior)
+		info, err := providerInfo(t.Context(), provider, parameterize.Value{
+			Resources: nil,
+		})
+		require.NoError(t, err)
+		assert.Empty(t, info.IgnoreMappings)
+
+		// Should have all resources in the Resources and DataSources maps
+		expectedResources := []string{"test_resource_a", "test_resource_b", "test_resource_c", "test_data_a", "test_data_b"}
+		actualResources := make([]string, 0, len(info.Resources)+len(info.DataSources))
+		for tfName := range info.Resources {
+			actualResources = append(actualResources, tfName)
+		}
+		for tfName := range info.DataSources {
+			actualResources = append(actualResources, tfName)
+		}
+		assert.ElementsMatch(t, expectedResources, actualResources)
+	})
+
+	t.Run("single resource filter", func(t *testing.T) {
+		// Test filtering to a single resource
+		info, err := providerInfo(t.Context(), provider, parameterize.Value{
+			Resources: []string{"test_resource_b"},
+		})
+		require.NoError(t, err)
+
+		expectedIgnored := []string{"test_resource_a", "test_resource_c", "test_data_a", "test_data_b"}
+		assert.ElementsMatch(t, expectedIgnored, info.IgnoreMappings)
+
+		// Should only have the single specified resource
+		expectedResources := []string{"test_resource_b"}
+		actualResources := make([]string, 0, len(info.Resources)+len(info.DataSources))
+		for tfName := range info.Resources {
+			actualResources = append(actualResources, tfName)
+		}
+		for tfName := range info.DataSources {
+			actualResources = append(actualResources, tfName)
+		}
+		assert.ElementsMatch(t, expectedResources, actualResources)
+	})
+
+	t.Run("non-existent resource", func(t *testing.T) {
+		// Test filtering with non-existent resource (should ignore all actual resources)
+		info, err := providerInfo(t.Context(), provider, parameterize.Value{
+			Resources: []string{"non_existent_resource"},
+		})
+		require.NoError(t, err)
+
+		// All actual resources should be ignored
+		expectedIgnored := []string{"test_resource_a", "test_resource_b", "test_resource_c", "test_data_a", "test_data_b"}
+		assert.ElementsMatch(t, expectedIgnored, info.IgnoreMappings)
+
+		// Should have no resources in the Resources and DataSources maps
+		actualResources := make([]string, 0, len(info.Resources)+len(info.DataSources))
+		for tfName := range info.Resources {
+			actualResources = append(actualResources, tfName)
+		}
+		for tfName := range info.DataSources {
+			actualResources = append(actualResources, tfName)
+		}
+		assert.Empty(t, actualResources)
+	})
+}
+
 type schemaOnlyProvider struct {
 	run.Provider
 	name, url, version string

--- a/dynamic/info_test.go
+++ b/dynamic/info_test.go
@@ -166,7 +166,7 @@ func TestResourceFiltering(t *testing.T) {
 	t.Run("filter specific resources", func(t *testing.T) {
 		// Test filtering to include only specific resources
 		info, err := providerInfo(context.Background(), provider, parameterize.Value{
-			Resources: []string{"test_resource_a", "test_data_a"},
+			Includes: []string{"test_resource_a", "test_data_a"},
 		})
 		require.NoError(t, err)
 
@@ -207,7 +207,7 @@ func TestResourceFiltering(t *testing.T) {
 	t.Run("nil resources includes all", func(t *testing.T) {
 		// Test nil resources (should include all - existing behavior)
 		info, err := providerInfo(context.Background(), provider, parameterize.Value{
-			Resources: nil,
+			Includes: nil,
 		})
 		require.NoError(t, err)
 		assert.Empty(t, info.IgnoreMappings)
@@ -224,10 +224,10 @@ func TestResourceFiltering(t *testing.T) {
 		assert.ElementsMatch(t, expectedResources, actualResources)
 	})
 
-	t.Run("single resource filter", func(t *testing.T) {
+	t.Run("single resource filter has single resource", func(t *testing.T) {
 		// Test filtering to a single resource
 		info, err := providerInfo(context.Background(), provider, parameterize.Value{
-			Resources: []string{"test_resource_b"},
+			Includes: []string{"test_resource_b"},
 		})
 		require.NoError(t, err)
 
@@ -246,10 +246,10 @@ func TestResourceFiltering(t *testing.T) {
 		assert.ElementsMatch(t, expectedResources, actualResources)
 	})
 
-	t.Run("non-existent resource", func(t *testing.T) {
+	t.Run("non-existent resource does not affect filter", func(t *testing.T) {
 		// Test filtering with non-existent resource (should ignore all actual resources)
 		info, err := providerInfo(context.Background(), provider, parameterize.Value{
-			Resources: []string{"non_existent_resource"},
+			Includes: []string{"non_existent_resource"},
 		})
 		require.NoError(t, err)
 

--- a/dynamic/main.go
+++ b/dynamic/main.go
@@ -172,7 +172,7 @@ func initialSetup() (info.Provider, pfbridge.ProviderMetadata, func() error) {
 			}
 
 			value := parameterize.Value{
-				Resources: args.Resources,
+				Includes: args.Includes,
 			}
 			if args.Local != nil {
 				value.Local = &parameterize.LocalValue{

--- a/dynamic/main.go
+++ b/dynamic/main.go
@@ -171,7 +171,9 @@ func initialSetup() (info.Provider, pfbridge.ProviderMetadata, func() error) {
 				return plugin.ParameterizeResponse{}, err
 			}
 
-			var value parameterize.Value
+			value := parameterize.Value{
+				Resources: args.Resources,
+			}
 			if args.Local != nil {
 				value.Local = &parameterize.LocalValue{
 					Path: args.Local.Path,

--- a/dynamic/parameterize/args.go
+++ b/dynamic/parameterize/args.go
@@ -32,9 +32,9 @@ import (
 type Args struct {
 	Remote *RemoteArgs
 	Local  *LocalArgs
-	// Resources is the list of resource names to include in the provider.
-	// If empty, all resources are included.
-	Resources []string
+	// Includes is the list of resource and datasource TF tokens to include in the
+	// provider.  If empty, all resources and datasources are included.
+	Includes []string
 }
 
 // RemoteArgs represents a TF provider referenced by name.
@@ -67,12 +67,12 @@ func ParseArgs(ctx context.Context, a []string) (Args, error) {
 	var fullDocs bool
 	var upstreamRepoPath string
 	var indexDocOutDir string
-	var resources []string
+	var includes []string
 	cmd := cobra.Command{
 		Use: "./local | remote version",
 		RunE: func(cmd *cobra.Command, a []string) error {
 			var err error
-			args, err = parseArgs(cmd.Context(), a, fullDocs, upstreamRepoPath, indexDocOutDir, resources)
+			args, err = parseArgs(cmd.Context(), a, fullDocs, upstreamRepoPath, indexDocOutDir, includes)
 			return err
 		},
 		Args: cobra.RangeArgs(1, 2),
@@ -84,8 +84,11 @@ func ParseArgs(ctx context.Context, a []string) (Args, error) {
 		"Specify a local file path to the root of the Git repository of the provider being dynamically bridged")
 	cmd.Flags().StringVar(&indexDocOutDir, "indexDocOutDir", "",
 		"Specify a local output directory for the provider's _index.md file")
-	cmd.Flags().StringSliceVar(&resources, "resources", nil,
-		"Comma-separated list of resource names to include in the provider (e.g. aws_instance,aws_vpc)")
+	cmd.Flags().StringSliceVar(&includes, "include", nil,
+		`Comma-separated list of resource and datasource Terraform tokens to include in the provider `+
+			`(e.g. aws_instance,aws_vpc).
+
+If no include filter is specified, all resources and datasources are mapped.`)
 
 	// We hide docs flags since they are not intended for end users, and they may not be stable.
 	if !env.Dev.Value() {
@@ -124,7 +127,7 @@ func parseArgs(
 	args []string,
 	fullDocs bool,
 	upstreamRepoPath, indexDocOutDir string,
-	resources []string,
+	includes []string,
 ) (Args, error) {
 	// If we see a local prefix (starts with '.' or '/'), parse args for a local provider
 	if strings.HasPrefix(args[0], ".") || strings.HasPrefix(args[0], "/") {
@@ -144,7 +147,7 @@ func parseArgs(
 				UpstreamRepoPath: upstreamRepoPath,
 				IndexDocOutDir:   indexDocOutDir,
 			},
-			Resources: resources,
+			Includes: includes,
 		}, nil
 	}
 
@@ -166,5 +169,5 @@ func parseArgs(
 		Version:        version,
 		Docs:           fullDocs,
 		IndexDocOutDir: indexDocOutDir,
-	}, Resources: resources}, nil
+	}, Includes: includes}, nil
 }

--- a/dynamic/parameterize/args_test.go
+++ b/dynamic/parameterize/args_test.go
@@ -126,52 +126,52 @@ func TestParseArgs(t *testing.T) {
 			),
 		},
 		{
-			name: "local with resources",
-			args: []string{"./my-provider", "--resources=resource1,resource2"},
+			name: "local with includes",
+			args: []string{"./my-provider", "--include=resource1,resource2"},
 			expect: Args{
-				Local:     &LocalArgs{Path: "./my-provider"},
-				Resources: []string{"resource1", "resource2"},
+				Local:    &LocalArgs{Path: "./my-provider"},
+				Includes: []string{"resource1", "resource2"},
 			},
 		},
 		{
-			name: "remote with resources",
-			args: []string{"registry/provider", "1.2.3", "--resources=res_a,res_b,res_c"},
+			name: "remote with includes",
+			args: []string{"registry/provider", "1.2.3", "--include=res_a,res_b,res_c"},
 			expect: Args{
 				Remote: &RemoteArgs{
 					Name:    "registry/provider",
 					Version: "1.2.3",
 				},
-				Resources: []string{"res_a", "res_b", "res_c"},
+				Includes: []string{"res_a", "res_b", "res_c"},
 			},
 		},
 		{
-			name: "single resource",
-			args: []string{"registry/provider", "--resources=single_resource"},
+			name: "single include",
+			args: []string{"registry/provider", "--include=single_resource"},
 			expect: Args{
 				Remote: &RemoteArgs{
 					Name: "registry/provider",
 				},
-				Resources: []string{"single_resource"},
+				Includes: []string{"single_resource"},
 			},
 		},
 		{
-			name: "empty resources flag",
-			args: []string{"registry/provider", "--resources="},
+			name: "empty include flag",
+			args: []string{"registry/provider", "--include="},
 			expect: Args{
 				Remote: &RemoteArgs{
 					Name: "registry/provider",
 				},
-				Resources: []string{},
+				Includes: []string{},
 			},
 		},
 		{
 			name: "multiple invocations",
-			args: []string{"registry/provider", "--resources", "res_a", "--resources", "res_b", "--resources", "res_c"},
+			args: []string{"registry/provider", "--include", "res_a", "--include", "res_b", "--include", "res_c"},
 			expect: Args{
 				Remote: &RemoteArgs{
 					Name: "registry/provider",
 				},
-				Resources: []string{"res_a", "res_b", "res_c"},
+				Includes: []string{"res_a", "res_b", "res_c"},
 			},
 		},
 	}

--- a/dynamic/parameterize/args_test.go
+++ b/dynamic/parameterize/args_test.go
@@ -125,6 +125,55 @@ func TestParseArgs(t *testing.T) {
 				"unknown flag: --invalid",
 			),
 		},
+		{
+			name: "local with resources",
+			args: []string{"./my-provider", "--resources=resource1,resource2"},
+			expect: Args{
+				Local:     &LocalArgs{Path: "./my-provider"},
+				Resources: []string{"resource1", "resource2"},
+			},
+		},
+		{
+			name: "remote with resources",
+			args: []string{"registry/provider", "1.2.3", "--resources=res_a,res_b,res_c"},
+			expect: Args{
+				Remote: &RemoteArgs{
+					Name:    "registry/provider",
+					Version: "1.2.3",
+				},
+				Resources: []string{"res_a", "res_b", "res_c"},
+			},
+		},
+		{
+			name: "single resource",
+			args: []string{"registry/provider", "--resources=single_resource"},
+			expect: Args{
+				Remote: &RemoteArgs{
+					Name: "registry/provider",
+				},
+				Resources: []string{"single_resource"},
+			},
+		},
+		{
+			name: "empty resources flag",
+			args: []string{"registry/provider", "--resources="},
+			expect: Args{
+				Remote: &RemoteArgs{
+					Name: "registry/provider",
+				},
+				Resources: []string{},
+			},
+		},
+		{
+			name: "multiple invocations",
+			args: []string{"registry/provider", "--resources", "res_a", "--resources", "res_b", "--resources", "res_c"},
+			expect: Args{
+				Remote: &RemoteArgs{
+					Name: "registry/provider",
+				},
+				Resources: []string{"res_a", "res_b", "res_c"},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/dynamic/parameterize/value.go
+++ b/dynamic/parameterize/value.go
@@ -28,9 +28,9 @@ import (
 type Value struct {
 	Remote *RemoteValue `json:"remote,omitempty"`
 	Local  *LocalValue  `json:"local,omitempty"`
-	// Resources is the list of resource names to include in the provider.
-	// If empty, all resources are included.
-	Resources []string `json:"resources,omitempty"`
+	// Includes is the list of resource and datasource names to include in the
+	// provider.  If empty, all resources are included.
+	Includes []string `json:"includes,omitempty"`
 }
 
 type RemoteValue struct {
@@ -100,10 +100,10 @@ func (p *Value) IntoArgs() Args {
 	if p.Local != nil {
 		return Args{Local: &LocalArgs{
 			Path: p.Local.Path,
-		}, Resources: p.Resources}
+		}, Includes: p.Includes}
 	}
 	return Args{Remote: &RemoteArgs{
 		Name:    p.Remote.URL,
 		Version: p.Remote.Version,
-	}, Resources: p.Resources}
+	}, Includes: p.Includes}
 }

--- a/dynamic/parameterize/value.go
+++ b/dynamic/parameterize/value.go
@@ -28,6 +28,9 @@ import (
 type Value struct {
 	Remote *RemoteValue `json:"remote,omitempty"`
 	Local  *LocalValue  `json:"local,omitempty"`
+	// Resources is the list of resource names to include in the provider.
+	// If empty, all resources are included.
+	Resources []string `json:"resources,omitempty"`
 }
 
 type RemoteValue struct {
@@ -97,10 +100,10 @@ func (p *Value) IntoArgs() Args {
 	if p.Local != nil {
 		return Args{Local: &LocalArgs{
 			Path: p.Local.Path,
-		}}
+		}, Resources: p.Resources}
 	}
 	return Args{Remote: &RemoteArgs{
 		Name:    p.Remote.URL,
 		Version: p.Remote.Version,
-	}}
+	}, Resources: p.Resources}
 }

--- a/dynamic/parameterize/value_test.go
+++ b/dynamic/parameterize/value_test.go
@@ -40,24 +40,24 @@ func TestMarshalValue(t *testing.T) {
 		}}.Marshal()))
 	})
 
-	t.Run("remote with resources", func(t *testing.T) {
+	t.Run("remote with includes", func(t *testing.T) {
 		autogold.Expect(
-			`{"remote":{"url":"registry/owner/type","version":"1.2.3"},"resources":["res1","res2"]}`,
+			`{"remote":{"url":"registry/owner/type","version":"1.2.3"},"includes":["res1","res2"]}`,
 		).Equal(t, string(Value{
 			Remote: &RemoteValue{
 				URL:     "registry/owner/type",
 				Version: "1.2.3",
 			},
-			Resources: []string{"res1", "res2"},
+			Includes: []string{"res1", "res2"},
 		}.Marshal()))
 	})
 
-	t.Run("local with resources", func(t *testing.T) {
-		autogold.Expect(`{"local":{"path":"./path"},"resources":["resource_a","resource_b"]}`).Equal(t, string(Value{
+	t.Run("local with includes", func(t *testing.T) {
+		autogold.Expect(`{"local":{"path":"./path"},"includes":["resource_a","resource_b"]}`).Equal(t, string(Value{
 			Local: &LocalValue{
 				Path: "./path",
 			},
-			Resources: []string{"resource_a", "resource_b"},
+			Includes: []string{"resource_a", "resource_b"},
 		}.Marshal()))
 	})
 
@@ -122,24 +122,24 @@ func TestUnmarshal(t *testing.T) {
 			err:   true,
 		},
 		{
-			name:  "remote with resources",
-			input: `{"remote":{"url":"registry/owner/type","version":"1.2.3"},"resources":["res1","res2"]}`,
+			name:  "remote with includes",
+			input: `{"remote":{"url":"registry/owner/type","version":"1.2.3"},"includes":["res1","res2"]}`,
 			expect: Value{
 				Remote: &RemoteValue{
 					URL:     "registry/owner/type",
 					Version: "1.2.3",
 				},
-				Resources: []string{"res1", "res2"},
+				Includes: []string{"res1", "res2"},
 			},
 		},
 		{
-			name:  "local with resources",
-			input: `{"local":{"path":"./path"},"resources":["resource_a"]}`,
+			name:  "local with includes",
+			input: `{"local":{"path":"./path"},"includes":["resource_a"]}`,
 			expect: Value{
 				Local: &LocalValue{
 					Path: "./path",
 				},
-				Resources: []string{"resource_a"},
+				Includes: []string{"resource_a"},
 			},
 		},
 	}
@@ -189,35 +189,35 @@ func TestValueIntoArgs(t *testing.T) {
 			}},
 		},
 		{
-			name: "remote with resources",
+			name: "remote with includes",
 			value: Value{
 				Remote: &RemoteValue{
 					URL:     "a/b/c",
 					Version: "1.2.3",
 				},
-				Resources: []string{"res1", "res2"},
+				Includes: []string{"res1", "res2"},
 			},
 			args: Args{
 				Remote: &RemoteArgs{
 					Name:    "a/b/c",
 					Version: "1.2.3",
 				},
-				Resources: []string{"res1", "res2"},
+				Includes: []string{"res1", "res2"},
 			},
 		},
 		{
-			name: "local with resources",
+			name: "local with includes",
 			value: Value{
 				Local: &LocalValue{
 					Path: "./a/b/c",
 				},
-				Resources: []string{"local_res"},
+				Includes: []string{"local_res"},
 			},
 			args: Args{
 				Local: &LocalArgs{
 					Path: "./a/b/c",
 				},
-				Resources: []string{"local_res"},
+				Includes: []string{"local_res"},
 			},
 		},
 	}

--- a/dynamic/parameterize/value_test.go
+++ b/dynamic/parameterize/value_test.go
@@ -40,6 +40,27 @@ func TestMarshalValue(t *testing.T) {
 		}}.Marshal()))
 	})
 
+	t.Run("remote with resources", func(t *testing.T) {
+		autogold.Expect(
+			`{"remote":{"url":"registry/owner/type","version":"1.2.3"},"resources":["res1","res2"]}`,
+		).Equal(t, string(Value{
+			Remote: &RemoteValue{
+				URL:     "registry/owner/type",
+				Version: "1.2.3",
+			},
+			Resources: []string{"res1", "res2"},
+		}.Marshal()))
+	})
+
+	t.Run("local with resources", func(t *testing.T) {
+		autogold.Expect(`{"local":{"path":"./path"},"resources":["resource_a","resource_b"]}`).Equal(t, string(Value{
+			Local: &LocalValue{
+				Path: "./path",
+			},
+			Resources: []string{"resource_a", "resource_b"},
+		}.Marshal()))
+	})
+
 	// Invalid values of Value should panic to help catch bugs early.
 	shouldPanicOnMarshal := []struct {
 		name string
@@ -100,6 +121,27 @@ func TestUnmarshal(t *testing.T) {
 			input: `{}`,
 			err:   true,
 		},
+		{
+			name:  "remote with resources",
+			input: `{"remote":{"url":"registry/owner/type","version":"1.2.3"},"resources":["res1","res2"]}`,
+			expect: Value{
+				Remote: &RemoteValue{
+					URL:     "registry/owner/type",
+					Version: "1.2.3",
+				},
+				Resources: []string{"res1", "res2"},
+			},
+		},
+		{
+			name:  "local with resources",
+			input: `{"local":{"path":"./path"},"resources":["resource_a"]}`,
+			expect: Value{
+				Local: &LocalValue{
+					Path: "./path",
+				},
+				Resources: []string{"resource_a"},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -145,6 +187,38 @@ func TestValueIntoArgs(t *testing.T) {
 			args: Args{Local: &LocalArgs{
 				Path: "./a/b/c",
 			}},
+		},
+		{
+			name: "remote with resources",
+			value: Value{
+				Remote: &RemoteValue{
+					URL:     "a/b/c",
+					Version: "1.2.3",
+				},
+				Resources: []string{"res1", "res2"},
+			},
+			args: Args{
+				Remote: &RemoteArgs{
+					Name:    "a/b/c",
+					Version: "1.2.3",
+				},
+				Resources: []string{"res1", "res2"},
+			},
+		},
+		{
+			name: "local with resources",
+			value: Value{
+				Local: &LocalValue{
+					Path: "./a/b/c",
+				},
+				Resources: []string{"local_res"},
+			},
+			args: Args{
+				Local: &LocalArgs{
+					Path: "./a/b/c",
+				},
+				Resources: []string{"local_res"},
+			},
 		},
 	}
 


### PR DESCRIPTION
This PR introduces a `--include` flag that allows users to specify which resources and datasources should be included when generating a dynamic Pulumi provider from a Terraform provider. This enables creating focused providers that contain only the subset of resources/datasources needed for a particular use case.

## Changes

The implementation adds a `Includes` field to both `Args` and `Value` structs to track the list of resource/datasources names to include. When specified, the filtering is applied in the `providerInfo` function by leveraging the existing `IgnoreMappings` mechanism - all resources/datasources not in the include list are added to `IgnoreMappings`, effectively excluding them from the generated provider.

Additionally, the `fixup.Default` function was modified to respect `IgnoreMappings`, ensuring ignored resources are completely skipped during fixup processing and eliminating the need for manual cleanup code.

Users can now run commands like:

    pulumi package get-schema terraform-provider -- hashicorp/aws --include aws_instance,aws_vpc             

This results in a focused AWS provider containing only the specified resources, reducing the generated provider size and improving development ergonomics when working with large Terraform providers.

Fixes https://github.com/pulumi/pulumi-terraform-provider/issues/91