### PR TITLE
Fix parsing of unquoted urns

### DIFF
--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -257,7 +257,7 @@ func (w *logSinkWriter) Write(p []byte) (n int, err error) {
 		return
 	}
 
-	raw := string(p)
+	raw := strings.TrimSuffix(string(p), "\n")
 	level, raw := parseLevelFromRawString(raw)
 
 	if level < w.desiredLevel {


### PR DESCRIPTION
The structured logs emitted by terraform have `key=value` pairs in the log message. Some characters, for example `$` cause the value to be quoted.

The parsing for the quoted urns worked nicely, however since the log message has a trailing `\n`, if the urn is not quoted, and it is the last key=value of the message, we would include the trailing `\n` as part of the urn.

The fix is to strip the trailing `\n` before attempting any parsing.

This lead to some display issues in https://github.com/pulumi/pulumi/issues/20269. I will leave that issue open, as this only fixes parts of the issue: seemingly duplicated resource rows showing up, once for `urn` and once for `urn\n`. The "scrolling" of the output is due to the raw `\n` in the output. The CLI should gracefully display these urns with control characters in them (there are not really any restrictions as to what can show up in an urn).
