### PR TITLE
[doc gen] Add support for `console` code blocks

### DIFF
--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -1230,6 +1230,7 @@ func (p *tfMarkdownParser) parseImports(body string) {
 		// There are multiple variations of codeblocks for import syntax
 		line = strings.ReplaceAll(line, "```shell", "")
 		line = strings.ReplaceAll(line, "```sh", "")
+		line = strings.ReplaceAll(line, "```console", "")
 		line = strings.ReplaceAll(line, "```", "")
 
 		// We have find a line that we assume looks like this:

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -1854,6 +1854,16 @@ func TestParseImports_NoOverrides(t *testing.T) {
 			expected: "## Import\n\n```sh\n$ pulumi import snowflake:index/apiIntegration:ApiIntegration example name\n```\n\n",
 		},
 		{
+			// The following test case contains a `console` codeblock that should be gone
+			input: strings.Join([]string{
+				"```console",
+				"terraform import snowflake_api_integration.example name",
+				"```",
+			}, "\n"),
+			token:    "snowflake:index/apiIntegration:ApiIntegration",
+			expected: "## Import\n\n```sh\n$ pulumi import snowflake:index/apiIntegration:ApiIntegration example name\n```\n\n",
+		},
+		{
 			input: strings.Join([]string{
 				"",
 				"This is a first line in a multi-line import section",


### PR DESCRIPTION
Fixes #3233

`tfgen/docs.go` has logic to detect the different types of `shell` code blocks when we are generating docs. A new type codeblock labeled `console` was added which meant that broke the rendering. This PR adds logic to remove those new `console` codeblocks.
