### PR TITLE
Add ephemeral resources as invokes

### DIFF
--- a/pkg/convert/convert.go
+++ b/pkg/convert/convert.go
@@ -41,6 +41,8 @@ type Encoding interface {
 	NewResourceEncoder(resource string, resourceType tftypes.Object) (Encoder, error)
 	NewDataSourceDecoder(dataSource string, dataSourceType tftypes.Object) (Decoder, error)
 	NewDataSourceEncoder(dataSource string, dataSourceType tftypes.Object) (Encoder, error)
+	NewEphemeralResourceDecoder(ephemeralResource string, resourceType tftypes.Object) (Decoder, error)
+	NewEphemeralResourceEncoder(ephemeralResource string, resourceType tftypes.Object) (Encoder, error)
 }
 
 // Like PropertyNames but specialized to either a type by token or config property.

--- a/pkg/convert/encoding.go
+++ b/pkg/convert/encoding.go
@@ -89,6 +89,24 @@ func (e *encoding) NewDataSourceDecoder(
 	return dec, nil
 }
 
+func (e *encoding) NewEphemeralResourceEncoder(resource string, objectType tftypes.Object) (Encoder, error) {
+	mctx := newEphemeralResourceSchemaMapContext(resource, e.SchemaOnlyProvider, e.ProviderInfo)
+	enc, err := NewObjectEncoder(ObjectSchema{mctx.schemaMap, mctx.schemaInfos, &objectType})
+	if err != nil {
+		return nil, fmt.Errorf("cannot derive an encoder for ephemeral resource %q: %w", resource, err)
+	}
+	return enc, nil
+}
+
+func (e *encoding) NewEphemeralResourceDecoder(resource string, objectType tftypes.Object) (Decoder, error) {
+	mctx := newEphemeralResourceSchemaMapContext(resource, e.SchemaOnlyProvider, e.ProviderInfo)
+	dec, err := NewObjectDecoder(ObjectSchema{mctx.schemaMap, mctx.schemaInfos, &objectType})
+	if err != nil {
+		return nil, fmt.Errorf("cannot derive a decoder for ephemeral resource %q: %w", resource, err)
+	}
+	return dec, nil
+}
+
 func buildPropertyEncoders(
 	mctx *schemaMapContext, objectType tftypes.Object,
 ) (map[terraformPropertyName]Encoder, error) {

--- a/pkg/convert/schema_context.go
+++ b/pkg/convert/schema_context.go
@@ -23,7 +23,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/walk"
 )
 
@@ -69,6 +69,21 @@ func newDataSourceSchemaMapContext(
 	var fields map[string]*tfbridge.SchemaInfo
 	if providerInfo != nil {
 		fields = providerInfo.DataSources[dataSource].GetFields()
+	}
+	return newSchemaMapContext(sm, fields)
+}
+
+func newEphemeralResourceSchemaMapContext(
+	resource string,
+	schemaOnlyProvider shim.Provider,
+	providerInfo *tfbridge.ProviderInfo,
+) *schemaMapContext {
+	r := schemaOnlyProvider.EphemeralResourcesMap().Get(resource)
+	contract.Assertf(r != nil, "no ephemeral resource %q found in ResourceMap", resource)
+	sm := r.Schema()
+	var fields map[string]*tfbridge.SchemaInfo
+	if providerInfo != nil {
+		fields = providerInfo.EphemeralResources[resource].GetFields()
 	}
 	return newSchemaMapContext(sm, fields)
 }

--- a/pkg/pf/internal/pfutils/attr.go
+++ b/pkg/pf/internal/pfutils/attr.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	dschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	eschema "github.com/hashicorp/terraform-plugin-framework/ephemeral/schema"
 	prschema "github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
@@ -62,6 +63,10 @@ func FromDataSourceAttribute(x dschema.Attribute) Attr {
 }
 
 func FromResourceAttribute(x rschema.Attribute) Attr {
+	return FromAttrLike(x)
+}
+
+func FromEphemeralResourceAttribute(x eschema.Attribute) Attr {
 	return FromAttrLike(x)
 }
 

--- a/pkg/pf/internal/pfutils/ephemeral_resources.go
+++ b/pkg/pf/internal/pfutils/ephemeral_resources.go
@@ -1,0 +1,74 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pfutils
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/runtypes"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+)
+
+func GatherEphemeralResources[F func(Schema) shim.SchemaMap](
+	ctx context.Context, prov provider.Provider, f F,
+) (runtypes.EphemeralResources, error) {
+	provMetadata := queryProviderMetadata(ctx, prov)
+	es := make(collection[func() ephemeral.EphemeralResource])
+
+	eprov, ok := prov.(provider.ProviderWithEphemeralResources)
+	if ok {
+		for _, makeEphemeralResource := range eprov.EphemeralResources(ctx) {
+			ephemeralResource := makeEphemeralResource()
+
+			meta := ephemeral.MetadataResponse{}
+			ephemeralResource.Metadata(ctx, ephemeral.MetadataRequest{
+				ProviderTypeName: provMetadata.TypeName,
+			}, &meta)
+
+			schemaResponse := &ephemeral.SchemaResponse{}
+			ephemeralResource.Schema(ctx, ephemeral.SchemaRequest{}, schemaResponse)
+
+			ephemeralResourceSchema := schemaResponse.Schema
+			diag := schemaResponse.Diagnostics
+			if err := checkDiagsForErrors(diag); err != nil {
+				return nil, fmt.Errorf("EphemeralResource %s GetSchema() error: %w", meta.TypeName, err)
+			}
+
+			es[runtypes.TypeOrRenamedEntityName(meta.TypeName)] = entry[func() ephemeral.EphemeralResource]{
+				t:      makeEphemeralResource,
+				schema: FromEphemeralResourceSchema(ephemeralResourceSchema),
+				tfName: runtypes.TypeName(meta.TypeName),
+			}
+		}
+	}
+
+	return &ephemeralResources{collection: es, convert: f}, nil
+}
+
+type ephemeralResources struct {
+	collection[func() ephemeral.EphemeralResource]
+	convert func(Schema) shim.SchemaMap
+}
+
+func (r ephemeralResources) Schema(t runtypes.TypeOrRenamedEntityName) runtypes.Schema {
+	entry := r.collection[t]
+	return runtypesSchemaAdapter{entry.schema, r.convert, entry.tfName}
+}
+
+func (ephemeralResources) IsEphemeralResources() {}

--- a/pkg/pf/internal/pfutils/schema.go
+++ b/pkg/pf/internal/pfutils/schema.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	dschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	eschema "github.com/hashicorp/terraform-plugin-framework/ephemeral/schema"
 	prschema "github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
@@ -64,6 +65,11 @@ func FromResourceSchema(x rschema.Schema) Schema {
 	attrs := convertMap(FromResourceAttribute, x.Attributes)
 	blocks := convertMap(FromResourceBlock, x.Blocks)
 	return newSchemaAdapter(x, x.Type(), x.DeprecationMessage, attrs, blocks, &x)
+}
+
+func FromEphemeralResourceSchema(x eschema.Schema) Schema {
+	attrs := convertMap(FromEphemeralResourceAttribute, x.Attributes)
+	return newSchemaAdapter(x, x.Type(), x.DeprecationMessage, attrs, nil, nil)
 }
 
 type schemaAdapter struct {

--- a/pkg/pf/internal/runtypes/types.go
+++ b/pkg/pf/internal/runtypes/types.go
@@ -66,3 +66,9 @@ type DataSources interface {
 	collection
 	IsDataSources()
 }
+
+// Represents all provider's ephemeral resources pre-indexed by TypeOrRenamedEntityName.
+type EphemeralResources interface {
+	collection
+	IsEphemeralResources()
+}

--- a/pkg/pf/internal/schemashim/ephemeral_resource_map.go
+++ b/pkg/pf/internal/schemashim/ephemeral_resource_map.go
@@ -1,0 +1,90 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schemashim
+
+import (
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/internalinter"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/runtypes"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+)
+
+// Resource map needs to support Set (mutability) for RenameResourceWithAlias.
+func newSchemaOnlyEphemeralResourceMap(resources runtypes.EphemeralResources) schemaOnlyEphemeralResourceMap {
+	m := schemaOnlyEphemeralResourceMap{Map: make(map[string]*schemaOnlyResource)}
+	for _, name := range resources.All() {
+		key := string(name)
+		v := resources.Schema(name)
+		m.Map[key] = newSchemaOnlyResource(v)
+	}
+	return m
+}
+
+type schemaOnlyEphemeralResourceMap struct {
+	internalinter.Internal
+	Map map[string]*schemaOnlyResource
+}
+
+var (
+	_ shim.ResourceMap            = schemaOnlyEphemeralResourceMap{}
+	_ runtypes.EphemeralResources = schemaOnlyEphemeralResourceMap{}
+)
+
+func (m schemaOnlyEphemeralResourceMap) Len() int {
+	return len(m.Map)
+}
+
+func (m schemaOnlyEphemeralResourceMap) Get(key string) shim.Resource {
+	return m.Map[key]
+}
+
+func (m schemaOnlyEphemeralResourceMap) GetOk(key string) (shim.Resource, bool) {
+	v, ok := m.Map[key]
+	return v, ok
+}
+
+func (m schemaOnlyEphemeralResourceMap) Range(each func(key string, value shim.Resource) bool) {
+	for k, v := range m.Map {
+		if !each(k, v) {
+			return
+		}
+	}
+}
+
+func (m schemaOnlyEphemeralResourceMap) Set(key string, value shim.Resource) {
+	v, ok := value.(*schemaOnlyResource)
+	contract.Assertf(ok, "Set must be a %T, found a %T", v, value)
+	m.Map[key] = v
+}
+
+func (m schemaOnlyEphemeralResourceMap) All() []runtypes.TypeOrRenamedEntityName {
+	arr := make([]runtypes.TypeOrRenamedEntityName, 0, len(m.Map))
+	for k := range m.Map {
+		arr = append(arr, runtypes.TypeOrRenamedEntityName(k))
+	}
+	return arr
+}
+
+func (m schemaOnlyEphemeralResourceMap) Has(key runtypes.TypeOrRenamedEntityName) bool {
+	_, ok := m.Map[string(key)]
+	return ok
+}
+
+func (m schemaOnlyEphemeralResourceMap) Schema(key runtypes.TypeOrRenamedEntityName) runtypes.Schema {
+	return m.Map[string(key)].tf
+}
+
+func (m schemaOnlyEphemeralResourceMap) IsEphemeralResources() {}

--- a/pkg/pf/internal/schemashim/provider.go
+++ b/pkg/pf/internal/schemashim/provider.go
@@ -33,10 +33,11 @@ import (
 var _ = pf.ShimProvider(&SchemaOnlyProvider{})
 
 type SchemaOnlyProvider struct {
-	ctx           context.Context
-	tf            pfprovider.Provider
-	resourceMap   schemaOnlyResourceMap
-	dataSourceMap schemaOnlyDataSourceMap
+	ctx                  context.Context
+	tf                   pfprovider.Provider
+	resourceMap          schemaOnlyResourceMap
+	dataSourceMap        schemaOnlyDataSourceMap
+	ephemeralResourceMap schemaOnlyEphemeralResourceMap
 	internalinter.Internal
 }
 
@@ -60,6 +61,10 @@ func (p *SchemaOnlyProvider) Resources(ctx context.Context) (runtypes.Resources,
 
 func (p *SchemaOnlyProvider) DataSources(ctx context.Context) (runtypes.DataSources, error) {
 	return p.dataSourceMap, nil
+}
+
+func (p *SchemaOnlyProvider) EphemeralResources(ctx context.Context) (runtypes.EphemeralResources, error) {
+	return p.ephemeralResourceMap, nil
 }
 
 func (p *SchemaOnlyProvider) Config(ctx context.Context) (tftypes.Object, error) {
@@ -91,6 +96,10 @@ func (p *SchemaOnlyProvider) ResourcesMap() shim.ResourceMap {
 
 func (p *SchemaOnlyProvider) DataSourcesMap() shim.ResourceMap {
 	return p.dataSourceMap
+}
+
+func (p *SchemaOnlyProvider) EphemeralResourcesMap() shim.ResourceMap {
+	return p.ephemeralResourceMap
 }
 
 func (p *SchemaOnlyProvider) InternalValidate() error {

--- a/pkg/pf/internal/schemashim/schemashim.go
+++ b/pkg/pf/internal/schemashim/schemashim.go
@@ -32,12 +32,18 @@ func ShimSchemaOnlyProvider(ctx context.Context, provider pfprovider.Provider) s
 	if err != nil {
 		panic(err)
 	}
+	ephemeralResources, err := pfutils.GatherEphemeralResources(ctx, provider, NewSchemaMap)
+	if err != nil {
+		panic(err)
+	}
 	resourceMap := newSchemaOnlyResourceMap(resources)
 	dataSourceMap := newSchemaOnlyDataSourceMap(dataSources)
+	ephemeralResourceMap := newSchemaOnlyEphemeralResourceMap(ephemeralResources)
 	return &SchemaOnlyProvider{
-		ctx:           ctx,
-		tf:            provider,
-		resourceMap:   resourceMap,
-		dataSourceMap: dataSourceMap,
+		ctx:                  ctx,
+		tf:                   provider,
+		resourceMap:          resourceMap,
+		dataSourceMap:        dataSourceMap,
+		ephemeralResourceMap: ephemeralResourceMap,
 	}
 }

--- a/pkg/pf/proto/protov6.go
+++ b/pkg/pf/proto/protov6.go
@@ -125,3 +125,12 @@ func (p Provider) DataSourcesMap() shim.ResourceMap {
 	}
 	return resourceMap(v.DataSourceSchemas)
 }
+
+func (p Provider) EphemeralResourcesMap() shim.ResourceMap {
+	v, err := p.getSchema()
+	if err != nil {
+		tfbridge.GetLogger(p.ctx).Error(err.Error())
+		return nil
+	}
+	return resourceMap(v.EphemeralResourceSchemas)
+}

--- a/pkg/pf/proto/runtypes.go
+++ b/pkg/pf/proto/runtypes.go
@@ -41,6 +41,14 @@ func (p Provider) DataSources(context.Context) (runtypes.DataSources, error) {
 	return datasources{collection(v.DataSourceSchemas)}, nil
 }
 
+func (p Provider) EphemeralResources(context.Context) (runtypes.EphemeralResources, error) {
+	v, err := p.getSchema()
+	if err != nil {
+		return nil, err
+	}
+	return ephemeralResources{collection(v.EphemeralResourceSchemas)}, nil
+}
+
 type schema struct {
 	s      *tfprotov6.Schema
 	tfName runtypes.TypeName
@@ -84,6 +92,12 @@ type datasources struct{ collection }
 var _ runtypes.DataSources = datasources{}
 
 func (datasources) IsDataSources() {}
+
+var _ runtypes.EphemeralResources = ephemeralResources{}
+
+type ephemeralResources struct{ collection }
+
+func (ephemeralResources) IsEphemeralResources() {}
 
 type collection map[string]*tfprotov6.Schema
 

--- a/pkg/pf/provider.go
+++ b/pkg/pf/provider.go
@@ -34,5 +34,6 @@ type ShimProvider interface {
 	Server(context.Context) (tfprotov6.ProviderServer, error)
 	Resources(context.Context) (runtypes.Resources, error)
 	DataSources(context.Context) (runtypes.DataSources, error)
+	EphemeralResources(context.Context) (runtypes.EphemeralResources, error)
 	Config(context.Context) (tftypes.Object, error)
 }

--- a/pkg/pf/tests/integration/program_test.go
+++ b/pkg/pf/tests/integration/program_test.go
@@ -253,6 +253,28 @@ func TestResourceWithoutID(t *testing.T) {
 	})
 }
 
+// E2E test for using an ephemeral resource
+func TestEphemeralResource(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping on Windows due to a PATH setup issue where the test cannot find pulumi-resource-testbridge.exe")
+	}
+	wd, err := os.Getwd()
+	assert.NoError(t, err)
+
+	bin := filepath.Join(wd, "..", "bin")
+
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Env: []string{fmt.Sprintf("PATH=%s", bin)},
+		Dir: filepath.Join("..", "testdata", "ephemeral-resource"),
+		PrepareProject: func(info *engine.Projinfo) error {
+			return prepareStateFolder(info.Root)
+		},
+	})
+}
+
 func prepareStateFolder(root string) error {
 	err := os.Mkdir(filepath.Join(root, "state"), 0o777)
 	if os.IsExist(err) {

--- a/pkg/pf/tests/internal/testprovider/cmd/pulumi-resource-testbridge/schema.json
+++ b/pkg/pf/tests/internal/testprovider/cmd/pulumi-resource-testbridge/schema.json
@@ -1100,6 +1100,36 @@
                 "type": "object"
             }
         },
+        "testbridge:index/ephemeral:Testeph": {
+            "inputs": {
+                "description": "A collection of arguments for invoking Testeph.\n",
+                "properties": {
+                    "statedir": {
+                        "type": "string"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "statedir"
+                ]
+            },
+            "outputs": {
+                "description": "A collection of values returned by Testeph.\n",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "statedir": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "id",
+                    "statedir"
+                ],
+                "type": "object"
+            }
+        },
         "testbridge:index/smac:SMAC": {
             "outputs": {
                 "description": "A collection of values returned by SMAC.\n",

--- a/pkg/pf/tests/internal/testprovider/testbridge.go
+++ b/pkg/pf/tests/internal/testprovider/testbridge.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2025, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	prschema "github.com/hashicorp/terraform-plugin-framework/provider/schema"
@@ -129,6 +130,10 @@ func SyntheticTestBridgeProvider() tfbridge.ProviderInfo {
 			"testbridge_smac_ds": {Tok: "testbridge:index/smac:SMAC"},
 		},
 
+		EphemeralResources: map[string]*tfbridge.EphemeralResourceInfo{
+			"testbridge_testeph": {Tok: "testbridge:index/ephemeral:Testeph"},
+		},
+
 		MetadataInfo: tfbridge.NewProviderMetadata(testBridgeMetadata),
 	}
 
@@ -144,7 +149,10 @@ type resourceData struct {
 	skipMetadataAPICheck *string
 }
 
-var _ provider.Provider = (*syntheticProvider)(nil)
+var (
+	_ provider.Provider                       = (*syntheticProvider)(nil)
+	_ provider.ProviderWithEphemeralResources = (*syntheticProvider)(nil)
+)
 
 func (p *syntheticProvider) Metadata(_ context.Context, _ provider.MetadataRequest, resp *provider.MetadataResponse) {
 	resp.TypeName = "testbridge"
@@ -335,5 +343,11 @@ func (p *syntheticProvider) Resources(context.Context) []func() resource.Resourc
 		newAutoNameRes,
 		newIntIDRes,
 		newVlanNamesRes,
+	}
+}
+
+func (p *syntheticProvider) EphemeralResources(context.Context) []func() ephemeral.EphemeralResource {
+	return []func() ephemeral.EphemeralResource{
+		newTesteph,
 	}
 }

--- a/pkg/pf/tests/internal/testprovider/testbridge_resource_testeph.go
+++ b/pkg/pf/tests/internal/testprovider/testbridge_resource_testeph.go
@@ -1,0 +1,225 @@
+// Copyright 2025-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testprovider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
+	eschema "github.com/hashicorp/terraform-plugin-framework/ephemeral/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/fsutil"
+)
+
+type testeph struct{}
+
+var _ ephemeral.EphemeralResource = &testeph{}
+
+func newTesteph() ephemeral.EphemeralResource {
+	return &testeph{}
+}
+
+func (*testeph) schema() eschema.Schema {
+	return eschema.Schema{
+		Description: `
+testbridge_testeph resource is built to facilitate testing ephemeral resources in the Pulumi bridge.
+
+It emulates cloud state by storing the state in a binary file identified, with location configured by the statedir
+attribute.
+`,
+		Attributes: map[string]eschema.Attribute{
+			"id": eschema.StringAttribute{
+				Computed: true,
+			},
+			"statedir": eschema.StringAttribute{
+				Required:    true,
+				Description: "Dir to store pseudo-cloud state in.",
+			},
+		},
+	}
+}
+
+func (e *testeph) Metadata(_ context.Context, req ephemeral.MetadataRequest, resp *ephemeral.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_testeph"
+}
+
+func (e *testeph) Schema(_ context.Context, _ ephemeral.SchemaRequest, resp *ephemeral.SchemaResponse) {
+	resp.Schema = e.schema()
+}
+
+func (e *testeph) Open(ctx context.Context, req ephemeral.OpenRequest, resp *ephemeral.OpenResponse) {
+	var statedir string
+	diags0 := req.Config.GetAttribute(ctx, path.Root("statedir"), &statedir)
+	resp.Diagnostics.Append(diags0...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resourceID, err := e.freshID(statedir)
+	if err != nil {
+		resp.Diagnostics.AddError("testres.freshID", err.Error())
+		return
+	}
+
+	cloudStateFile := e.cloudStateFile(statedir, resourceID)
+	if _, gotState, err := e.readCloudState(ctx, cloudStateFile); gotState && err == nil {
+		resp.Diagnostics.AddError("testbridge_testres.Create found unexpected pseudo-cloud state",
+			cloudStateFile)
+	}
+
+	// Copy plan to state.
+	resp.Result.Raw = req.Config.Raw.Copy()
+
+	// Set id computed by the provider.
+	diags2 := resp.Result.SetAttribute(ctx, path.Root("id"), resourceID)
+	resp.Diagnostics.Append(diags2...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := e.writeCloudState(ctx, cloudStateFile, resp.Result); err != nil {
+		resp.Diagnostics.AddError("testbridge_testres.Create cannot write pseudo-cloud state",
+			err.Error())
+	}
+
+	setJSON := func(key string, value string) {
+		data, err := json.Marshal(value)
+		if err != nil {
+			resp.Diagnostics.AddError("testbridge_testres.Open cannot marshal private state",
+				err.Error())
+			return
+		}
+		diags := resp.Private.SetKey(ctx, key, data)
+		resp.Diagnostics.Append(diags...)
+	}
+
+	setJSON("statedir", statedir)
+	setJSON("id", resourceID)
+}
+
+func (e *testeph) Close(ctx context.Context, req ephemeral.CloseRequest, resp *ephemeral.CloseResponse) {
+	getJSON := func(key string) string {
+		var value string
+		data, diags := req.Private.GetKey(ctx, key)
+		if diags.HasError() {
+			resp.Diagnostics.Append(diags...)
+			return ""
+		}
+		if err := json.Unmarshal(data, &value); err != nil {
+			resp.Diagnostics.AddError("testbridge_testres.Close cannot unmarshal private state",
+				err.Error())
+			return ""
+		}
+		return value
+	}
+
+	statedir := getJSON("statedir")
+	if statedir == "" {
+		return
+	}
+	resourceID := getJSON("id")
+	if resourceID == "" {
+		return
+	}
+
+	cloudStateFile := e.cloudStateFile(statedir, resourceID)
+	if err := e.deleteCloudState(cloudStateFile); err != nil {
+		resp.Diagnostics.AddError("testbridge_testres.Close cannot delete pseudo-cloud state",
+			err.Error())
+	}
+}
+
+func (e *testeph) freshID(statedir string) (string, error) {
+	mu := fsutil.NewFileMutex(filepath.Join(statedir, "testres.lock"))
+	if err := mu.Lock(); err != nil {
+		return "", err
+	}
+	defer func() {
+		if err := mu.Unlock(); err != nil {
+			panic(err)
+		}
+	}()
+
+	cF := filepath.Join(statedir, "testres.counter")
+
+	i := 0
+	f, err := os.ReadFile(cF)
+	if err != nil && !os.IsNotExist(err) {
+		return "", err
+	}
+	if err == nil {
+		i, err = strconv.Atoi(string(f))
+		if err != nil {
+			return "", err
+		}
+	}
+
+	if err := os.WriteFile(cF, []byte(fmt.Sprintf("%d", i+1)), 0o600); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%d", i), nil
+}
+
+func (e *testeph) cloudStateFile(statedir, resourceID string) string {
+	return filepath.Join(statedir, fmt.Sprintf("%s.bin", resourceID))
+}
+
+func (e *testeph) deleteCloudState(file string) error {
+	return os.Remove(file)
+}
+
+func (e *testeph) readCloudState(ctx context.Context, file string) (tfsdk.State, bool, error) {
+	bytes, err := os.ReadFile(file)
+
+	if err != nil && os.IsNotExist(err) {
+		return tfsdk.State{}, false, nil
+	}
+
+	if err != nil {
+		return tfsdk.State{}, false, err
+	}
+
+	state, err := e.bytesToState(ctx, bytes)
+	return state, err == nil, err
+}
+
+func (e *testeph) writeCloudState(ctx context.Context, file string, state tfsdk.EphemeralResultData) error {
+	stateBytes, err := e.stateToBytes(ctx, state)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(file, stateBytes, 0o600)
+}
+
+func (*testeph) stateToBytes(ctx context.Context, state tfsdk.EphemeralResultData) ([]byte, error) {
+	typ := state.Schema.Type().TerraformType(ctx)
+	dv, err := tfprotov6.NewDynamicValue(typ, state.Raw)
+	return dv.MsgPack, err
+}
+
+func (e *testeph) bytesToState(ctx context.Context, raw []byte) (tfsdk.State, error) {
+	schema := e.schema()
+	dv := tfprotov6.DynamicValue{MsgPack: raw}
+	typ := schema.Type().TerraformType(ctx)
+	v, err := dv.Unmarshal(typ)
+	return tfsdk.State{Raw: v, Schema: schema}, err
+}

--- a/pkg/pf/tests/provider_epemeral_test.go
+++ b/pkg/pf/tests/provider_epemeral_test.go
@@ -1,0 +1,59 @@
+// Copyright 2025-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfbridgetests
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/testprovider"
+)
+
+func TestEphemeralInvokeClose(t *testing.T) {
+	t.Parallel()
+	server, err := newProviderServer(t, testprovider.SyntheticTestBridgeProvider())
+	require.NoError(t, err)
+
+	tmp := t.TempDir()
+
+	properties, err := structpb.NewStruct(map[string]any{
+		"statedir": tmp,
+	})
+	require.NoError(t, err)
+	resp, err := server.Invoke(t.Context(), &pulumirpc.InvokeRequest{
+		Tok:  "testbridge:index/ephemeral:Testeph",
+		Args: properties,
+	})
+	require.NoError(t, err)
+
+	id := resp.Return.Fields["id"].GetStringValue()
+
+	path := filepath.Join(tmp, id+".bin")
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Contains(t, string(data), "\xa8statedir")
+	require.Contains(t, string(data), tmp)
+
+	_, err = server.Cancel(t.Context(), &emptypb.Empty{})
+	require.NoError(t, err)
+	_, err = os.Stat(path)
+	require.True(t, os.IsNotExist(err))
+}

--- a/pkg/pf/tests/testdata/ephemeral-resource/Pulumi.yaml
+++ b/pkg/pf/tests/testdata/ephemeral-resource/Pulumi.yaml
@@ -1,0 +1,15 @@
+name: ephemeralprogram
+runtime: yaml
+outputs:
+  testEph:
+    fn::invoke:
+      function: testbridge:index/echo:Echo
+      arguments:
+        input: "Hello"
+  testEcho__expect:
+    input:
+      "Hello"
+    output:
+      "Hello"
+    sensitive:
+      "Hello"

--- a/pkg/pf/tfbridge/naming.go
+++ b/pkg/pf/tfbridge/naming.go
@@ -37,3 +37,22 @@ func functionPropertyKey(ds datasourceHandle, path *tftypes.AttributePath) (reso
 		return "", false
 	}
 }
+
+func ephemeralFunctionPropertyKey(
+	eh ephemeralResourceHandle, path *tftypes.AttributePath,
+) (resource.PropertyKey, bool) {
+	if path == nil {
+		return "", false
+	}
+	if len(path.Steps()) != 1 {
+		return "", false
+	}
+	switch attrName := path.LastStep().(type) {
+	case tftypes.AttributeName:
+		pulumiName := tfbridge.TerraformToPulumiNameV2(string(attrName),
+			eh.schemaOnlyShim.Schema(), eh.pulumiEphemeralResourceInfo.GetFields())
+		return resource.PropertyKey(pulumiName), true
+	default:
+		return "", false
+	}
+}

--- a/pkg/pf/tfbridge/provider.go
+++ b/pkg/pf/tfbridge/provider.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/blang/semver"
 	pfprovider "github.com/hashicorp/terraform-plugin-framework/provider"
@@ -74,22 +76,29 @@ func getProviderOptions(opts []providerOption) (providerOptions, error) {
 	return res, nil
 }
 
+type ephemeral struct {
+	typeName string
+	renewAt  time.Time
+	private  []byte
+}
+
 // Provider implements the Pulumi resource provider operations for any
 // Terraform plugin built with Terraform Plugin Framework.
 //
 // https://www.terraform.io/plugin/framework
 type provider struct {
-	tfServer      tfprotov6.ProviderServer
-	info          tfbridge.ProviderInfo
-	resources     runtypes.Resources
-	datasources   runtypes.DataSources
-	pulumiSchema  func(context.Context, plugin.GetSchemaRequest) ([]byte, error)
-	encoding      convert.Encoding
-	diagSink      diag.Sink
-	configEncoder convert.Encoder
-	configType    tftypes.Object
-	version       semver.Version
-	logSink       logging.Sink
+	tfServer           tfprotov6.ProviderServer
+	info               tfbridge.ProviderInfo
+	resources          runtypes.Resources
+	datasources        runtypes.DataSources
+	ephemeralResources runtypes.EphemeralResources
+	pulumiSchema       func(context.Context, plugin.GetSchemaRequest) ([]byte, error)
+	encoding           convert.Encoding
+	diagSink           diag.Sink
+	configEncoder      convert.Encoder
+	configType         tftypes.Object
+	version            semver.Version
+	logSink            logging.Sink
 
 	parameterize func(context.Context, plugin.ParameterizeRequest) (plugin.ParameterizeResponse, error)
 
@@ -99,6 +108,10 @@ type provider struct {
 
 	schemaOnlyProvider shim.Provider
 	providerOpts       []providerOption
+
+	// ephemeralState holds any provider-specific state that needs propagating across operations.
+	ephemeralState     []ephemeral
+	ephemeralStateLock sync.Mutex
 }
 
 var _ pl.ProviderWithContext = &provider{}
@@ -150,6 +163,10 @@ func newProviderWithContext(ctx context.Context, info tfbridge.ProviderInfo,
 	if err != nil {
 		return nil, err
 	}
+	ephemeralResources, err := pfServer.EphemeralResources(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	if info.MetadataInfo == nil {
 		return nil, fmt.Errorf("[pf/tfbridge] ProviderInfo.BridgeMetadata is required but is nil")
@@ -191,6 +208,7 @@ func newProviderWithContext(ctx context.Context, info tfbridge.ProviderInfo,
 		info:               info,
 		resources:          resources,
 		datasources:        datasources,
+		ephemeralResources: ephemeralResources,
 		pulumiSchema:       schema,
 		encoding:           enc,
 		configEncoder:      configEncoder,
@@ -298,6 +316,21 @@ func (p *provider) GetPluginInfoWithContext(_ context.Context) (workspace.Plugin
 // initialization error. SignalCancellation is advisory and non-blocking; it is up to the host to decide how long to
 // wait after SignalCancellation is called before (e.g.) hard-closing any gRPC connection.
 func (p *provider) SignalCancellationWithContext(_ context.Context) error {
+	// Close any ephemeral resources.
+	p.ephemeralStateLock.Lock()
+	defer p.ephemeralStateLock.Unlock()
+
+	for _, e := range p.ephemeralState {
+		req := &tfprotov6.CloseEphemeralResourceRequest{
+			TypeName: e.typeName,
+			Private:  e.private,
+		}
+		_, err := p.tfServer.CloseEphemeralResource(context.Background(), req)
+		if err != nil {
+			p.diagSink.Warningf(diag.Message("", fmt.Sprintf("error closing ephemeral resource: %v", err)))
+		}
+	}
+
 	// Some improvements are possible here to gracefully shut down.
 	return nil
 }
@@ -318,6 +351,15 @@ func (p *provider) terraformDatasourceNameOrRenamedEntity(functionToken tokens.M
 		}
 	}
 	return "", fmt.Errorf("[pf/tfbridge] unknown datasource token: %v", functionToken)
+}
+
+func (p *provider) terraformEphemeralResourceNameOrRenamedEntity(resourceToken tokens.ModuleMember) (string, bool) {
+	for tfname, v := range p.info.EphemeralResources {
+		if v.Tok == resourceToken {
+			return tfname, true
+		}
+	}
+	return "", false
 }
 
 func (p *provider) returnTerraformConfig() (resource.PropertyMap, error) {

--- a/pkg/pf/tfbridge/provider_ephemeral_resources.go
+++ b/pkg/pf/tfbridge/provider_ephemeral_resources.go
@@ -1,0 +1,82 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfbridge
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/convert"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/runtypes"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+)
+
+type ephemeralResourceHandle struct {
+	token                          tokens.ModuleMember
+	terraformEphemeralResourceName string
+	schema                         runtypes.Schema
+	pulumiEphemeralResourceInfo    *tfbridge.EphemeralResourceInfo // optional
+	encoder                        convert.Encoder
+	decoder                        convert.Decoder
+	schemaOnlyShim                 shim.Resource
+}
+
+func (p *provider) ephemeralResourceHandle(
+	ctx context.Context, tok tokens.ModuleMember,
+) (ephemeralResourceHandle, bool, error) {
+	typeOrRenamedEntityName, has := p.terraformEphemeralResourceNameOrRenamedEntity(tok)
+	if !has {
+		return ephemeralResourceHandle{}, false, nil
+	}
+
+	schema := p.ephemeralResources.Schema(runtypes.TypeOrRenamedEntityName(typeOrRenamedEntityName))
+
+	result := ephemeralResourceHandle{
+		terraformEphemeralResourceName: string(schema.TFName()),
+		schema:                         schema,
+	}
+
+	if info, ok := p.info.EphemeralResources[typeOrRenamedEntityName]; ok {
+		result.pulumiEphemeralResourceInfo = info
+	}
+
+	token := result.pulumiEphemeralResourceInfo.Tok
+	if token == "" {
+		return ephemeralResourceHandle{}, true, fmt.Errorf("Tok cannot be empty: %s", token)
+	}
+
+	objectType := result.schema.Type(ctx).(tftypes.Object)
+
+	encoder, err := p.encoding.NewEphemeralResourceEncoder(typeOrRenamedEntityName, objectType)
+	if err != nil {
+		return ephemeralResourceHandle{}, true, fmt.Errorf("Failed to prepare an ephemeral resource encoder: %s", err)
+	}
+
+	outputsDecoder, err := p.encoding.NewEphemeralResourceDecoder(typeOrRenamedEntityName, objectType)
+	if err != nil {
+		return ephemeralResourceHandle{}, true, fmt.Errorf("Failed to prepare an ephemeral resource decoder: %s", err)
+	}
+
+	result.encoder = encoder
+	result.decoder = outputsDecoder
+	result.token = token
+
+	result.schemaOnlyShim, _ = p.schemaOnlyProvider.EphemeralResourcesMap().GetOk(typeOrRenamedEntityName)
+	return result, true, nil
+}

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -121,6 +121,8 @@ type AliasInfo = info.Alias
 // ResourceOrDataSourceInfo is a shared interface to ResourceInfo and DataSourceInfo mappings
 type ResourceOrDataSourceInfo = info.ResourceOrDataSource
 
+type EphemeralResourceInfo = info.EphemeralResource
+
 // ResourceInfo is a top-level type exported by a provider.  This structure can override the type to generate.  It can
 // also give custom metadata for fields, using the SchemaInfo structure below.  Finally, a set of composite keys can be
 // given; this is used when Terraform needs more than just the ID to uniquely identify and query for a resource.

--- a/pkg/tfshim/schema/provider.go
+++ b/pkg/tfshim/schema/provider.go
@@ -49,6 +49,10 @@ func (s ProviderShim) DataSourcesMap() shim.ResourceMap {
 	return s.V.DataSourcesMap
 }
 
+func (s ProviderShim) EphemeralResourcesMap() shim.ResourceMap {
+	return ResourceMap{}
+}
+
 func (s ProviderShim) InternalValidate() error {
 	return nil
 }

--- a/pkg/tfshim/sdk-v1/provider.go
+++ b/pkg/tfshim/sdk-v1/provider.go
@@ -73,6 +73,10 @@ func (p v1Provider) DataSourcesMap() shim.ResourceMap {
 	return v1ResourceMap(p.tf.DataSourcesMap)
 }
 
+func (p v1Provider) EphemeralResourcesMap() shim.ResourceMap {
+	return v1ResourceMap{}
+}
+
 func (p v1Provider) InternalValidate() error {
 	return p.tf.InternalValidate()
 }

--- a/pkg/tfshim/sdk-v2/provider.go
+++ b/pkg/tfshim/sdk-v2/provider.go
@@ -81,6 +81,10 @@ func (p v2Provider) DataSourcesMap() shim.ResourceMap {
 	return v2ResourceMap(p.tf.DataSourcesMap)
 }
 
+func (p v2Provider) EphemeralResourcesMap() shim.ResourceMap {
+	return v2ResourceMap{}
+}
+
 func (p v2Provider) InternalValidate() error {
 	return p.tf.InternalValidate()
 }

--- a/pkg/tfshim/shim.go
+++ b/pkg/tfshim/shim.go
@@ -300,6 +300,7 @@ type Provider interface {
 	Schema() SchemaMap
 	ResourcesMap() ResourceMap
 	DataSourcesMap() ResourceMap
+	EphemeralResourcesMap() ResourceMap
 
 	InternalValidate() error
 	Validate(ctx context.Context, c ResourceConfig) ([]string, []error)

--- a/pkg/tfshim/util/filter.go
+++ b/pkg/tfshim/util/filter.go
@@ -41,9 +41,10 @@ import (
 //      PULUMI_SKIP_EXTRA_MAPPING_ERROR=1 make provider
 
 type FilteringProvider struct {
-	Provider         shim.Provider
-	ResourceFilter   func(token string) bool
-	DataSourceFilter func(token string) bool
+	Provider                shim.Provider
+	ResourceFilter          func(token string) bool
+	DataSourceFilter        func(token string) bool
+	EphemeralResourceFilter func(token string) bool
 	internalinter.Internal
 }
 
@@ -59,6 +60,10 @@ func (p *FilteringProvider) ResourcesMap() shim.ResourceMap {
 
 func (p *FilteringProvider) DataSourcesMap() shim.ResourceMap {
 	return &filteringMap{p.Provider.DataSourcesMap(), p.DataSourceFilter}
+}
+
+func (p *FilteringProvider) EphemeralResourcesMap() shim.ResourceMap {
+	return &filteringMap{p.Provider.EphemeralResourcesMap(), p.EphemeralResourceFilter}
 }
 
 func (p *FilteringProvider) InternalValidate() error {

--- a/pkg/tfshim/util/util.go
+++ b/pkg/tfshim/util/util.go
@@ -31,6 +31,9 @@ type UnimplementedProvider struct {
 func (UnimplementedProvider) Schema() shim.SchemaMap           { panic("unimplemented") }
 func (UnimplementedProvider) ResourcesMap() shim.ResourceMap   { panic("unimplemented") }
 func (UnimplementedProvider) DataSourcesMap() shim.ResourceMap { panic("unimplemented") }
+func (UnimplementedProvider) EphemeralResourcesMap() shim.ResourceMap {
+	panic("unimplemented")
+}
 
 func (UnimplementedProvider) InternalValidate() error { panic("unimplemented") }
 


### PR DESCRIPTION
A (probably better) alternative to https://github.com/pulumi/pulumi-terraform-bridge/pull/3227. Terraform treats ephemeral resources more like data sources, so rather than exposing these as resources this PR exposes them as invokes.


# Questions
1. Are we ok just keeping track of private state and renewals within the bridge process? Seems to work fine, and the engine does promise providers can be stateful.