### PR TITLE
Test some ignoreChanges functionality

### DIFF
--- a/pkg/tests/ignore_changes_test.go
+++ b/pkg/tests/ignore_changes_test.go
@@ -18,7 +18,10 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/tests/pulcheck"
 )
 
-func TestIgnoreChangesCollections(t *testing.T) {
+// Collection of tests that test ignoreChanges functionality _with_ core involved.
+// Both core and bridge process ignoreChanges.
+// These tests compliment the tests in `pkg/tfbridge/ignore_changes_test.go`
+func TestIgnoreChanges_withCore(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {
 		name                string
@@ -78,7 +81,7 @@ func TestIgnoreChangesCollections(t *testing.T) {
 			ignoreChanges: `["items[*].weight"]`,
 		},
 		{
-			name: "ListIndexNestedFieldWildcard",
+			name: "SetIndexNestedFieldWildcard",
 			itemsSchema: &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -343,6 +346,7 @@ func extractDiff(t *testing.T, pt *pulumitest.PulumiTest, name string) diffResul
 		u := &updates[i]
 		if u.Request.Name == name {
 			updateProps = u.Response.Properties.AsMap()
+			delete(updateProps, "__pulumi_raw_state_delta")
 		}
 	}
 	diffs, err := grpc.Diffs()


### PR DESCRIPTION
This adds some tests for the `ignoreChanges` functionality, specifically for sdkv2. Some things this highlights:

- wildcards (for lists, sets, maps) do not get processed at all in the bridge. We completely rely on `ignoreChanges` in core.
- Do we need `ignoreChanges` processing in the bridge at all? Is the logic in core enough?

It looks like `ignoreChanges` is processed [here](https://github.com/pulumi/pulumi-terraform-bridge/blob/92748b5518d84600fabbbf16ec14792470c6c8fb/pkg/tfbridge/diff.go#L296-L305), but the way it is currently written wildcards will never be matched.

re https://github.com/pulumi/pulumi-terraform-bridge/issues/3186
re https://github.com/pulumi/pulumi-terraform-bridge/issues/3177

> [!CAUTION]
> Currently blocked by [upgrading pu/pu to 3.194.0](#3187) which includes some fixes to ignoreChanges.