### PR TITLE
Add support for provider actions

### DIFF
--- a/pkg/convert/convert.go
+++ b/pkg/convert/convert.go
@@ -41,6 +41,7 @@ type Encoding interface {
 	NewResourceEncoder(resource string, resourceType tftypes.Object) (Encoder, error)
 	NewDataSourceDecoder(dataSource string, dataSourceType tftypes.Object) (Decoder, error)
 	NewDataSourceEncoder(dataSource string, dataSourceType tftypes.Object) (Encoder, error)
+	NewActionEncoder(action string, actionType tftypes.Object) (Encoder, error)
 }
 
 // Like PropertyNames but specialized to either a type by token or config property.

--- a/pkg/convert/encoding.go
+++ b/pkg/convert/encoding.go
@@ -89,6 +89,17 @@ func (e *encoding) NewDataSourceDecoder(
 	return dec, nil
 }
 
+func (e *encoding) NewActionEncoder(
+	dataSource string, objectType tftypes.Object,
+) (Encoder, error) {
+	mctx := newActionSchemaMapContext(dataSource, e.SchemaOnlyProvider, e.ProviderInfo)
+	enc, err := NewObjectEncoder(ObjectSchema{mctx.schemaMap, mctx.schemaInfos, &objectType})
+	if err != nil {
+		return nil, fmt.Errorf("cannot derive an encoder for action %q: %w", dataSource, err)
+	}
+	return enc, nil
+}
+
 func buildPropertyEncoders(
 	mctx *schemaMapContext, objectType tftypes.Object,
 ) (map[terraformPropertyName]Encoder, error) {

--- a/pkg/convert/schema_context.go
+++ b/pkg/convert/schema_context.go
@@ -23,7 +23,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/walk"
 )
 
@@ -69,6 +69,21 @@ func newDataSourceSchemaMapContext(
 	var fields map[string]*tfbridge.SchemaInfo
 	if providerInfo != nil {
 		fields = providerInfo.DataSources[dataSource].GetFields()
+	}
+	return newSchemaMapContext(sm, fields)
+}
+
+func newActionSchemaMapContext(
+	action string,
+	schemaOnlyProvider shim.Provider,
+	providerInfo *tfbridge.ProviderInfo,
+) *schemaMapContext {
+	r := schemaOnlyProvider.ActionsMap().Get(action)
+	contract.Assertf(r != nil, "no action %q found in ActionsMap", action)
+	sm := r.Schema()
+	var fields map[string]*tfbridge.SchemaInfo
+	if providerInfo != nil {
+		fields = providerInfo.Actions[action].GetFields()
 	}
 	return newSchemaMapContext(sm, fields)
 }

--- a/pkg/pf/internal/pfutils/actions.go
+++ b/pkg/pf/internal/pfutils/actions.go
@@ -1,0 +1,74 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pfutils
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/action"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/runtypes"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+)
+
+func GatherActions[F func(Schema) shim.SchemaMap](
+	ctx context.Context, prov provider.Provider, f F,
+) (runtypes.Actions, error) {
+	provMetadata := queryProviderMetadata(ctx, prov)
+	ds := make(collection[func() action.Action])
+
+	aprov, is := prov.(provider.ProviderWithActions)
+	if is {
+		for _, makeAction := range aprov.Actions(ctx) {
+			act := makeAction()
+
+			meta := action.MetadataResponse{}
+			act.Metadata(ctx, action.MetadataRequest{
+				ProviderTypeName: provMetadata.TypeName,
+			}, &meta)
+
+			schemaResponse := &action.SchemaResponse{}
+			act.Schema(ctx, action.SchemaRequest{}, schemaResponse)
+
+			actionSchema := schemaResponse.Schema
+			diag := schemaResponse.Diagnostics
+			if err := checkDiagsForErrors(diag); err != nil {
+				return nil, fmt.Errorf("Action %s GetSchema() error: %w", meta.TypeName, err)
+			}
+
+			ds[runtypes.TypeOrRenamedEntityName(meta.TypeName)] = entry[func() action.Action]{
+				t:      makeAction,
+				schema: FromActionSchema(actionSchema),
+				tfName: runtypes.TypeName(meta.TypeName),
+			}
+		}
+	}
+
+	return &actions{collection: ds, convert: f}, nil
+}
+
+type actions struct {
+	collection[func() action.Action]
+	convert func(Schema) shim.SchemaMap
+}
+
+func (r actions) Schema(t runtypes.TypeOrRenamedEntityName) runtypes.Schema {
+	entry := r.collection[t]
+	return runtypesSchemaAdapter{entry.schema, r.convert, entry.tfName}
+}
+
+func (actions) IsActions() {}

--- a/pkg/pf/internal/pfutils/attr.go
+++ b/pkg/pf/internal/pfutils/attr.go
@@ -17,6 +17,7 @@ package pfutils
 import (
 	"fmt"
 
+	aschema "github.com/hashicorp/terraform-plugin-framework/action/schema"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	dschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	prschema "github.com/hashicorp/terraform-plugin-framework/provider/schema"
@@ -62,6 +63,10 @@ func FromDataSourceAttribute(x dschema.Attribute) Attr {
 }
 
 func FromResourceAttribute(x rschema.Attribute) Attr {
+	return FromAttrLike(x)
+}
+
+func FromActionAttribute(x aschema.Attribute) Attr {
 	return FromAttrLike(x)
 }
 

--- a/pkg/pf/internal/pfutils/block.go
+++ b/pkg/pf/internal/pfutils/block.go
@@ -21,6 +21,7 @@ import (
 	"slices"
 	"strconv"
 
+	aschema "github.com/hashicorp/terraform-plugin-framework/action/schema"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	dschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	prschema "github.com/hashicorp/terraform-plugin-framework/provider/schema"
@@ -59,6 +60,10 @@ func FromDataSourceBlock(x dschema.Block) Block {
 }
 
 func FromResourceBlock(x rschema.Block) Block {
+	return FromBlockLike(x)
+}
+
+func FromActionBlock(x aschema.Block) Block {
 	return FromBlockLike(x)
 }
 

--- a/pkg/pf/internal/pfutils/schema.go
+++ b/pkg/pf/internal/pfutils/schema.go
@@ -17,6 +17,7 @@ package pfutils
 import (
 	"context"
 
+	aschema "github.com/hashicorp/terraform-plugin-framework/action/schema"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	dschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	prschema "github.com/hashicorp/terraform-plugin-framework/provider/schema"
@@ -64,6 +65,12 @@ func FromResourceSchema(x rschema.Schema) Schema {
 	attrs := convertMap(FromResourceAttribute, x.Attributes)
 	blocks := convertMap(FromResourceBlock, x.Blocks)
 	return newSchemaAdapter(x, x.Type(), x.DeprecationMessage, attrs, blocks, &x)
+}
+
+func FromActionSchema(x aschema.Schema) Schema {
+	attrs := convertMap(FromActionAttribute, x.Attributes)
+	blocks := convertMap(FromActionBlock, x.Blocks)
+	return newSchemaAdapter(x, x.Type(), x.DeprecationMessage, attrs, blocks, nil)
 }
 
 type schemaAdapter struct {

--- a/pkg/pf/internal/plugin/provider_context.go
+++ b/pkg/pf/internal/plugin/provider_context.go
@@ -21,8 +21,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
 )
@@ -32,6 +30,9 @@ type ProviderWithContext interface {
 	io.Closer
 
 	Pkg() tokens.Package
+
+	HandshakeWithContext(ctx context.Context, req plugin.ProviderHandshakeRequest,
+	) (*plugin.ProviderHandshakeResponse, error)
 
 	GetSchemaWithContext(ctx context.Context, req plugin.GetSchemaRequest) ([]byte, error)
 
@@ -68,7 +69,7 @@ type ProviderWithContext interface {
 		options plugin.ConstructOptions) (plugin.ConstructResult, error)
 
 	InvokeWithContext(ctx context.Context, tok tokens.ModuleMember,
-		args resource.PropertyMap) (resource.PropertyMap, []plugin.CheckFailure, error)
+		args resource.PropertyMap, preview bool) (resource.PropertyMap, []plugin.CheckFailure, error)
 
 	CallWithContext(ctx context.Context, tok tokens.ModuleMember, args resource.PropertyMap, info plugin.CallInfo,
 		options plugin.CallOptions) (plugin.CallResult, error)
@@ -100,7 +101,7 @@ func (prov *provider) Pkg() tokens.Package { return prov.ProviderWithContext.Pkg
 func (prov *provider) Handshake(ctx context.Context,
 	req plugin.ProviderHandshakeRequest,
 ) (*plugin.ProviderHandshakeResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "Handshake is not yet implemented")
+	return prov.HandshakeWithContext(ctx, req)
 }
 
 func (prov *provider) Parameterize(
@@ -203,7 +204,7 @@ func (prov *provider) Construct(
 func (prov *provider) Invoke(
 	ctx context.Context, req plugin.InvokeRequest,
 ) (plugin.InvokeResponse, error) {
-	p, f, err := prov.InvokeWithContext(ctx, req.Tok, req.Args)
+	p, f, err := prov.InvokeWithContext(ctx, req.Tok, req.Args, req.Preview)
 	return plugin.InvokeResponse{Properties: p, Failures: f}, err
 }
 

--- a/pkg/pf/internal/plugin/provider_server.go
+++ b/pkg/pf/internal/plugin/provider_server.go
@@ -23,6 +23,7 @@ import (
 	pbempty "github.com/golang/protobuf/ptypes/empty"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	pl "github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -164,7 +165,19 @@ func (p *providerServer) Parameterize(
 func (p *providerServer) Handshake(ctx context.Context,
 	req *pulumirpc.ProviderHandshakeRequest,
 ) (*pulumirpc.ProviderHandshakeResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "Handshake is not yet implemented")
+	mreq := plugin.ProviderHandshakeRequest{
+		InvokeWithPreview: req.GetInvokeWithPreview(),
+	}
+	resp, err := p.provider.HandshakeWithContext(ctx, mreq)
+	if err != nil {
+		return nil, err
+	}
+	return &pulumirpc.ProviderHandshakeResponse{
+		AcceptSecrets:                   resp.AcceptSecrets,
+		AcceptResources:                 resp.AcceptResources,
+		AcceptOutputs:                   resp.AcceptOutputs,
+		SupportsAutonamingConfiguration: resp.SupportsAutonamingConfiguration,
+	}, nil
 }
 
 func (p *providerServer) GetSchema(ctx context.Context,
@@ -620,7 +633,7 @@ func (p *providerServer) Invoke(ctx context.Context, req *pulumirpc.InvokeReques
 		return nil, err
 	}
 
-	result, failures, err := p.provider.InvokeWithContext(ctx, tokens.ModuleMember(req.GetTok()), args)
+	result, failures, err := p.provider.InvokeWithContext(ctx, tokens.ModuleMember(req.GetTok()), args, req.Preview)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/pf/internal/runtypes/types.go
+++ b/pkg/pf/internal/runtypes/types.go
@@ -66,3 +66,9 @@ type DataSources interface {
 	collection
 	IsDataSources()
 }
+
+// Represents all provider's actions pre-indexed by TypeOrRenamedEntityName.
+type Actions interface {
+	collection
+	IsActions()
+}

--- a/pkg/pf/internal/schemashim/action.go
+++ b/pkg/pf/internal/schemashim/action.go
@@ -1,0 +1,52 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schemashim
+
+import (
+	"context"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/internalinter"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/runtypes"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/valueshim"
+)
+
+type schemaOnlyAction struct {
+	tf runtypes.Schema
+	internalinter.Internal
+}
+
+var _ shim.Action = (*schemaOnlyAction)(nil)
+
+func (r *schemaOnlyAction) SchemaType() valueshim.Type {
+	protoSchema, err := r.tf.ResourceProtoSchema(context.Background())
+	contract.AssertNoErrorf(err, "ResourceProtoSchema failed")
+	return valueshim.FromTType(protoSchema.ValueType())
+}
+
+func (r *schemaOnlyAction) Schema() shim.SchemaMap {
+	return r.tf.Shim()
+}
+
+func (r *schemaOnlyAction) Metadata() string {
+	panic("schemaOnlyAction does not implement runtime operation Metadata")
+}
+
+func (r *schemaOnlyAction) Invoke(context.Context, resource.PropertyMap) (resource.PropertyMap, error) {
+	panic("schemaOnlyAction does not implement runtime operation Invoke")
+}

--- a/pkg/pf/internal/schemashim/actions_map.go
+++ b/pkg/pf/internal/schemashim/actions_map.go
@@ -1,0 +1,87 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schemashim
+
+import (
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/internalinter"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/runtypes"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+)
+
+// Data Source map needs to support Set (mutability) for RenameAction.
+func newSchemaOnlyActionMap(actions runtypes.Actions) schemaOnlyActionMap {
+	m := schemaOnlyActionMap{}
+	for _, name := range actions.All() {
+		key := string(name)
+		v := actions.Schema(name)
+		m[key] = &schemaOnlyAction{v, internalinter.Internal{}}
+	}
+	return m
+}
+
+type schemaOnlyActionMap map[string]*schemaOnlyAction
+
+var (
+	_ shim.ActionMap   = schemaOnlyActionMap{}
+	_ runtypes.Actions = schemaOnlyActionMap{}
+)
+
+func (m schemaOnlyActionMap) Len() int {
+	return len(m)
+}
+
+func (m schemaOnlyActionMap) Get(key string) shim.Action {
+	return m[key]
+}
+
+func (m schemaOnlyActionMap) GetOk(key string) (shim.Action, bool) {
+	v, ok := m[key]
+	return v, ok
+}
+
+func (m schemaOnlyActionMap) Range(each func(key string, value shim.Action) bool) {
+	for k, v := range m {
+		if !each(k, v) {
+			return
+		}
+	}
+}
+
+func (m schemaOnlyActionMap) Set(key string, value shim.Action) {
+	v, ok := value.(*schemaOnlyAction)
+	contract.Assertf(ok, "Set must be a %T, found a %T", v, value)
+	m[key] = v
+}
+
+func (m schemaOnlyActionMap) All() []runtypes.TypeOrRenamedEntityName {
+	arr := make([]runtypes.TypeOrRenamedEntityName, 0, len(m))
+	for k := range m {
+		arr = append(arr, runtypes.TypeOrRenamedEntityName(k))
+	}
+	return arr
+}
+
+func (m schemaOnlyActionMap) Has(key runtypes.TypeOrRenamedEntityName) bool {
+	_, ok := m[string(key)]
+	return ok
+}
+
+func (m schemaOnlyActionMap) Schema(key runtypes.TypeOrRenamedEntityName) runtypes.Schema {
+	return m[string(key)].tf
+}
+
+func (m schemaOnlyActionMap) IsActions() {}

--- a/pkg/pf/internal/schemashim/provider.go
+++ b/pkg/pf/internal/schemashim/provider.go
@@ -38,6 +38,7 @@ type SchemaOnlyProvider struct {
 	tf            pfprovider.Provider
 	resourceMap   schemaOnlyResourceMap
 	dataSourceMap schemaOnlyDataSourceMap
+	actionsMap    schemaOnlyActionMap
 	internalinter.Internal
 }
 
@@ -61,6 +62,10 @@ func (p *SchemaOnlyProvider) Resources(ctx context.Context) (runtypes.Resources,
 
 func (p *SchemaOnlyProvider) DataSources(ctx context.Context) (runtypes.DataSources, error) {
 	return p.dataSourceMap, nil
+}
+
+func (p *SchemaOnlyProvider) Actions(ctx context.Context) (runtypes.Actions, error) {
+	return p.actionsMap, nil
 }
 
 func (p *SchemaOnlyProvider) Config(ctx context.Context) (tftypes.Object, error) {
@@ -92,6 +97,10 @@ func (p *SchemaOnlyProvider) ResourcesMap() shim.ResourceMap {
 
 func (p *SchemaOnlyProvider) DataSourcesMap() shim.ResourceMap {
 	return p.dataSourceMap
+}
+
+func (p *SchemaOnlyProvider) ActionsMap() shim.ActionMap {
+	return p.actionsMap
 }
 
 func (p *SchemaOnlyProvider) InternalValidate() error {

--- a/pkg/pf/internal/schemashim/schemashim.go
+++ b/pkg/pf/internal/schemashim/schemashim.go
@@ -32,12 +32,18 @@ func ShimSchemaOnlyProvider(ctx context.Context, provider pfprovider.Provider) s
 	if err != nil {
 		panic(err)
 	}
+	actions, err := pfutils.GatherActions(ctx, provider, NewSchemaMap)
+	if err != nil {
+		panic(err)
+	}
 	resourceMap := newSchemaOnlyResourceMap(resources)
 	dataSourceMap := newSchemaOnlyDataSourceMap(dataSources)
+	actionsMap := newSchemaOnlyActionMap(actions)
 	return &SchemaOnlyProvider{
 		ctx:           ctx,
 		tf:            provider,
 		resourceMap:   resourceMap,
 		dataSourceMap: dataSourceMap,
+		actionsMap:    actionsMap,
 	}
 }

--- a/pkg/pf/proto/action.go
+++ b/pkg/pf/proto/action.go
@@ -1,0 +1,86 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proto
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	cres "github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/internalinter"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+)
+
+var (
+	_ = shim.ActionMap(actionMap{})
+	_ = shim.Action(action{})
+)
+
+type actionMap map[string]*tfprotov6.ActionSchema
+
+func (m actionMap) Len() int {
+	return len(m)
+}
+
+func (m actionMap) Get(key string) shim.Action {
+	v, ok := m.GetOk(key)
+	contract.Assertf(ok, "unknown key %q", key)
+	return v
+}
+
+func (m actionMap) GetOk(key string) (shim.Action, bool) {
+	v, ok := m[key]
+	if !ok {
+		return nil, false
+	}
+	return newAction(v), true
+}
+
+func (m actionMap) Range(each func(key string, value shim.Action) bool) {
+	for k, v := range m {
+		if !each(k, newAction(v)) {
+			return
+		}
+	}
+}
+
+func (m actionMap) Set(key string, value shim.Action) {
+	v, ok := value.(action)
+	contract.Assertf(ok, "Set must be a %T, found a %T", v, value)
+	m[key] = v.r
+}
+
+type action struct {
+	r *tfprotov6.ActionSchema
+	internalinter.Internal
+}
+
+func newAction(r *tfprotov6.ActionSchema) *action {
+	return &action{r, internalinter.Internal{}}
+}
+
+func (r action) Schema() shim.SchemaMap {
+	return blockMap{r.r.Schema.Block}
+}
+
+func (r action) Metadata() string {
+	return ""
+}
+
+func (r action) Invoke(ctx context.Context, inputs cres.PropertyMap) (cres.PropertyMap, error) {
+	return nil, nil
+}

--- a/pkg/pf/proto/protov6.go
+++ b/pkg/pf/proto/protov6.go
@@ -125,3 +125,12 @@ func (p Provider) DataSourcesMap() shim.ResourceMap {
 	}
 	return resourceMap(v.DataSourceSchemas)
 }
+
+func (p Provider) ActionsMap() shim.ActionMap {
+	v, err := p.getSchema()
+	if err != nil {
+		tfbridge.GetLogger(p.ctx).Error(err.Error())
+		return nil
+	}
+	return actionMap(v.ActionSchemas)
+}

--- a/pkg/pf/proto/runtypes.go
+++ b/pkg/pf/proto/runtypes.go
@@ -41,6 +41,14 @@ func (p Provider) DataSources(context.Context) (runtypes.DataSources, error) {
 	return datasources{collection(v.DataSourceSchemas)}, nil
 }
 
+func (p Provider) Actions(context.Context) (runtypes.Actions, error) {
+	v, err := p.getSchema()
+	if err != nil {
+		return nil, err
+	}
+	return actions{actionCollection(v.ActionSchemas)}, nil
+}
+
 type schema struct {
 	s      *tfprotov6.Schema
 	tfName runtypes.TypeName
@@ -105,4 +113,32 @@ func (c collection) Schema(key runtypes.TypeOrRenamedEntityName) runtypes.Schema
 	contract.Assertf(ok, "called Schema on a resource that does not exist")
 
 	return schema{s, runtypes.TypeName(key)}
+}
+
+type actions struct{ actionCollection }
+
+var _ runtypes.Actions = actions{}
+
+func (actions) IsActions() {}
+
+type actionCollection map[string]*tfprotov6.ActionSchema
+
+func (c actionCollection) All() []runtypes.TypeOrRenamedEntityName {
+	arr := make([]runtypes.TypeOrRenamedEntityName, 0, len(c))
+	for k := range c {
+		arr = append(arr, runtypes.TypeOrRenamedEntityName(k))
+	}
+	return arr
+}
+
+func (c actionCollection) Has(key runtypes.TypeOrRenamedEntityName) bool {
+	_, ok := c[string(key)]
+	return ok
+}
+
+func (c actionCollection) Schema(key runtypes.TypeOrRenamedEntityName) runtypes.Schema {
+	s, ok := c[string(key)]
+	contract.Assertf(ok, "called Schema on an action that does not exist")
+
+	return schema{s.Schema, runtypes.TypeName(key)}
 }

--- a/pkg/pf/provider.go
+++ b/pkg/pf/provider.go
@@ -35,4 +35,5 @@ type ShimProvider interface {
 	Resources(context.Context) (runtypes.Resources, error)
 	DataSources(context.Context) (runtypes.DataSources, error)
 	Config(context.Context) (tftypes.Object, error)
+	Actions(context.Context) (runtypes.Actions, error)
 }

--- a/pkg/pf/tests/internal/testprovider/cmd/pulumi-resource-testbridge/schema.json
+++ b/pkg/pf/tests/internal/testprovider/cmd/pulumi-resource-testbridge/schema.json
@@ -1100,6 +1100,28 @@
                 "type": "object"
             }
         },
+        "testbridge:index/print:Print": {
+            "inputs": {
+                "description": "A collection of arguments for invoking Print.\n",
+                "properties": {
+                    "count": {
+                        "type": "number"
+                    },
+                    "text": {
+                        "type": "string"
+                    },
+                    "urn": {
+                        "type": "string",
+                        "description": "The URN to run this action against."
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "text",
+                    "urn"
+                ]
+            }
+        },
         "testbridge:index/smac:SMAC": {
             "outputs": {
                 "description": "A collection of values returned by SMAC.\n",

--- a/pkg/pf/tests/internal/testprovider/testbridge.go
+++ b/pkg/pf/tests/internal/testprovider/testbridge.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/hashicorp/terraform-plugin-framework/action"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -129,6 +130,10 @@ func SyntheticTestBridgeProvider() tfbridge.ProviderInfo {
 			"testbridge_smac_ds": {Tok: "testbridge:index/smac:SMAC"},
 		},
 
+		Actions: map[string]*tfbridge.ActionInfo{
+			"testbridge_print": {Tok: "testbridge:index/print:Print"},
+		},
+
 		MetadataInfo: tfbridge.NewProviderMetadata(testBridgeMetadata),
 	}
 
@@ -144,7 +149,10 @@ type resourceData struct {
 	skipMetadataAPICheck *string
 }
 
-var _ provider.Provider = (*syntheticProvider)(nil)
+var (
+	_ provider.Provider            = (*syntheticProvider)(nil)
+	_ provider.ProviderWithActions = (*syntheticProvider)(nil)
+)
 
 func (p *syntheticProvider) Metadata(_ context.Context, _ provider.MetadataRequest, resp *provider.MetadataResponse) {
 	resp.TypeName = "testbridge"
@@ -335,5 +343,11 @@ func (p *syntheticProvider) Resources(context.Context) []func() resource.Resourc
 		newAutoNameRes,
 		newIntIDRes,
 		newVlanNamesRes,
+	}
+}
+
+func (p *syntheticProvider) Actions(context.Context) []func() action.Action {
+	return []func() action.Action{
+		newPrintAction,
 	}
 }

--- a/pkg/pf/tests/internal/testprovider/testbridge_action_print.go
+++ b/pkg/pf/tests/internal/testprovider/testbridge_action_print.go
@@ -1,0 +1,81 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testprovider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/action"
+	"github.com/hashicorp/terraform-plugin-framework/action/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func newPrintAction() action.Action {
+	return &printAction{}
+}
+
+type printAction struct{}
+
+func (*printAction) Metadata(ctx context.Context, req action.MetadataRequest,
+	resp *action.MetadataResponse,
+) {
+	resp.TypeName = req.ProviderTypeName + "_print"
+}
+
+func (*printAction) Schema(_ context.Context, _ action.SchemaRequest, resp *action.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Prints string N times",
+		Attributes: map[string]schema.Attribute{
+			"text": schema.StringAttribute{
+				Description: "String to print",
+				Required:    true,
+			},
+			"count": schema.Float64Attribute{
+				Description: "Number of times to print the string",
+				Optional:    true,
+			},
+		},
+	}
+}
+
+func (a *printAction) Invoke(ctx context.Context, req action.InvokeRequest, resp *action.InvokeResponse) {
+	var config printModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	text := config.Text.ValueString()
+
+	count := 1.0
+	if !config.Count.IsNull() {
+		count = config.Count.ValueFloat64()
+	}
+
+	iCount := int(count)
+
+	for i := 0; i < iCount; i++ {
+		resp.SendProgress(action.InvokeProgressEvent{
+			Message: fmt.Sprintf("%s", text),
+		})
+	}
+}
+
+type printModel struct {
+	Text  types.String  `tfsdk:"text"`
+	Count types.Float64 `tfsdk:"count"`
+}

--- a/pkg/pf/tests/provider_action_test.go
+++ b/pkg/pf/tests/provider_action_test.go
@@ -1,0 +1,78 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfbridgetests
+
+import (
+	"testing"
+
+	testutils "github.com/pulumi/providertest/replay"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/testprovider"
+)
+
+func TestActionSchema(t *testing.T) {
+	t.Parallel()
+	handshake := `
+        {
+          "method": "/pulumirpc.ResourceProvider/Handshake",
+          "request": {
+            "invokeWithPreview": true
+          },
+          "errors": ["rpc error: code = Unimplemented desc = Handshake is not yet implemented"]
+        }`
+
+	server, err := newProviderServer(t, testprovider.SyntheticTestBridgeProvider())
+	require.NoError(t, err)
+	// We need to handshake to tell the server actions are ok to run
+	testutils.Replay(t, server, handshake)
+
+	testCase := `
+        {
+          "method": "/pulumirpc.ResourceProvider/Invoke",
+          "request": {
+            "tok": "testbridge:index/print:Print",
+            "preview": true,
+            "args": {
+              "urn": "urn:pulumi:st::pg::testprovider:index/res:Res::r",
+              "text": "hello world",
+              "count": 3
+            }
+          },
+          "response": {
+            "return": {}
+          }
+        }
+        `
+	testutils.Replay(t, server, testCase)
+
+	testCase = `
+        {
+          "method": "/pulumirpc.ResourceProvider/Invoke",
+          "request": {
+            "tok": "testbridge:index/print:Print",
+            "preview": false,
+            "args": {
+              "urn": "urn:pulumi:st::pg::testprovider:index/res:Res::r",
+              "text": "hello world"
+            }
+          },
+          "response": {
+            "return": {}
+          }
+        }
+        `
+	testutils.Replay(t, server, testCase)
+}

--- a/pkg/pf/tests/schema_test.go
+++ b/pkg/pf/tests/schema_test.go
@@ -65,6 +65,9 @@ func TestSchemaGen(t *testing.T) {
 		actionParameterPhases := spec.Types["testbridge:index/TestnestRuleActionParametersPhases:TestnestRuleActionParametersPhases"]
 		assert.Equal(t, "object", actionParameterPhases.Type)
 		assert.Equal(t, "boolean", actionParameterPhases.Properties["p2"].Type)
+
+		printAction := spec.Functions["testbridge:index/print:Print"]
+		assert.Equal(t, "string", printAction.Inputs.Properties["text"].Type)
 	})
 }
 

--- a/pkg/pf/tfbridge/naming.go
+++ b/pkg/pf/tfbridge/naming.go
@@ -37,3 +37,20 @@ func functionPropertyKey(ds datasourceHandle, path *tftypes.AttributePath) (reso
 		return "", false
 	}
 }
+
+func actionPropertyKey(action actionHandle, path *tftypes.AttributePath) (resource.PropertyKey, bool) {
+	if path == nil {
+		return "", false
+	}
+	if len(path.Steps()) != 1 {
+		return "", false
+	}
+	switch attrName := path.LastStep().(type) {
+	case tftypes.AttributeName:
+		pulumiName := tfbridge.TerraformToPulumiNameV2(string(attrName),
+			action.schemaOnlyShim.Schema(), action.pulumiActionInfo.GetFields())
+		return resource.PropertyKey(pulumiName), true
+	default:
+		return "", false
+	}
+}

--- a/pkg/pf/tfbridge/provider.go
+++ b/pkg/pf/tfbridge/provider.go
@@ -32,6 +32,8 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/internal/logging"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/convert"
@@ -80,6 +82,7 @@ type provider struct {
 	info          tfbridge.ProviderInfo
 	resources     runtypes.Resources
 	datasources   runtypes.DataSources
+	actions       runtypes.Actions
 	pulumiSchema  func(context.Context, plugin.GetSchemaRequest) ([]byte, error)
 	encoding      convert.Encoding
 	configEncoder convert.Encoder
@@ -95,6 +98,8 @@ type provider struct {
 
 	schemaOnlyProvider shim.Provider
 	providerOpts       []providerOption
+
+	invokeWithPreview bool
 }
 
 var _ pl.ProviderWithContext = &provider{}
@@ -146,6 +151,10 @@ func newProviderWithContext(ctx context.Context, info tfbridge.ProviderInfo,
 	if err != nil {
 		return nil, err
 	}
+	actions, err := pfServer.Actions(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	if info.MetadataInfo == nil {
 		return nil, fmt.Errorf("[pf/tfbridge] ProviderInfo.BridgeMetadata is required but is nil")
@@ -187,6 +196,7 @@ func newProviderWithContext(ctx context.Context, info tfbridge.ProviderInfo,
 		info:               info,
 		resources:          resources,
 		datasources:        datasources,
+		actions:            actions,
 		pulumiSchema:       schema,
 		encoding:           enc,
 		configEncoder:      configEncoder,
@@ -249,6 +259,14 @@ func XParameterizeResetProvider(ctx context.Context, info tfbridge.ProviderInfo,
 	return ctx.Value(xResetProviderKey{}).(xParameterizeResetProviderFunc)(ctx, info, meta)
 }
 
+func (p *provider) HandshakeWithContext(ctx context.Context, req plugin.ProviderHandshakeRequest,
+) (*plugin.ProviderHandshakeResponse, error) {
+	p.invokeWithPreview = req.InvokeWithPreview
+	// We look at the request sent to handshake so we can error if actions are run against old CLI versions, but we tell
+	// the CLI this is unimplemented so it continues to call our current Configure logic.
+	return nil, status.Error(codes.Unimplemented, "Handshake is not yet implemented")
+}
+
 func (p *provider) ParameterizeWithContext(
 	ctx context.Context, req plugin.ParameterizeRequest,
 ) (plugin.ParameterizeResponse, error) {
@@ -305,13 +323,22 @@ func (p *provider) terraformResourceNameOrRenamedEntity(resourceToken tokens.Typ
 	return "", fmt.Errorf("[pf/tfbridge] unknown resource token: %v", resourceToken)
 }
 
-func (p *provider) terraformDatasourceNameOrRenamedEntity(functionToken tokens.ModuleMember) (string, error) {
-	for tfname, v := range p.info.DataSources {
+func (p *provider) terraformActionNameOrRenamedEntity(functionToken tokens.ModuleMember) (string, bool) {
+	for tfname, v := range p.info.Actions {
 		if v.Tok == functionToken {
-			return tfname, nil
+			return tfname, true
 		}
 	}
-	return "", fmt.Errorf("[pf/tfbridge] unknown datasource token: %v", functionToken)
+	return "", false
+}
+
+func (p *provider) terraformDatasourceNameOrRenamedEntity(functionToken tokens.ModuleMember) (string, bool) {
+	for tfname, v := range p.info.DataSources {
+		if v.Tok == functionToken {
+			return tfname, true
+		}
+	}
+	return "", false
 }
 
 func (p *provider) returnTerraformConfig() (resource.PropertyMap, error) {

--- a/pkg/pf/tfbridge/provider_actions.go
+++ b/pkg/pf/tfbridge/provider_actions.go
@@ -1,0 +1,68 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfbridge
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/convert"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/runtypes"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+)
+
+type actionHandle struct {
+	token               tokens.ModuleMember
+	terraformActionName string
+	schema              runtypes.Schema
+	encoder             convert.Encoder
+	schemaOnlyShim      shim.Action
+	pulumiActionInfo    *tfbridge.ActionInfo // optional
+}
+
+func (p *provider) actionHandle(ctx context.Context, token tokens.ModuleMember) (actionHandle, bool, error) {
+	actName, has := p.terraformActionNameOrRenamedEntity(token)
+	if !has {
+		return actionHandle{}, false, nil
+	}
+
+	schema := p.actions.Schema(runtypes.TypeOrRenamedEntityName(actName))
+
+	typ := schema.Type(ctx).(tftypes.Object)
+
+	encoder, err := p.encoding.NewActionEncoder(actName, typ)
+	if err != nil {
+		return actionHandle{}, true, err
+	}
+
+	shim, _ := p.schemaOnlyProvider.ActionsMap().GetOk(actName)
+
+	result := actionHandle{
+		token:               token,
+		terraformActionName: actName,
+		schema:              schema,
+		encoder:             encoder,
+		schemaOnlyShim:      shim,
+	}
+
+	if info, ok := p.info.Actions[actName]; ok {
+		result.pulumiActionInfo = info
+	}
+
+	return result, true, nil
+}

--- a/pkg/pf/tfbridge/provider_datasources.go
+++ b/pkg/pf/tfbridge/provider_datasources.go
@@ -36,10 +36,10 @@ type datasourceHandle struct {
 	pulumiDataSourceInfo    *tfbridge.DataSourceInfo // optional
 }
 
-func (p *provider) datasourceHandle(ctx context.Context, token tokens.ModuleMember) (datasourceHandle, error) {
-	dsName, err := p.terraformDatasourceNameOrRenamedEntity(token)
-	if err != nil {
-		return datasourceHandle{}, err
+func (p *provider) datasourceHandle(ctx context.Context, token tokens.ModuleMember) (datasourceHandle, bool, error) {
+	dsName, has := p.terraformDatasourceNameOrRenamedEntity(token)
+	if !has {
+		return datasourceHandle{}, false, nil
 	}
 
 	schema := p.datasources.Schema(runtypes.TypeOrRenamedEntityName(dsName))
@@ -48,12 +48,12 @@ func (p *provider) datasourceHandle(ctx context.Context, token tokens.ModuleMemb
 
 	encoder, err := p.encoding.NewDataSourceEncoder(dsName, typ)
 	if err != nil {
-		return datasourceHandle{}, err
+		return datasourceHandle{}, true, err
 	}
 
 	decoder, err := p.encoding.NewDataSourceDecoder(dsName, typ)
 	if err != nil {
-		return datasourceHandle{}, err
+		return datasourceHandle{}, true, err
 	}
 
 	shim, _ := p.schemaOnlyProvider.DataSourcesMap().GetOk(dsName)
@@ -71,5 +71,5 @@ func (p *provider) datasourceHandle(ctx context.Context, token tokens.ModuleMemb
 		result.pulumiDataSourceInfo = info
 	}
 
-	return result, nil
+	return result, true, nil
 }

--- a/pkg/pf/tfbridge/provider_invoke.go
+++ b/pkg/pf/tfbridge/provider_invoke.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -37,35 +38,84 @@ func (p *provider) InvokeWithContext(
 	ctx context.Context,
 	tok tokens.ModuleMember,
 	args resource.PropertyMap,
+	preview bool,
 ) (resource.PropertyMap, []plugin.CheckFailure, error) {
 	ctx = p.initLogging(ctx, p.logSink, "")
 
-	handle, err := p.datasourceHandle(ctx, tok)
+	// First check if this is an action
+	actionHandle, isAction, err := p.actionHandle(ctx, tok)
 	if err != nil {
 		return nil, nil, err
 	}
+	if isAction {
+		// We can only call actions if it's safe, i.e. the engine has told us if this invoke is in a preview or not.
+		if !p.invokeWithPreview {
+			return nil, nil, fmt.Errorf("cannot invoke action %q without preview information from the engine; "+
+				"ensure you are using a recent version of the Pulumi CLI", actionHandle.token)
+		}
 
-	typ := handle.schema.Type(ctx).(tftypes.Object)
+		typ := actionHandle.schema.Type(ctx).(tftypes.Object)
 
-	// Transform args to apply Pulumi-level defaults.
-	argsWithDefaults := defaults.ApplyDefaultInfoValues(ctx, defaults.ApplyDefaultInfoValuesArgs{
-		SchemaMap:      handle.schemaOnlyShim.Schema(),
-		SchemaInfos:    handle.pulumiDataSourceInfo.GetFields(),
-		PropertyMap:    args,
-		ProviderConfig: p.lastKnownProviderConfig,
-	})
+		urn, has := args["urn"]
+		if !has {
+			return nil, nil, fmt.Errorf("missing required argument 'urn' to Invoke for action %q", actionHandle.token)
+		}
+		if !urn.IsString() {
+			return nil, nil, fmt.Errorf("expected argument 'urn' to Invoke for action %q to be a string", actionHandle.token)
+		}
+		urnStr := resource.URN(urn.StringValue())
+		delete(args, "urn")
 
-	config, err := convert.EncodePropertyMapToDynamic(handle.encoder, typ, argsWithDefaults)
+		// Transform args to apply Pulumi-level defaults.
+		argsWithDefaults := defaults.ApplyDefaultInfoValues(ctx, defaults.ApplyDefaultInfoValuesArgs{
+			SchemaMap:      actionHandle.schemaOnlyShim.Schema(),
+			SchemaInfos:    actionHandle.pulumiActionInfo.GetFields(),
+			PropertyMap:    args,
+			ProviderConfig: p.lastKnownProviderConfig,
+		})
+
+		config, err := convert.EncodePropertyMapToDynamic(actionHandle.encoder, typ, argsWithDefaults)
+		if err != nil {
+			return nil, nil, fmt.Errorf("cannot encode config to call ReadDataSource for %q: %w",
+				actionHandle.terraformActionName, err)
+		}
+
+		if failures, err := p.validateActionConfig(ctx, actionHandle, config); err != nil || len(failures) > 0 {
+			return nil, failures, err
+		}
+
+		return p.invokeAction(ctx, actionHandle, urnStr, preview, config)
+	}
+
+	datasourceHandle, isDatasource, err := p.datasourceHandle(ctx, tok)
 	if err != nil {
-		return nil, nil, fmt.Errorf("cannot encode config to call ReadDataSource for %q: %w",
-			handle.terraformDataSourceName, err)
+		return nil, nil, err
+	}
+	if isDatasource {
+		typ := datasourceHandle.schema.Type(ctx).(tftypes.Object)
+
+		// Transform args to apply Pulumi-level defaults.
+		argsWithDefaults := defaults.ApplyDefaultInfoValues(ctx, defaults.ApplyDefaultInfoValuesArgs{
+			SchemaMap:      datasourceHandle.schemaOnlyShim.Schema(),
+			SchemaInfos:    datasourceHandle.pulumiDataSourceInfo.GetFields(),
+			PropertyMap:    args,
+			ProviderConfig: p.lastKnownProviderConfig,
+		})
+
+		config, err := convert.EncodePropertyMapToDynamic(datasourceHandle.encoder, typ, argsWithDefaults)
+		if err != nil {
+			return nil, nil, fmt.Errorf("cannot encode config to call ReadDataSource for %q: %w",
+				datasourceHandle.terraformDataSourceName, err)
+		}
+
+		if failures, err := p.validateDataResourceConfig(ctx, datasourceHandle, config); err != nil || len(failures) > 0 {
+			return nil, failures, err
+		}
+
+		return p.readDataSource(ctx, datasourceHandle, config)
 	}
 
-	if failures, err := p.validateDataResourceConfig(ctx, handle, config); err != nil || len(failures) > 0 {
-		return nil, failures, err
-	}
-
-	return p.readDataSource(ctx, handle, config)
+	return nil, nil, fmt.Errorf("[pf/tfbridge] unknown datasource or action token: %v", tok)
 }
 
 func (p *provider) validateDataResourceConfig(ctx context.Context, handle datasourceHandle,
@@ -152,6 +202,122 @@ func (p *provider) parseInvokePropertyCheckFailures(ds datasourceHandle, diags [
 
 	for _, d := range diags {
 		if pk, ok := functionPropertyKey(ds, d.Attribute); ok {
+			reason := strings.Join([]string{d.Summary, d.Detail}, ": ")
+			failure := plugin.CheckFailure{
+				Property: pk,
+				Reason:   reason,
+			}
+			failures = append(failures, failure)
+			continue
+		}
+		rest = append(rest, d)
+	}
+
+	return failures, rest
+}
+
+func (p *provider) validateActionConfig(ctx context.Context, handle actionHandle,
+	config *tfprotov6.DynamicValue,
+) ([]plugin.CheckFailure, error) {
+	req := &tfprotov6.ValidateActionConfigRequest{
+		ActionType: handle.terraformActionName,
+		Config:     config,
+	}
+
+	aserver := p.tfServer.(tfprotov6.ActionServer)
+	resp, err := aserver.ValidateActionConfig(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("error calling ValidateActionConfig: %w", err)
+	}
+	return p.processActionInvokeDiagnostics(ctx, handle, resp.Diagnostics)
+}
+
+func (p *provider) invokeAction(ctx context.Context, handle actionHandle,
+	urn resource.URN, preview bool, config *tfprotov6.DynamicValue,
+) (resource.PropertyMap, []plugin.CheckFailure, error) {
+	aserver := p.tfServer.(tfprotov6.ActionServer)
+
+	if preview {
+		req := &tfprotov6.PlanActionRequest{
+			Config:     config,
+			ActionType: handle.terraformActionName,
+			// TODO: Set Capabilities
+		}
+		resp, err := aserver.PlanAction(ctx, req)
+		if err != nil {
+			return nil, nil, fmt.Errorf("error calling ReadDataSource: %w", err)
+		}
+
+		// TODO: Do we need to look at resp.Deferred?
+
+		failures, err := p.processActionInvokeDiagnostics(ctx, handle, resp.Diagnostics)
+		if err != nil || len(failures) > 0 {
+			return nil, failures, err
+		}
+
+		return resource.PropertyMap{}, failures, nil
+	}
+
+	req := &tfprotov6.InvokeActionRequest{
+		Config:     config,
+		ActionType: handle.terraformActionName,
+		// TODO: Set Capabilities
+	}
+	resp, err := aserver.InvokeAction(ctx, req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error calling ReadDataSource: %w", err)
+	}
+
+	var diagnostics []*tfprotov6.Diagnostic
+	for event := range resp.Events {
+		switch e := event.Type.(type) {
+		case tfprotov6.ProgressInvokeActionEventType:
+			err = p.logSink.Log(ctx, diag.Info, urn, e.Message)
+			if err != nil {
+				diagnostics = append(diagnostics, &tfprotov6.Diagnostic{
+					Severity: tfprotov6.DiagnosticSeverityError,
+					Summary:  "Failed to log progress message",
+					Detail:   err.Error(),
+				})
+			}
+		case tfprotov6.CompletedInvokeActionEventType:
+			diagnostics = append(diagnostics, e.Diagnostics...)
+		}
+	}
+
+	failures, err := p.processActionInvokeDiagnostics(ctx, handle, diagnostics)
+	if err != nil || len(failures) > 0 {
+		return nil, failures, err
+	}
+
+	return resource.PropertyMap{}, failures, nil
+}
+
+func (p *provider) processActionInvokeDiagnostics(ctx context.Context, act actionHandle,
+	diags []*tfprotov6.Diagnostic,
+) ([]plugin.CheckFailure, error) {
+	failures, rest := p.parseActionInvokePropertyCheckFailures(act, diags)
+	var sc *schemaContext
+	if act.schemaOnlyShim != nil {
+		fields := map[string]*tfbridge.SchemaInfo{}
+		if act.pulumiActionInfo != nil {
+			fields = act.pulumiActionInfo.GetFields()
+		}
+		sc = &schemaContext{schemaMap: act.schemaOnlyShim.Schema(), schemaInfos: fields}
+	}
+	return failures, p.processDiagnosticsWithContext(ctx, rest, sc)
+}
+
+// Some of the diagnostics pertain to an individual property and should be returned as plugin.CheckFailure for an
+// optimal rendering by Pulumi CLI.
+func (p *provider) parseActionInvokePropertyCheckFailures(act actionHandle, diags []*tfprotov6.Diagnostic) (
+	[]plugin.CheckFailure, []*tfprotov6.Diagnostic,
+) {
+	rest := []*tfprotov6.Diagnostic{}
+	failures := []plugin.CheckFailure{}
+
+	for _, d := range diags {
+		if pk, ok := actionPropertyKey(act, d.Attribute); ok {
 			reason := strings.Join([]string{d.Summary, d.Detail}, ": ")
 			failure := plugin.CheckFailure{
 				Property: pk,

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -135,6 +135,8 @@ type PreCheckCallback = info.PreCheckCallback
 // DataSourceInfo can be used to override a data source's standard name mangling and argument/return information.
 type DataSourceInfo = info.DataSource
 
+type ActionInfo = info.Action
+
 // SchemaInfo contains optional name transformations to apply.
 type SchemaInfo = info.Schema
 

--- a/pkg/tfbridge/info/info.go
+++ b/pkg/tfbridge/info/info.go
@@ -73,6 +73,7 @@ type Provider struct {
 	ExtraConfig    map[string]*Config                 // a list of Pulumi-only configuration variables.
 	Resources      map[string]*Resource               // a map of TF type or renamed entity name to Pulumi resource info.
 	DataSources    map[string]*DataSource             // a map of TF type or renamed entity name to Pulumi resource info.
+	Actions        map[string]*Action                 // a map of TF type or renamed entity name to Pulumi action info.
 	ExtraTypes     map[string]pschema.ComplexTypeSpec // a map of Pulumi token to schema type for extra types.
 	ExtraResources map[string]pschema.ResourceSpec    // a map of Pulumi token to schema type for extra resources.
 	ExtraFunctions map[string]pschema.FunctionSpec    // a map of Pulumi token to schema type for extra functions.
@@ -445,6 +446,33 @@ func (info *Resource) GetDocs() *Doc { return info.Docs }
 
 // ReplaceExamplesSection returns whether to replace the upstream examples with our own source
 func (info *Resource) ReplaceExamplesSection() bool {
+	return info.Docs != nil && info.Docs.ReplaceExamplesSection
+}
+
+// Action can be used to override an action's standard name mangling and argument information.
+type Action struct {
+	Tok                tokens.ModuleMember
+	Fields             map[string]*Schema
+	Docs               *Doc   // overrides for finding and mapping TF docs.
+	DeprecationMessage string // message to use in deprecation warning
+}
+
+// GetTok returns a action type token
+func (info *Action) GetTok() tokens.Token { return tokens.Token(info.Tok) }
+
+// GetFields returns information about the action's custom fields
+func (info *Action) GetFields() map[string]*Schema {
+	if info == nil {
+		return nil
+	}
+	return info.Fields
+}
+
+// GetDocs returns a action docs override from the Pulumi provider
+func (info *Action) GetDocs() *Doc { return info.Docs }
+
+// ReplaceExamplesSection returns whether to replace the upstream examples with our own source
+func (info *Action) ReplaceExamplesSection() bool {
 	return info.Docs != nil && info.Docs.ReplaceExamplesSection
 }
 

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -151,6 +151,8 @@ const (
 	ResourceDocs DocKind = "resources"
 	// DataSourceDocs indicates documentation pertaining to data source entities.
 	DataSourceDocs DocKind = "data-sources"
+	// ActionDocs indicates documentation pertaining to action entities.
+	ActionDocs DocKind = "actions"
 	// InstallationDocs indicates documentation pertaining to provider configuration and installation.
 	InstallationDocs DocKind = "installation"
 )
@@ -159,6 +161,8 @@ func (k DocKind) String() string {
 	switch k {
 	case DataSourceDocs:
 		return "data source"
+	case ActionDocs:
+		return "action"
 	case ResourceDocs:
 		return "resource"
 	default:
@@ -197,6 +201,8 @@ func getDocsForResource(g *Generator, source DocsSource, kind DocKind,
 		docFile, err = source.getResource(rawname, docInfo)
 	case DataSourceDocs:
 		docFile, err = source.getDatasource(rawname, docInfo)
+	case ActionDocs:
+		docFile, err = source.getAction(rawname, docInfo)
 	default:
 		panic("unknown docs kind")
 	}

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -2683,6 +2683,10 @@ func (m mockSource) getDatasource(rawname string, info *tfbridge.DocInfo) (*DocF
 	return nil, nil
 }
 
+func (m mockSource) getAction(rawname string, info *tfbridge.DocInfo) (*DocFile, error) {
+	return nil, nil
+}
+
 func (m mockSource) getInstallation(info *tfbridge.DocInfo) (*DocFile, error) {
 	f, ok := m["index.md"]
 	if !ok {

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -870,6 +870,27 @@ func (rf *resourceFunc) ModuleMemberToken() tokens.ModuleMember {
 	return tokens.NewModuleMemberToken(rf.mod, tokens.ModuleMemberName(rf.name))
 }
 
+// actionFunc is a generated resource function that is exposed to interact with Pulumi objects.
+type actionFunc struct {
+	mod        tokens.Module
+	name       string
+	doc        string
+	args       []*variable
+	reqargs    map[string]bool
+	argst      *propertyType
+	schema     shim.Action
+	info       *tfbridge.ActionInfo
+	entityDocs entityDocs
+	actionPath *paths.ActionPath
+}
+
+func (rf *actionFunc) Name() string { return rf.name }
+func (rf *actionFunc) Doc() string  { return rf.doc }
+
+func (rf *actionFunc) ModuleMemberToken() tokens.ModuleMember {
+	return tokens.NewModuleMemberToken(rf.mod, tokens.ModuleMemberName(rf.name))
+}
+
 // overlayFile is a file that should be added to a module "as-is" and then exported from its index.
 type overlayFile struct {
 	name string
@@ -1270,6 +1291,13 @@ func (g *Generator) gatherPackage() (*pkg, error) {
 		return nil, pkgerrors.Wrapf(err, "problem gathering data sources")
 	} else if dsmods != nil {
 		pack.addModuleMap(dsmods)
+	}
+
+	actmods, err := g.gatherActions()
+	if err != nil {
+		return nil, pkgerrors.Wrapf(err, "problem gathering actions")
+	} else if actmods != nil {
+		pack.addModuleMap(actmods)
 	}
 
 	// Now go ahead and merge in any overlays into the modules if there are any.
@@ -1757,6 +1785,175 @@ func (g *Generator) gatherDataSource(rawname string,
 	return fun, nil
 }
 
+func (g *Generator) gatherActions() (moduleMap, error) {
+	// If there aren't any data sources, skip this altogether.
+	sources := g.provider().ActionsMap()
+	if sources.Len() == 0 {
+		return nil, nil
+	}
+	modules := make(moduleMap)
+
+	skipFailBuildOnMissingMapError := cmdutil.IsTruthy(os.Getenv("PULUMI_SKIP_MISSING_MAPPING_ERROR")) ||
+		cmdutil.IsTruthy(os.Getenv("PULUMI_SKIP_PROVIDER_MAP_ERROR"))
+	skipFailBuildOnExtraMapError := cmdutil.IsTruthy(os.Getenv("PULUMI_SKIP_EXTRA_MAPPING_ERROR"))
+
+	// let's keep a list of TF mapping errors that we can present to the user
+	var dataSourceMappingErrors error
+
+	// For each data source, create its own dedicated function and module export.
+	var dserr error
+	seen := make(map[string]bool)
+	for _, ds := range stableActions(sources) {
+		dsinfo := g.info.Actions[ds]
+		if dsinfo == nil {
+			if sliceContains(g.info.IgnoreMappings, ds) {
+				g.debug("TF data source %q not found in provider map but ignored", ds)
+				continue
+			}
+
+			if !skipFailBuildOnMissingMapError {
+				dataSourceMappingErrors = multierror.Append(dataSourceMappingErrors,
+					fmt.Errorf("TF data source %q not mapped to the Pulumi provider", ds))
+			} else {
+				g.warn("TF data source %q not found in provider map", ds)
+			}
+			continue
+		}
+		seen[ds] = true
+
+		fun, err := g.gatherAction(ds, sources.Get(ds), dsinfo)
+		if err != nil {
+			// Keep track of the error, but keep going, so we can expose more at once.
+			dserr = multierror.Append(dserr, err)
+		} else {
+			// Add any members returned to the specified module.
+			modules.ensureModule(fun.mod).addMember(fun)
+		}
+	}
+	if dserr != nil {
+		return nil, dserr
+	}
+
+	// Emit a warning if there is a map but some names didn't match.
+	var names []string
+	for name := range g.info.Actions {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		if !seen[name] {
+			if !skipFailBuildOnExtraMapError {
+				dataSourceMappingErrors = multierror.Append(dataSourceMappingErrors,
+					fmt.Errorf("Pulumi token %q is mapped to TF provider data source %q, but no such "+
+						"data source found. Remove the mapping and try again",
+						g.info.Actions[name].Tok, name))
+			} else {
+				g.warn("Pulumi token %q is mapped to TF provider data source %q, but no such "+
+					"data source found. The mapping will be ignored in the generated provider",
+					g.info.Actions[name].Tok, name)
+			}
+		}
+	}
+
+	// let's check the unmapped Action Errors
+	if dataSourceMappingErrors != nil {
+		return nil, dataSourceMappingErrors
+	}
+
+	return modules, nil
+}
+
+// gatherAction returns the module name and members for the given data source function.
+func (g *Generator) gatherAction(rawname string,
+	act shim.Action, info *tfbridge.ActionInfo,
+) (*actionFunc, error) {
+	// Generate the name and module for this data source.
+	name, moduleName := actionName(g.info.Name, rawname, info)
+	mod := tokens.NewModuleToken(g.pkg, moduleName)
+	actionPath := paths.NewActionPath(rawname, tokens.NewModuleMemberToken(mod, name))
+
+	// Collect documentation information for this data source.
+	source := NewGitRepoDocsSource(g)
+	entityDocs, err := getDocsForResource(g, source, ActionDocs, rawname, info)
+	if err != nil && !g.checkNoDocsError(err) {
+		return nil, err
+	}
+
+	// Build up the function information.
+	fun := &actionFunc{
+		mod:        mod,
+		name:       name.String(),
+		doc:        entityDocs.Description,
+		reqargs:    make(map[string]bool),
+		schema:     act,
+		info:       info,
+		entityDocs: entityDocs,
+		actionPath: actionPath,
+	}
+
+	// See if arguments for this function are optional, and generate detailed metadata.
+	for _, arg := range stableSchemas(act.Schema()) {
+		sch := act.Schema().Get(arg)
+		if sch.Removed() != "" {
+			continue
+		}
+		cust := info.Fields[arg]
+
+		// Remember detailed information for every input arg (we will use it below).
+		if input(sch, cust) {
+			doc, foundInAttributes := getDescriptionFromParsedDocs(entityDocs, arg)
+			if foundInAttributes {
+				argumentDescriptionsFromAttributes++
+				msg := fmt.Sprintf("Argument desc taken from attributes: data source, rawname = '%s', property = '%s'",
+					rawname, arg)
+				g.debug(msg)
+			}
+
+			argvar, err := g.propertyVariable(actionPath.Args(),
+				arg, act.Schema(), info.Fields, doc, "", false /*out*/, entityDocs)
+			if err != nil {
+				return nil, err
+			}
+			if argvar != nil {
+				fun.args = append(fun.args, argvar)
+				if !argvar.optional() {
+					fun.reqargs[argvar.name] = true
+				}
+			}
+		}
+	}
+
+	// Make up a urn property
+	if urn, has := act.Schema().GetOk("urn"); has && urn.Removed() == "" {
+		return nil, fmt.Errorf("action %q must not have a 'urn' property in its schema", rawname)
+	}
+	cust := map[string]*tfbridge.SchemaInfo{"urn": {}}
+	rawdoc := "The URN to run this action against."
+	urnSchema := schema.SchemaMap(map[string]shim.Schema{
+		"urn": (&schema.Schema{Type: shim.TypeString, Required: true}).Shim(),
+	})
+	p, err := g.propertyVariable(actionPath.Args(), "urn", urnSchema, cust, "",
+		rawdoc, true /*out*/, entityDocs)
+	if err != nil {
+		return nil, err
+	}
+	if p != nil {
+		fun.args = append(fun.args, p)
+	}
+
+	// Produce the args/return types, if needed.
+	if len(fun.args) > 0 {
+		fun.argst = &propertyType{
+			kind:       kindObject,
+			name:       fmt.Sprintf("%sArgs", upperFirst(name.String())),
+			doc:        fmt.Sprintf("A collection of arguments for invoking %s.", name),
+			properties: fun.args,
+		}
+	}
+
+	return fun, nil
+}
+
 // gatherOverlays returns any overlay modules and their contents.
 func (g *Generator) gatherOverlays() (moduleMap, error) {
 	modules := make(moduleMap)
@@ -1971,6 +2168,20 @@ func (g *Generator) propertyVariable(parentPath paths.TypePath, key string,
 	return nil, nil
 }
 
+// actionName translates a Terraform name into its Pulumi name equivalent.
+func actionName(provider string, rawname string,
+	info *tfbridge.ActionInfo,
+) (tokens.ModuleMemberName, tokens.ModuleName) {
+	if info == nil || info.Tok == "" {
+		// default transformations.
+		name := withoutPackageName(provider, rawname) // strip off the pkg prefix.
+		name = tfbridge.TerraformToPulumiNameV2(name, nil, nil)
+		return tokens.ModuleMemberName(name), tokens.ModuleName(name)
+	}
+	// otherwise, a custom transformation exists; use it.
+	return info.Tok.Name(), info.Tok.Module().Name()
+}
+
 // dataSourceName translates a Terraform name into its Pulumi name equivalent.
 func dataSourceName(provider string, rawname string,
 	info *tfbridge.DataSourceInfo,
@@ -2019,6 +2230,16 @@ func withoutPackageName(pkg string, rawname string) string {
 	//
 	// Therefore the code trims the prefix if it finds it, but leaves as-is otherwise.
 	return strings.TrimPrefix(rawname, pkg+"_")
+}
+
+func stableActions(actions shim.ActionMap) []string {
+	var acts []string
+	actions.Range(func(a string, _ shim.Action) bool {
+		acts = append(acts, a)
+		return true
+	})
+	sort.Strings(acts)
+	return acts
 }
 
 func stableResources(resources shim.ResourceMap) []string {

--- a/pkg/tfgen/source.go
+++ b/pkg/tfgen/source.go
@@ -35,6 +35,9 @@ type DocsSource interface {
 	// Get the bytes for a datasource with TF token rawname.
 	getDatasource(rawname string, info *tfbridge.DocInfo) (*DocFile, error)
 
+	// Get the bytes for an action with TF token rawname.
+	getAction(rawname string, info *tfbridge.DocInfo) (*DocFile, error)
+
 	// Get the bytes for the provider installation doc.
 	getInstallation(info *tfbridge.DocInfo) (*DocFile, error)
 }
@@ -74,6 +77,10 @@ func (gh *gitRepoSource) getDatasource(rawname string, info *tfbridge.DocInfo) (
 	return gh.getFile(rawname, info, DataSourceDocs)
 }
 
+func (gh *gitRepoSource) getAction(rawname string, info *tfbridge.DocInfo) (*DocFile, error) {
+	return gh.getFile(rawname, info, ActionDocs)
+}
+
 func (gh *gitRepoSource) getInstallation(info *tfbridge.DocInfo) (*DocFile, error) {
 	// The installation docs do not have a rawname.
 	return gh.getFile("", info, InstallationDocs)
@@ -99,7 +106,7 @@ func (gh *gitRepoSource) getFile(
 	switch kind {
 	case InstallationDocs:
 		possibleMarkdownNames = append(possibleMarkdownNames, "index.md", "index.html.markdown")
-	case ResourceDocs, DataSourceDocs:
+	case ResourceDocs, DataSourceDocs, ActionDocs:
 		possibleMarkdownNames = getMarkdownNames(gh.resourcePrefix, rawname, gh.docRules)
 		if info != nil && info.Source != "" {
 			possibleMarkdownNames = append(possibleMarkdownNames, info.Source)

--- a/pkg/tfshim/schema/action.go
+++ b/pkg/tfshim/schema/action.go
@@ -1,0 +1,66 @@
+package schema
+
+import (
+	"context"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/internalinter"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+)
+
+var _ = shim.ActionMap(ActionMap{})
+
+type Action struct {
+	Schema   shim.SchemaMap
+	Metadata string
+	Invoke   func(ctx context.Context, ps resource.PropertyMap) (resource.PropertyMap, error)
+}
+
+func (r *Action) Shim() shim.Action {
+	return ActionShim{V: r}
+}
+
+type ActionShim struct {
+	V *Action
+	internalinter.Internal
+}
+
+func (r ActionShim) Schema() shim.SchemaMap {
+	return r.V.Schema
+}
+
+func (r ActionShim) Metadata() string {
+	return r.V.Metadata
+}
+
+func (r ActionShim) Invoke(ctx context.Context, ps resource.PropertyMap) (resource.PropertyMap, error) {
+	return r.V.Invoke(ctx, ps)
+}
+
+type ActionMap map[string]shim.Action
+
+func (m ActionMap) Len() int {
+	return len(m)
+}
+
+func (m ActionMap) Get(key string) shim.Action {
+	return m[key]
+}
+
+func (m ActionMap) GetOk(key string) (shim.Action, bool) {
+	r, ok := m[key]
+	return r, ok
+}
+
+func (m ActionMap) Range(each func(key string, value shim.Action) bool) {
+	for key, value := range m {
+		if !each(key, value) {
+			return
+		}
+	}
+}
+
+func (m ActionMap) Set(key string, value shim.Action) {
+	m[key] = value
+}

--- a/pkg/tfshim/schema/provider.go
+++ b/pkg/tfshim/schema/provider.go
@@ -12,6 +12,7 @@ type Provider struct {
 	Schema         shim.SchemaMap
 	ResourcesMap   shim.ResourceMap
 	DataSourcesMap shim.ResourceMap
+	ActionsMap     shim.ActionMap
 	internalinter.Internal
 }
 
@@ -25,6 +26,9 @@ func (p *Provider) Shim() shim.Provider {
 	}
 	if c.DataSourcesMap == nil {
 		c.DataSourcesMap = ResourceMap{}
+	}
+	if c.ActionsMap == nil {
+		c.ActionsMap = ActionMap{}
 	}
 	return newProviderShim(c)
 }
@@ -48,6 +52,10 @@ func (s ProviderShim) ResourcesMap() shim.ResourceMap {
 
 func (s ProviderShim) DataSourcesMap() shim.ResourceMap {
 	return s.V.DataSourcesMap
+}
+
+func (s ProviderShim) ActionsMap() shim.ActionMap {
+	return s.V.ActionsMap
 }
 
 func (s ProviderShim) InternalValidate() error {

--- a/pkg/tfshim/sdk-v1/action.go
+++ b/pkg/tfshim/sdk-v1/action.go
@@ -1,0 +1,59 @@
+package sdkv1
+
+import (
+	"context"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/internalinter"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+)
+
+var (
+	_ = shim.Action(v1Action{})
+	_ = shim.ActionMap(v1ActionMap{})
+)
+
+type v1Action struct {
+	internalinter.Internal
+}
+
+func (a v1Action) Schema() shim.SchemaMap {
+	contract.Failf("v1Action does not support Schema")
+	return nil
+}
+
+func (a v1Action) Metadata() string {
+	contract.Failf("v1Action does not support Metadata")
+	return ""
+}
+
+func (a v1Action) Invoke(
+	ctx context.Context,
+	inputs resource.PropertyMap,
+) (resource.PropertyMap, error) {
+	contract.Failf("v1Action does not support Invoke")
+	return nil, nil
+}
+
+type v1ActionMap map[string]any
+
+func (m v1ActionMap) Len() int {
+	return 0
+}
+
+func (m v1ActionMap) Get(key string) shim.Action {
+	return nil
+}
+
+func (m v1ActionMap) GetOk(key string) (shim.Action, bool) {
+	return nil, false
+}
+
+func (m v1ActionMap) Range(each func(key string, value shim.Action) bool) {
+}
+
+func (m v1ActionMap) Set(key string, value shim.Action) {
+	contract.Failf("cannot set on v1ActionMap")
+}

--- a/pkg/tfshim/sdk-v1/provider.go
+++ b/pkg/tfshim/sdk-v1/provider.go
@@ -74,6 +74,10 @@ func (p v1Provider) DataSourcesMap() shim.ResourceMap {
 	return v1ResourceMap(p.tf.DataSourcesMap)
 }
 
+func (p v1Provider) ActionsMap() shim.ActionMap {
+	return v1ActionMap{}
+}
+
 func (p v1Provider) InternalValidate() error {
 	return p.tf.InternalValidate()
 }

--- a/pkg/tfshim/sdk-v2/action.go
+++ b/pkg/tfshim/sdk-v2/action.go
@@ -1,0 +1,59 @@
+package sdkv2
+
+import (
+	"context"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/internalinter"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+)
+
+var (
+	_ = shim.Action(v2Action{})
+	_ = shim.ActionMap(v2ActionMap{})
+)
+
+type v2Action struct {
+	internalinter.Internal
+}
+
+func (a v2Action) Schema() shim.SchemaMap {
+	contract.Failf("v2Action does not support Schema")
+	return nil
+}
+
+func (a v2Action) Metadata() string {
+	contract.Failf("v2Action does not support Metadata")
+	return ""
+}
+
+func (a v2Action) Invoke(
+	ctx context.Context,
+	inputs resource.PropertyMap,
+) (resource.PropertyMap, error) {
+	contract.Failf("v2Action does not support Invoke")
+	return nil, nil
+}
+
+type v2ActionMap map[string]any
+
+func (m v2ActionMap) Len() int {
+	return 0
+}
+
+func (m v2ActionMap) Get(key string) shim.Action {
+	return nil
+}
+
+func (m v2ActionMap) GetOk(key string) (shim.Action, bool) {
+	return nil, false
+}
+
+func (m v2ActionMap) Range(each func(key string, value shim.Action) bool) {
+}
+
+func (m v2ActionMap) Set(key string, value shim.Action) {
+	contract.Failf("cannot set on v2ActionMap")
+}

--- a/pkg/tfshim/sdk-v2/provider.go
+++ b/pkg/tfshim/sdk-v2/provider.go
@@ -78,6 +78,10 @@ func (p v2Provider) Schema() shim.SchemaMap {
 	return v2SchemaMap(p.tf.Schema)
 }
 
+func (p v2Provider) ActionsMap() shim.ActionMap {
+	return v2ActionMap{}
+}
+
 func (p v2Provider) DataSourcesMap() shim.ResourceMap {
 	return v2ResourceMap(p.tf.DataSourcesMap)
 }

--- a/pkg/tfshim/shim.go
+++ b/pkg/tfshim/shim.go
@@ -297,10 +297,29 @@ func CloneResource(rm ResourceMap, oldKey string, newKey string) error {
 	}
 }
 
+type Action interface {
+	Schema() SchemaMap
+	Metadata() (typeName string)
+	Invoke(
+		ctx context.Context,
+		inputs resource.PropertyMap,
+	) (resource.PropertyMap, error)
+}
+
+type ActionMap interface {
+	Len() int
+	Get(key string) Action
+	GetOk(key string) (Action, bool)
+	Range(each func(key string, value Action) bool)
+
+	Set(key string, value Action)
+}
+
 type Provider interface {
 	Schema() SchemaMap
 	ResourcesMap() ResourceMap
 	DataSourcesMap() ResourceMap
+	ActionsMap() ActionMap
 
 	InternalValidate() error
 	Validate(ctx context.Context, c ResourceConfig) ([]diagnostics.ValidationWarning, []error)

--- a/pkg/tfshim/util/filter.go
+++ b/pkg/tfshim/util/filter.go
@@ -45,6 +45,7 @@ type FilteringProvider struct {
 	Provider         shim.Provider
 	ResourceFilter   func(token string) bool
 	DataSourceFilter func(token string) bool
+	ActionFilter     func(token string) bool
 	internalinter.Internal
 }
 
@@ -60,6 +61,10 @@ func (p *FilteringProvider) ResourcesMap() shim.ResourceMap {
 
 func (p *FilteringProvider) DataSourcesMap() shim.ResourceMap {
 	return &filteringMap{p.Provider.DataSourcesMap(), p.DataSourceFilter}
+}
+
+func (p *FilteringProvider) ActionsMap() shim.ActionMap {
+	return &filteringActionMap{p.Provider.ActionsMap(), p.ActionFilter}
 }
 
 func (p *FilteringProvider) InternalValidate() error {
@@ -192,3 +197,40 @@ func (f *filteringMap) Set(key string, value shim.Resource) {
 }
 
 var _ shim.ResourceMap = (*filteringMap)(nil)
+
+type filteringActionMap struct {
+	inner       shim.ActionMap
+	tokenFilter func(string) bool
+}
+
+func (f *filteringActionMap) Range(each func(key string, value shim.Action) bool) {
+	f.inner.Range(func(key string, value shim.Action) bool {
+		if f.tokenFilter != nil && !f.tokenFilter(key) {
+			return true
+		}
+		return each(key, value)
+	})
+}
+
+func (f *filteringActionMap) Len() int {
+	n := 0
+	f.Range(func(key string, value shim.Action) bool {
+		n = n + 1
+		return true
+	})
+	return n
+}
+
+func (f *filteringActionMap) Get(key string) shim.Action {
+	return f.inner.Get(key)
+}
+
+func (f *filteringActionMap) GetOk(key string) (shim.Action, bool) {
+	return f.inner.GetOk(key)
+}
+
+func (f *filteringActionMap) Set(key string, value shim.Action) {
+	f.inner.Set(key, value)
+}
+
+var _ shim.ActionMap = (*filteringActionMap)(nil)

--- a/pkg/tfshim/util/util.go
+++ b/pkg/tfshim/util/util.go
@@ -32,6 +32,7 @@ type UnimplementedProvider struct {
 func (UnimplementedProvider) Schema() shim.SchemaMap           { panic("unimplemented") }
 func (UnimplementedProvider) ResourcesMap() shim.ResourceMap   { panic("unimplemented") }
 func (UnimplementedProvider) DataSourcesMap() shim.ResourceMap { panic("unimplemented") }
+func (UnimplementedProvider) ActionsMap() shim.ActionMap       { panic("unimplemented") }
 
 func (UnimplementedProvider) InternalValidate() error { panic("unimplemented") }
 


### PR DESCRIPTION
This adds support for terraform provider actions, exposing them as invokes. Every invoke takes the parameters for the action plus a resource URN so that we can log the action output messages against a specific resource. 

The intention of these is to use them inside resource lifecycle hooks (where you'll have access to the resource URN), and is very similar to how terraform intends to use these actions. Of course being invokes users could also make use of these anywhere else as well, but as their generally mutating/side-effectful operations you probably don't want to do that.