### PR TITLE
Add metadata-aware case-insensitive token deduplication

### DIFF
--- a/dynamic/info.go
+++ b/dynamic/info.go
@@ -134,8 +134,10 @@ func providerInfo(ctx context.Context, p run.Provider, value parameterize.Value)
 		return prov, err
 	}
 
-	err := prov.ComputeTokens(tokens.SingleModule(
-		prov.GetResourcePrefix(), "index", tokens.MakeStandard(providerName)))
+	makeStandard := tokens.MakeStandard(providerName)
+	err := prov.ComputeTokens(tokens.WithCaseInsensitiveDedup(
+		tokens.SingleModule(prov.GetResourcePrefix(), "index", makeStandard),
+		makeStandard, prov.MetadataInfo.Data))
 	if err != nil {
 		return prov, err
 	}

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 # Runtimes
-go = '1.23'
+go = '1.24.1'
 # Executable tools
 golangci-lint = '2'
 pulumi = "{{ exec(command='go list -m -f={{.Version}} github.com/pulumi/pulumi/sdk/v3') | trim | replace(from='v', to='') }}"

--- a/pkg/tfbridge/tokens/case_insensitive_dedup.go
+++ b/pkg/tfbridge/tokens/case_insensitive_dedup.go
@@ -1,0 +1,296 @@
+package tokens
+
+import (
+	"fmt"
+	"strings"
+
+	ptokens "github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
+	md "github.com/pulumi/pulumi-terraform-bridge/v3/unstable/metadata"
+)
+
+// WithCaseInsensitiveDedup wraps an existing strategy and rewrites automatically generated
+// tokens whose names collide when compared case-insensitively. The first occurrence of a
+// token is preserved; subsequent collisions receive a deterministic V suffix. The
+// provided finalize function must be the same one used by the underlying strategy (e.g.
+// tokens.MakeStandard). When provider metadata is supplied, previously emitted tokens are
+// replayed from the auto-alias history so that the same resource keeps the unsuffixed name
+// across multiple tfgen runs—a necessity for stable published providers.
+func WithCaseInsensitiveDedup(base Strategy, finalize Make, metadata info.ProviderMetadata) Strategy {
+	if base.Resource == nil && base.DataSource == nil {
+		return base
+	}
+
+	resourceDeduper := newStandardTokenDeduper(finalize, metadata, deduperKindResource)
+	dataSourceDeduper := newStandardTokenDeduper(finalize, metadata, deduperKindDataSource)
+
+	wrapResource := func(tfToken string, elem *info.Resource) error {
+		if err := resourceDeduper.Err(); err != nil {
+			return err
+		}
+		if elem != nil && elem.Tok == "" {
+			if prior, ok := resourceDeduper.priorToken(tfToken); ok {
+				elem.Tok = ptokens.Type(prior)
+			}
+		}
+		var userOverride string
+		// Remember user-specified tokens (and prior tokens) so we don't rewrite them
+		if elem != nil && elem.Tok != "" {
+			userOverride = string(elem.Tok)
+			resourceDeduper.register(userOverride)
+		}
+		// If there is no Strategy then we are done
+		if base.Resource == nil {
+			return nil
+		}
+		if err := base.Resource(tfToken, elem); err != nil {
+			return err
+		}
+		// If after running the Strategy we still don't have a token, then
+		// we are done
+		if elem == nil || elem.Tok == "" {
+			return nil
+		}
+		if userOverride != "" {
+			current := string(elem.Tok)
+			// None of the current built-in strategies will override a user provided token, but
+			// we should still handle this in case users provide one that does
+			if userOverride != current {
+				resourceDeduper.unregister(userOverride)
+				resourceDeduper.register(current)
+			}
+			return nil
+		}
+		tok, err := resourceDeduper.ensureUnique(string(elem.Tok))
+		if err != nil {
+			return fmt.Errorf("resource %q: %w", tfToken, err)
+		}
+		elem.Tok = ptokens.Type(tok)
+		return nil
+	}
+
+	wrapDataSource := func(tfToken string, elem *info.DataSource) error {
+		if err := dataSourceDeduper.Err(); err != nil {
+			return err
+		}
+		if elem != nil && elem.Tok == "" {
+			if prior, ok := dataSourceDeduper.priorToken(tfToken); ok {
+				elem.Tok = ptokens.ModuleMember(prior)
+			}
+		}
+		var userOverride string
+		if elem != nil && elem.Tok != "" {
+			userOverride = string(elem.Tok)
+			dataSourceDeduper.register(userOverride)
+		}
+		if base.DataSource == nil {
+			return nil
+		}
+		if err := base.DataSource(tfToken, elem); err != nil {
+			return err
+		}
+		if elem == nil || elem.Tok == "" {
+			return nil
+		}
+		if userOverride != "" {
+			current := string(elem.Tok)
+			if userOverride != current {
+				dataSourceDeduper.unregister(userOverride)
+				dataSourceDeduper.register(current)
+			}
+			return nil
+		}
+		tok, err := dataSourceDeduper.ensureUnique(string(elem.Tok))
+		if err != nil {
+			return fmt.Errorf("datasource %q: %w", tfToken, err)
+		}
+		elem.Tok = ptokens.ModuleMember(tok)
+		return nil
+	}
+
+	return Strategy{
+		Resource:   wrapResource,
+		DataSource: wrapDataSource,
+	}
+}
+
+type standardTokenDeduper struct {
+	finalize Make
+	seen     map[string]int
+	metadata info.ProviderMetadata
+	prior    map[string]string
+	err      error
+	kind     deduperKind
+}
+
+const aliasMetadataKey = "auto-aliasing"
+
+type deduperKind int
+
+const (
+	deduperKindResource deduperKind = iota
+	deduperKindDataSource
+)
+
+type aliasHistorySnapshot struct {
+	Resources   map[string]aliasTokenSnapshot `json:"resources,omitempty"`
+	DataSources map[string]aliasTokenSnapshot `json:"datasources,omitempty"`
+}
+
+type aliasTokenSnapshot struct {
+	Current string `json:"current"`
+}
+
+// newStandardTokenDeduper constructs a deduper for either resources or data sources and
+// immediately seeds it from persisted metadata when available.
+func newStandardTokenDeduper(finalize Make, metadata info.ProviderMetadata, kind deduperKind) *standardTokenDeduper {
+	d := &standardTokenDeduper{
+		finalize: finalize,
+		seen:     map[string]int{},
+		metadata: metadata,
+		prior:    map[string]string{},
+		kind:     kind,
+	}
+	d.seedFromMetadata()
+	return d
+}
+
+// seedFromMetadata replays the token chosen in prior runs so the same TF token keeps the
+// unsuffixed name and the counter continues from the last V suffix.
+func (d *standardTokenDeduper) seedFromMetadata() {
+	if d.metadata == nil || d.err != nil {
+		return
+	}
+	history, ok, err := md.Get[aliasHistorySnapshot](d.metadata, aliasMetadataKey)
+	if err != nil {
+		d.err = fmt.Errorf("reading %q metadata: %w", aliasMetadataKey, err)
+		return
+	}
+	if !ok {
+		return
+	}
+
+	var entries map[string]aliasTokenSnapshot
+	switch d.kind {
+	case deduperKindResource:
+		entries = history.Resources
+	case deduperKindDataSource:
+		entries = history.DataSources
+	default:
+		return
+	}
+	for tfToken, snapshot := range entries {
+		if snapshot.Current == "" {
+			continue
+		}
+		// Record the last published token so that when we encounter the TF token again on
+		// a future run we can reuse that identity rather than giving the unsuffixed name to
+		// a newly added resource that happens to sort earlier.
+		d.prior[tfToken] = snapshot.Current
+		// Seeding the counter ensures subsequent collisions pick the next available suffix
+		// instead of reusing V2 and producing churn in generated SDKs.
+		d.register(snapshot.Current)
+	}
+}
+
+// register notes that we have already seen a token at least once and should begin handing
+// out V2 on the next collision. Safe to call multiple times on the same token.
+func (d *standardTokenDeduper) register(token string) {
+	parts, ok := parseStandardToken(token)
+	if !ok {
+		return
+	}
+	key := parts.normalizedKey()
+	if _, exists := d.seen[key]; !exists {
+		d.seen[key] = 2
+	}
+}
+
+// unregister forgets a previously recorded token, typically because a manual override
+// changed after the base strategy ran.
+func (d *standardTokenDeduper) unregister(token string) {
+	parts, ok := parseStandardToken(token)
+	if !ok {
+		return
+	}
+	key := parts.normalizedKey()
+	delete(d.seen, key)
+}
+
+// Err exposes any initialization or metadata failures so callers can stop early.
+func (d *standardTokenDeduper) Err() error {
+	return d.err
+}
+
+// priorToken reports the last emitted Pulumi token for the given TF token, if we seeded it
+// from metadata.
+func (d *standardTokenDeduper) priorToken(tfToken string) (string, bool) {
+	if d.prior == nil {
+		return "", false
+	}
+	tok, ok := d.prior[tfToken]
+	return tok, ok
+}
+
+// ensureUnique hands back either the original token or a V suffix that does not
+// collide case-insensitively with previously seen tokens.
+func (d *standardTokenDeduper) ensureUnique(token string) (string, error) {
+	if d.err != nil {
+		return "", d.err
+	}
+	parts, ok := parseStandardToken(token)
+	if !ok {
+		// Token format is not recognized; leave it unchanged.
+		return token, nil
+	}
+	key := parts.normalizedKey()
+	next, exists := d.seen[key]
+	if !exists {
+		d.seen[key] = 2
+		return token, nil
+	}
+	variant := next
+	for {
+		candidateName := fmt.Sprintf("%sV%d", parts.PascalName, variant)
+		newToken, err := d.finalize(parts.Module, candidateName)
+		if err != nil {
+			return "", err
+		}
+		nextParts, ok := parseStandardToken(newToken)
+		if !ok {
+			return "", fmt.Errorf("unexpected token format from finalize: %q", newToken)
+		}
+		candidateKey := nextParts.normalizedKey()
+		if _, exists := d.seen[candidateKey]; !exists {
+			d.seen[key] = variant + 1
+			d.seen[candidateKey] = 2
+			return newToken, nil
+		}
+		variant++
+	}
+}
+
+type tokenParts struct {
+	Package    string
+	Module     string
+	PascalName string
+}
+
+func (p tokenParts) normalizedKey() string {
+	return strings.ToLower(p.Module) + ":" + strings.ToLower(p.PascalName)
+}
+
+// parseStandardToken splits a standard Pulumi token (pkg:module/lower:Name) into its
+// constituent parts; tokens outside that format are ignored by the deduper.
+func parseStandardToken(token string) (tokenParts, bool) {
+	if member, err := ptokens.ParseModuleMember(token); err == nil {
+		qName := ptokens.IntoQName(member.Module().Name().String())
+		return tokenParts{
+			Package:    member.Package().String(),
+			Module:     qName.Namespace().String(),
+			PascalName: member.Name().String(),
+		}, true
+	}
+	return tokenParts{}, false
+}

--- a/pkg/tfbridge/tokens/case_insensitive_dedup_test.go
+++ b/pkg/tfbridge/tokens/case_insensitive_dedup_test.go
@@ -1,0 +1,20 @@
+package tokens
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_parseStandardToken(t *testing.T) {
+	t.Parallel()
+
+	tok := "pkg:module/lower:Name"
+	res, ok := parseStandardToken(tok)
+	require.True(t, ok)
+	require.Equal(t, tokenParts{
+		Package:    "pkg",
+		Module:     "module",
+		PascalName: "Name",
+	}, res)
+}

--- a/pkg/tfbridge/tokens_test.go
+++ b/pkg/tfbridge/tokens_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/tokens"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/metadata"
 	md "github.com/pulumi/pulumi-terraform-bridge/v3/unstable/metadata"
 )
 
@@ -558,6 +559,208 @@ func TestTokensInferredModules(t *testing.T) {
 			assert.Equal(t, tt.resourceMapping, mapping)
 		})
 	}
+}
+
+func TestCaseInsensitiveDedupSingleModule(t *testing.T) {
+	t.Parallel()
+
+	info := tfbridge.ProviderInfo{
+		P: (&schema.Provider{
+			ResourcesMap: schema.ResourceMap{
+				"fortios_firewall_security_policy": nil,
+				"fortios_firewall_securitypolicy":  nil,
+			},
+		}).Shim(),
+	}
+
+	makeStandard := tokens.MakeStandard("fortios")
+	strategy := tokens.WithCaseInsensitiveDedup(
+		tokens.SingleModule("fortios_", "index", makeStandard), makeStandard, nil)
+
+	require.NoError(t, info.ComputeTokens(strategy))
+
+	assert.Equal(t, map[string]*tfbridge.ResourceInfo{
+		"fortios_firewall_security_policy": {
+			Tok: "fortios:index/firewallSecurityPolicy:FirewallSecurityPolicy",
+		},
+		"fortios_firewall_securitypolicy": {
+			Tok: "fortios:index/firewallSecuritypolicyV2:FirewallSecuritypolicyV2",
+		},
+	}, info.Resources)
+}
+
+func TestCaseInsensitiveDedupRespectsManualToken(t *testing.T) {
+	t.Parallel()
+
+	info := tfbridge.ProviderInfo{
+		P: (&schema.Provider{
+			ResourcesMap: schema.ResourceMap{
+				"pkg_examplealt":  nil,
+				"pkg_example_alt": nil,
+			},
+		}).Shim(),
+		Resources: map[string]*tfbridge.ResourceInfo{
+			"pkg_examplealt": {
+				Tok: "pkg:index/example:Example",
+			},
+		},
+	}
+
+	makeStandard := tokens.MakeStandard("pkg")
+	strategy := tokens.WithCaseInsensitiveDedup(
+		tokens.SingleModule("pkg_", "index", makeStandard), makeStandard, nil)
+
+	require.NoError(t, info.ComputeTokens(strategy))
+
+	require.Contains(t, info.Resources, "pkg_examplealt")
+	require.Contains(t, info.Resources, "pkg_example_alt")
+	assert.Equal(t, "pkg:index/example:Example", string(info.Resources["pkg_examplealt"].Tok))
+	// Automatic mapping still runs for the other resource, but should not disturb the manual token.
+	assert.Equal(t, "pkg:index/exampleAlt:ExampleAlt", string(info.Resources["pkg_example_alt"].Tok))
+}
+
+func TestCaseInsensitiveDedupSeedsFromMetadata(t *testing.T) {
+	t.Parallel()
+
+	type aliasTokenSnapshot struct {
+		Current string `json:"current"`
+	}
+	type aliasHistorySnapshot struct {
+		Resources   map[string]aliasTokenSnapshot `json:"resources,omitempty"`
+		DataSources map[string]aliasTokenSnapshot `json:"datasources,omitempty"`
+	}
+
+	metadataStore, err := md.New(nil)
+	require.NoError(t, err)
+	err = metadata.Set(metadataStore, "auto-aliasing", aliasHistorySnapshot{
+		Resources: map[string]aliasTokenSnapshot{
+			"pkg_example_b": {Current: "pkg:index/exampleB2:ExampleB2"},
+		},
+	})
+	require.NoError(t, err)
+
+	metaInfo := &tfbridge.MetadataInfo{Data: metadataStore, Path: "must be non-empty"}
+
+	makeStandard := tokens.MakeStandard("pkg")
+	strategy := func() tokens.Strategy {
+		return tokens.WithCaseInsensitiveDedup(
+			tokens.SingleModule("pkg_", "index", makeStandard),
+			makeStandard,
+			metaInfo.Data,
+		)
+	}
+
+	providerOne := tfbridge.ProviderInfo{
+		P: (&schema.Provider{
+			ResourcesMap: schema.ResourceMap{
+				"pkg_example_b": nil,
+			},
+		}).Shim(),
+		MetadataInfo: metaInfo,
+	}
+
+	require.NoError(t, providerOne.ComputeTokens(strategy()))
+	require.Contains(t, providerOne.Resources, "pkg_example_b")
+	require.Equal(t,
+		"pkg:index/exampleB2:ExampleB2",
+		string(providerOne.Resources["pkg_example_b"].Tok),
+	)
+	require.NoError(t, providerOne.ApplyAutoAliases())
+
+	providerTwo := tfbridge.ProviderInfo{
+		P: (&schema.Provider{
+			ResourcesMap: schema.ResourceMap{
+				"pkg_example_B": nil,
+				"pkg_example_b": nil,
+			},
+		}).Shim(),
+		MetadataInfo: metaInfo,
+	}
+
+	require.NoError(t, providerTwo.ComputeTokens(strategy()))
+	require.Equal(t, map[string]*tfbridge.ResourceInfo{
+		"pkg_example_b": {Tok: "pkg:index/exampleB2:ExampleB2"},
+		"pkg_example_B": {Tok: "pkg:index/exampleB:ExampleB"},
+	}, providerTwo.Resources)
+}
+
+func TestCaseInsensitiveDedupSeedsFromEmptyMetadata(t *testing.T) {
+	t.Parallel()
+
+	metadataStore, err := md.New(nil)
+	require.NoError(t, err)
+
+	metaInfo := &tfbridge.MetadataInfo{Data: metadataStore, Path: "must be non-empty"}
+
+	makeStandard := tokens.MakeStandard("pkg")
+	strategy := func() tokens.Strategy {
+		return tokens.WithCaseInsensitiveDedup(
+			tokens.SingleModule("pkg_", "index", makeStandard),
+			makeStandard,
+			metaInfo.Data,
+		)
+	}
+
+	providerOne := tfbridge.ProviderInfo{
+		P: (&schema.Provider{
+			ResourcesMap: schema.ResourceMap{
+				"pkg_example_b": nil,
+			},
+		}).Shim(),
+		MetadataInfo: metaInfo,
+	}
+
+	require.NoError(t, providerOne.ComputeTokens(strategy()))
+	require.Contains(t, providerOne.Resources, "pkg_example_b")
+	require.Equal(t,
+		"pkg:index/exampleB:ExampleB",
+		string(providerOne.Resources["pkg_example_b"].Tok),
+	)
+	require.NoError(t, providerOne.ApplyAutoAliases())
+
+	providerTwo := tfbridge.ProviderInfo{
+		P: (&schema.Provider{
+			ResourcesMap: schema.ResourceMap{
+				"pkg_example_B": nil,
+				"pkg_example_b": nil,
+			},
+		}).Shim(),
+		MetadataInfo: metaInfo,
+	}
+
+	require.NoError(t, providerTwo.ComputeTokens(strategy()))
+	require.Equal(t, map[string]*tfbridge.ResourceInfo{
+		"pkg_example_b": {Tok: "pkg:index/exampleB:ExampleB"},
+		"pkg_example_B": {Tok: "pkg:index/exampleBV2:ExampleBV2"},
+	}, providerTwo.Resources)
+}
+
+func TestCaseInsensitiveDedupDataSources(t *testing.T) {
+	t.Parallel()
+
+	info := tfbridge.ProviderInfo{
+		P: (&schema.Provider{
+			DataSourcesMap: schema.ResourceMap{
+				"fortios_firewall_security_policy": nil,
+				"fortios_firewall_securitypolicy":  nil,
+			},
+		}).Shim(),
+	}
+
+	makeStandard := tokens.MakeStandard("fortios")
+	strategy := tokens.WithCaseInsensitiveDedup(
+		tokens.SingleModule("fortios_", "index", makeStandard), makeStandard, nil)
+
+	require.NoError(t, info.ComputeTokens(strategy))
+
+	assert.Equal(t, map[string]*tfbridge.DataSourceInfo{
+		"fortios_firewall_security_policy": {
+			Tok: "fortios:index/getFirewallSecurityPolicy:getFirewallSecurityPolicy",
+		},
+		"fortios_firewall_securitypolicy": {
+			Tok: "fortios:index/getFirewallSecuritypolicyV2:getFirewallSecuritypolicyV2",
+		},
+	}, info.DataSources)
 }
 
 func makeAutoAliasing(t *testing.T) (


### PR DESCRIPTION
**Why we’re doing this**

Terraform providers frequently export resources whose names differ only by underscores or case (`foo_bar`, `foo-bar`, `fooBar`). Our standard token strategy collapses them to the same Pulumi token (`pkg:index/fooBar:FooBar`), forcing provider authors to hand-maintain overrides and often pushing breaking changes downstream. We wanted a turnkey wrapper that (a) keeps automatically generated tokens unique, (b) leaves manual overrides untouched, and (c) stays stable across successive tfgen runs so the “winner” of the unsuffixed name never flips.

**Key ideas**

- Wrap any existing `tokens.Strategy` with `WithCaseInsensitiveDedup`. The wrapper runs the base strategy first, then checks the normalized (module, PascalName) key against a small state machine to decide whether to reuse the original token or append a suffix.
- Persistence comes for free: the deduper consults the provider’s bridge-metadata.json (specifically the auto-aliasing history) to preload which token owned the unsuffixed name last time and what suffix counter we reached. That means the original resource keeps `Foo` even if a `foo_` resource is added later and happens to sort first.
- Suffixes use the compact `FooV2` format.

**How it works (by example)**

Suppose last release shipped a single TF
resource `foo_widget` -> `pkg:index/fooWidget:FooWidget`. After running tfgen, the metadata history records `{ "foo_widget": { "current": "pkg:index/fooWidget:FooWidget" } }`.

_A week later:_

1. We create the deduper: `seedFromMetadata` reads the auto-aliasing blob, records that `foo_widget` already owns `FooWidget`, and registers the normalized key `index:foowidget` so the suffix counter starts at 2.
2. When `ComputeTokens` walks the existing TF resource, `wrapResource` sees `elem.Tok` is empty, replays the metadata token, registers it (keeping the counter at 2), and exits because it’s a manual override.
3. A new TF resource `foo_Widget` arrives; the base strategy proposes `FooWidget`. `ensureUnique` notices the normalized key already exists with counter 2, so it returns `FooWidgetV2`, registers both `index:foowidget` (now bumped to 3) and `index:foowidgetv2`, and we assign the suffixed token. No resource renamed.
4. Future collisions get `FooWidgetV3`, etc., because we never reset the counter.

If metadata is missing (dynamic provider CLI, first run, metadata not enabled yet) the deduper still works—but only within that run. The doc calls this out so authors know stability requires metadata.

**Major components**

- `WithCaseInsensitiveDedup` signature gained a `info.ProviderMetadata` parameter (nullable). `Strategy` wrappers call it with either the provider’s metadata blob or nil.
- `standardTokenDeduper` tracks seen normalized keys, prior tokens, metadata, and any initialization error. register/unregister manage the per-key counter, while priorToken allows the wrapper to prefill existing resources.
- `seedFromMetadata` reads auto-aliasing history, caches the previously published token per TF token, and registers keys so `ensureUnique` starts from the last used suffix.

**Trade-offs / limitations**

- Manual overrides remain authoritative: if a provider author sets `info.Resources["foo_widget"].Tok` before calling `ComputeTokens`, we do not rewrite it, but we still update the counter so future collisions keep incrementing.
- Dynamic providers at runtime pass metadata with Path: "", so behaviour is per-run. That is documented; if we ever want runtime persistence we’ll need a different storage mechanism.

fixes #2904