### PR TITLE
Fix package location: `pf` lives under `pkg`

### DIFF
--- a/docs/guides/new-pf-provider.md
+++ b/docs/guides/new-pf-provider.md
@@ -46,7 +46,7 @@ Follow these steps to bridge a Terraform Provider to Pulumi.
     package main
 
     import (
-        "github.com/pulumi/pulumi-terraform-bridge/v3/pf/tfgen"
+        "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfgen"
         // import myprovider
     )
 

--- a/docs/guides/upgrade-sdk-to-mux.md
+++ b/docs/guides/upgrade-sdk-to-mux.md
@@ -14,7 +14,7 @@ Framework](https://github.com/hashicorp/terraform-plugin-framework?tab=readme).
 
 1. Find the tfgen binary `main` that calls `tfgen.Main` from
    `github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen` and update it to call
-   `tfgen.MainWithMuxer` from `github.com/pulumi/pulumi-terraform-bridge/v3/pf/tfgen`.
+   `tfgen.MainWithMuxer` from `github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfgen`.
 
    Note that the extra version parameter is removed from `tfgen.Main`, so this code:
 
@@ -29,7 +29,7 @@ Framework](https://github.com/hashicorp/terraform-plugin-framework?tab=readme).
    Becomes:
 
    ``` go
-   import "github.com/pulumi/pulumi-terraform-bridge/v3/pf/tfgen"
+   import "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfgen"
 
    ...
 

--- a/pkg/pf/tfbridge/metadata.go
+++ b/pkg/pf/tfbridge/metadata.go
@@ -21,7 +21,7 @@ import (
 )
 
 // Defines bridged provider metadata that is pre-computed at build time with tfgen (tfgen
-// ("github.com/pulumi/pulumi-terraform-bridge/v3/pf/tfgen") and typically made available to the provider
+// ("github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfgen") and typically made available to the provider
 // binary at runtime with [embed].
 //
 // [embed]: https://pkg.go.dev/embed


### PR DESCRIPTION
A few documentation fixes to reflect the correct Go package location.

Old:

```go
github.com/pulumi/pulumi-terraform-bridge/v3/pf/tfgen
```

New:

```go
github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfgen
```