### PR TITLE
Remove info.SkipExamples

### DIFF
--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -394,9 +394,6 @@ func ConfigBoolValue(vars resource.PropertyMap, prop resource.PropertyKey, envs 
 	return false
 }
 
-// EXPERIMENTAL: the signature may change in minor releases.
-type SkipExamplesArgs = info.SkipExamplesArgs
-
 // If specified, the hook will run just prior to executing Terraform state upgrades to transform the resource state as
 // stored in Pulumi. It can be used to perform idempotent corrections on corrupt state and to compensate for
 // Terraform-level state upgrade not working as expected. Returns the corrected resource state and version. To be used

--- a/pkg/tfbridge/info/info.go
+++ b/pkg/tfbridge/info/info.go
@@ -136,13 +136,6 @@ type Provider struct {
 
 	// EXPERIMENTAL: the signature may change in minor releases.
 	//
-	// If set, allows selecting individual examples to skip generating into the PackageSchema (and eventually API
-	// docs). The primary use case for this hook is to ignore problematic or flaky examples temporarily until the
-	// underlying issues are resolved and the examples can be rendered correctly.
-	SkipExamples func(SkipExamplesArgs) bool
-
-	// EXPERIMENTAL: the signature may change in minor releases.
-	//
 	// Optional function to post-process the generated schema spec after
 	// the bridge completed its original version based on the TF schema.
 	// A hook to enable custom schema modifications specific to a provider.
@@ -1373,19 +1366,6 @@ type PreStateUpgradeHookArgs struct {
 	PriorState              resource.PropertyMap
 	PriorStateSchemaVersion int64
 	ResourceSchemaVersion   int64
-}
-
-// EXPERIMENTAL: the signature may change in minor releases.
-type SkipExamplesArgs struct {
-	// token will be a resource, function, or type token from Pulumi Package Schema. For instance,
-	// "aws:acm/certificate:Certificate" would indicate the example pertains to the Certificate resource in the AWS
-	// provider.
-	Token string
-
-	// examplePath will provide even more information on where the example is found. For instance,
-	// "#/resources/aws:acm/certificate:Certificate/arn" would encode that the example pertains to the arn property
-	// of the Certificate resource in the AWS provider.
-	ExamplePath string
 }
 
 var rawStateDeltaEnabledEnvVarValue = os.Getenv("PULUMI_RAW_STATE_DELTA_ENABLED")

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -1474,15 +1474,6 @@ func (g *Generator) convertExamples(docs string, path examplePath) string {
 		return ""
 	}
 
-	if g.info.SkipExamples != nil {
-		if g.info.SkipExamples(tfbridge.SkipExamplesArgs{
-			Token:       path.Token(),
-			ExamplePath: path.String(),
-		}) {
-			return ""
-		}
-	}
-
 	if strings.Contains(docs, "{{% examples %}}") {
 		// The provider author has explicitly written an entire markdown document including examples.
 		// We'll just return it as is.


### PR DESCRIPTION
This pull request removes the experimental feature of info.SkipExamples.

It was intended as a more granular example-skipping feature for use on individual resources in providers.

Only two providers are using this currently, and using the feature results in loss of documentation. For more context, see https://github.com/pulumi/pulumi-aws/issues/5691.

Blocked by https://github.com/pulumi/pulumi-aws/issues/5691, https://github.com/pulumi/pulumi-alicloud/issues/1044.

Fixes #3152.
