### PR TITLE
Fix set diff fallback for Optional non-Computed fields without Default

### DIFF
--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/added.golden
@@ -1,0 +1,40 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{"value"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + prop {
+          + nested_prop = "value"
+            # (1 unchanged attribute hidden)
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + props: [
+      +     [0]: {
+              + nestedProp: "value"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/added_end.golden
@@ -1,0 +1,61 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val3"
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val1"
+        }
+      + prop {
+          + nested_prop = "val2"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [2]: {
+                  + nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/added_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/added_end_unordered.golden
@@ -1,0 +1,61 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val1"
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val2"
+        }
+      + prop {
+          + nested_prop = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [2]: {
+                  + nestedProp: "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/added_front.golden
@@ -1,0 +1,61 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val1"
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val2"
+        }
+      + prop {
+          + nested_prop = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [0]: {
+                  + nestedProp: "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/added_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/added_front_unordered.golden
@@ -1,0 +1,61 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val2"
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val1"
+        }
+      + prop {
+          + nested_prop = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [0]: {
+                  + nestedProp: "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/added_middle.golden
@@ -1,0 +1,61 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val2"
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val1"
+        }
+      + prop {
+          + nested_prop = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [1]: {
+                  + nestedProp: "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/added_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/added_middle_unordered.golden
@@ -1,0 +1,61 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val3"
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val1"
+        }
+      + prop {
+          + nested_prop = "val2"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [1]: {
+                  + nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/changed_empty_to_null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/changed_empty_to_null.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  nil,
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/changed_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/changed_non-null.golden
@@ -1,0 +1,46 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value1"},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = "value" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "value1"
+            # (1 unchanged attribute hidden)
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [0]: {
+                  ~ nestedProp: "value" => "value1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[0].nestedProp": map[string]interface{}{"kind": "UPDATE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/changed_non-null_to_null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/changed_non-null_to_null.golden
@@ -1,0 +1,43 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: nil,
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = "value" -> null
+            # (1 unchanged attribute hidden)
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      - props: [
+      -     [0]: {
+              - description: ""
+              - nestedProp : "value"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/changed_null_to_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/changed_null_to_empty.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: nil, changeValue: &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/changed_null_to_non-null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/changed_null_to_non-null.golden
@@ -1,0 +1,41 @@
+tests.testOutput{
+	initialValue: nil, changeValue: &[]string{
+		"value",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      + prop {
+          + nested_prop = "value"
+            # (1 unchanged attribute hidden)
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      + props: [
+      +     [0]: {
+              + nestedProp: "value"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/removed.golden
@@ -1,0 +1,43 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = "value" -> null
+            # (1 unchanged attribute hidden)
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      - props: [
+      -     [0]: {
+              - description: ""
+              - nestedProp : "value"
+            }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/removed_end.golden
@@ -1,0 +1,62 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val1"
+        }
+      + prop {
+          + nested_prop = "val2"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [2]: {
+                  - description: ""
+                  - nestedProp : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/removed_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/removed_end_unordered.golden
@@ -1,0 +1,62 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val2"
+        }
+      + prop {
+          + nested_prop = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [0]: {
+                  - description: ""
+                  - nestedProp : "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/removed_front.golden
@@ -1,0 +1,62 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val2"
+        }
+      + prop {
+          + nested_prop = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [0]: {
+                  - description: ""
+                  - nestedProp : "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/removed_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/removed_front_unordered.golden
@@ -1,0 +1,62 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val1"
+        }
+      + prop {
+          + nested_prop = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [1]: {
+                  - description: ""
+                  - nestedProp : "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/removed_middle.golden
@@ -1,0 +1,62 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val1"
+        }
+      + prop {
+          + nested_prop = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [1]: {
+                  - description: ""
+                  - nestedProp : "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/removed_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/removed_middle_unordered.golden
@@ -1,0 +1,62 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val1"
+        }
+      + prop {
+          + nested_prop = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [1]: {
+                  - description: ""
+                  - nestedProp : "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/same_element_updated.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/same_element_updated.golden
@@ -1,0 +1,66 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val4",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val4"
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val1"
+        }
+      + prop {
+          + nested_prop = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [1]: {
+                  ~ nestedProp: "val2" => "val4"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[1].nestedProp": map[string]interface{}{"kind": "UPDATE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/same_element_updated_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/same_element_updated_unordered.golden
@@ -1,0 +1,73 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val4",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val4"
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val1"
+        }
+      + prop {
+          + nested_prop = "val2"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [1]: {
+                  + nestedProp: "val4"
+                }
+          - [2]: {
+                  - description: ""
+                  - nestedProp : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[1]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/shuffled.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/shuffled.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/shuffled_added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/shuffled_added_end.golden
@@ -1,0 +1,61 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+		"val3",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val3"
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val1"
+        }
+      + prop {
+          + nested_prop = "val2"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [2]: {
+                  + nestedProp: "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/shuffled_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/shuffled_added_front.golden
@@ -1,0 +1,61 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val3",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val1"
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val2"
+        }
+      + prop {
+          + nested_prop = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [0]: {
+                  + nestedProp: "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/shuffled_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/shuffled_added_middle.golden
@@ -1,0 +1,61 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val2"
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val1"
+        }
+      + prop {
+          + nested_prop = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [1]: {
+                  + nestedProp: "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/shuffled_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/shuffled_removed_end.golden
@@ -1,0 +1,62 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val2",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val1"
+        }
+      + prop {
+          + nested_prop = "val2"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [2]: {
+                  - description: ""
+                  - nestedProp : "val3"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[2]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/shuffled_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/shuffled_removed_front.golden
@@ -1,0 +1,62 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val2"
+        }
+      + prop {
+          + nested_prop = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [0]: {
+                  - description: ""
+                  - nestedProp : "val1"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[0]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/shuffled_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/shuffled_removed_middle.golden
@@ -1,0 +1,62 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val1"
+        }
+      + prop {
+          + nested_prop = "val3"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [1]: {
+                  - description: ""
+                  - nestedProp : "val2"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{"props[1]": map[string]interface{}{"kind": "DELETE"}},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/shuffled_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/shuffled_unordered.golden
@@ -1,0 +1,24 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/shuffled_with_duplicates.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/shuffled_with_duplicates.golden
@@ -1,0 +1,25 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/shuffled_with_duplicates_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/shuffled_with_duplicates_unordered.golden
@@ -1,0 +1,25 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val2",
+		"val3",
+		"val1",
+	},
+	changeValue: &[]string{
+		"val3",
+		"val1",
+		"val2",
+		"val3",
+	},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/two_added.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/two_added.golden
@@ -1,0 +1,72 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val3"
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val4"
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val1"
+        }
+      + prop {
+          + nested_prop = "val2"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [2]: {
+                  + nestedProp: "val3"
+                }
+          + [3]: {
+                  + nestedProp: "val4"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[2]": map[string]interface{}{},
+		"props[3]": map[string]interface{}{},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/two_added_and_two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/two_added_and_two_removed.golden
@@ -1,0 +1,82 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+		"val5",
+		"val6",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val4" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val5"
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val6"
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val1"
+        }
+      + prop {
+          + nested_prop = "val2"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          ~ [2]: {
+                  ~ nestedProp: "val3" => "val5"
+                }
+          ~ [3]: {
+                  ~ nestedProp: "val4" => "val6"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -1,0 +1,92 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val5",
+		"val6",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val4" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val5"
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val6"
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val1"
+        }
+      + prop {
+          + nested_prop = "val2"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [0]: {
+                  + nestedProp: "val5"
+                }
+          + [1]: {
+                  + nestedProp: "val6"
+                }
+          - [2]: {
+                  - description: ""
+                  - nestedProp : "val3"
+                }
+          - [3]: {
+                  - description: ""
+                  - nestedProp : "val4"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[0]": map[string]interface{}{},
+		"props[1]": map[string]interface{}{},
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -1,0 +1,87 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val5",
+		"val6",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val4" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val5"
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val6"
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val1"
+        }
+      + prop {
+          + nested_prop = "val2"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [1]: {
+                  + nestedProp: "val5"
+                }
+          ~ [2]: {
+                  ~ nestedProp: "val3" => "val6"
+                }
+          - [3]: {
+                  - description: ""
+                  - nestedProp : "val4"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[1]":            map[string]interface{}{},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3]":            map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/two_added_and_two_removed_shuffled,_with_duplicates.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/two_added_and_two_removed_shuffled,_with_duplicates.golden
@@ -1,0 +1,89 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val5",
+		"val6",
+		"val2",
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val4" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val5"
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val6"
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val1"
+        }
+      + prop {
+          + nested_prop = "val2"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          + [1]: {
+                  + nestedProp: "val5"
+                }
+          ~ [2]: {
+                  ~ nestedProp: "val3" => "val6"
+                }
+          - [3]: {
+                  - description: ""
+                  - nestedProp : "val4"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[1]":            map[string]interface{}{},
+		"props[2].nestedProp": map[string]interface{}{"kind": "UPDATE"},
+		"props[3]":            map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/two_removed.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/two_removed.golden
@@ -1,0 +1,74 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+	},
+	changeValue: &[]string{
+		"val1",
+		"val2",
+	},
+	tfOut: `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  ~ update in-place
+
+Terraform will perform the following actions:
+
+  # crossprovider_test_res.example will be updated in-place
+  ~ resource "crossprovider_test_res" "example" {
+        id = "newid"
+
+      - prop {
+          - nested_prop = "val1" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val2" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val3" -> null
+            # (1 unchanged attribute hidden)
+        }
+      - prop {
+          - nested_prop = "val4" -> null
+            # (1 unchanged attribute hidden)
+        }
+      + prop {
+          + nested_prop = "val1"
+        }
+      + prop {
+          + nested_prop = "val2"
+        }
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.
+
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+    ~ crossprovider:index/testRes:TestRes: (update)
+        [id=newid]
+        [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
+      ~ props: [
+          - [2]: {
+                  - description: ""
+                  - nestedProp : "val3"
+                }
+          - [3]: {
+                  - description: ""
+                  - nestedProp : "val4"
+                }
+        ]
+Resources:
+    ~ 1 to update
+    1 unchanged
+`,
+	detailedDiff: map[string]interface{}{
+		"props[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[3]": map[string]interface{}{"kind": "DELETE"},
+	},
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/unchanged_empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/unchanged_empty.golden
@@ -1,0 +1,16 @@
+tests.testOutput{
+	initialValue: &[]string{},
+	changeValue:  &[]string{},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/unchanged_non-empty.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/unchanged_non-empty.golden
@@ -1,0 +1,18 @@
+tests.testOutput{
+	initialValue: &[]string{
+		"value",
+	},
+	changeValue: &[]string{"value"},
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/unchanged_null.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffSetBlockOptionalUnspecified/block_optional_unspecified/unchanged_null.golden
@@ -1,0 +1,15 @@
+tests.testOutput{
+	initialValue: nil, changeValue: nil,
+	tfOut: `
+No changes. Your infrastructure matches the configuration.
+
+Terraform has compared your real infrastructure against your configuration
+and found no differences, so no changes are needed.
+`,
+	pulumiOut: `Previewing update (test):
+  pulumi:pulumi:Stack: (same)
+    [urn=urn:pulumi:test::project::pulumi:pulumi:Stack::project-test]
+Resources:
+    2 unchanged
+`,
+}


### PR DESCRIPTION
## Summary

When a `TypeSet` block contains an **Optional, non-Computed field without a Default** that the user doesn't specify, SDKv2 fills in the zero value (`""` for strings) in the planned state. The bridge's `validInputsFromPlan` function was failing to match these elements because `null != ""`.

This caused noisy whole-set `UPDATE` diffs instead of precise element-level diffs on resources like `google_compute_url_map` where `host_rule` has an optional `description` field.

## Fix

The fix treats `null` input as equal to the zero value for Optional non-Computed fields, allowing `matchPlanElementsToInputs` to succeed and produce correct element-level diffs.

Added `isZeroValue` helper that checks if a property value is the zero value for its schema type (empty string, false, 0, empty array/map).

## Testing

- Added `TestSDKv2DetailedDiffSetBlockOptionalUnspecified` with 40 test cases covering add/remove/shuffle scenarios
- All existing set diff tests pass

## Before/After

**Before:** Adding one host rule to a URL map with 40 rules shows:
```
~ hostRules: UPDATE
```

**After:** Shows precise element-level diff:
```
~ hostRules: [
    + [5]: { hosts: ["new.example.com"], pathMatcher: "pm-new" }
  ]
```

Fixes #3324, replaces PR #3325