### PR TITLE
Fix PF provider silently dropping deprecation warnings (#1373)

### DIFF
--- a/pkg/pf/tfbridge/provider.go
+++ b/pkg/pf/tfbridge/provider.go
@@ -26,7 +26,6 @@ import (
 	pfprovider "github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -83,7 +82,6 @@ type provider struct {
 	datasources   runtypes.DataSources
 	pulumiSchema  func(context.Context, plugin.GetSchemaRequest) ([]byte, error)
 	encoding      convert.Encoding
-	diagSink      diag.Sink
 	configEncoder convert.Encoder
 	configType    tftypes.Object
 	version       semver.Version

--- a/pkg/pf/tfbridge/provider_check.go
+++ b/pkg/pf/tfbridge/provider_check.go
@@ -131,7 +131,7 @@ func (p *provider) validateResourceConfig(
 		remainingDiagnostics = append(remainingDiagnostics, diag)
 	}
 
-	if err := p.processDiagnostics(remainingDiagnostics); err != nil {
+	if err := p.processDiagnostics(ctx, remainingDiagnostics); err != nil {
 		return nil, err
 	}
 

--- a/pkg/pf/tfbridge/provider_checkconfig.go
+++ b/pkg/pf/tfbridge/provider_checkconfig.go
@@ -223,7 +223,7 @@ func (p *provider) validateProviderConfig(
 		}
 	}
 
-	if err := p.processDiagnostics(remainingDiagnostics); err != nil {
+	if err := p.processDiagnostics(ctx, remainingDiagnostics); err != nil {
 		return nil, err
 	}
 

--- a/pkg/pf/tfbridge/provider_configure.go
+++ b/pkg/pf/tfbridge/provider_configure.go
@@ -95,5 +95,5 @@ func (p *provider) ConfigureWithContext(ctx context.Context, inputs resource.Pro
 	}
 
 	resp.Diagnostics = replaceConfigInDiagnostics(p.info.Config, p.info.P.Schema(), resp.Diagnostics)
-	return p.processDiagnostics(resp.Diagnostics)
+	return p.processDiagnostics(ctx, resp.Diagnostics)
 }

--- a/pkg/pf/tfbridge/provider_create.go
+++ b/pkg/pf/tfbridge/provider_create.go
@@ -53,7 +53,7 @@ func (p *provider) CreateWithContext(
 		return "", nil, 0, err
 	}
 
-	if err := p.processDiagnostics(planResp.Diagnostics); err != nil {
+	if err := p.processDiagnostics(ctx, planResp.Diagnostics); err != nil {
 		return "", nil, 0, err
 	}
 
@@ -99,7 +99,7 @@ func (p *provider) CreateWithContext(
 		return "", nil, 0, err
 	}
 
-	if err := p.processDiagnostics(resp.Diagnostics); err != nil {
+	if err := p.processDiagnostics(ctx, resp.Diagnostics); err != nil {
 		return "", nil, 0, err
 	}
 

--- a/pkg/pf/tfbridge/provider_delete.go
+++ b/pkg/pf/tfbridge/provider_delete.go
@@ -73,7 +73,7 @@ func (p *provider) DeleteWithContext(
 
 	// NOTE: no need to handle resp.Private in Delete.
 
-	if err := p.processDiagnostics(resp.Diagnostics); err != nil {
+	if err := p.processDiagnostics(ctx, resp.Diagnostics); err != nil {
 		return resource.StatusPartialFailure, err
 	}
 

--- a/pkg/pf/tfbridge/provider_diagnostics.go
+++ b/pkg/pf/tfbridge/provider_diagnostics.go
@@ -15,18 +15,18 @@
 package tfbridge
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/log"
 )
 
-func (p *provider) processDiagnostics(diagnostics []*tfprotov6.Diagnostic) error {
-	// Format and flush to diagSink.
-	if p.diagSink != nil {
-		for _, d := range diagnostics {
-			p.logDiagnostic(d)
-		}
+func (p *provider) processDiagnostics(ctx context.Context, diagnostics []*tfprotov6.Diagnostic) error {
+	// Format and log diagnostics via context-based logging.
+	for _, d := range diagnostics {
+		p.logDiagnostic(ctx, d)
 	}
 
 	// Check for errors and return non-nil if there is an error.
@@ -46,8 +46,9 @@ func (p *provider) processDiagnostics(diagnostics []*tfprotov6.Diagnostic) error
 	return nil
 }
 
-func (p *provider) logDiagnostic(d *tfprotov6.Diagnostic) {
-	if p.diagSink == nil {
+func (p *provider) logDiagnostic(ctx context.Context, d *tfprotov6.Diagnostic) {
+	logger := log.TryGetLogger(ctx)
+	if logger == nil {
 		return
 	}
 	msg := fmt.Sprintf("[%s] %s", d.Severity.String(), d.Detail)
@@ -59,8 +60,8 @@ func (p *provider) logDiagnostic(d *tfprotov6.Diagnostic) {
 	}
 	switch d.Severity {
 	case tfprotov6.DiagnosticSeverityError, tfprotov6.DiagnosticSeverityInvalid:
-		p.diagSink.Errorf(&diag.Diag{Message: msg})
+		logger.Error(msg)
 	case tfprotov6.DiagnosticSeverityWarning:
-		p.diagSink.Warningf(&diag.Diag{Message: msg})
+		logger.Warn(msg)
 	}
 }

--- a/pkg/pf/tfbridge/provider_diagnostics_test.go
+++ b/pkg/pf/tfbridge/provider_diagnostics_test.go
@@ -1,0 +1,325 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfbridge
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/internal/logging"
+)
+
+// testLogSink captures log output for assertions.
+type testLogSink struct {
+	buf *bytes.Buffer
+}
+
+func (s *testLogSink) Log(_ context.Context, sev diag.Severity, _ resource.URN, msg string) error {
+	fmt.Fprintf(s.buf, "%v: %s\n", sev, msg)
+	return nil
+}
+
+func (s *testLogSink) LogStatus(_ context.Context, sev diag.Severity, _ resource.URN, msg string) error {
+	fmt.Fprintf(s.buf, "[status] %v: %s\n", sev, msg)
+	return nil
+}
+
+func initTestLogging(sink logging.Sink) context.Context {
+	return logging.InitLogging(context.Background(), logging.LogOptions{LogSink: sink})
+}
+
+func TestLogDiagnosticWarning(t *testing.T) {
+	t.Parallel()
+	sink := &testLogSink{buf: &bytes.Buffer{}}
+	ctx := initTestLogging(sink)
+	p := &provider{}
+
+	p.logDiagnostic(ctx, &tfprotov6.Diagnostic{
+		Severity:  tfprotov6.DiagnosticSeverityWarning,
+		Summary:   "field is deprecated",
+		Detail:    "Use other_field instead",
+		Attribute: tftypes.NewAttributePath().WithAttributeName("old_field"),
+	})
+
+	out := sink.buf.String()
+	assert.Contains(t, out, "warning:")
+	assert.Contains(t, out, "Use other_field instead")
+	assert.Contains(t, out, "field is deprecated")
+}
+
+func TestLogDiagnosticError(t *testing.T) {
+	t.Parallel()
+	sink := &testLogSink{buf: &bytes.Buffer{}}
+	ctx := initTestLogging(sink)
+	p := &provider{}
+
+	p.logDiagnostic(ctx, &tfprotov6.Diagnostic{
+		Severity: tfprotov6.DiagnosticSeverityError,
+		Summary:  "something broke",
+		Detail:   "invalid value",
+	})
+
+	out := sink.buf.String()
+	assert.Contains(t, out, "error:")
+	assert.Contains(t, out, "invalid value")
+}
+
+func TestLogDiagnosticNoLogger(t *testing.T) {
+	t.Parallel()
+	p := &provider{}
+
+	// Should not panic when context has no logger.
+	assert.NotPanics(t, func() {
+		p.logDiagnostic(context.Background(), &tfprotov6.Diagnostic{
+			Severity: tfprotov6.DiagnosticSeverityWarning,
+			Summary:  "some warning",
+			Detail:   "some detail",
+		})
+	})
+}
+
+func TestLogDiagnosticInvalid(t *testing.T) {
+	t.Parallel()
+	sink := &testLogSink{buf: &bytes.Buffer{}}
+	ctx := initTestLogging(sink)
+	p := &provider{}
+
+	p.logDiagnostic(ctx, &tfprotov6.Diagnostic{
+		Severity: tfprotov6.DiagnosticSeverityInvalid,
+		Detail:   "invalid severity diag",
+	})
+
+	// Invalid severity is routed to Error.
+	out := sink.buf.String()
+	assert.Contains(t, out, "error:")
+	assert.Contains(t, out, "invalid severity diag")
+}
+
+func TestLogDiagnosticMessageFormat(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		diag     *tfprotov6.Diagnostic
+		contains []string
+	}{
+		{
+			name: "detail only",
+			diag: &tfprotov6.Diagnostic{
+				Severity: tfprotov6.DiagnosticSeverityWarning,
+				Detail:   "some detail",
+			},
+			contains: []string{"[WARNING] some detail"},
+		},
+		{
+			name: "detail and summary",
+			diag: &tfprotov6.Diagnostic{
+				Severity: tfprotov6.DiagnosticSeverityWarning,
+				Summary:  "some summary",
+				Detail:   "some detail",
+			},
+			contains: []string{"[WARNING] some detail: some summary"},
+		},
+		{
+			name: "detail summary and attribute",
+			diag: &tfprotov6.Diagnostic{
+				Severity:  tfprotov6.DiagnosticSeverityWarning,
+				Summary:   "some summary",
+				Detail:    "some detail",
+				Attribute: tftypes.NewAttributePath().WithAttributeName("attr"),
+			},
+			contains: []string{
+				"[WARNING] some detail: some summary",
+				"at attribute",
+			},
+		},
+		{
+			name: "empty detail with summary",
+			diag: &tfprotov6.Diagnostic{
+				Severity: tfprotov6.DiagnosticSeverityWarning,
+				Summary:  "some summary",
+			},
+			contains: []string{"[WARNING] : some summary"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			sink := &testLogSink{buf: &bytes.Buffer{}}
+			ctx := initTestLogging(sink)
+			p := &provider{}
+
+			p.logDiagnostic(ctx, tc.diag)
+
+			out := sink.buf.String()
+			for _, s := range tc.contains {
+				assert.Contains(t, out, s)
+			}
+		})
+	}
+}
+
+func TestProcessDiagnosticsWarningOnly(t *testing.T) {
+	t.Parallel()
+	sink := &testLogSink{buf: &bytes.Buffer{}}
+	ctx := initTestLogging(sink)
+	p := &provider{}
+
+	err := p.processDiagnostics(ctx, []*tfprotov6.Diagnostic{
+		{
+			Severity: tfprotov6.DiagnosticSeverityWarning,
+			Summary:  "deprecated field",
+			Detail:   "use new_field instead",
+		},
+	})
+
+	assert.NoError(t, err)
+	assert.Contains(t, sink.buf.String(), "use new_field instead")
+}
+
+func TestProcessDiagnosticsErrorReturned(t *testing.T) {
+	t.Parallel()
+	sink := &testLogSink{buf: &bytes.Buffer{}}
+	ctx := initTestLogging(sink)
+	p := &provider{}
+
+	err := p.processDiagnostics(ctx, []*tfprotov6.Diagnostic{
+		{
+			Severity: tfprotov6.DiagnosticSeverityError,
+			Summary:  "validation failed",
+			Detail:   "invalid input",
+		},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "validation failed")
+	assert.Contains(t, err.Error(), "invalid input")
+}
+
+func TestProcessDiagnosticsErrorWithAttribute(t *testing.T) {
+	t.Parallel()
+	sink := &testLogSink{buf: &bytes.Buffer{}}
+	ctx := initTestLogging(sink)
+	p := &provider{}
+
+	err := p.processDiagnostics(ctx, []*tfprotov6.Diagnostic{
+		{
+			Severity:  tfprotov6.DiagnosticSeverityError,
+			Summary:   "bad value",
+			Detail:    "must be positive",
+			Attribute: tftypes.NewAttributePath().WithAttributeName("foo"),
+		},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `[AttributeName("foo")]`)
+	assert.Contains(t, err.Error(), "bad value")
+}
+
+func TestProcessDiagnosticsErrorSameSummaryDetail(t *testing.T) {
+	t.Parallel()
+	sink := &testLogSink{buf: &bytes.Buffer{}}
+	ctx := initTestLogging(sink)
+	p := &provider{}
+
+	err := p.processDiagnostics(ctx, []*tfprotov6.Diagnostic{
+		{
+			Severity: tfprotov6.DiagnosticSeverityError,
+			Summary:  "something went wrong",
+			Detail:   "something went wrong",
+		},
+	})
+
+	require.Error(t, err)
+	// When summary == detail, the message should not be duplicated.
+	assert.Equal(t, "something went wrong", err.Error())
+}
+
+func TestProcessDiagnosticsMixed(t *testing.T) {
+	t.Parallel()
+	sink := &testLogSink{buf: &bytes.Buffer{}}
+	ctx := initTestLogging(sink)
+	p := &provider{}
+
+	err := p.processDiagnostics(ctx, []*tfprotov6.Diagnostic{
+		{
+			Severity: tfprotov6.DiagnosticSeverityWarning,
+			Summary:  "warn1",
+			Detail:   "warning one",
+		},
+		{
+			Severity: tfprotov6.DiagnosticSeverityWarning,
+			Summary:  "warn2",
+			Detail:   "warning two",
+		},
+		{
+			Severity: tfprotov6.DiagnosticSeverityError,
+			Summary:  "err1",
+			Detail:   "error one",
+		},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "err1")
+
+	// Both warnings should have been logged before the error was returned.
+	out := sink.buf.String()
+	assert.Contains(t, out, "warning one")
+	assert.Contains(t, out, "warning two")
+}
+
+func TestProcessDiagnosticsEmpty(t *testing.T) {
+	t.Parallel()
+	sink := &testLogSink{buf: &bytes.Buffer{}}
+	ctx := initTestLogging(sink)
+	p := &provider{}
+
+	err := p.processDiagnostics(ctx, []*tfprotov6.Diagnostic{})
+
+	assert.NoError(t, err)
+	assert.Empty(t, sink.buf.String())
+}
+
+func TestDeprecationWarningLogged(t *testing.T) {
+	t.Parallel()
+	sink := &testLogSink{buf: &bytes.Buffer{}}
+	ctx := initTestLogging(sink)
+	p := &provider{}
+
+	// Reproduce the exact pattern from issue #1370.
+	err := p.processDiagnostics(ctx, []*tfprotov6.Diagnostic{
+		{
+			Severity:  tfprotov6.DiagnosticSeverityWarning,
+			Summary:   "Attribute Deprecated",
+			Detail:    "**NOTE**: This is deprecated, use numeric instead.",
+			Attribute: tftypes.NewAttributePath().WithAttributeName("number"),
+		},
+	})
+
+	assert.NoError(t, err, "deprecation warnings should not cause errors")
+	out := sink.buf.String()
+	assert.Contains(t, out, "**NOTE**: This is deprecated, use numeric instead.")
+	assert.Contains(t, out, "Attribute Deprecated")
+}

--- a/pkg/pf/tfbridge/provider_diff.go
+++ b/pkg/pf/tfbridge/provider_diff.go
@@ -83,7 +83,7 @@ func (p *provider) DiffWithContext(
 	// state. Currently assume that planResp will signal RequiresReplace if needed anyway and there is no useful way
 	// to surface private state differences to the user from the Diff method.
 
-	if err := p.processDiagnostics(planResp.Diagnostics); err != nil {
+	if err := p.processDiagnostics(ctx, planResp.Diagnostics); err != nil {
 		return plugin.DiffResult{}, err
 	}
 

--- a/pkg/pf/tfbridge/provider_invoke.go
+++ b/pkg/pf/tfbridge/provider_invoke.go
@@ -78,7 +78,7 @@ func (p *provider) validateDataResourceConfig(ctx context.Context, handle dataso
 	if err != nil {
 		return nil, fmt.Errorf("error calling ValidateDataResourceConfig: %w", err)
 	}
-	return p.processInvokeDiagnostics(handle, resp.Diagnostics)
+	return p.processInvokeDiagnostics(ctx, handle, resp.Diagnostics)
 }
 
 func (p *provider) readDataSource(ctx context.Context, handle datasourceHandle,
@@ -97,7 +97,7 @@ func (p *provider) readDataSource(ctx context.Context, handle datasourceHandle,
 		return nil, nil, fmt.Errorf("error calling ReadDataSource: %w", err)
 	}
 
-	failures, err := p.processInvokeDiagnostics(handle, resp.Diagnostics)
+	failures, err := p.processInvokeDiagnostics(ctx, handle, resp.Diagnostics)
 	if err != nil || len(failures) > 0 {
 		return nil, failures, err
 	}
@@ -126,11 +126,11 @@ func (p *provider) readDataSource(ctx context.Context, handle datasourceHandle,
 	return propertyMap, nil, nil
 }
 
-func (p *provider) processInvokeDiagnostics(ds datasourceHandle,
+func (p *provider) processInvokeDiagnostics(ctx context.Context, ds datasourceHandle,
 	diags []*tfprotov6.Diagnostic,
 ) ([]plugin.CheckFailure, error) {
 	failures, rest := p.parseInvokePropertyCheckFailures(ds, diags)
-	return failures, p.processDiagnostics(rest)
+	return failures, p.processDiagnostics(ctx, rest)
 }
 
 // Some of the diagnostics pertain to an individual property and should be returned as plugin.CheckFailure for an

--- a/pkg/pf/tfbridge/provider_read.go
+++ b/pkg/pf/tfbridge/provider_read.go
@@ -166,7 +166,7 @@ func (p *provider) readResource(
 		return plugin.ReadResult{}, nil, err
 	}
 
-	if err := p.processDiagnostics(resp.Diagnostics); err != nil {
+	if err := p.processDiagnostics(ctx, resp.Diagnostics); err != nil {
 		return plugin.ReadResult{}, nil, err
 	}
 
@@ -236,7 +236,7 @@ func (p *provider) importResource(
 		return plugin.ReadResult{}, nil, err
 	}
 
-	if err := p.processDiagnostics(resp.Diagnostics); err != nil {
+	if err := p.processDiagnostics(ctx, resp.Diagnostics); err != nil {
 		return plugin.ReadResult{}, nil, err
 	}
 

--- a/pkg/pf/tfbridge/provider_update.go
+++ b/pkg/pf/tfbridge/provider_update.go
@@ -108,7 +108,7 @@ func (p *provider) UpdateWithContext(
 		return nil, 0, err
 	}
 
-	if err := p.processDiagnostics(resp.Diagnostics); err != nil {
+	if err := p.processDiagnostics(ctx, resp.Diagnostics); err != nil {
 		return nil, 0, err
 	}
 

--- a/pkg/pf/tfbridge/resource_state.go
+++ b/pkg/pf/tfbridge/resource_state.go
@@ -285,7 +285,7 @@ func (p *provider) upgradeResourceState(
 	if err != nil {
 		return nil, fmt.Errorf("error calling UpgradeResourceState: %w", err)
 	}
-	if err := p.processDiagnostics(resp.Diagnostics); err != nil {
+	if err := p.processDiagnostics(ctx, resp.Diagnostics); err != nil {
 		return nil, err
 	}
 	v, err := resp.UpgradedState.Unmarshal(tfType)


### PR DESCRIPTION
Replace the never-initialized diagSink field with context-based logging
(log.TryGetLogger) so PF provider warning diagnostics are actually
emitted instead of silently dropped. This matches the SDK v2 pattern.

Fixes #1373.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
