### PR TITLE
Fix computed propagation in proto element shim

### DIFF
--- a/pkg/pf/proto/attribute.go
+++ b/pkg/pf/proto/attribute.go
@@ -90,7 +90,7 @@ func (a attribute) Elem() interface{} {
 			contract.Failf("Invalid attribute nesting: %s", a.attr.NestedType.Nesting)
 		}
 	}
-	return newElement(a.attr.ValueType(), a.Optional()).Elem()
+	return newElement(a.attr.ValueType(), a.Optional(), a.Computed()).Elem()
 }
 
 // Defaults are applied in the provider binary, not here


### PR DESCRIPTION
Dynamic (proto) schema generation dropped Computed when deep nesting forced SchemaAttribute.ValueType() paths (no NestedType). The proto element wrapper stored only Optional, so element.Computed() always returned false. That made computed-only fields appear required on inputs, while shimv2 correctly treated them as output-only requiredOutputs.

Example mismatch (before):
- bridged/shimv2 object: requiredOutputs = [allowedValueType maxValue minValue possibleValues]
- dynamic/proto object: required       = [allowedValueType maxValue minValue possibleValues]

Fix by carrying Computed through proto.element and into elementObjectMap so nested attributes inherit the computed flag when created from ValueType().

Added regression coverage:
- proto-only schema with nested object via ValueType() shows requiredOutputs in nodejs language metadata and no input required fields
- sdkv2 -> tf5to6server upgrade -> proto -> tfgen reproduces the deep nesting case and asserts the same requiredOutputs behavior