### PR TITLE
Add mise.toml

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -4,3 +4,4 @@ go = '1.23'
 # Executable tools
 golangci-lint = '2'
 pulumi = "{{ exec(command='go list -m -f={{.Version}} github.com/pulumi/pulumi/sdk/v3') | trim | replace(from='v', to='') }}"
+terraform = 'latest'

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,6 @@
+[tools]
+# Runtimes
+go = '1.23'
+# Executable tools
+golangci-lint = '2'
+pulumi = "{{ exec(command='go list -m -f={{.Version}} github.com/pulumi/pulumi/sdk/v3') | trim | replace(from='v', to='') }}"


### PR DESCRIPTION
Adds a simple mise.toml file. I think this is all that is needed for the
bridge?

The main motivation for me is most of the provider repos are still on
golangci-lint v1