### PR TITLE
Add --provider-name flag to enable provider aliasing

### DIFF
--- a/dynamic/info.go
+++ b/dynamic/info.go
@@ -34,9 +34,14 @@ import (
 func providerInfo(ctx context.Context, p run.Provider, value parameterize.Value) (tfbridge.ProviderInfo, error) {
 	provider := proto.New(ctx, p)
 
+	providerName := p.Name()
+	if value.ProviderName != "" {
+		providerName = value.ProviderName
+	}
+
 	prov := tfbridge.ProviderInfo{
 		P:              provider,
-		Name:           p.Name(),
+		Name:           providerName,
 		Version:        p.Version(),
 		Description:    "A Pulumi provider dynamically bridged from " + p.Name() + ".",
 		ResourcePrefix: inferResourcePrefix(provider),
@@ -61,11 +66,11 @@ func providerInfo(ctx context.Context, p run.Provider, value parameterize.Value)
 		Golang: &tfbridge.GolangInfo{
 			ImportBasePath: path.Join(
 				"github.com/pulumi/pulumi-terraform-provider/sdks/go",
-				p.Name(),
+				providerName,
 				tfbridge.GetModuleMajorVersion(p.Version()),
-				p.Name(),
+				providerName,
 			),
-			RootPackageName:              p.Name(),
+			RootPackageName:              providerName,
 			LiftSingleValueMethodReturns: true,
 			GenerateExtraInputTypes:      true,
 			RespectSchemaVersion:         true,
@@ -130,7 +135,7 @@ func providerInfo(ctx context.Context, p run.Provider, value parameterize.Value)
 	}
 
 	err := prov.ComputeTokens(tokens.SingleModule(
-		prov.GetResourcePrefix(), "index", tokens.MakeStandard(p.Name())))
+		prov.GetResourcePrefix(), "index", tokens.MakeStandard(providerName)))
 	if err != nil {
 		return prov, err
 	}

--- a/dynamic/main.go
+++ b/dynamic/main.go
@@ -172,7 +172,8 @@ func initialSetup() (info.Provider, pfbridge.ProviderMetadata, func() error) {
 			}
 
 			value := parameterize.Value{
-				Includes: args.Includes,
+				Includes:     args.Includes,
+				ProviderName: args.ProviderName,
 			}
 			if args.Local != nil {
 				value.Local = &parameterize.LocalValue{
@@ -238,8 +239,13 @@ func initialSetup() (info.Provider, pfbridge.ProviderMetadata, func() error) {
 				}
 			}
 
+			responseProviderName := p.Name()
+			if args.ProviderName != "" {
+				responseProviderName = args.ProviderName
+			}
+
 			return plugin.ParameterizeResponse{
-				Name:    p.Name(),
+				Name:    responseProviderName,
 				Version: v,
 			}, nil
 		},

--- a/dynamic/parameterize/args.go
+++ b/dynamic/parameterize/args.go
@@ -35,6 +35,9 @@ type Args struct {
 	// Includes is the list of resource and datasource TF tokens to include in the
 	// provider.  If empty, all resources and datasources are included.
 	Includes []string
+	// ProviderName is the custom name for the generated provider.
+	// If empty, the default Terraform provider name is used.
+	ProviderName string
 }
 
 // RemoteArgs represents a TF provider referenced by name.
@@ -68,11 +71,12 @@ func ParseArgs(ctx context.Context, a []string) (Args, error) {
 	var upstreamRepoPath string
 	var indexDocOutDir string
 	var includes []string
+	var providerName string
 	cmd := cobra.Command{
 		Use: "./local | remote version",
 		RunE: func(cmd *cobra.Command, a []string) error {
 			var err error
-			args, err = parseArgs(cmd.Context(), a, fullDocs, upstreamRepoPath, indexDocOutDir, includes)
+			args, err = parseArgs(cmd.Context(), a, fullDocs, upstreamRepoPath, indexDocOutDir, includes, providerName)
 			return err
 		},
 		Args: cobra.RangeArgs(1, 2),
@@ -89,6 +93,8 @@ func ParseArgs(ctx context.Context, a []string) (Args, error) {
 			`(e.g. aws_instance,aws_vpc).
 
 If no include filter is specified, all resources and datasources are mapped.`)
+	cmd.Flags().StringVar(&providerName, "provider-name", "",
+		"Custom name for the generated provider to avoid name collisions")
 
 	// We hide docs flags since they are not intended for end users, and they may not be stable.
 	if !env.Dev.Value() {
@@ -128,6 +134,7 @@ func parseArgs(
 	fullDocs bool,
 	upstreamRepoPath, indexDocOutDir string,
 	includes []string,
+	providerName string,
 ) (Args, error) {
 	// If we see a local prefix (starts with '.' or '/'), parse args for a local provider
 	if strings.HasPrefix(args[0], ".") || strings.HasPrefix(args[0], "/") {
@@ -147,7 +154,8 @@ func parseArgs(
 				UpstreamRepoPath: upstreamRepoPath,
 				IndexDocOutDir:   indexDocOutDir,
 			},
-			Includes: includes,
+			Includes:     includes,
+			ProviderName: providerName,
 		}, nil
 	}
 
@@ -169,5 +177,5 @@ func parseArgs(
 		Version:        version,
 		Docs:           fullDocs,
 		IndexDocOutDir: indexDocOutDir,
-	}, Includes: includes}, nil
+	}, Includes: includes, ProviderName: providerName}, nil
 }

--- a/dynamic/parameterize/args_test.go
+++ b/dynamic/parameterize/args_test.go
@@ -174,6 +174,46 @@ func TestParseArgs(t *testing.T) {
 				Includes: []string{"res_a", "res_b", "res_c"},
 			},
 		},
+		{
+			name: "local with provider name",
+			args: []string{"./my-provider", "--provider-name=custom-provider"},
+			expect: Args{
+				Local:        &LocalArgs{Path: "./my-provider"},
+				ProviderName: "custom-provider",
+			},
+		},
+		{
+			name: "remote with provider name",
+			args: []string{"registry/provider", "1.2.3", "--provider-name=my-custom-provider"},
+			expect: Args{
+				Remote: &RemoteArgs{
+					Name:    "registry/provider",
+					Version: "1.2.3",
+				},
+				ProviderName: "my-custom-provider",
+			},
+		},
+		{
+			name: "provider name with resources",
+			args: []string{"registry/provider", "--provider-name=aliased-provider", "--resources=res_a,res_b"},
+			expect: Args{
+				Remote: &RemoteArgs{
+					Name: "registry/provider",
+				},
+				ProviderName: "aliased-provider",
+				Includes:     []string{"res_a", "res_b"},
+			},
+		},
+		{
+			name: "empty provider name flag",
+			args: []string{"registry/provider", "--provider-name="},
+			expect: Args{
+				Remote: &RemoteArgs{
+					Name: "registry/provider",
+				},
+				ProviderName: "",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/dynamic/parameterize/value.go
+++ b/dynamic/parameterize/value.go
@@ -31,6 +31,9 @@ type Value struct {
 	// Includes is the list of resource and datasource names to include in the
 	// provider.  If empty, all resources are included.
 	Includes []string `json:"includes,omitempty"`
+	// ProviderName is the custom name for the generated provider.
+	// If empty, the default Terraform provider name is used.
+	ProviderName string `json:"providerName,omitempty"`
 }
 
 type RemoteValue struct {
@@ -100,10 +103,10 @@ func (p *Value) IntoArgs() Args {
 	if p.Local != nil {
 		return Args{Local: &LocalArgs{
 			Path: p.Local.Path,
-		}, Includes: p.Includes}
+		}, Includes: p.Includes, ProviderName: p.ProviderName}
 	}
 	return Args{Remote: &RemoteArgs{
 		Name:    p.Remote.URL,
 		Version: p.Remote.Version,
-	}, Includes: p.Includes}
+	}, Includes: p.Includes, ProviderName: p.ProviderName}
 }


### PR DESCRIPTION
This change adds support for customizing the generated Pulumi provider name when using dynamic provider generation, addressing name collisions between different Terraform providers that share the same name.

Key changes:
- Add ProviderName field to Args and Value structs in parameterize package
- Implement --provider-name CLI flag parsing with proper validation
- Update providerInfo function to use custom provider name throughout:
  - Provider Name field
  - Golang ImportBasePath and RootPackageName
  - Token generation with custom provider name
- Modify parameterization response to return custom provider name
- Add comprehensive test coverage for both CLI parsing and provider info

Example usage:

    # Use custom provider name to avoid conflicts 
    pulumi package add terraform-provider bpg/proxmox     -- --provider-name=proxmox-bpg
    pulumi package add terraform-provider telmate/proxmox -- --provider-name=proxmox-telmate

    # Works with resource filtering too
    pulumi package add terraform-provider hashicorp/aws -- --provider-name=awsvpc --resources=aws_vpc

Stacked on https://github.com/pulumi/pulumi-terraform-bridge/pull/3147.

Fixes https://github.com/pulumi/pulumi-terraform-provider/issues/70