### PR TITLE
Expose ToCtyType

### DIFF
--- a/pkg/valueshim/cty.go
+++ b/pkg/valueshim/cty.go
@@ -33,6 +33,14 @@ func FromCtyType(v cty.Type) Type {
 	return ctyTypeShim(v)
 }
 
+// ToCtyType extracts the underlying cty.Type from a Type.
+func ToCtyType(t Type) (cty.Type, error) {
+	if ct, ok := t.(ctyTypeShim); ok {
+		return ct.ty(), nil
+	}
+	return cty.Type{}, fmt.Errorf("Cannot convert Type to cty.Type: %#T", t)
+}
+
 type ctyValueShim cty.Value
 
 var _ Value = (*ctyValueShim)(nil)


### PR DESCRIPTION
This exposes a new method `ToCtyType` which converts a `valushim.Type` to its underlying `cty.Type` if possible.

part of https://github.com/pulumi/pulumi-service/issues/34617