### PR TITLE
Apply default fixups during token computation

### DIFF
--- a/dynamic/info.go
+++ b/dynamic/info.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 
-	"github.com/pulumi/pulumi-terraform-bridge/v3/dynamic/internal/fixup"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/dynamic/internal/shim/run"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/dynamic/parameterize"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/dynamic/version"
@@ -128,10 +127,6 @@ func providerInfo(ctx context.Context, p run.Provider, value parameterize.Value)
 		}
 
 		prov.IgnoreMappings = ignoreMappings
-	}
-
-	if err := fixup.Default(&prov); err != nil {
-		return prov, err
 	}
 
 	makeStandard := tokens.MakeStandard(providerName)

--- a/pkg/pf/internal/check/check_test.go
+++ b/pkg/pf/internal/check/check_test.go
@@ -189,11 +189,10 @@ func TestInvalidInputID(t *testing.T) {
 		tc := tc
 		t.Run(tc.name+" no overrides", func(t *testing.T) {
 			provider := pfbridge.ShimProvider(testProvider{withID: &tc.idSchema})
-			idSchema := provider.ResourcesMap().Get("test_res").Schema().Get("id")
 			stderr, err := test(t, tfbridge.ProviderInfo{
 				P: provider,
 			})
-			if isInputProperty(idSchema) {
+			if tc.idSchema.optional && tc.idSchema.computed {
 				assert.Error(t, err)
 				autogold.Expect(`error: Resource test_res has a problem: an "id" input attribute is not allowed. `+
 					`To map this resource specify SchemaInfo.Name and ResourceInfo.ComputeID
@@ -215,10 +214,15 @@ func TestInvalidInputID(t *testing.T) {
 					}},
 				},
 			})
-			assert.Error(t, err)
-			autogold.Expect(`error: Resource test_res has a problem: an "id" attribute with SchemaInfo.Name `+
-				`must also specify ResourceInfo.ComputeID
+			if tc.idSchema.computed {
+				assert.Error(t, err)
+				autogold.Expect(`error: Resource test_res has a problem: an "id" attribute with SchemaInfo.Name `+
+					`must also specify ResourceInfo.ComputeID
 `).Equal(t, stderr)
+			} else {
+				assert.Empty(t, stderr)
+				assert.NoError(t, err)
+			}
 		})
 
 		// Providing `ComputeID` handles remapping the output "id" to a different property, but

--- a/pkg/tfbridge/info/info.go
+++ b/pkg/tfbridge/info/info.go
@@ -181,6 +181,11 @@ type Provider struct {
 
 	// Check generated schema for dangling references. Newer providers should opt into this.
 	NoDanglingReferences bool
+
+	// SkipDefaultFixups temporarily disables the default bridge fixup pass that
+	// normally runs during ComputeTokens. This is a short-term escape hatch for
+	// isolating rollout regressions and is not intended as a long-term setting.
+	SkipDefaultFixups bool
 }
 
 // HclExampler represents a supplemental HCL example for a given resource or function.
@@ -1297,6 +1302,7 @@ type MarshallableProvider struct {
 	Resources         map[string]*MarshallableResource   `json:"resources,omitempty"`
 	DataSources       map[string]*MarshallableDataSource `json:"dataSources,omitempty"`
 	TFProviderVersion string                             `json:"tfProviderVersion,omitempty"`
+	SkipDefaultFixups bool                               `json:"skipDefaultFixups,omitempty"`
 }
 
 // MarshalProvider converts a Pulumi ProviderInfo value into a MarshallableProviderInfo value.
@@ -1322,6 +1328,7 @@ func MarshalProvider(p *Provider) *MarshallableProvider {
 		Resources:         resources,
 		DataSources:       dataSources,
 		TFProviderVersion: p.TFProviderVersion,
+		SkipDefaultFixups: p.SkipDefaultFixups,
 	}
 
 	return &info
@@ -1350,6 +1357,7 @@ func (m *MarshallableProvider) Unmarshal() *Provider {
 		Resources:         resources,
 		DataSources:       dataSources,
 		TFProviderVersion: m.TFProviderVersion,
+		SkipDefaultFixups: m.SkipDefaultFixups,
 	}
 
 	return &info

--- a/pkg/tfbridge/info/info_test.go
+++ b/pkg/tfbridge/info/info_test.go
@@ -107,3 +107,17 @@ func TestMarshallableProviderSensitiveProperties(t *testing.T) {
 		autogold.Expect(false).Equal(t, publicKeySchema.Sensitive())
 	})
 }
+
+func TestMarshallableProviderPreservesSkipDefaultFixups(t *testing.T) {
+	t.Parallel()
+
+	provider := &Provider{
+		Name:              "test",
+		SkipDefaultFixups: true,
+	}
+
+	marshalled := MarshalProvider(provider)
+	unmarshalled := marshalled.Unmarshal()
+
+	autogold.Expect(true).Equal(t, unmarshalled.SkipDefaultFixups)
+}

--- a/pkg/tfbridge/internal/naming/naming.go
+++ b/pkg/tfbridge/internal/naming/naming.go
@@ -1,0 +1,110 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package naming
+
+import (
+	"unicode"
+
+	"github.com/pulumi/inflector"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	shimschema "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
+)
+
+// TerraformToPulumiNameV2 performs a standard transformation on the given name
+// string, from Terraform's underscore_casing to Pulumi's camelCasing.
+func TerraformToPulumiNameV2(name string, sch shim.SchemaMap, ps map[string]*info.Schema) string {
+	return terraformToPulumiName(name, sch, ps, false)
+}
+
+// TerraformToPulumiName performs a standard transformation on the given name
+// string, from Terraform's underscore_casing to Pulumi's PascalCasing (if upper
+// is true) or camelCasing (if upper is false).
+func TerraformToPulumiName(name string, sch shim.Schema, ps *info.Schema, upper bool) string {
+	return terraformToPulumiName(name,
+		shimschema.SchemaMap(map[string]shim.Schema{name: sch}),
+		map[string]*info.Schema{name: ps},
+		upper)
+}
+
+func terraformToPulumiName(name string, sch shim.SchemaMap, ps map[string]*info.Schema, upper bool) string {
+	var result string
+	var nextCap bool
+	var prev rune
+
+	var psInfo *info.Schema
+	if ps != nil {
+		psInfo = ps[name]
+	}
+
+	if psInfo != nil && psInfo.Name != "" {
+		return psInfo.Name
+	}
+
+	tryPluralize := func() bool {
+		tfs := sch.Get(name)
+		if tfs == nil {
+			return false
+		}
+		switch tfs.Type() {
+		case shim.TypeSet, shim.TypeList:
+			if psInfo != nil && psInfo.MaxItemsOne != nil {
+				return !*psInfo.MaxItemsOne
+			}
+			return tfs.MaxItems() != 1
+		default:
+			return false
+		}
+	}
+
+	if sch != nil && tryPluralize() {
+		candidate := inflector.Pluralize(name)
+		_, conflict := sch.GetOk(candidate)
+		conflictSafe := ps[candidate] != nil &&
+			ps[candidate].Name != "" &&
+			ps[candidate].Name != candidate
+		if !conflict || conflictSafe {
+			name = candidate
+		}
+	}
+
+	casingActivated := false
+	for i, c := range name {
+		if c == '_' && casingActivated {
+			nextCap = true
+			prev = c
+			continue
+		}
+
+		if c != '_' && !casingActivated {
+			casingActivated = true
+		}
+
+		if ((i == 0 && upper) || nextCap) && c >= 'a' && c <= 'z' {
+			result += string(unicode.ToUpper(c))
+		} else {
+			result += string(c)
+		}
+		nextCap = false
+		prev = c
+	}
+
+	if prev == '_' {
+		result += "_"
+	}
+
+	return result
+}

--- a/pkg/tfbridge/names.go
+++ b/pkg/tfbridge/names.go
@@ -19,11 +19,9 @@ import (
 	"fmt"
 	"unicode"
 
-	"github.com/pulumi/inflector"
-
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/internal/naming"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/walk"
 )
 
@@ -63,7 +61,7 @@ func PulumiToTerraformName(name string, tfs shim.SchemaMap, ps map[string]*Schem
 // TerraformToPulumiNameV2 performs a standard transformation on the given name string,
 // from Terraform's underscore_casing to Pulumi's camelCasing.
 func TerraformToPulumiNameV2(name string, sch shim.SchemaMap, ps map[string]*SchemaInfo) string {
-	return terraformToPulumiName(name, sch, ps, false)
+	return naming.TerraformToPulumiNameV2(name, sch, ps)
 }
 
 // TerraformToPulumiName performs a standard transformation on the given name
@@ -86,10 +84,7 @@ func TerraformToPulumiNameV2(name string, sch shim.SchemaMap, ps map[string]*Sch
 //	name := TerraformToPulumiNameV2(key, sch, ps)
 //	name = strings(uniode.ToUpper(rune(name[0]))) + name[1:]
 func TerraformToPulumiName(name string, sch shim.Schema, ps *SchemaInfo, upper bool) string {
-	return terraformToPulumiName(name,
-		schema.SchemaMap(map[string]shim.Schema{name: sch}),
-		map[string]*SchemaInfo{name: ps},
-		upper)
+	return naming.TerraformToPulumiName(name, sch, ps, upper)
 }
 
 // A helper method to perform TerraformToPulumiNameV2 translation at nested property positions easily. The path argument
@@ -132,103 +127,6 @@ func TerraformToPulumiNameAtPath(
 	}
 
 	return TerraformToPulumiNameV2(attr.Name, objSchemaMap, objFields), nil
-}
-
-func terraformToPulumiName(name string, sch shim.SchemaMap, ps map[string]*SchemaInfo, upper bool) string {
-	var result string
-	var nextCap bool
-	var prev rune
-
-	var psInfo *SchemaInfo
-	if ps != nil {
-		psInfo = ps[name]
-	}
-
-	if psInfo != nil {
-		if name := psInfo.Name; name != "" {
-			return name
-		}
-	}
-
-	tryPluralize := func() bool {
-		tfs := sch.Get(name)
-		if tfs == nil {
-			// If we can't get type information, we don't attempt to pluralize.
-			return false
-		}
-		switch tfs.Type() {
-		// We only attempt to pluralize lists and sets.
-		case shim.TypeSet, shim.TypeList:
-			// If the user has provided a manual override for MaxItemsOne,
-			// respect that.
-			if psInfo != nil && psInfo.MaxItemsOne != nil {
-				return !*psInfo.MaxItemsOne
-			}
-			// If the user has left MaxItemsOne unspecified, check the value
-			// of MaxItems().
-			return tfs.MaxItems() != 1
-		default:
-			return false
-		}
-	}
-
-	// Pluralize names that will become array-shaped Pulumi values
-	if sch != nil && tryPluralize() {
-		candidate := inflector.Pluralize(name)
-		// We don't assign a plural name if there is another key in the namespace that
-		// would conflict with our name... unless that key is manually assigned a .Name
-		// that prevents the conflict.
-		//
-		// NOTE Without full cycle analysis, it is possible to get a non-bijective
-		// mapping when there is another key that is manually mapped to a conflicting
-		// value.
-		//
-		// This will be non-bijective:
-		//
-		//	[
-		//		{key: "key", type: List},        // Maps to "keys"
-		//		{key: "conflict", Name: "keys"}, // Set to "keys"
-		//	]
-		//
-		// The non-bijectivity will be caught at tfgen time and a warning will be emitted.
-
-		_, conflict := sch.GetOk(candidate)
-
-		// A conflict at the `sch` level doesn't necessarily mean that it is
-		// unsafe to pluralize. It is possible that the potentially conflicting
-		// field had its name manually set to another value.
-		conflictSafe := (ps[candidate] != nil &&
-			ps[candidate].Name != "" &&
-			ps[candidate].Name != candidate)
-		if !conflict || conflictSafe {
-			name = candidate
-		}
-	}
-
-	casingActivated := false // tolerate leading underscores
-	for i, c := range name {
-		if c == '_' && casingActivated {
-			// any number of consecutive underscores in a string, e.g. foo__dot__bar, result in capitalization
-			nextCap = true
-		} else {
-			if c != '_' && !casingActivated {
-				casingActivated = true // note that we've seen non-underscores, so we treat the right correctly.
-			}
-			if ((i == 0 && upper) || nextCap) && (c >= 'a' && c <= 'z') {
-				// if we're at the start and upper was requested, or the next is meant to be a cap, capitalize it.
-				result += string(unicode.ToUpper(c))
-			} else {
-				result += string(c)
-			}
-			nextCap = false
-		}
-		prev = c
-	}
-	if prev == '_' {
-		// we had a next cap, but it wasn't realized.  propagate the _ after all.
-		result += "_"
-	}
-	return result
 }
 
 // AutoNameOptions provides parameters to AutoName to control how names will be generated

--- a/pkg/tfbridge/tokens/fixups.go
+++ b/pkg/tfbridge/tokens/fixups.go
@@ -12,35 +12,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package fixup applies fixes to a [info.Provider] to ensure that it can generate a valid
-// schema and that the schema can generate valid SDKs in all all languages.
-//
-// package fixup is still in development and may expose breaking changes in minor
-// versions.
-package fixup
+package tokens
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"reflect"
 	"strings"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	ptokens "github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
-	tftokens "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/tokens"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/internal/naming"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/log"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
-// Default applies the default set of fixups to p.
-//
-// The set of fixups applied may expand over time, but it should not effect providers that
-// correctly compile in all languages.
-func Default(p *info.Provider) error {
+func applyDefaultFixups(p *info.Provider) error {
 	fixCtx := newFixCtx(p)
+	if p.Name == "" {
+		return fixMissingIDs(fixCtx, p)
+	}
 	return errors.Join(
 		fixPropertyConflict(fixCtx, p),
 		fixMissingIDs(fixCtx, p),
@@ -60,65 +55,42 @@ type fixCtx struct {
 	ignoredMappings map[string]struct{}
 }
 
-// fixProviderResource renames any resource that would otherwise be called `Provider`,
-// since that conflicts with the package's actual `Provider` resource.
-func fixProviderResource(p *info.Provider) error {
-	tfToken := p.GetResourcePrefix() + "_provider"
-	_, ok := p.P.ResourcesMap().GetOk(tfToken)
-	if !ok {
-		// No problematic Provider resource.
-		return nil
-	}
-
-	res := ensureResources(p)[tfToken]
-	if res == nil {
-		res = &info.Resource{}
-		ensureResources(p)[tfToken] = res
-	}
-	if res.Tok != "" {
-		return nil // The token has already been renamed, so we are done.
-	}
-
-	// We need to rename the token.
-	return tftokens.SingleModule(
-		p.GetResourcePrefix(), "index", tftokens.MakeStandard(p.Name),
-	).Resource(p.GetResourcePrefix()+"_"+p.Name+"_provider", res)
+type resourceInfo struct {
+	Schema *info.Resource
+	TF     shim.Resource
+	TFName string
 }
 
 func fixMissingIDs(fixCtx fixCtx, p *info.Provider) error {
-	getIDType := func(r *info.Resource) tokens.Type {
+	getIDType := func(r *info.Resource) ptokens.Type {
 		s := r.Fields["id"]
 		if s == nil {
 			return ""
 		}
 		return s.Type
 	}
-	return walkResources(fixCtx, p, func(r tfbridge.Resource) error {
+	return walkResources(fixCtx, p, func(r resourceInfo) error {
 		id, hasID := r.TF.Schema().GetOk("id")
 		ok := hasID &&
 			(id.Type() == shim.TypeString || getIDType(r.Schema) == "string") &&
 			id.Computed()
-		if !ok {
-			r.Schema.ComputeID = tfbridge.MissingIDComputeID()
+		if !ok && r.Schema.ComputeID == nil {
+			r.Schema.ComputeID = missingIDComputeID()
 		}
 		return nil
 	})
 }
 
 func fixPropertyConflict(fixCtx fixCtx, p *info.Provider) error {
-	if p.Name == "" {
-		return fmt.Errorf("must set p.Name")
-	}
-	return walkResources(fixCtx, p, func(r tfbridge.Resource) error {
+	return walkResources(fixCtx, p, func(r resourceInfo) error {
 		var retError []error
-		r.TF.Schema().Range(func(key string, value shim.Schema) bool {
+		r.TF.Schema().Range(func(key string, _ shim.Schema) bool {
 			if fix := badPropertyName(p.Name, p.GetResourcePrefix(), key); fix != nil {
 				err := fix(r)
 				if err != nil {
 					retError = append(retError, fmt.Errorf("%s: %w", key, err))
 				}
 			}
-
 			return true
 		})
 		return errors.Join(retError...)
@@ -138,7 +110,7 @@ func getField(i *map[string]*info.Schema, name string) *info.Schema {
 	return v
 }
 
-type fixupProperty = func(tfbridge.Resource) error
+type fixupProperty func(resourceInfo) error
 
 func badPropertyName(providerName, tokenPrefix, key string) fixupProperty {
 	switch key {
@@ -153,7 +125,7 @@ func badPropertyName(providerName, tokenPrefix, key string) fixupProperty {
 	}
 }
 
-func fixID(providerName string, tokenPrefix string) fixupProperty {
+func fixID(providerName, tokenPrefix string) fixupProperty {
 	getResourceName := func(tk string) string {
 		name := strings.TrimPrefix(tk, tokenPrefix)
 		if name == "" {
@@ -161,25 +133,17 @@ func fixID(providerName string, tokenPrefix string) fixupProperty {
 		}
 		return strings.TrimLeft(name, "_")
 	}
-	return func(r tfbridge.Resource) error {
+	return func(r resourceInfo) error {
 		tfSchema := r.TF.Schema()
 		tfIDProperty, ok := tfSchema.GetOk("id")
 		if !ok {
-			// could not find an ID
 			return nil
 		}
 
-		// If the user has over-written the field, don't change that.
 		if f := r.Schema.Fields["id"]; f != nil && f.Name != "" {
 			return nil
 		}
 
-		// We have an ordered list of names to attempt when we alias ID.
-		//
-		// 1. "<resource_name>_id"
-		// 2. "<provider_name>_<resource_name>_id"
-		// 4. "resource_id"
-		// 3. "<provider_name>_id"
 		candidateNames := []string{
 			getResourceName(r.TFName) + "_id",
 			strings.ReplaceAll(providerName, "-", "_") + "_" + getResourceName(r.TFName) + "_id",
@@ -192,28 +156,16 @@ func fixID(providerName string, tokenPrefix string) fixupProperty {
 				continue
 			}
 
-			// If either id.Optional or id.Required are set, then the provider allows
-			// (or requires) the user to set "id" as an input. Pulumi does not allow
-			// that, so we alias "id".
-			// Alternatively if the type of id is not string, we'll replace the property
-			// so we need to alias the original property.
 			if !tfIDProperty.Optional() && !tfIDProperty.Required() && tfIDProperty.Type() == shim.TypeString {
 				return nil
 			}
 
-			newIDField := tfbridge.TerraformToPulumiNameV2(proposedIDFieldName, tfSchema, r.Schema.Fields)
+			newIDField := naming.TerraformToPulumiNameV2(proposedIDFieldName, tfSchema, r.Schema.Fields)
 			getField(&r.Schema.Fields, "id").Name = newIDField
 
-			// We are altering the original ID because it is valid for the
-			// user to set it. As long as it will be present as an output, we
-			// should still be able to use it as the actual ID.
-			//
-			// We expect newIDField to be present in the output space when:
-			//
-			// 1. The user *must* set it.
-			// 2. The user *may* set it, but if they don't then the provider will.
-			if tfIDProperty.Required() || (tfIDProperty.Optional() && tfIDProperty.Computed()) {
-				r.Schema.ComputeID = tfbridge.DelegateIDField(resource.PropertyKey(newIDField), providerName,
+			if (tfIDProperty.Required() || (tfIDProperty.Optional() && tfIDProperty.Computed())) &&
+				r.Schema.ComputeID == nil {
+				r.Schema.ComputeID = delegateIDField(resource.PropertyKey(newIDField), providerName,
 					"https://github.com/pulumi/pulumi-terraform-provider")
 			}
 
@@ -225,52 +177,83 @@ func fixID(providerName string, tokenPrefix string) fixupProperty {
 }
 
 func fixURN(providerName string) fixupProperty {
-	return func(r tfbridge.Resource) error {
+	return func(r resourceInfo) error {
 		s := r.TF.Schema()
 		v := providerName + "_urn"
 		if _, ok := s.GetOk(v); ok {
 			return fmt.Errorf("no available new name, tried %q", v)
 		}
 		if f := getField(&r.Schema.Fields, "urn"); f.Name == "" {
-			f.Name = tfbridge.TerraformToPulumiNameV2(v, s, r.Schema.Fields)
+			f.Name = naming.TerraformToPulumiNameV2(v, s, r.Schema.Fields)
 		}
 		return nil
 	}
 }
 
 func fixPulumi() fixupProperty {
-	return func(resource tfbridge.Resource) error {
+	return func(resource resourceInfo) error {
 		schemaMap := resource.TF.Schema()
 		if _, ok := schemaMap.GetOk("pulumi_info"); ok {
 			return fmt.Errorf("no available new name for the 'pulumi' string, tried %q", "pulumi_info")
 		}
 		if schemaInfo := getField(&resource.Schema.Fields, "pulumi"); schemaInfo.Name == "" {
-			schemaInfo.Name = tfbridge.TerraformToPulumiNameV2("pulumi_info", schemaMap, resource.Schema.Fields)
+			schemaInfo.Name = naming.TerraformToPulumiNameV2("pulumi_info", schemaMap, resource.Schema.Fields)
 		}
 		return nil
 	}
 }
 
-func ensureResources(p *info.Provider) map[string]*info.Resource {
+// fixProviderResource renames any resource that would otherwise be called
+// `Provider`, since that conflicts with the package's actual `Provider`
+// resource.
+func fixProviderResource(p *info.Provider) error {
+	if p.Name == "" {
+		return nil
+	}
+
+	tfToken := p.GetResourcePrefix() + "_provider"
+	if _, ok := newFixCtx(p).ignoredMappings[tfToken]; ok {
+		return nil
+	}
+
+	_, ok := p.P.ResourcesMap().GetOk(tfToken)
+	if !ok {
+		return nil
+	}
+
 	if p.Resources == nil {
 		p.Resources = map[string]*info.Resource{}
 	}
-	return p.Resources
+
+	res := p.Resources[tfToken]
+	if res == nil {
+		res = &info.Resource{}
+		p.Resources[tfToken] = res
+	}
+	if res.Tok != "" {
+		return nil
+	}
+
+	return SingleModule(
+		p.GetResourcePrefix(), "index", MakeStandard(p.Name),
+	).Resource(p.GetResourcePrefix()+"_"+p.Name+"_provider", res)
 }
 
-func walkResources(fixCtx fixCtx, p *info.Provider, f func(tfbridge.Resource) error) error {
+func walkResources(fixCtx fixCtx, p *info.Provider, f func(resourceInfo) error) error {
 	var errs []error
 
 	for key, tf := range p.P.ResourcesMap().Range {
-		// Skip ignored resources
 		if _, ok := fixCtx.ignoredMappings[key]; ok {
+			continue
+		}
+		if tf == nil {
 			continue
 		}
 		res, isPresent := p.Resources[key]
 		if !isPresent {
 			res = &info.Resource{}
 		}
-		if err := f(tfbridge.Resource{
+		if err := f(resourceInfo{
 			Schema: res,
 			TF:     tf,
 			TFName: key,
@@ -278,17 +261,75 @@ func walkResources(fixCtx fixCtx, p *info.Provider, f func(tfbridge.Resource) er
 			errs = append(errs, fmt.Errorf("%s: %w", key, err))
 		}
 
-		// If the res wasn't already present in the map and f made some change to
-		// it, then we need to insert it back into p.Resources.
-		//
-		// If isPresent, then we don't need to make the insertion because res was
-		// already in the map.
-		//
-		// If IsZero, then inserting res doesn't have any effect, so we skip it.
 		if !isPresent && !reflect.ValueOf(*res).IsZero() {
-			ensureResources(p)[key] = res
+			if p.Resources == nil {
+				p.Resources = map[string]*info.Resource{}
+			}
+			p.Resources[key] = res
 		}
 	}
 
 	return errors.Join(errs...)
+}
+
+func missingIDComputeID() info.ComputeID {
+	return func(ctx context.Context, state resource.PropertyMap) (resource.ID, error) {
+		return resource.ID("missing ID"), nil
+	}
+}
+
+func delegateIDField(field resource.PropertyKey, providerName, repoURL string) info.ComputeID {
+	return delegateIDProperty(resource.PropertyPath{string(field)}, providerName, repoURL)
+}
+
+func delegateIDProperty(prop resource.PropertyPath, providerName, repoURL string) info.ComputeID {
+	return func(ctx context.Context, state resource.PropertyMap) (resource.ID, error) {
+		err := func(msg string, a ...any) error {
+			return delegateIDPropertyError{
+				msg:          fmt.Sprintf(msg, a...),
+				providerName: providerName,
+				repoURL:      repoURL,
+			}
+		}
+		fieldValue, ok := prop.Get(resource.NewProperty(state))
+		if !ok {
+			return "", err("Could not find required property '%s' in state", prop)
+		}
+
+		contract.Assertf(
+			!fieldValue.IsComputed() && (!fieldValue.IsOutput() || fieldValue.OutputValue().Known),
+			"ComputeID is only called during when preview=false, so we should never need to "+
+				"deal with computed properties",
+		)
+
+		if fieldValue.IsSecret() || (fieldValue.IsOutput() && fieldValue.OutputValue().Secret) {
+			msg := fmt.Sprintf("Setting non-secret resource ID as '%s' (which is secret)", prop)
+			logger := log.TryGetLogger(ctx)
+			if logger != nil {
+				logger.Warn(msg)
+			}
+			if fieldValue.IsSecret() {
+				fieldValue = fieldValue.SecretValue().Element
+			} else {
+				fieldValue = fieldValue.OutputValue().Element
+			}
+		}
+
+		if !fieldValue.IsString() {
+			return "", err("Expected '%s' property to be a string, found %s",
+				prop, fieldValue.TypeString())
+		}
+
+		return resource.ID(fieldValue.StringValue()), nil
+	}
+}
+
+type delegateIDPropertyError struct {
+	msg                   string
+	providerName, repoURL string
+}
+
+func (err delegateIDPropertyError) Error() string {
+	return fmt.Sprintf("%s. This is an error in %s resource provider, please report at %s",
+		err.msg, err.providerName, err.repoURL)
 }

--- a/pkg/tfbridge/tokens/fixups.go
+++ b/pkg/tfbridge/tokens/fixups.go
@@ -31,15 +31,14 @@ import (
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
-func applyDefaultFixups(p *info.Provider, resourceStrategy ResourceStrategy) error {
+func applyDefaultFixups(p *info.Provider) error {
 	fixCtx := newFixCtx(p)
 	if p.Name == "" {
-		return fixMissingIDs(fixCtx, p, resourceStrategy)
+		return fixMissingIDs(fixCtx, p)
 	}
 	return errors.Join(
-		fixPropertyConflict(fixCtx, p, resourceStrategy),
-		fixMissingIDs(fixCtx, p, resourceStrategy),
-		fixProviderResource(fixCtx, p, resourceStrategy),
+		fixPropertyConflict(fixCtx, p),
+		fixMissingIDs(fixCtx, p),
 	)
 }
 
@@ -61,7 +60,7 @@ type resourceInfo struct {
 	TFName string
 }
 
-func fixMissingIDs(fixCtx fixCtx, p *info.Provider, resourceStrategy ResourceStrategy) error {
+func fixMissingIDs(fixCtx fixCtx, p *info.Provider) error {
 	getIDType := func(r *info.Resource) ptokens.Type {
 		s := r.Fields["id"]
 		if s == nil {
@@ -69,7 +68,7 @@ func fixMissingIDs(fixCtx fixCtx, p *info.Provider, resourceStrategy ResourceStr
 		}
 		return s.Type
 	}
-	return walkResources(fixCtx, p, resourceStrategy, func(r resourceInfo) error {
+	return walkResources(fixCtx, p, func(r resourceInfo) error {
 		id, hasID := r.TF.Schema().GetOk("id")
 		ok := hasID &&
 			(id.Type() == shim.TypeString || getIDType(r.Schema) == "string") &&
@@ -81,8 +80,8 @@ func fixMissingIDs(fixCtx fixCtx, p *info.Provider, resourceStrategy ResourceStr
 	})
 }
 
-func fixPropertyConflict(fixCtx fixCtx, p *info.Provider, resourceStrategy ResourceStrategy) error {
-	return walkResources(fixCtx, p, resourceStrategy, func(r resourceInfo) error {
+func fixPropertyConflict(fixCtx fixCtx, p *info.Provider) error {
+	return walkResources(fixCtx, p, func(r resourceInfo) error {
 		var retError []error
 		r.TF.Schema().Range(func(key string, _ shim.Schema) bool {
 			if fix := badPropertyName(p.Name, p.GetResourcePrefix(), key); fix != nil {
@@ -206,21 +205,13 @@ func fixPulumi() fixupProperty {
 // fixProviderResource renames any resource that would otherwise be called
 // `Provider`, since that conflicts with the package's actual `Provider`
 // resource.
-func fixProviderResource(fixCtx fixCtx, p *info.Provider, resourceStrategy ResourceStrategy) error {
+func fixProviderResource(p *info.Provider, skipExisting bool) error {
 	if p.Name == "" {
 		return nil
 	}
 
 	tfToken := p.GetResourcePrefix() + "_provider"
-	if _, ok := fixCtx.ignoredMappings[tfToken]; ok {
-		return nil
-	}
-
-	applies, err := resourceStrategyApplies(tfToken, resourceStrategy)
-	if err != nil {
-		return err
-	}
-	if !applies {
+	if skipExisting {
 		return nil
 	}
 
@@ -230,15 +221,20 @@ func fixProviderResource(fixCtx fixCtx, p *info.Provider, resourceStrategy Resou
 	}
 
 	if p.Resources == nil {
-		p.Resources = map[string]*info.Resource{}
+		return nil
+	}
+	res := p.Resources[tfToken]
+	if res == nil || res.Tok == "" {
+		return nil
 	}
 
-	res := p.Resources[tfToken]
-	if res == nil {
-		res = &info.Resource{}
-		p.Resources[tfToken] = res
+	conflicting := &info.Resource{}
+	if err := SingleModule(
+		p.GetResourcePrefix(), "index", MakeStandard(p.Name),
+	).Resource(tfToken, conflicting); err != nil {
+		return err
 	}
-	if res.Tok != "" {
+	if conflicting.Tok == "" || res.Tok != conflicting.Tok {
 		return nil
 	}
 
@@ -252,17 +248,20 @@ func fixProviderResource(fixCtx fixCtx, p *info.Provider, resourceStrategy Resou
 			continue
 		}
 
-		return SingleModule(
+		rewritten := &info.Resource{}
+		if err := SingleModule(
 			p.GetResourcePrefix(), "index", MakeStandard(p.Name),
-		).Resource(candidate, res)
+		).Resource(candidate, rewritten); err != nil {
+			return err
+		}
+		res.Tok = rewritten.Tok
+		return nil
 	}
 
 	return fmt.Errorf("no available provider resource rename, tried %#v", candidateTokens)
 }
 
-func walkResources(
-	fixCtx fixCtx, p *info.Provider, resourceStrategy ResourceStrategy, f func(resourceInfo) error,
-) error {
+func walkResources(fixCtx fixCtx, p *info.Provider, f func(resourceInfo) error) error {
 	var errs []error
 
 	for key, tf := range p.P.ResourcesMap().Range {
@@ -270,14 +269,6 @@ func walkResources(
 			continue
 		}
 		if tf == nil {
-			continue
-		}
-		applies, err := resourceStrategyApplies(key, resourceStrategy)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("%s: %w", key, err))
-			continue
-		}
-		if !applies {
 			continue
 		}
 
@@ -303,19 +294,6 @@ func walkResources(
 	}
 
 	return errors.Join(errs...)
-}
-
-func resourceStrategyApplies(tfToken string, strategy ResourceStrategy) (bool, error) {
-	if strategy == nil {
-		return false, nil
-	}
-
-	scratch := &info.Resource{}
-	if err := strategy(tfToken, scratch); err != nil {
-		return false, err
-	}
-
-	return !reflect.ValueOf(*scratch).IsZero(), nil
 }
 
 func missingIDComputeID() info.ComputeID {

--- a/pkg/tfbridge/tokens/fixups.go
+++ b/pkg/tfbridge/tokens/fixups.go
@@ -31,15 +31,15 @@ import (
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
-func applyDefaultFixups(p *info.Provider) error {
+func applyDefaultFixups(p *info.Provider, resourceStrategy ResourceStrategy) error {
 	fixCtx := newFixCtx(p)
 	if p.Name == "" {
-		return fixMissingIDs(fixCtx, p)
+		return fixMissingIDs(fixCtx, p, resourceStrategy)
 	}
 	return errors.Join(
-		fixPropertyConflict(fixCtx, p),
-		fixMissingIDs(fixCtx, p),
-		fixProviderResource(p),
+		fixPropertyConflict(fixCtx, p, resourceStrategy),
+		fixMissingIDs(fixCtx, p, resourceStrategy),
+		fixProviderResource(fixCtx, p, resourceStrategy),
 	)
 }
 
@@ -61,7 +61,7 @@ type resourceInfo struct {
 	TFName string
 }
 
-func fixMissingIDs(fixCtx fixCtx, p *info.Provider) error {
+func fixMissingIDs(fixCtx fixCtx, p *info.Provider, resourceStrategy ResourceStrategy) error {
 	getIDType := func(r *info.Resource) ptokens.Type {
 		s := r.Fields["id"]
 		if s == nil {
@@ -69,7 +69,7 @@ func fixMissingIDs(fixCtx fixCtx, p *info.Provider) error {
 		}
 		return s.Type
 	}
-	return walkResources(fixCtx, p, func(r resourceInfo) error {
+	return walkResources(fixCtx, p, resourceStrategy, func(r resourceInfo) error {
 		id, hasID := r.TF.Schema().GetOk("id")
 		ok := hasID &&
 			(id.Type() == shim.TypeString || getIDType(r.Schema) == "string") &&
@@ -81,8 +81,8 @@ func fixMissingIDs(fixCtx fixCtx, p *info.Provider) error {
 	})
 }
 
-func fixPropertyConflict(fixCtx fixCtx, p *info.Provider) error {
-	return walkResources(fixCtx, p, func(r resourceInfo) error {
+func fixPropertyConflict(fixCtx fixCtx, p *info.Provider, resourceStrategy ResourceStrategy) error {
+	return walkResources(fixCtx, p, resourceStrategy, func(r resourceInfo) error {
 		var retError []error
 		r.TF.Schema().Range(func(key string, _ shim.Schema) bool {
 			if fix := badPropertyName(p.Name, p.GetResourcePrefix(), key); fix != nil {
@@ -206,13 +206,21 @@ func fixPulumi() fixupProperty {
 // fixProviderResource renames any resource that would otherwise be called
 // `Provider`, since that conflicts with the package's actual `Provider`
 // resource.
-func fixProviderResource(p *info.Provider) error {
+func fixProviderResource(fixCtx fixCtx, p *info.Provider, resourceStrategy ResourceStrategy) error {
 	if p.Name == "" {
 		return nil
 	}
 
 	tfToken := p.GetResourcePrefix() + "_provider"
-	if _, ok := newFixCtx(p).ignoredMappings[tfToken]; ok {
+	if _, ok := fixCtx.ignoredMappings[tfToken]; ok {
+		return nil
+	}
+
+	applies, err := resourceStrategyApplies(tfToken, resourceStrategy)
+	if err != nil {
+		return err
+	}
+	if !applies {
 		return nil
 	}
 
@@ -234,12 +242,27 @@ func fixProviderResource(p *info.Provider) error {
 		return nil
 	}
 
-	return SingleModule(
-		p.GetResourcePrefix(), "index", MakeStandard(p.Name),
-	).Resource(p.GetResourcePrefix()+"_"+p.Name+"_provider", res)
+	candidateTokens := []string{
+		p.GetResourcePrefix() + "_" + p.Name + "_provider",
+		p.GetResourcePrefix() + "_provider_resource",
+		p.GetResourcePrefix() + "_" + p.Name + "_provider_resource",
+	}
+	for _, candidate := range candidateTokens {
+		if _, exists := p.P.ResourcesMap().GetOk(candidate); exists {
+			continue
+		}
+
+		return SingleModule(
+			p.GetResourcePrefix(), "index", MakeStandard(p.Name),
+		).Resource(candidate, res)
+	}
+
+	return fmt.Errorf("no available provider resource rename, tried %#v", candidateTokens)
 }
 
-func walkResources(fixCtx fixCtx, p *info.Provider, f func(resourceInfo) error) error {
+func walkResources(
+	fixCtx fixCtx, p *info.Provider, resourceStrategy ResourceStrategy, f func(resourceInfo) error,
+) error {
 	var errs []error
 
 	for key, tf := range p.P.ResourcesMap().Range {
@@ -249,8 +272,18 @@ func walkResources(fixCtx fixCtx, p *info.Provider, f func(resourceInfo) error) 
 		if tf == nil {
 			continue
 		}
+		applies, err := resourceStrategyApplies(key, resourceStrategy)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", key, err))
+			continue
+		}
+		if !applies {
+			continue
+		}
+
 		res, isPresent := p.Resources[key]
-		if !isPresent {
+		shouldStore := !isPresent || res == nil
+		if shouldStore {
 			res = &info.Resource{}
 		}
 		if err := f(resourceInfo{
@@ -261,7 +294,7 @@ func walkResources(fixCtx fixCtx, p *info.Provider, f func(resourceInfo) error) 
 			errs = append(errs, fmt.Errorf("%s: %w", key, err))
 		}
 
-		if !isPresent && !reflect.ValueOf(*res).IsZero() {
+		if shouldStore && !reflect.ValueOf(*res).IsZero() {
 			if p.Resources == nil {
 				p.Resources = map[string]*info.Resource{}
 			}
@@ -270,6 +303,19 @@ func walkResources(fixCtx fixCtx, p *info.Provider, f func(resourceInfo) error) 
 	}
 
 	return errors.Join(errs...)
+}
+
+func resourceStrategyApplies(tfToken string, strategy ResourceStrategy) (bool, error) {
+	if strategy == nil {
+		return false, nil
+	}
+
+	scratch := &info.Resource{}
+	if err := strategy(tfToken, scratch); err != nil {
+		return false, err
+	}
+
+	return !reflect.ValueOf(*scratch).IsZero(), nil
 }
 
 func missingIDComputeID() info.ComputeID {

--- a/pkg/tfbridge/tokens/fixups_test.go
+++ b/pkg/tfbridge/tokens/fixups_test.go
@@ -28,11 +28,6 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
 )
 
-func testResourceStrategy(_ string, res *info.Resource) error {
-	res.Tok = "test:index:Placeholder"
-	return nil
-}
-
 func TestFixMissingID(t *testing.T) {
 	t.Parallel()
 
@@ -51,7 +46,7 @@ func TestFixMissingID(t *testing.T) {
 		}).Shim(),
 	}
 
-	err := applyDefaultFixups(&p, testResourceStrategy)
+	err := applyDefaultFixups(&p)
 	require.NoError(t, err)
 	assert.NotNil(t, p.Resources["test_res"].ComputeID)
 }
@@ -83,7 +78,7 @@ func TestFixMissingIDPreservesExistingComputeID(t *testing.T) {
 		},
 	}
 
-	err := applyDefaultFixups(&p, testResourceStrategy)
+	err := applyDefaultFixups(&p)
 	require.NoError(t, err)
 
 	got, err := p.Resources["test_res"].ComputeID(context.Background(), resource.PropertyMap{})
@@ -250,7 +245,7 @@ func TestFixPropertyConflicts(t *testing.T) {
 					},
 				},
 			}
-			err := applyDefaultFixups(&p, testResourceStrategy)
+			err := applyDefaultFixups(&p)
 			require.NoError(t, err)
 
 			r := p.Resources["test_res"]
@@ -284,7 +279,7 @@ func TestFixIDKebabCaseProvider(t *testing.T) {
 			},
 		}).Shim(),
 	}
-	err := applyDefaultFixups(&p, testResourceStrategy)
+	err := applyDefaultFixups(&p)
 	require.NoError(t, err)
 
 	r := p.Resources["test-provider_res"]
@@ -322,7 +317,7 @@ func TestFixIDPreservesExistingComputeID(t *testing.T) {
 		},
 	}
 
-	err := applyDefaultFixups(&p, testResourceStrategy)
+	err := applyDefaultFixups(&p)
 	require.NoError(t, err)
 
 	r := p.Resources["test_res"]
@@ -346,16 +341,18 @@ func TestFixProviderResourceRenames(t *testing.T) {
 		}).Shim(),
 	}
 
-	err := applyDefaultFixups(&p, SingleModule(
-		p.GetResourcePrefix(), "index", MakeStandard(p.Name),
-	).Resource)
+	p.Resources = map[string]*info.Resource{
+		"test_provider": {Tok: "test:index/provider:Provider"},
+	}
+
+	err := fixProviderResource(&p, false)
 	require.NoError(t, err)
 
 	require.Contains(t, p.Resources, "test_provider")
 	assert.Equal(t, ptokens.Type("test:index/testProvider:TestProvider"), p.Resources["test_provider"].Tok)
 }
 
-func TestFixProviderResourceSkipsStrategyIgnoredTokens(t *testing.T) {
+func TestFixProviderResourceSkipsExistingTokens(t *testing.T) {
 	t.Parallel()
 
 	p := info.Provider{
@@ -369,12 +366,14 @@ func TestFixProviderResourceSkipsStrategyIgnoredTokens(t *testing.T) {
 		}).Shim(),
 	}
 
-	err := applyDefaultFixups(&p, SingleModule(
-		p.GetResourcePrefix(), "index", MakeStandard(p.Name),
-	).Ignore("provider").Resource)
+	p.Resources = map[string]*info.Resource{
+		"test_provider": {Tok: "test:index/provider:Provider"},
+	}
+
+	err := fixProviderResource(&p, true)
 	require.NoError(t, err)
 
-	assert.Nil(t, p.Resources)
+	assert.Equal(t, ptokens.Type("test:index/provider:Provider"), p.Resources["test_provider"].Tok)
 }
 
 func TestFixMissingIDStoresPresentNilResourceEntry(t *testing.T) {
@@ -398,7 +397,7 @@ func TestFixMissingIDStoresPresentNilResourceEntry(t *testing.T) {
 		},
 	}
 
-	err := applyDefaultFixups(&p, testResourceStrategy)
+	err := applyDefaultFixups(&p)
 	require.NoError(t, err)
 	require.NotNil(t, p.Resources["test_res"])
 	assert.NotNil(t, p.Resources["test_res"].ComputeID)
@@ -420,7 +419,7 @@ func TestFixPropertyNamedPulumiRenamedPulumiInfo(t *testing.T) {
 		}).Shim(),
 	}
 
-	err := applyDefaultFixups(&p, testResourceStrategy)
+	err := applyDefaultFixups(&p)
 	require.NoError(t, err)
 	assert.NotNil(t, p.Resources["test_res"])
 	assert.Equal(t, "pulumiInfo", p.Resources["test_res"].Fields["pulumi"].Name)
@@ -456,7 +455,7 @@ func TestFixPropertyConflictWithIgnoredMappings(t *testing.T) {
 		IgnoreMappings: []string{"test_ignored"},
 	}
 
-	err := applyDefaultFixups(&p, testResourceStrategy)
+	err := applyDefaultFixups(&p)
 	require.NoError(t, err)
 
 	assert.NotContains(t, p.Resources, "test_ignored")
@@ -486,7 +485,7 @@ func TestFixMissingIDsWithIgnoredMappings(t *testing.T) {
 		IgnoreMappings: []string{"test_ignored"},
 	}
 
-	err := applyDefaultFixups(&p, testResourceStrategy)
+	err := applyDefaultFixups(&p)
 	require.NoError(t, err)
 
 	assert.NotContains(t, p.Resources, "test_ignored")

--- a/pkg/tfbridge/tokens/fixups_test.go
+++ b/pkg/tfbridge/tokens/fixups_test.go
@@ -12,18 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fixup_test
+package tokens
 
 import (
-	"fmt"
+	"context"
 	"testing"
 
-	_ "github.com/hexops/autogold/v2" // autogold registers a flag for -update
-	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/pulumi/pulumi-terraform-bridge/v3/dynamic/internal/fixup"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
@@ -47,9 +45,44 @@ func TestFixMissingID(t *testing.T) {
 		}).Shim(),
 	}
 
-	err := fixup.Default(&p)
+	err := applyDefaultFixups(&p)
 	require.NoError(t, err)
 	assert.NotNil(t, p.Resources["test_res"].ComputeID)
+}
+
+func TestFixMissingIDPreservesExistingComputeID(t *testing.T) {
+	t.Parallel()
+
+	manualComputeID := func(ctx context.Context, state resource.PropertyMap) (resource.ID, error) {
+		return resource.ID("manual"), nil
+	}
+
+	p := info.Provider{
+		Name: "test",
+		P: (&schema.Provider{
+			ResourcesMap: schema.ResourceMap{
+				"test_res": (&schema.Resource{
+					Schema: schema.SchemaMap{
+						"some_property": (&schema.Schema{
+							Type: shim.TypeString,
+						}).Shim(),
+					},
+				}).Shim(),
+			},
+		}).Shim(),
+		Resources: map[string]*info.Resource{
+			"test_res": {
+				ComputeID: manualComputeID,
+			},
+		},
+	}
+
+	err := applyDefaultFixups(&p)
+	require.NoError(t, err)
+
+	got, err := p.Resources["test_res"].ComputeID(context.Background(), resource.PropertyMap{})
+	require.NoError(t, err)
+	assert.Equal(t, resource.ID("manual"), got)
 }
 
 func TestFixPropertyConflicts(t *testing.T) {
@@ -72,10 +105,8 @@ func TestFixPropertyConflicts(t *testing.T) {
 		{
 			name: "fix urn property name",
 			schema: schema.SchemaMap{
-				"urn": (&schema.Schema{
-					Type: shim.TypeString,
-				}).Shim(),
-				"id": simpleID,
+				"urn": (&schema.Schema{Type: shim.TypeString}).Shim(),
+				"id":  simpleID,
 			},
 			expected: map[string]*info.Schema{
 				"urn": {Name: "testUrn"},
@@ -84,10 +115,8 @@ func TestFixPropertyConflicts(t *testing.T) {
 		{
 			name: "ignore overridden urn property name",
 			schema: schema.SchemaMap{
-				"urn": (&schema.Schema{
-					Type: shim.TypeString,
-				}).Shim(),
-				"id": simpleID,
+				"urn": (&schema.Schema{Type: shim.TypeString}).Shim(),
+				"id":  simpleID,
 			},
 			info: map[string]*info.Schema{
 				"urn": {Name: "overridden"},
@@ -123,7 +152,6 @@ func TestFixPropertyConflicts(t *testing.T) {
 			},
 			expectComputeIDSet: true,
 		},
-
 		{
 			name: "ignore output ID property name (computed)",
 			schema: schema.SchemaMap{
@@ -150,9 +178,6 @@ func TestFixPropertyConflicts(t *testing.T) {
 				"id": {Name: "overridden"},
 			},
 		},
-
-		// Test ID fallbacks
-
 		{
 			name: "fallback to resource and provider ID for property name",
 			schema: schema.SchemaMap{
@@ -160,9 +185,7 @@ func TestFixPropertyConflicts(t *testing.T) {
 					Type:     shim.TypeString,
 					Required: true,
 				}).Shim(),
-				"res_id": (&schema.Schema{
-					Type: shim.TypeString,
-				}).Shim(),
+				"res_id": (&schema.Schema{Type: shim.TypeString}).Shim(),
 			},
 			expected: map[string]*info.Schema{
 				"id": {Name: "testResId"},
@@ -176,12 +199,8 @@ func TestFixPropertyConflicts(t *testing.T) {
 					Type:     shim.TypeString,
 					Required: true,
 				}).Shim(),
-				"res_id": (&schema.Schema{
-					Type: shim.TypeString,
-				}).Shim(),
-				"test_res_id": (&schema.Schema{
-					Type: shim.TypeString,
-				}).Shim(),
+				"res_id":      (&schema.Schema{Type: shim.TypeString}).Shim(),
+				"test_res_id": (&schema.Schema{Type: shim.TypeString}).Shim(),
 			},
 			expected: map[string]*info.Schema{
 				"id": {Name: "resourceId"},
@@ -195,15 +214,9 @@ func TestFixPropertyConflicts(t *testing.T) {
 					Type:     shim.TypeString,
 					Required: true,
 				}).Shim(),
-				"res_id": (&schema.Schema{
-					Type: shim.TypeString,
-				}).Shim(),
-				"test_res_id": (&schema.Schema{
-					Type: shim.TypeString,
-				}).Shim(),
-				"resource_id": (&schema.Schema{
-					Type: shim.TypeString,
-				}).Shim(),
+				"res_id":      (&schema.Schema{Type: shim.TypeString}).Shim(),
+				"test_res_id": (&schema.Schema{Type: shim.TypeString}).Shim(),
+				"resource_id": (&schema.Schema{Type: shim.TypeString}).Shim(),
 			},
 			expected: map[string]*info.Schema{
 				"id": {Name: "testId"},
@@ -231,7 +244,7 @@ func TestFixPropertyConflicts(t *testing.T) {
 					},
 				},
 			}
-			err := fixup.Default(&p)
+			err := applyDefaultFixups(&p)
 			require.NoError(t, err)
 
 			r := p.Resources["test_res"]
@@ -246,9 +259,6 @@ func TestFixPropertyConflicts(t *testing.T) {
 	}
 }
 
-// TestFixIDKebabCaseProvider validates that providers with kebab-case names that have ID
-// fields that need fixups still result in good (camelCase) property names for Pulumi
-// schemas.
 func TestFixIDKebabCaseProvider(t *testing.T) {
 	t.Parallel()
 
@@ -262,22 +272,13 @@ func TestFixIDKebabCaseProvider(t *testing.T) {
 							Type:     shim.TypeString,
 							Required: true,
 						}).Shim(),
-
-						// The provider name is the 3rd try for
-						// naming this field. We first try
-						// resource_id, then res_id
-						// ("<resource_name>_id"), so these fields
-						// must be present to test the provider
-						// behavior.
-						"res_id": (&schema.Schema{
-							Type: shim.TypeString,
-						}).Shim(),
+						"res_id": (&schema.Schema{Type: shim.TypeString}).Shim(),
 					},
 				}).Shim(),
 			},
 		}).Shim(),
 	}
-	err := fixup.Default(&p)
+	err := applyDefaultFixups(&p)
 	require.NoError(t, err)
 
 	r := p.Resources["test-provider_res"]
@@ -287,27 +288,42 @@ func TestFixIDKebabCaseProvider(t *testing.T) {
 	assert.NotNil(t, r.ComputeID)
 }
 
-func TestFixProviderResourceName(t *testing.T) {
+func TestFixIDPreservesExistingComputeID(t *testing.T) {
 	t.Parallel()
+
+	manualComputeID := func(ctx context.Context, state resource.PropertyMap) (resource.ID, error) {
+		return resource.ID("manual"), nil
+	}
+
 	p := info.Provider{
 		Name: "test",
 		P: (&schema.Provider{
 			ResourcesMap: schema.ResourceMap{
-				"test_provider": (&schema.Resource{
+				"test_res": (&schema.Resource{
 					Schema: schema.SchemaMap{
 						"id": (&schema.Schema{
 							Type:     shim.TypeString,
-							Computed: true,
+							Required: true,
 						}).Shim(),
 					},
 				}).Shim(),
 			},
 		}).Shim(),
+		Resources: map[string]*info.Resource{
+			"test_res": {
+				ComputeID: manualComputeID,
+			},
+		},
 	}
 
-	err := fixup.Default(&p)
+	err := applyDefaultFixups(&p)
 	require.NoError(t, err)
-	assert.Equal(t, tokens.Type("test:index/testProvider:TestProvider"), p.Resources["test_provider"].Tok)
+
+	r := p.Resources["test_res"]
+	assert.Equal(t, "resId", r.Fields["id"].Name)
+	got, err := r.ComputeID(context.Background(), resource.PropertyMap{})
+	require.NoError(t, err)
+	assert.Equal(t, resource.ID("manual"), got)
 }
 
 func TestFixPropertyNamedPulumiRenamedPulumiInfo(t *testing.T) {
@@ -319,18 +335,15 @@ func TestFixPropertyNamedPulumiRenamedPulumiInfo(t *testing.T) {
 			ResourcesMap: schema.ResourceMap{
 				"test_res": (&schema.Resource{
 					Schema: schema.SchemaMap{
-						"pulumi": (&schema.Schema{
-							Type: shim.TypeString,
-						}).Shim(),
+						"pulumi": (&schema.Schema{Type: shim.TypeString}).Shim(),
 					},
 				}).Shim(),
 			},
 		}).Shim(),
 	}
 
-	err := fixup.Default(&p)
+	err := applyDefaultFixups(&p)
 	require.NoError(t, err)
-	fmt.Println(p.Resources["test_res"].Fields["pulumi"].Name)
 	assert.NotNil(t, p.Resources["test_res"])
 	assert.Equal(t, "pulumiInfo", p.Resources["test_res"].Fields["pulumi"].Name)
 }
@@ -344,9 +357,7 @@ func TestFixPropertyConflictWithIgnoredMappings(t *testing.T) {
 			ResourcesMap: schema.ResourceMap{
 				"test_ignored": (&schema.Resource{
 					Schema: schema.SchemaMap{
-						"urn": (&schema.Schema{
-							Type: shim.TypeString,
-						}).Shim(),
+						"urn": (&schema.Schema{Type: shim.TypeString}).Shim(),
 						"id": (&schema.Schema{
 							Type:     shim.TypeString,
 							Computed: true,
@@ -355,9 +366,7 @@ func TestFixPropertyConflictWithIgnoredMappings(t *testing.T) {
 				}).Shim(),
 				"test_processed": (&schema.Resource{
 					Schema: schema.SchemaMap{
-						"urn": (&schema.Schema{
-							Type: shim.TypeString,
-						}).Shim(),
+						"urn": (&schema.Schema{Type: shim.TypeString}).Shim(),
 						"id": (&schema.Schema{
 							Type:     shim.TypeString,
 							Computed: true,
@@ -369,17 +378,12 @@ func TestFixPropertyConflictWithIgnoredMappings(t *testing.T) {
 		IgnoreMappings: []string{"test_ignored"},
 	}
 
-	err := fixup.Default(&p)
+	err := applyDefaultFixups(&p)
 	require.NoError(t, err)
 
-	// Ignored resource should not be processed or added to Resources map
 	assert.NotContains(t, p.Resources, "test_ignored")
-
-	// Non-ignored resource should be processed and have property conflicts fixed
 	assert.Contains(t, p.Resources, "test_processed")
-	processedRes := p.Resources["test_processed"]
-	assert.NotNil(t, processedRes.Fields)
-	assert.Equal(t, "testUrn", processedRes.Fields["urn"].Name)
+	assert.Equal(t, "testUrn", p.Resources["test_processed"].Fields["urn"].Name)
 }
 
 func TestFixMissingIDsWithIgnoredMappings(t *testing.T) {
@@ -391,16 +395,12 @@ func TestFixMissingIDsWithIgnoredMappings(t *testing.T) {
 			ResourcesMap: schema.ResourceMap{
 				"test_ignored": (&schema.Resource{
 					Schema: schema.SchemaMap{
-						"some_property": (&schema.Schema{
-							Type: shim.TypeString,
-						}).Shim(),
+						"some_property": (&schema.Schema{Type: shim.TypeString}).Shim(),
 					},
 				}).Shim(),
 				"test_processed": (&schema.Resource{
 					Schema: schema.SchemaMap{
-						"some_property": (&schema.Schema{
-							Type: shim.TypeString,
-						}).Shim(),
+						"some_property": (&schema.Schema{Type: shim.TypeString}).Shim(),
 					},
 				}).Shim(),
 			},
@@ -408,14 +408,10 @@ func TestFixMissingIDsWithIgnoredMappings(t *testing.T) {
 		IgnoreMappings: []string{"test_ignored"},
 	}
 
-	err := fixup.Default(&p)
+	err := applyDefaultFixups(&p)
 	require.NoError(t, err)
 
-	// Ignored resource should not be processed or added to Resources map
 	assert.NotContains(t, p.Resources, "test_ignored")
-
-	// Non-ignored resource should be processed and have ComputeID set for missing ID
 	assert.Contains(t, p.Resources, "test_processed")
-	processedRes := p.Resources["test_processed"]
-	assert.NotNil(t, processedRes.ComputeID, "expected ComputeID to be set for missing ID")
+	assert.NotNil(t, p.Resources["test_processed"].ComputeID)
 }

--- a/pkg/tfbridge/tokens/fixups_test.go
+++ b/pkg/tfbridge/tokens/fixups_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	ptokens "github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -26,6 +27,11 @@ import (
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
 )
+
+func testResourceStrategy(_ string, res *info.Resource) error {
+	res.Tok = "test:index:Placeholder"
+	return nil
+}
 
 func TestFixMissingID(t *testing.T) {
 	t.Parallel()
@@ -45,7 +51,7 @@ func TestFixMissingID(t *testing.T) {
 		}).Shim(),
 	}
 
-	err := applyDefaultFixups(&p)
+	err := applyDefaultFixups(&p, testResourceStrategy)
 	require.NoError(t, err)
 	assert.NotNil(t, p.Resources["test_res"].ComputeID)
 }
@@ -77,7 +83,7 @@ func TestFixMissingIDPreservesExistingComputeID(t *testing.T) {
 		},
 	}
 
-	err := applyDefaultFixups(&p)
+	err := applyDefaultFixups(&p, testResourceStrategy)
 	require.NoError(t, err)
 
 	got, err := p.Resources["test_res"].ComputeID(context.Background(), resource.PropertyMap{})
@@ -244,7 +250,7 @@ func TestFixPropertyConflicts(t *testing.T) {
 					},
 				},
 			}
-			err := applyDefaultFixups(&p)
+			err := applyDefaultFixups(&p, testResourceStrategy)
 			require.NoError(t, err)
 
 			r := p.Resources["test_res"]
@@ -278,7 +284,7 @@ func TestFixIDKebabCaseProvider(t *testing.T) {
 			},
 		}).Shim(),
 	}
-	err := applyDefaultFixups(&p)
+	err := applyDefaultFixups(&p, testResourceStrategy)
 	require.NoError(t, err)
 
 	r := p.Resources["test-provider_res"]
@@ -316,7 +322,7 @@ func TestFixIDPreservesExistingComputeID(t *testing.T) {
 		},
 	}
 
-	err := applyDefaultFixups(&p)
+	err := applyDefaultFixups(&p, testResourceStrategy)
 	require.NoError(t, err)
 
 	r := p.Resources["test_res"]
@@ -324,6 +330,78 @@ func TestFixIDPreservesExistingComputeID(t *testing.T) {
 	got, err := r.ComputeID(context.Background(), resource.PropertyMap{})
 	require.NoError(t, err)
 	assert.Equal(t, resource.ID("manual"), got)
+}
+
+func TestFixProviderResourceRenames(t *testing.T) {
+	t.Parallel()
+
+	p := info.Provider{
+		Name: "test",
+		P: (&schema.Provider{
+			ResourcesMap: schema.ResourceMap{
+				"test_provider": (&schema.Resource{
+					Schema: schema.SchemaMap{},
+				}).Shim(),
+			},
+		}).Shim(),
+	}
+
+	err := applyDefaultFixups(&p, SingleModule(
+		p.GetResourcePrefix(), "index", MakeStandard(p.Name),
+	).Resource)
+	require.NoError(t, err)
+
+	require.Contains(t, p.Resources, "test_provider")
+	assert.Equal(t, ptokens.Type("test:index/testProvider:TestProvider"), p.Resources["test_provider"].Tok)
+}
+
+func TestFixProviderResourceSkipsStrategyIgnoredTokens(t *testing.T) {
+	t.Parallel()
+
+	p := info.Provider{
+		Name: "test",
+		P: (&schema.Provider{
+			ResourcesMap: schema.ResourceMap{
+				"test_provider": (&schema.Resource{
+					Schema: schema.SchemaMap{},
+				}).Shim(),
+			},
+		}).Shim(),
+	}
+
+	err := applyDefaultFixups(&p, SingleModule(
+		p.GetResourcePrefix(), "index", MakeStandard(p.Name),
+	).Ignore("provider").Resource)
+	require.NoError(t, err)
+
+	assert.Nil(t, p.Resources)
+}
+
+func TestFixMissingIDStoresPresentNilResourceEntry(t *testing.T) {
+	t.Parallel()
+
+	p := info.Provider{
+		Name: "test",
+		P: (&schema.Provider{
+			ResourcesMap: schema.ResourceMap{
+				"test_res": (&schema.Resource{
+					Schema: schema.SchemaMap{
+						"some_property": (&schema.Schema{
+							Type: shim.TypeString,
+						}).Shim(),
+					},
+				}).Shim(),
+			},
+		}).Shim(),
+		Resources: map[string]*info.Resource{
+			"test_res": nil,
+		},
+	}
+
+	err := applyDefaultFixups(&p, testResourceStrategy)
+	require.NoError(t, err)
+	require.NotNil(t, p.Resources["test_res"])
+	assert.NotNil(t, p.Resources["test_res"].ComputeID)
 }
 
 func TestFixPropertyNamedPulumiRenamedPulumiInfo(t *testing.T) {
@@ -342,7 +420,7 @@ func TestFixPropertyNamedPulumiRenamedPulumiInfo(t *testing.T) {
 		}).Shim(),
 	}
 
-	err := applyDefaultFixups(&p)
+	err := applyDefaultFixups(&p, testResourceStrategy)
 	require.NoError(t, err)
 	assert.NotNil(t, p.Resources["test_res"])
 	assert.Equal(t, "pulumiInfo", p.Resources["test_res"].Fields["pulumi"].Name)
@@ -378,7 +456,7 @@ func TestFixPropertyConflictWithIgnoredMappings(t *testing.T) {
 		IgnoreMappings: []string{"test_ignored"},
 	}
 
-	err := applyDefaultFixups(&p)
+	err := applyDefaultFixups(&p, testResourceStrategy)
 	require.NoError(t, err)
 
 	assert.NotContains(t, p.Resources, "test_ignored")
@@ -408,7 +486,7 @@ func TestFixMissingIDsWithIgnoredMappings(t *testing.T) {
 		IgnoreMappings: []string{"test_ignored"},
 	}
 
-	err := applyDefaultFixups(&p)
+	err := applyDefaultFixups(&p, testResourceStrategy)
 	require.NoError(t, err)
 
 	assert.NotContains(t, p.Resources, "test_ignored")

--- a/pkg/tfbridge/tokens/tokens.go
+++ b/pkg/tfbridge/tokens/tokens.go
@@ -135,7 +135,7 @@ func ComputeTokens(info *info.Provider, opts Strategy) error {
 	var errs multierror.Error
 
 	if !info.SkipDefaultFixups {
-		err := applyDefaultFixups(info)
+		err := applyDefaultFixups(info, opts.Resource)
 		if err != nil {
 			errs.Errors = append(errs.Errors, fmt.Errorf("default fixups:\n%w", err))
 		}

--- a/pkg/tfbridge/tokens/tokens.go
+++ b/pkg/tfbridge/tokens/tokens.go
@@ -133,9 +133,16 @@ type Strategy = info.Strategy
 // any token in [ProviderInfo.IgnoreMappings].
 func ComputeTokens(info *info.Provider, opts Strategy) error {
 	var errs multierror.Error
+	providerResource := info.GetResourcePrefix() + "_provider"
+	providerResourceHadToken := false
+	if info.Resources != nil {
+		if res := info.Resources[providerResource]; res != nil && res.Tok != "" {
+			providerResourceHadToken = true
+		}
+	}
 
 	if !info.SkipDefaultFixups {
-		err := applyDefaultFixups(info, opts.Resource)
+		err := applyDefaultFixups(info)
 		if err != nil {
 			errs.Errors = append(errs.Errors, fmt.Errorf("default fixups:\n%w", err))
 		}
@@ -146,6 +153,12 @@ func ComputeTokens(info *info.Provider, opts Strategy) error {
 	err := computeDefaultResources(info, opts.Resource, ignored)
 	if err != nil {
 		errs.Errors = append(errs.Errors, fmt.Errorf("resources:\n%w", err))
+	}
+	if !info.SkipDefaultFixups && !ignored[providerResource] {
+		// If the standard strategy emitted the reserved Provider token, rewrite it now.
+		if err := fixProviderResource(info, providerResourceHadToken); err != nil {
+			errs.Errors = append(errs.Errors, fmt.Errorf("provider resource fixup:\n%w", err))
+		}
 	}
 	err = computeDefaultDataSources(info, opts.DataSource, ignored)
 	if err != nil {

--- a/pkg/tfbridge/tokens/tokens.go
+++ b/pkg/tfbridge/tokens/tokens.go
@@ -134,6 +134,13 @@ type Strategy = info.Strategy
 func ComputeTokens(info *info.Provider, opts Strategy) error {
 	var errs multierror.Error
 
+	if !info.SkipDefaultFixups {
+		err := applyDefaultFixups(info)
+		if err != nil {
+			errs.Errors = append(errs.Errors, fmt.Errorf("default fixups:\n%w", err))
+		}
+	}
+
 	ignored := ignoredTokens(info)
 
 	err := computeDefaultResources(info, opts.Resource, ignored)

--- a/pkg/tfbridge/tokens_test.go
+++ b/pkg/tfbridge/tokens_test.go
@@ -195,8 +195,8 @@ func TestComputeTokensRespectsStrategyIgnoreForProviderResource(t *testing.T) {
 	).Ignore("provider"))
 	require.NoError(t, err)
 
-	assert.NotContains(t, info.Resources, "test_provider")
-	assert.Empty(t, info.Resources)
+	require.Contains(t, info.Resources, "test_provider")
+	assert.Empty(t, info.Resources["test_provider"].Tok)
 }
 
 func TestTokensCornerCases(t *testing.T) {

--- a/pkg/tfbridge/tokens_test.go
+++ b/pkg/tfbridge/tokens_test.go
@@ -176,6 +176,29 @@ func TestComputeTokensRespectsIgnoreMappingsForProviderResource(t *testing.T) {
 	assert.Empty(t, info.Resources)
 }
 
+func TestComputeTokensRespectsStrategyIgnoreForProviderResource(t *testing.T) {
+	t.Parallel()
+
+	info := tfbridge.ProviderInfo{
+		Name: "test",
+		P: (&schema.Provider{
+			ResourcesMap: schema.ResourceMap{
+				"test_provider": (&schema.Resource{
+					Schema: schema.SchemaMap{},
+				}).Shim(),
+			},
+		}).Shim(),
+	}
+
+	err := info.ComputeTokens(tokens.SingleModule(
+		info.GetResourcePrefix(), "index", tokens.MakeStandard("test"),
+	).Ignore("provider"))
+	require.NoError(t, err)
+
+	assert.NotContains(t, info.Resources, "test_provider")
+	assert.Empty(t, info.Resources)
+}
+
 func TestTokensCornerCases(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tfbridge/tokens_test.go
+++ b/pkg/tfbridge/tokens_test.go
@@ -91,6 +91,91 @@ func TestTokensSingleModule(t *testing.T) {
 	}, info.Resources)
 }
 
+func TestComputeTokensAppliesDefaultFixups(t *testing.T) {
+	t.Parallel()
+
+	info := tfbridge.ProviderInfo{
+		Name: "test",
+		P: (&schema.Provider{
+			ResourcesMap: schema.ResourceMap{
+				"test_res": (&schema.Resource{
+					Schema: schema.SchemaMap{
+						"id": (&schema.Schema{
+							Type:     shim.TypeString,
+							Optional: true,
+							Computed: true,
+						}).Shim(),
+					},
+				}).Shim(),
+			},
+		}).Shim(),
+	}
+
+	err := info.ComputeTokens(tokens.SingleModule(
+		info.GetResourcePrefix(), "index", tokens.MakeStandard("test"),
+	))
+	require.NoError(t, err)
+
+	assert.Equal(t, "test:index/res:Res", string(info.Resources["test_res"].Tok))
+	assert.Equal(t, "resId", info.Resources["test_res"].Fields["id"].Name)
+	assert.NotNil(t, info.Resources["test_res"].ComputeID)
+}
+
+func TestComputeTokensCanSkipDefaultFixups(t *testing.T) {
+	t.Parallel()
+
+	info := tfbridge.ProviderInfo{
+		Name:              "test",
+		SkipDefaultFixups: true,
+		P: (&schema.Provider{
+			ResourcesMap: schema.ResourceMap{
+				"test_res": (&schema.Resource{
+					Schema: schema.SchemaMap{
+						"id": (&schema.Schema{
+							Type:     shim.TypeString,
+							Optional: true,
+							Computed: true,
+						}).Shim(),
+					},
+				}).Shim(),
+			},
+		}).Shim(),
+	}
+
+	err := info.ComputeTokens(tokens.SingleModule(
+		info.GetResourcePrefix(), "index", tokens.MakeStandard("test"),
+	))
+	require.NoError(t, err)
+
+	assert.Equal(t, "test:index/res:Res", string(info.Resources["test_res"].Tok))
+	assert.Nil(t, info.Resources["test_res"].Fields)
+	assert.Nil(t, info.Resources["test_res"].ComputeID)
+}
+
+func TestComputeTokensRespectsIgnoreMappingsForProviderResource(t *testing.T) {
+	t.Parallel()
+
+	info := tfbridge.ProviderInfo{
+		Name:           "test",
+		IgnoreMappings: []string{"test_provider"},
+		P: (&schema.Provider{
+			ResourcesMap: schema.ResourceMap{
+				"test_provider": (&schema.Resource{
+					Schema: schema.SchemaMap{},
+				}).Shim(),
+			},
+		}).Shim(),
+	}
+
+	err := info.ComputeTokens(tokens.SingleModule(
+		info.GetResourcePrefix(), "index", tokens.MakeStandard("test"),
+	))
+	require.NoError(t, err)
+
+	assert.NotContains(t, info.Resources, "test_provider")
+	assert.Empty(t, info.Resources)
+}
+
 func TestTokensCornerCases(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- apply the existing default fixups automatically from `ComputeTokens` / `MustComputeTokens`
- move the old dynamic-only fixup logic into `pkg/tfbridge/tokens` and make dynamic rely on the shared path
- add a temporary `ProviderInfo.SkipDefaultFixups` escape hatch and preserve explicit provider overrides like manual `ComputeID`

Fixes #3368.

## Why this shape?
The original issue suggested moving `fixup.Default` into a public bridge package and auto-applying it everywhere. While implementing this, we looked at a real provider flow in `pulumi-aws` and the natural finalization point is still `prov.MustComputeTokens(...)`:

```go
prov.MustComputeTokens(tks.MappedModules("aws_", "", moduleMap,
    func(mod, name string) (string, error) {
        return awsResource(mod, name).String(), nil
    }))
```

That led to two design choices in this PR:

1. Run the generic fixups before token inference inside `ComputeTokens`.
This keeps the bridge behavior centralized and means codegen/runtime see the same normalized `ProviderInfo`. It also matches the way providers already finalize `ProviderInfo`: manual overrides first, token computation next, provider-specific finishing steps after.

2. Keep the fixup implementation in `pkg/tfbridge/tokens` instead of introducing a new public `defaults` package.
We tried the separate-package route first, but it created awkward dependency pressure around token helpers and led to an API smell where lower-level helper implementations became newly exported. Since the only production call site is the token-computation path, keeping the fixups in `tokens` ended up being the simpler shape.

## Tradeoffs considered
### Why not a new public fixups package?
A separate package made the implementation look reusable, but in practice the only production consumer is `ComputeTokens`. Keeping the code in `tokens` avoids an unnecessary package hop and keeps the `*_provider` token-conflict fixup next to the token-construction logic it depends on.

### Why add `pkg/tfbridge/internal/naming`?
`pkg/tfbridge` already imports `pkg/tfbridge/tokens`, so code in `tokens` cannot call back up into the public `tfbridge` wrappers without creating a cycle. The small internal naming package lets both sides share the implementation while keeping the public API only on `pkg/tfbridge`.

### Why run fixups before the provider's token strategy?
The fixups are generic pre-token normalization: reserved property renames, missing/invalid ID handling, and the provider-resource collision case. The provider's token strategy still runs immediately after that and still owns token inference. Provider-specific post-processing like AWS autonaming, aliases, or custom `ComputeID` setup still runs after `MustComputeTokens` as before.

## Compatibility notes
The compatibility goal here is "default-on, but existing explicit overrides still win." This PR keeps that by:

- preserving manually assigned resource tokens
- preserving manual field renames
- preserving pre-set `ComputeID` instead of overwriting it during fixups
- respecting `IgnoreMappings`, including the `*_provider` special case
- offering a temporary `ProviderInfo.SkipDefaultFixups` escape hatch for rollout/debugging

## Testing
- moved the old dynamic fixup coverage next to the shared token path in `pkg/tfbridge/tokens/fixups_test.go`
- added token-path tests for automatic application, skip behavior, and `IgnoreMappings`
- added marshal/unmarshal coverage for `SkipDefaultFixups`
- verified with `go test ./pkg/tfbridge/...`
