### PR TITLE
Fix secret value logged when type checking fails

### DIFF
--- a/pkg/tfbridge/typechecker/typechecker_test.go
+++ b/pkg/tfbridge/typechecker/typechecker_test.go
@@ -1520,7 +1520,10 @@ func TestValidateInputType_toplevel(t *testing.T) {
 				ResourcePath: "secret_nested_mismatch_redacted.inner",
 			}}),
 			inputProperties: map[string]pschema.PropertySpec{
-				"secret_nested_mismatch_redacted": {TypeSpec: pschema.TypeSpec{Type: "object", AdditionalProperties: &pschema.TypeSpec{Type: "string"}}},
+				"secret_nested_mismatch_redacted": {TypeSpec: pschema.TypeSpec{
+					Type:                 "object",
+					AdditionalProperties: &pschema.TypeSpec{Type: "string"},
+				}},
 			},
 		},
 		{

--- a/pkg/tfbridge/typechecker/typechecker_test.go
+++ b/pkg/tfbridge/typechecker/typechecker_test.go
@@ -1496,6 +1496,34 @@ func TestValidateInputType_toplevel(t *testing.T) {
 			},
 		},
 		{
+			name: "secret_type_mismatch_redacted",
+			input: resource.NewSecretProperty(&resource.Secret{
+				Element: resource.NewObjectProperty(
+					resource.NewPropertyMapFromMap(map[string]interface{}{"password": "SuperSecretValue123"}),
+				),
+			}),
+			failures: autogold.Expect([]Failure{{
+				Reason:       "expected string type, got secret(<redacted>) of type object",
+				ResourcePath: "secret_type_mismatch_redacted",
+			}}),
+			inputProperties: map[string]pschema.PropertySpec{
+				"secret_type_mismatch_redacted": {TypeSpec: pschema.TypeSpec{Type: "string"}},
+			},
+		},
+		{
+			name: "secret_nested_mismatch_redacted",
+			input: resource.NewSecretProperty(&resource.Secret{
+				Element: resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{"inner": []int{42}})),
+			}),
+			failures: autogold.Expect([]Failure{{
+				Reason:       "expected string type, got secret(<redacted>) of type []",
+				ResourcePath: "secret_nested_mismatch_redacted.inner",
+			}}),
+			inputProperties: map[string]pschema.PropertySpec{
+				"secret_nested_mismatch_redacted": {TypeSpec: pschema.TypeSpec{Type: "object", AdditionalProperties: &pschema.TypeSpec{Type: "string"}}},
+			},
+		},
+		{
 			name:  "output_type_success",
 			input: resource.NewOutputProperty(resource.Output{Element: resource.NewStringProperty("foo")}),
 			inputProperties: map[string]pschema.PropertySpec{


### PR DESCRIPTION
In the typechecker we have to unwrap the secret value to do the nested
type checking, but if it fails we log the value for the user. While it
is useful to see the actual data to know what shape the data is in, we
have to prevent secrets from being logged. They will still see the
`type`, they just won't be able to see the actual value.

fixes #3158