### PR TITLE
feat(dynamic): Add network mirror support for dynamic provider fetching

### DIFF
--- a/dynamic/internal/shim/run/loader.go
+++ b/dynamic/internal/shim/run/loader.go
@@ -72,8 +72,16 @@ type Provider interface {
 // version is installed then the latest version can be used.
 //
 // `=`, `<=`, `>=` sigils can be used just like in TF.
+//
+// To use a network mirror, embed the mirror base URL as a prefix with more than 3
+// path segments, e.g.:
+//
+//	"tofu.example.com/providers/registry.tofu.io/hashicorp/random"
+//	 → mirror: "https://tofu.example.com/providers", provider: "registry.tofu.io/hashicorp/random"
 func NamedProvider(ctx context.Context, key, version string) (Provider, error) {
-	p, err := regaddr.ParseProviderSource(key)
+	mirrorBase, providerKey := splitMirrorURL(key)
+
+	p, err := regaddr.ParseProviderSource(providerKey)
 	if err != nil {
 		return nil, fmt.Errorf("invalid provider name: %w", err)
 	}
@@ -83,7 +91,25 @@ func NamedProvider(ctx context.Context, key, version string) (Provider, error) {
 		return nil, fmt.Errorf("could not parse version constraint %q: %w", version, err)
 	}
 
-	return getProviderServer(ctx, p, v, disco.New())
+	return getProviderServer(ctx, p, v, disco.New(), mirrorBase, key)
+}
+
+// splitMirrorURL splits a provider key that may have an embedded mirror base URL.
+// If key has more than 3 path segments, the first len(parts)-3 segments form the mirror
+// base URL and the last 3 are the provider address (hostname/namespace/type).
+// Returns ("", key) if key has 3 or fewer segments.
+func splitMirrorURL(key string) (mirrorBase, providerAddr string) {
+	parts := strings.Split(key, "/")
+	if len(parts) <= 3 {
+		return "", key
+	}
+	mirrorParts := parts[:len(parts)-3]
+	providerAddr = strings.Join(parts[len(parts)-3:], "/")
+	mirrorBase = strings.Join(mirrorParts, "/")
+	if !strings.Contains(mirrorBase, "://") {
+		mirrorBase = "https://" + mirrorBase
+	}
+	return mirrorBase, providerAddr
 }
 
 // LocalProvider runs a provider by it's path.
@@ -97,7 +123,7 @@ func LocalProvider(ctx context.Context, path string) (Provider, error) {
 		Provider:   addrs.Provider{Type: name},
 		Version:    versions.Version{},
 		PackageDir: dir,
-	})
+	}, "")
 }
 
 func cutLast(s, sep string) (string, string, bool) {
@@ -134,7 +160,7 @@ func (p provider) Close() error { return p.close() }
 
 func getProviderServer(
 	ctx context.Context, addr addrs.Provider, version getproviders.VersionConstraints,
-	registryDisco *disco.Disco,
+	registryDisco *disco.Disco, mirrorBase string, displayURL string,
 ) (Provider, error) {
 	cacheDir, err := getPluginCache()
 	if err != nil {
@@ -154,7 +180,7 @@ func getProviderServer(
 					slog.Any("addr", addr.String()),
 					slog.Any("version", p.Version.String()))
 				p := p
-				return runProvider(ctx, &p)
+				return runProvider(ctx, &p, displayURL)
 			}
 		}
 	}
@@ -162,7 +188,13 @@ func getProviderServer(
 	// We have not found a package that fits our constraints, so we need to download
 	// one.
 
-	source := getproviders.NewRegistrySource(ctx, registryDisco, nil, getproviders.LocationConfig{})
+	var source getproviders.Source
+	if mirrorBase != "" {
+		slog.InfoContext(ctx, "Using network mirror", slog.String("url", mirrorBase))
+		source = getproviders.NewNetworkMirrorSource(ctx, mirrorBase, nil)
+	} else {
+		source = getproviders.NewRegistrySource(ctx, registryDisco, nil, getproviders.LocationConfig{})
+	}
 
 	availableVersions, warnings, err := source.AvailableVersions(ctx, addr)
 	for _, w := range warnings {
@@ -191,7 +223,7 @@ func getProviderServer(
 	p := systemCache.ProviderVersion(addr, desiredVersion)
 	contract.Assertf(p != nil, "We just downloaded (%s,%s) so it should be in the cache", addr, desiredVersion)
 
-	return runProvider(ctx, p)
+	return runProvider(ctx, p, displayURL)
 }
 
 func includePanic(
@@ -216,7 +248,10 @@ func includePanic(
 // runProvider produces a provider factory that runs up the executable
 // file in the given cache package and uses go-plugin to implement
 // providers.Interface against it.
-func runProvider(ctx context.Context, meta *providercache.CachedProvider) (Provider, error) {
+//
+// displayURL, if non-empty, overrides the URL stored in the returned Provider
+// (used to preserve mirror-qualified addresses across re-parameterization).
+func runProvider(ctx context.Context, meta *providercache.CachedProvider, displayURL string) (Provider, error) {
 	execFile, err := meta.ExecutableFile()
 	if err != nil {
 		return nil, err
@@ -250,6 +285,11 @@ func runProvider(ctx context.Context, meta *providercache.CachedProvider) (Provi
 		return nil, err
 	}
 
+	providerURL := meta.Provider.String()
+	if displayURL != "" {
+		providerURL = displayURL
+	}
+
 	switch client.NegotiatedVersion() {
 	case 5:
 		p := raw.(*tfplugin.GRPCProvider)
@@ -266,14 +306,14 @@ func runProvider(ctx context.Context, meta *providercache.CachedProvider) (Provi
 		}
 		return provider{
 			v6,
-			meta.Provider.Type, meta.Version.String(), meta.Provider.String(),
+			meta.Provider.Type, meta.Version.String(), providerURL,
 			rpcClient.Close,
 		}, nil
 	case 6:
 		p := tfplugin6.NewProviderClient(rpcClient.(*plugin.GRPCClient).Conn)
 		return provider{
 			v6shim.New(p),
-			meta.Provider.Type, meta.Version.String(), meta.Provider.String(),
+			meta.Provider.Type, meta.Version.String(), providerURL,
 			rpcClient.Close,
 		}, nil
 	default:

--- a/dynamic/internal/shim/run/loader_test.go
+++ b/dynamic/internal/shim/run/loader_test.go
@@ -25,6 +25,47 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestSplitMirrorURL(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		key            string
+		wantMirrorBase string
+		wantProvider   string
+	}{
+		{
+			key:          "hashicorp/random",
+			wantProvider: "hashicorp/random",
+		},
+		{
+			key:          "registry.terraform.io/hashicorp/random",
+			wantProvider: "registry.terraform.io/hashicorp/random",
+		},
+		{
+			key:            "tofu.example.com/providers/registry.tofu.io/hashicorp/random",
+			wantMirrorBase: "https://tofu.example.com/providers",
+			wantProvider:   "registry.tofu.io/hashicorp/random",
+		},
+		{
+			key:            "https://mirror.example.com/terraform/providers/registry.terraform.io/hashicorp/aws",
+			wantMirrorBase: "https://mirror.example.com/terraform/providers",
+			wantProvider:   "registry.terraform.io/hashicorp/aws",
+		},
+		{
+			key:            "mirror.example.com/registry.terraform.io/hashicorp/tls",
+			wantMirrorBase: "https://mirror.example.com",
+			wantProvider:   "registry.terraform.io/hashicorp/tls",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			t.Parallel()
+			gotMirror, gotProvider := splitMirrorURL(tt.key)
+			assert.Equal(t, tt.wantMirrorBase, gotMirror)
+			assert.Equal(t, tt.wantProvider, gotProvider)
+		})
+	}
+}
+
 func Integration(t *testing.T) {
 	t.Helper()
 	if testing.Short() {

--- a/pkg/vendored/opentofu/getproviders/network_mirror_source.go
+++ b/pkg/vendored/opentofu/getproviders/network_mirror_source.go
@@ -1,0 +1,201 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package getproviders
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/vendored/opentofu/addrs"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/vendored/opentofu/httpclient"
+)
+
+// NetworkMirrorSource implements the Terraform Network Mirror Protocol.
+// See: https://developer.hashicorp.com/terraform/internals/provider-network-mirror-protocol
+type NetworkMirrorSource struct {
+	baseURL    string
+	httpClient *retryablehttp.Client
+}
+
+var _ Source = (*NetworkMirrorSource)(nil)
+
+// NewNetworkMirrorSource creates a NetworkMirrorSource that fetches providers from the
+// given mirror base URL (e.g. "https://mirror.example.com/providers").
+func NewNetworkMirrorSource(ctx context.Context, baseURL string, httpClient *retryablehttp.Client) *NetworkMirrorSource {
+	if httpClient == nil {
+		httpClient = httpclient.NewForRegistryRequests(ctx, 1, 10*time.Second)
+	}
+	return &NetworkMirrorSource{
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		httpClient: httpClient,
+	}
+}
+
+// AvailableVersions queries the mirror for all available versions of the given provider.
+// Endpoint: GET {baseURL}/{hostname}/{namespace}/{type}/index.json
+// Response: {"versions": {"1.0.0": {}, "1.2.3": {}}}
+func (s *NetworkMirrorSource) AvailableVersions(ctx context.Context, provider addrs.Provider) (VersionList, Warnings, error) {
+	indexURL := fmt.Sprintf("%s/%s/%s/%s/index.json",
+		s.baseURL,
+		provider.Hostname.ForDisplay(),
+		provider.Namespace,
+		provider.Type,
+	)
+
+	var result struct {
+		Versions map[string]json.RawMessage `json:"versions"`
+	}
+	if err := s.getJSON(ctx, indexURL, &result); err != nil {
+		return nil, nil, ErrQueryFailed{Provider: provider, Wrapped: err}
+	}
+
+	versions := make(VersionList, 0, len(result.Versions))
+	for vstr := range result.Versions {
+		v, err := ParseVersion(vstr)
+		if err != nil {
+			return nil, nil, ErrQueryFailed{
+				Provider: provider,
+				Wrapped:  fmt.Errorf("mirror response includes invalid version string %q: %w", vstr, err),
+			}
+		}
+		versions = append(versions, v)
+	}
+	versions.Sort()
+	return versions, nil, nil
+}
+
+// PackageMeta queries the mirror for metadata about a specific provider version and platform.
+// Endpoint: GET {baseURL}/{hostname}/{namespace}/{type}/{version}.json
+// Response: {"archives": {"linux_amd64": {"url": "...", "hashes": ["zh:..."]}}}
+func (s *NetworkMirrorSource) PackageMeta(ctx context.Context, provider addrs.Provider, version Version, target Platform) (PackageMeta, error) {
+	versionURL := fmt.Sprintf("%s/%s/%s/%s/%s.json",
+		s.baseURL,
+		provider.Hostname.ForDisplay(),
+		provider.Namespace,
+		provider.Type,
+		version,
+	)
+
+	var result struct {
+		Archives map[string]struct {
+			URL    string   `json:"url"`
+			Hashes []string `json:"hashes"`
+		} `json:"archives"`
+	}
+	if err := s.getJSON(ctx, versionURL, &result); err != nil {
+		return PackageMeta{}, ErrQueryFailed{Provider: provider, Wrapped: err}
+	}
+
+	platformKey := target.String()
+	archive, ok := result.Archives[platformKey]
+	if !ok {
+		return PackageMeta{}, ErrPlatformNotSupported{
+			Provider: provider,
+			Version:  version,
+			Platform: target,
+		}
+	}
+
+	// The archive URL may be relative; resolve it against the version JSON URL.
+	pkgURL, err := resolveURL(versionURL, archive.URL)
+	if err != nil {
+		return PackageMeta{}, ErrQueryFailed{
+			Provider: provider,
+			Wrapped:  fmt.Errorf("invalid archive URL %q from mirror: %w", archive.URL, err),
+		}
+	}
+
+	httpClient := s.httpClient
+	meta := PackageMeta{
+		Provider:       provider,
+		Version:        version,
+		TargetPlatform: target,
+		Location: PackageHTTPURL{
+			URL: pkgURL,
+			ClientBuilder: func(ctx context.Context) *retryablehttp.Client {
+				return httpClient
+			},
+		},
+	}
+
+	if len(archive.Hashes) > 0 {
+		hashes := make([]Hash, 0, len(archive.Hashes))
+		for _, h := range archive.Hashes {
+			hash, err := ParseHash(h)
+			if err != nil {
+				// Non-fatal: skip unrecognized hash formats.
+				continue
+			}
+			hashes = append(hashes, hash)
+		}
+		if len(hashes) > 0 {
+			meta.Authentication = NewPackageHashAuthentication(target, hashes)
+		}
+	}
+
+	return meta, nil
+}
+
+func (s *NetworkMirrorSource) ForDisplay(provider addrs.Provider) string {
+	return fmt.Sprintf("network mirror %s", s.baseURL)
+}
+
+func (s *NetworkMirrorSource) getJSON(ctx context.Context, rawURL string, out interface{}) error {
+	req, err := retryablehttp.NewRequestWithContext(ctx, "GET", rawURL, nil)
+	if err != nil {
+		return fmt.Errorf("invalid request URL %q: %w", rawURL, err)
+	}
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request to %s failed: %w", rawURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unsuccessful request to %s: %s", rawURL, resp.Status)
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return fmt.Errorf("invalid JSON response from %s: %w", rawURL, err)
+	}
+	return nil
+}
+
+func resolveURL(base, ref string) (string, error) {
+	if ref == "" {
+		return "", fmt.Errorf("empty URL")
+	}
+	// If ref already has a scheme, it's absolute.
+	if strings.Contains(ref, "://") {
+		return ref, nil
+	}
+	baseURL, err := url.Parse(base)
+	if err != nil {
+		return "", err
+	}
+	refURL, err := url.Parse(ref)
+	if err != nil {
+		return "", err
+	}
+	return baseURL.ResolveReference(refURL).String(), nil
+}

--- a/pkg/vendored/opentofu/getproviders/network_mirror_source_test.go
+++ b/pkg/vendored/opentofu/getproviders/network_mirror_source_test.go
@@ -1,0 +1,168 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package getproviders
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	regaddr "github.com/opentofu/registry-address/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func mustProvider(source string) regaddr.Provider {
+	p, err := regaddr.ParseProviderSource(source)
+	if err != nil {
+		panic(err)
+	}
+	return p
+}
+
+func TestNetworkMirrorSource_AvailableVersions(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/registry.terraform.io/hashicorp/random/index.json":
+			json.NewEncoder(w).Encode(map[string]interface{}{ //nolint:errcheck
+				"versions": map[string]interface{}{
+					"3.5.1": map[string]interface{}{},
+					"3.6.0": map[string]interface{}{},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	provider := mustProvider("registry.terraform.io/hashicorp/random")
+
+	ctx := context.Background()
+	source := NewNetworkMirrorSource(ctx, srv.URL, nil)
+	versions, warnings, err := source.AvailableVersions(ctx, provider)
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+	require.Len(t, versions, 2)
+	assert.Equal(t, "3.5.1", versions[0].String())
+	assert.Equal(t, "3.6.0", versions[1].String())
+}
+
+func TestNetworkMirrorSource_PackageMeta(t *testing.T) {
+	t.Parallel()
+
+	archiveSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("fake zip content")) //nolint:errcheck
+	}))
+	defer archiveSrv.Close()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/registry.terraform.io/hashicorp/random/3.5.1.json":
+			json.NewEncoder(w).Encode(map[string]interface{}{ //nolint:errcheck
+				"archives": map[string]interface{}{
+					"linux_amd64": map[string]interface{}{
+						"url":    archiveSrv.URL + "/terraform-provider-random_3.5.1_linux_amd64.zip",
+						"hashes": []string{},
+					},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	provider := mustProvider("registry.terraform.io/hashicorp/random")
+	version := MustParseVersion("3.5.1")
+	platform := Platform{OS: "linux", Arch: "amd64"}
+
+	ctx := context.Background()
+	source := NewNetworkMirrorSource(ctx, srv.URL, nil)
+	meta, err := source.PackageMeta(ctx, provider, version, platform)
+	require.NoError(t, err)
+	assert.Equal(t, provider, meta.Provider)
+	assert.Equal(t, version, meta.Version)
+	assert.Equal(t, platform, meta.TargetPlatform)
+
+	httpLoc, ok := meta.Location.(PackageHTTPURL)
+	require.True(t, ok, "expected PackageHTTPURL location")
+	assert.Equal(t, archiveSrv.URL+"/terraform-provider-random_3.5.1_linux_amd64.zip", httpLoc.URL)
+}
+
+func TestNetworkMirrorSource_PackageMeta_PlatformNotSupported(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{ //nolint:errcheck
+			"archives": map[string]interface{}{
+				"linux_amd64": map[string]interface{}{
+					"url": "https://example.com/provider.zip",
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	provider := mustProvider("registry.terraform.io/hashicorp/random")
+	version := MustParseVersion("3.5.1")
+	platform := Platform{OS: "windows", Arch: "amd64"}
+
+	ctx := context.Background()
+	source := NewNetworkMirrorSource(ctx, srv.URL, nil)
+	_, err := source.PackageMeta(ctx, provider, version, platform)
+	require.Error(t, err)
+	var notSupported ErrPlatformNotSupported
+	require.ErrorAs(t, err, &notSupported)
+}
+
+func TestNetworkMirrorSource_RelativeURL(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/registry.terraform.io/hashicorp/random/3.5.1.json":
+			json.NewEncoder(w).Encode(map[string]interface{}{ //nolint:errcheck
+				"archives": map[string]interface{}{
+					"linux_amd64": map[string]interface{}{
+						"url":    "../files/terraform-provider-random_3.5.1_linux_amd64.zip",
+						"hashes": []string{},
+					},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	provider := mustProvider("registry.terraform.io/hashicorp/random")
+	version := MustParseVersion("3.5.1")
+	platform := Platform{OS: "linux", Arch: "amd64"}
+
+	ctx := context.Background()
+	source := NewNetworkMirrorSource(ctx, srv.URL, nil)
+	meta, err := source.PackageMeta(ctx, provider, version, platform)
+	require.NoError(t, err)
+
+	httpLoc, ok := meta.Location.(PackageHTTPURL)
+	require.True(t, ok)
+	// Relative URL should be resolved against the version JSON URL.
+	assert.Contains(t, httpLoc.URL, "terraform-provider-random_3.5.1_linux_amd64.zip")
+}


### PR DESCRIPTION
Fixes #3334

Adds support for the [Terraform Network Mirror Protocol](https://developer.hashicorp.com/terraform/internals/provider-network-mirror-protocol), allowing the dynamic provider to fetch Terraform providers from custom mirrors in air-gapped or restricted environments.

Users can embed the mirror base URL directly in the provider source string:

```
pulumi package add terraform-provider tofu.example.com/providers/registry.tofu.io/hashicorp/random
```

Provider keys with more than 3 path segments are interpreted as `{mirror_base}/{provider_address}`, where the last 3 segments are always the provider address (`hostname/namespace/type`). Keys with 3 or fewer segments use the standard registry behaviour unchanged.

## Changes

- **`pkg/vendored/opentofu/getproviders/network_mirror_source.go`** (new): `NetworkMirrorSource` implementing the `Source` interface using the network mirror protocol
- **`dynamic/internal/shim/run/loader.go`**:
  - `splitMirrorURL()` — parses mirror-qualified provider keys
  - `NamedProvider()` — routes to mirror or registry based on key format
  - `getProviderServer()` — selects `NetworkMirrorSource` or `RegistrySource`
  - `runProvider()` — preserves the mirror-qualified URL across re-parameterization

## Testing

```
# Unit tests for mirror URL parsing
go test -run TestSplitMirrorURL ./dynamic/internal/shim/run/...

# Unit tests for NetworkMirrorSource (uses local httptest.Server, no network required)
go test -run TestNetworkMirrorSource ./pkg/vendored/opentofu/getproviders/...
```