### PR TITLE
tfgen: support bash fenced import rewrites

### DIFF
--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -1339,10 +1339,10 @@ func rewriteImportFence(
 	if info == "terraform" && looksLikeTerraformImportBlock(code) {
 		return nil, false, false
 	}
-	if info == "" || info == "console" || info == "shell" || info == "sh" {
+	if info == "" || info == "console" || info == "shell" || info == "sh" || info == "bash" {
 		forcedStart := startLine
 		forcedEnd := endLine
-		if info == "" || info == "console" || info == "shell" {
+		if info == "" || info == "console" || info == "shell" || info == "bash" {
 			forcedStart = fmt.Sprintf("%s```sh", indent)
 			forcedEnd = fmt.Sprintf("%s```", indent)
 		}
@@ -1381,7 +1381,7 @@ func rewriteImportFence(
 	}
 
 	rewritten := make([]string, 0, len(lines)+2)
-	if info == "" || info == "console" || info == "shell" {
+	if info == "" || info == "console" || info == "shell" || info == "bash" {
 		rewritten = append(rewritten, fmt.Sprintf("%s```sh", indent))
 	} else {
 		rewritten = append(rewritten, startLine)

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -1928,6 +1928,11 @@ func TestParseImports_NoOverrides(t *testing.T) {
 			expectedFile: "test_data/parse-imports/auth0pages-expected.md",
 		},
 		{
+			input:        readfile(t, "test_data/parse-imports/bash-import.md"),
+			token:        "pkg:mod/name:Type",
+			expectedFile: "test_data/parse-imports/bash-import-expected.md",
+		},
+		{
 			input: strings.Join([]string{
 				"",
 				"### This is a sub-section",

--- a/pkg/tfgen/test_data/parse-imports/bash-import-expected.md
+++ b/pkg/tfgen/test_data/parse-imports/bash-import-expected.md
@@ -1,0 +1,8 @@
+## Import
+
+This resource supports import using Terraform.
+
+```sh
+$ pulumi import pkg:mod/name:Type example foobar123
+```
+

--- a/pkg/tfgen/test_data/parse-imports/bash-import.md
+++ b/pkg/tfgen/test_data/parse-imports/bash-import.md
@@ -1,0 +1,7 @@
+## Import
+
+This resource supports import using Terraform.
+
+```bash
+terraform import example_resource.example foobar123
+```


### PR DESCRIPTION
## Summary
- add a regression fixture and test case for `## Import` sections containing ```bash fenced Terraform import commands
- treat `bash` fences as shell-like in import rewrite logic so `terraform import ...` is rewritten to `$ pulumi import ...`
- normalize rewritten import fence output to ```sh for consistency with existing import docs output


closes pulumi/pulumi-keycloak#931