### PR TITLE
chore: update pulumi to v3.214.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -221,8 +221,8 @@ require (
 	github.com/pkg/term v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/posener/complete v1.2.3 // indirect
-	github.com/pulumi/pulumi/pkg/v3 v3.213.0
-	github.com/pulumi/pulumi/sdk/v3 v3.213.0
+	github.com/pulumi/pulumi/pkg/v3 v3.214.0
+	github.com/pulumi/pulumi/sdk/v3 v3.214.0
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2425,10 +2425,10 @@ github.com/pulumi/pulumi-java/pkg v1.12.0 h1:T7yFnFr0bgqy6huVUANMyUeGO1/Y3r2CJJ6
 github.com/pulumi/pulumi-java/pkg v1.12.0/go.mod h1:g8QQjEgB5wTsZptyf1vbIcI/pgYEGJObnihAEgymkAo=
 github.com/pulumi/pulumi-yaml v1.19.1 h1:Y92eTQv07p5RbbNj6s/54+ibdPgvndLJ2Lb1IjYffng=
 github.com/pulumi/pulumi-yaml v1.19.1/go.mod h1:n1JTtfUXR1IWVJ86HvMvQglK5mrDeDduxsLifGW1WIA=
-github.com/pulumi/pulumi/pkg/v3 v3.213.0 h1:Vs7uooioUTgoe9OiusNIr3n5Emjw7gU38NCp3gGzZq0=
-github.com/pulumi/pulumi/pkg/v3 v3.213.0/go.mod h1:rqMSDY7SPN6ymilqjHImS+z+TsHCs5rqcJVhDNAFvuY=
-github.com/pulumi/pulumi/sdk/v3 v3.213.0 h1:ICp0WJlTShaTLrx2fDI52fJ3xwCf1h8T8tVrKDRNUB4=
-github.com/pulumi/pulumi/sdk/v3 v3.213.0/go.mod h1:Bn5Z9Rzp1lPqdAccaB+F2ivUBiamEl2TNR3Gg/h7iLs=
+github.com/pulumi/pulumi/pkg/v3 v3.214.0 h1:YTdU/VuVXP1Mk05FvCyTGO6+85DTuXacVoH2dhu8gRs=
+github.com/pulumi/pulumi/pkg/v3 v3.214.0/go.mod h1:HVYW1gwE3eGtHImAfCs/Ww0yyW0PujHpsAA8S3RGxoo=
+github.com/pulumi/pulumi/sdk/v3 v3.214.0 h1:MBUrjhaY7i9RmEQddyH/HR0kvF5Kxl3WT+/Ra9wV3YM=
+github.com/pulumi/pulumi/sdk/v3 v3.214.0/go.mod h1:Bn5Z9Rzp1lPqdAccaB+F2ivUBiamEl2TNR3Gg/h7iLs=
 github.com/pulumi/terraform-diff-reader v0.0.2 h1:kTE4nEXU3/SYXESvAIem+wyHMI3abqkI3OhJ0G04LLI=
 github.com/pulumi/terraform-diff-reader v0.0.2/go.mod h1:sZ9FUzGO+yM41hsQHs/yIcj/Y993qMdBxBU5mpDmAfQ=
 github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20250923233607-7f1981c8674a h1:bTwou+tt2fyfuuCp9+VQOlgEJk/xKEaYeoX2HCtp2es=

--- a/pkg/pf/internal/plugin/provider_context.go
+++ b/pkg/pf/internal/plugin/provider_context.go
@@ -21,7 +21,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -74,7 +73,7 @@ type ProviderWithContext interface {
 	CallWithContext(ctx context.Context, tok tokens.ModuleMember, args resource.PropertyMap, info plugin.CallInfo,
 		options plugin.CallOptions) (plugin.CallResult, error)
 
-	GetPluginInfoWithContext(ctx context.Context) (workspace.PluginInfo, error)
+	GetPluginInfoWithContext(ctx context.Context) (plugin.PluginInfo, error)
 
 	SignalCancellationWithContext(ctx context.Context) error
 
@@ -214,7 +213,7 @@ func (prov *provider) Call(
 	return prov.CallWithContext(ctx, req.Tok, req.Args, req.Info, req.Options)
 }
 
-func (prov *provider) GetPluginInfo(ctx context.Context) (workspace.PluginInfo, error) {
+func (prov *provider) GetPluginInfo(ctx context.Context) (plugin.PluginInfo, error) {
 	return prov.GetPluginInfoWithContext(ctx)
 }
 

--- a/pkg/pf/tfbridge/provider.go
+++ b/pkg/pf/tfbridge/provider.go
@@ -26,14 +26,12 @@ import (
 	pfprovider "github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/internal/logging"
@@ -284,11 +282,9 @@ func (p *provider) GetSchemaWithContext(ctx context.Context, req plugin.GetSchem
 }
 
 // GetPluginInfo returns this plugin's information.
-func (p *provider) GetPluginInfoWithContext(_ context.Context) (workspace.PluginInfo, error) {
-	info := workspace.PluginInfo{
-		Name:    p.info.Name,
+func (p *provider) GetPluginInfoWithContext(_ context.Context) (plugin.PluginInfo, error) {
+	info := plugin.PluginInfo{
 		Version: &p.version,
-		Kind:    apitype.ResourcePlugin,
 	}
 	return info, nil
 }

--- a/pkg/tfgen/convert_cli_test.go
+++ b/pkg/tfgen/convert_cli_test.go
@@ -505,7 +505,7 @@ func (*testPluginHost) PolicyAnalyzer(
 
 func (*testPluginHost) ListAnalyzers() []plugin.Analyzer { panic("Unexpected call") }
 
-func (*testPluginHost) Provider(pkg workspace.PackageDescriptor) (plugin.Provider, error) {
+func (*testPluginHost) Provider(pkg workspace.PluginDescriptor) (plugin.Provider, error) {
 	return &plugin.MockProvider{}, nil
 }
 

--- a/pkg/tfgen/pluginHost_test.go
+++ b/pkg/tfgen/pluginHost_test.go
@@ -35,14 +35,10 @@ func TestCachingPluginHost(t *testing.T) {
 
 	for _, pkg := range []tokens.Package{"a", "b"} {
 		for _, version := range []*semver.Version{nil, &v1, &v2} {
-			p1, err := h.Provider(workspace.PackageDescriptor{
-				PluginDescriptor: workspace.PluginDescriptor{Name: string(pkg), Version: version},
-			})
+			p1, err := h.Provider(workspace.PluginDescriptor{Name: string(pkg), Version: version})
 			require.NoError(t, err)
 
-			p2, err := c.Provider(workspace.PackageDescriptor{
-				PluginDescriptor: workspace.PluginDescriptor{Name: string(pkg), Version: version},
-			})
+			p2, err := c.Provider(workspace.PluginDescriptor{Name: string(pkg), Version: version})
 			require.NoError(t, err)
 
 			require.Equal(t, p1.(*testProvider).pkg, p2.(*testProvider).pkg)
@@ -50,9 +46,7 @@ func TestCachingPluginHost(t *testing.T) {
 		}
 	}
 
-	_, err := newCachingProviderHost(&testHost{nil, true}).Provider(workspace.PackageDescriptor{
-		PluginDescriptor: workspace.PluginDescriptor{Name: "a", Version: &v1},
-	})
+	_, err := newCachingProviderHost(&testHost{nil, true}).Provider(workspace.PluginDescriptor{Name: "a", Version: &v1})
 	require.Error(t, err)
 }
 
@@ -67,7 +61,7 @@ type testHost struct {
 	fail bool
 }
 
-func (th *testHost) Provider(pkg workspace.PackageDescriptor) (plugin.Provider, error) {
+func (th *testHost) Provider(pkg workspace.PluginDescriptor) (plugin.Provider, error) {
 	if th.fail {
 		return nil, fmt.Errorf("failed")
 	}


### PR DESCRIPTION
Done manually to absorb breaking changes to the Go provider interface.
