### PR TITLE
Use g.pkg.Name() for determining location of schema file

### DIFF
--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -1112,7 +1112,7 @@ func (g *Generator) Generate() (*GenerateSchemaResult, error) {
 		return g.UnstableGenerateFromSchema(genSchemaResult)
 	}
 	// Read the provider schema from file
-	schemaBytes, err := os.ReadFile(fmt.Sprintf("provider/cmd/pulumi-resource-%s/schema.json", g.info.Name))
+	schemaBytes, err := os.ReadFile(fmt.Sprintf("provider/cmd/pulumi-resource-%s/schema.json", g.pkg.Name().String()))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Basically what it says on the box.

When we read the schema into the language filter, it expects a location in the Pulumi repo. That repo is named after the Pulumi package name, not the ProviderInfo.Name (which is the Terraform name).
This pull request uses g.pkg.Name() to pass along this information.

Fixes #3198.

