### PR TITLE
Add empty lines check to findCodeBlocks to avoid panic

### DIFF
--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -1551,6 +1551,11 @@ func findCodeBlocks(docs []byte) []codeBlock {
 	parse.WalkNode(rootNode, func(cb *gmast.FencedCodeBlock) {
 		lines := cb.Lines()
 
+		// Skip empty code blocks to avoid panic
+		if lines.Len() == 0 {
+			return
+		}
+
 		headerStart := -1
 		for p := cb.Parent(); p != nil; p = p.Parent() {
 			if s, ok := p.(*section.Section); ok {

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -2278,6 +2278,14 @@ func TestFindFencesAndHeaders(t *testing.T) {
 				{start: 1897, end: 2245, headerStart: 1624, language: "hcl"},
 			},
 		},
+		{
+			name: "handles empty code blocks without panic",
+			path: filepath.Join("test_data", "parse-inner-docs",
+				"empty-code-blocks.md"),
+			expected: []codeBlock{
+				{start: 0, end: 113, headerStart: -1, language: "terraform"},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/tfgen/test_data/parse-inner-docs/empty-code-blocks.md
+++ b/pkg/tfgen/test_data/parse-inner-docs/empty-code-blocks.md
@@ -1,0 +1,14 @@
+```terraform
+resource "aws_instance" "example" {
+  ami           = "ami-12345678"
+  instance_type = "t2.micro"
+}
+```
+
+```
+```
+
+```terraform
+```
+
+Some text after empty code blocks.


### PR DESCRIPTION
This pull request fixes a build panic encountered in pulumi-mongodbatlas when we pass empty code blocks.


