### PR TITLE
Set Checker interface for schema.go

### DIFF
--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -1024,13 +1024,19 @@ func makeTerraformUnknown(tfs shim.Schema) interface{} {
 	}
 }
 
+type SetChecker interface {
+	IsSet(ctx context.Context, v interface{}) ([]interface{}, bool)
+}
+
+var _ SetChecker = shim.Provider(nil)
+
 // MakeTerraformResult expands a Terraform state into an expanded Pulumi resource property map.  This respects
 // the property maps so that results end up with their correct Pulumi names when shipping back to the engine.
 //
 // May be called with unknowns during preview.
 func MakeTerraformResult(
 	ctx context.Context,
-	p shim.Provider,
+	p SetChecker,
 	state shim.InstanceState,
 	tfs shim.SchemaMap,
 	ps map[string]*SchemaInfo,
@@ -1066,7 +1072,7 @@ func MakeTerraformResult(
 // the property maps so that results end up with their correct Pulumi names when shipping back to the engine.
 func MakeTerraformOutputs(
 	ctx context.Context,
-	p shim.Provider,
+	p SetChecker,
 	outs map[string]interface{},
 	tfs shim.SchemaMap,
 	ps map[string]*SchemaInfo,
@@ -1097,14 +1103,14 @@ func MakeTerraformOutputs(
 // MakeTerraformOutput takes a single Terraform property and returns the Pulumi equivalent.
 func MakeTerraformOutput(
 	ctx context.Context,
-	p shim.Provider,
+	p SetChecker,
 	v interface{},
 	tfs shim.Schema,
 	ps *SchemaInfo,
 	assets AssetTable,
 	supportsSecrets bool,
 ) resource.PropertyValue {
-	buildOutput := func(p shim.Provider, v interface{},
+	buildOutput := func(p SetChecker, v interface{},
 		tfs shim.Schema, ps *SchemaInfo, assets AssetTable, supportsSecrets bool,
 	) resource.PropertyValue {
 		if assets != nil && ps != nil && ps.Asset != nil {


### PR DESCRIPTION
This is a pure refactor. The schema.go functions don't use the full `shim.Provider` interface, so this just narrows the required interface to what is used to make it easier to implement.

part of https://github.com/pulumi/pulumi-service/issues/34617