### PR TITLE
Fix workflow failures by updating Go version to 1.24.x

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -66,7 +66,7 @@ jobs:
         #
         # When we decide to bump our minimum go version, we need to remember to bump the
         # go version in our go.mod files.
-        go-version: [1.23.x, 1.24.x]
+        go-version: [1.24.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
         feature-flags: ["DEFAULT"]
         # Needs to match TOTAL_SHARDS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.x
+          go-version: 1.24.x
           cache-dependency-path: |
             **/go.sum
       - name: Find pulumi version

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: true
       matrix:
         goversion:
-        - 1.23.x
+        - 1.24.x
     steps:
     - name: Fetch secrets from ESC
       id: esc-secrets


### PR DESCRIPTION
The go.mod file requires Go 1.24.7, but workflows were still using 1.23.x, causing build failures in weekly-pulumi-update workflow.

Updated all workflows to use Go 1.24.x to match go.mod requirements.

Part of pulumi/pulumi-terraform-bridge#3341
Related to pulumi/pulumi-terraform-bridge#3347: Weekly Pulumi Update triggered on branch still fails: https://github.com/pulumi/pulumi-terraform-bridge/actions/runs/22227418567