### PR TITLE
Rewrite Terraform property names in warning messages to Pulumi format

### DIFF
--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -751,7 +751,8 @@ func validateProviderConfig(
 	// Perform validation of the config state so we can offer nice errors.
 	warns, errs := p.tf.Validate(ctx, config)
 	for _, warn := range warns {
-		logErr := p.host.Log(ctx, diag.Warning, "", fmt.Sprintf("provider config warning: %v", warn))
+		msg := rewriteWarningMessage(warn, p.info.GetConfig(), p.config)
+		logErr := p.host.Log(ctx, diag.Warning, "", fmt.Sprintf("provider config warning: %v", msg))
 		if logErr != nil {
 			glog.V(9).Infof("Failed to log to the engine: %v", logErr)
 			continue
@@ -1031,7 +1032,8 @@ func (p *Provider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (*pul
 	rescfg := MakeTerraformConfigFromInputs(ctx, p.tf, inputs)
 	warns, errs := p.tf.ValidateResource(ctx, tfname, rescfg)
 	for _, warn := range warns {
-		logger.Warn(fmt.Sprintf("%v verification warning: %v", urn, warn))
+		msg := rewriteWarningMessage(warn, schemaInfos, schemaMap)
+		logger.Warn(msg)
 	}
 
 	// Now produce CheckFalures for any properties that failed verification.
@@ -1940,7 +1942,8 @@ func (p *Provider) Invoke(ctx context.Context, req *pulumirpc.InvokeRequest) (*p
 	rescfg := MakeTerraformConfigFromInputs(ctx, p.tf, inputs)
 	warns, errs := p.tf.ValidateDataSource(ctx, tfname, rescfg)
 	for _, warn := range warns {
-		if err = p.host.Log(ctx, diag.Warning, "", fmt.Sprintf("%v verification warning: %v", tok, warn)); err != nil {
+		msg := rewriteWarningMessage(warn, ds.Schema.GetFields(), ds.TF.Schema())
+		if err = p.host.Log(ctx, diag.Warning, "", fmt.Sprintf("%v: %v", tok, msg)); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -1508,6 +1508,68 @@ This will become a hard error in the future.
 `).Equal(t, logs.String())
 }
 
+func TestCheckWarningsPropertyReplacement(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	var logs bytes.Buffer
+	ctx = logging.InitLogging(ctx, logging.LogOptions{
+		LogSink: &testWarnLogSink{&logs},
+	})
+	p := &schemav2.Provider{
+		Schema: map[string]*schemav2.Schema{},
+		ResourcesMap: map[string]*schemav2.Resource{
+			"example_resource": {
+				Schema: map[string]*schemav2.Schema{
+					"resource_group_name": {
+						Type:       schemav2.TypeString,
+						Optional:   true,
+						Deprecated: `use "new_resource_group" instead`,
+					},
+					"new_resource_group": {
+						Type:     schemav2.TypeString,
+						Optional: true,
+					},
+				},
+			},
+		},
+	}
+	shimProvider := shimv2.NewProvider(p)
+
+	provider := &Provider{
+		tf:            shimProvider,
+		module:        "testprov",
+		config:        shimv2.NewSchemaMap(p.Schema),
+		hasTypeErrors: make(map[resource.URN]struct{}),
+		resources: map[tokens.Type]Resource{
+			"ExampleResource": {
+				TF:     shimProvider.ResourcesMap().Get("example_resource"),
+				TFName: "example_resource",
+				Schema: &ResourceInfo{
+					Tok: "ExampleResource",
+				},
+			},
+		},
+	}
+
+	args, err := structpb.NewStruct(map[string]interface{}{
+		"resourceGroupName": "my-rg",
+	})
+	require.NoError(t, err)
+	_, err = provider.Check(ctx, &pulumirpc.CheckRequest{
+		Urn:  "urn:pulumi:dev::teststack::ExampleResource::exres",
+		Olds: &structpb.Struct{},
+		News: args,
+	})
+	require.NoError(t, err)
+
+	logStr := logs.String()
+	// The warning should contain Pulumi camelCase names, not Terraform snake_case.
+	assert.Contains(t, logStr, `"newResourceGroup"`)
+	assert.NotContains(t, logStr, `"new_resource_group"`)
+	// The warning should not redundantly include the URN in the message text.
+	assert.NotContains(t, logStr, "urn:pulumi:")
+}
+
 func TestSDKv2CheckConfig(t *testing.T) {
 	t.Parallel()
 	t.Run("minimal", func(t *testing.T) {

--- a/pkg/tfbridge/replace_error_properties.go
+++ b/pkg/tfbridge/replace_error_properties.go
@@ -7,6 +7,9 @@ import (
 )
 
 func replaceSubstringsRegex(s string, replacements map[string]string) (string, error) {
+	if len(replacements) == 0 {
+		return s, nil
+	}
 	regexPattern := `"(`
 	for k := range replacements {
 		regexPattern += regexp.QuoteMeta(k) + "|"
@@ -35,6 +38,18 @@ func getConfigReplacements(
 		return true
 	})
 	return renames
+}
+
+// rewriteWarningMessage replaces Terraform property names (snake_case) in the given
+// warning message with their Pulumi equivalents (camelCase).
+func rewriteWarningMessage(msg string, schemaInfos map[string]*SchemaInfo, schemaMap shim.SchemaMap) string {
+	if schemaMap == nil {
+		return msg
+	}
+	if replaced, err := replaceSubstringsRegex(msg, getConfigReplacements(schemaInfos, schemaMap)); err == nil {
+		msg = replaced
+	}
+	return msg
 }
 
 // ReplaceConfigProperties replaces all Terraform config property names

--- a/pkg/tfbridge/replace_error_properties_test.go
+++ b/pkg/tfbridge/replace_error_properties_test.go
@@ -4,6 +4,9 @@ import (
 	"testing"
 
 	"gotest.tools/v3/assert"
+
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
 )
 
 func TestReplaceSubstringsRegex(t *testing.T) {
@@ -18,6 +21,14 @@ func TestReplaceSubstringsRegex(t *testing.T) {
 		{`"hello" "helloWorld"`, map[string]string{"hello": "hi", "helloWorld": "hiHi"}, `"hi" "hiHi"`},
 		{`"helloWorld" "hello"`, map[string]string{"hello": "hi", "helloWorld": "hiHi"}, `"hiHi" "hi"`},
 		{`"hello" "world" "hello" "world"`, map[string]string{"hello": "hi", "world": "earth"}, `"hi" "earth" "hi" "earth"`},
+		// Deprecation warning pattern
+		{
+			`"resource_group_name": [DEPRECATED] use "new_field" instead`,
+			map[string]string{"resource_group_name": "resourceGroupName", "new_field": "newField"},
+			`"resourceGroupName": [DEPRECATED] use "newField" instead`,
+		},
+		// Empty replacements map returns input unchanged
+		{`"hello" world`, map[string]string{}, `"hello" world`},
 	}
 
 	for _, tc := range cases {
@@ -25,4 +36,25 @@ func TestReplaceSubstringsRegex(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Equal(t, result, tc.expected)
 	}
+}
+
+func TestRewriteWarningMessage(t *testing.T) {
+	t.Parallel()
+
+	schemaMap := schema.SchemaMap(map[string]shim.Schema{
+		"resource_group_name": (&schema.Schema{Type: shim.TypeString}).Shim(),
+		"new_field":           (&schema.Schema{Type: shim.TypeString}).Shim(),
+	})
+
+	msg := `"resource_group_name": [DEPRECATED] use "new_field" instead`
+	result := rewriteWarningMessage(msg, nil, schemaMap)
+	assert.Equal(t, result, `"resourceGroupName": [DEPRECATED] use "newField" instead`)
+}
+
+func TestRewriteWarningMessageNilSchema(t *testing.T) {
+	t.Parallel()
+
+	msg := `some warning without property names`
+	result := rewriteWarningMessage(msg, nil, nil)
+	assert.Equal(t, result, msg)
 }


### PR DESCRIPTION
Fix for https://github.com/pulumi/pulumi-terraform-bridge/issues/6

## Summary
This PR updates warning messages generated during provider validation to use Pulumi property names (camelCase) instead of Terraform property names (snake_case), improving consistency and clarity for users.

## Key Changes
- Added `rewriteWarningMessage()` function to convert Terraform snake_case property names to Pulumi camelCase equivalents in warning messages
- Updated `validateProviderConfig()` to rewrite provider config warnings
- Updated `Check()` to rewrite resource validation warnings and remove redundant URN information from messages
- Updated `Invoke()` to rewrite data source validation warnings
- Enhanced `replaceSubstringsRegex()` to handle empty replacement maps efficiently
- Added comprehensive test coverage for the new warning rewriting functionality, including:
  - `TestCheckWarningsPropertyReplacement()` - validates that deprecated property warnings use Pulumi naming conventions
  - `TestReplaceSubstringsRegex()` - tests regex replacement with deprecation warning patterns
  - `TestRewriteWarningMessage()` - tests the core rewriting logic
  - `TestRewriteWarningMessageNilSchema()` - tests graceful handling of nil schemas

## Implementation Details
- The `rewriteWarningMessage()` function leverages the existing `getConfigReplacements()` and `replaceSubstringsRegex()` utilities to perform the name transformations
- Warning messages are only rewritten when a valid schema map is available; otherwise they pass through unchanged
- The implementation removes redundant URN information from warning messages in the `Check()` method, making them more concise

https://claude.ai/code/session_014Y9EggfWiZKXJqgXk6zqZk