### PR TITLE
Fix RawConfig parity for omitted falsy TF defaults

### DIFF
--- a/pkg/tests/configure_test.go
+++ b/pkg/tests/configure_test.go
@@ -127,6 +127,8 @@ func TestConfigureCrossTest(t *testing.T) {
 		pt := pulcheck.PulCheck(t, bridgedProvider, pulumiProgram)
 		pt.Preview(t)
 		require.NotNil(t, puRd)
+		// Provider Configure can also observe RawConfig, so this is the
+		// provider-config analogue of the resource Create/Update parity checks.
 		require.Equal(t, tfRd.GetRawConfig(), puRd.GetRawConfig())
 	}
 
@@ -155,6 +157,71 @@ resources:
 			`
 provider "prov" {
 	config = "val"
+}
+
+resource "prov_test" "test" {
+	test = "val"
+}`)
+	})
+
+	t.Run("omitted bool default false", func(t *testing.T) {
+		// Keep provider config aligned with Terraform when an optional bool default
+		// is omitted. This exercises the broader applyDefaults seam, not just
+		// resource Check/Create.
+		runTest(t,
+			map[string]*schema.Schema{
+				"config": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+			},
+			`
+name: test
+runtime: yaml
+resources:
+	prov:
+		type: pulumi:providers:prov
+		defaultProvider: true
+	mainRes:
+		type: prov:index:Test
+		properties:
+			test: "val"
+`,
+			`
+provider "prov" {
+}
+
+resource "prov_test" "test" {
+	test = "val"
+}`)
+	})
+
+	t.Run("omitted string default empty", func(t *testing.T) {
+		// Top-level empty-string defaults are the same RawConfig parity problem as
+		// false/0; Terraform keeps the field omitted here.
+		runTest(t,
+			map[string]*schema.Schema{
+				"config": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Default:  "",
+				},
+			},
+			`
+name: test
+runtime: yaml
+resources:
+	prov:
+		type: pulumi:providers:prov
+		defaultProvider: true
+	mainRes:
+		type: prov:index:Test
+		properties:
+			test: "val"
+`,
+			`
+provider "prov" {
 }
 
 resource "prov_test" "test" {

--- a/pkg/tests/create_test.go
+++ b/pkg/tests/create_test.go
@@ -359,6 +359,124 @@ func TestExplicitNilList(t *testing.T) {
 	)
 }
 
+// Regression tests for pulumi/pulumi-terraform-bridge#2618.
+func TestCreateFalsyTFDefaultParity(t *testing.T) {
+	t.Parallel()
+
+	t.Run("top-level scalar defaults", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("string_default_empty", func(t *testing.T) {
+			t.Parallel()
+
+			// Terraform keeps omitted falsy defaults out of RawConfig on Create.
+			// Pulumi used to replay "" here as if the user had explicitly set it.
+			crosstests.Create(t,
+				map[string]*schema.Schema{
+					"default_location": {
+						Type:     schema.TypeString,
+						Optional: true,
+						Default:  "",
+					},
+				},
+				cty.ObjectVal(map[string]cty.Value{}),
+			)
+		})
+
+		t.Run("auth0_style_bool_default_false", func(t *testing.T) {
+			t.Parallel()
+
+			// pulumi/pulumi-auth0#657:
+			// omitted false was being replayed as an explicit value, which changed
+			// provider behavior for APIs that treat "present false" differently from
+			// "field omitted".
+			crosstests.Create(t,
+				map[string]*schema.Schema{
+					"is_signup_enabled": {
+						Type:     schema.TypeBool,
+						Optional: true,
+						Default:  false,
+					},
+				},
+				cty.ObjectVal(map[string]cty.Value{}),
+			)
+		})
+
+		t.Run("int zero default", func(t *testing.T) {
+			t.Parallel()
+
+			// Zero behaves like the other falsy scalar defaults for RawConfig parity.
+			crosstests.Create(t,
+				map[string]*schema.Schema{
+					"max_groups_to_retrieve": {
+						Type:     schema.TypeInt,
+						Optional: true,
+						Default:  0,
+					},
+				},
+				cty.ObjectVal(map[string]cty.Value{}),
+			)
+		})
+	})
+
+	t.Run("azuredevops_style_nested_set_element_defaults_stay_omitted", func(t *testing.T) {
+		t.Parallel()
+
+		// pulumi/pulumi-azuredevops#514:
+		// nested falsy defaults used to get materialized into set elements, which
+		// changed the element shape/hash and made GetRawConfig observe authored
+		// secret flags/values that Terraform kept omitted.
+		crosstests.Create(t,
+			map[string]*schema.Schema{
+				"variables": {
+					Type:     schema.TypeSet,
+					Required: true,
+					MinItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"name": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"value": {
+								Type:     schema.TypeString,
+								Optional: true,
+								Default:  "",
+							},
+							"secret_value": {
+								Type:     schema.TypeString,
+								Optional: true,
+								Default:  "",
+							},
+							"is_secret": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Default:  false,
+							},
+						},
+					},
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"variables": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"name":  cty.StringVal("key1"),
+						"value": cty.StringVal("val1"),
+					}),
+				}),
+			}),
+			crosstests.CreatePulumiConfig(resource.NewPropertyMapFromMap(map[string]interface{}{
+				"variables": []interface{}{
+					map[string]interface{}{
+						"name":  "key1",
+						"value": "val1",
+					},
+				},
+			})),
+		)
+	})
+}
+
 func TestInputsEmptyCollections(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tests/invoke_raw_config_test.go
+++ b/pkg/tests/invoke_raw_config_test.go
@@ -18,17 +18,34 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	testutils "github.com/pulumi/providertest/replay"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/tfcheck"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
 )
 
+func getRawConfigAttr(raw cty.Value, key string) (cty.Value, bool) {
+	// GetRawConfig can omit attributes from the object type entirely when the
+	// user left them out, so cross-tests need a safe probe instead of GetAttr.
+	if !raw.Type().IsObjectType() || !raw.Type().HasAttribute(key) {
+		return cty.NilVal, false
+	}
+	v := raw.GetAttr(key)
+	if v.IsNull() {
+		return cty.NilVal, false
+	}
+	return v, true
+}
+
 func TestInvokeRawConfigDoesNotPanic(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
 	resource := &schema.Resource{
 		ReadWithoutTimeout: func(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
@@ -65,7 +82,7 @@ func TestInvokeRawConfigDoesNotPanic(t *testing.T) {
 		},
 	}
 
-	server := tfbridge.NewProvider(ctx,
+	server := tfbridge.NewProvider(context.Background(),
 		nil,      /* hostClient */
 		"aws",    /* module */
 		"",       /* version */
@@ -96,4 +113,134 @@ func TestInvokeRawConfigDoesNotPanic(t *testing.T) {
   }
 }`
 	testutils.Replay(t, server, testCase)
+}
+
+func TestInvokeCrossTest(t *testing.T) {
+	t.Parallel()
+
+	runTest := func(t *testing.T, extraSchema map[string]*schema.Schema, tfBody string, argsMap map[string]interface{}) {
+		var tfRd *schema.ResourceData
+		var puRd *schema.ResourceData
+
+		resourceSchema := map[string]*schema.Schema{
+			"engine": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		}
+		for k, v := range extraSchema {
+			resourceSchema[k] = v
+		}
+
+		resource := &schema.Resource{
+			ReadWithoutTimeout: func(ctx context.Context, data *schema.ResourceData, _ interface{}) diag.Diagnostics {
+				if tfRd == nil {
+					tfRd = data
+				} else {
+					puRd = data
+				}
+
+				if v, ok := getRawConfigAttr(data.GetRawConfig(), "is_signup_enabled"); ok {
+					err := data.Set("is_signup_enabled", v.True())
+					require.NoError(t, err)
+				}
+				if v, ok := getRawConfigAttr(data.GetRawConfig(), "default_location"); ok {
+					err := data.Set("default_location", v.AsString())
+					require.NoError(t, err)
+				}
+				rawEngine := data.GetRawConfig().GetAttr("engine")
+				err := data.Set("engine", rawEngine.AsString())
+				require.NoError(t, err)
+				data.SetId("123")
+				return nil
+			},
+			Schema: resourceSchema,
+		}
+
+		tfProvider := &schema.Provider{
+			Schema: map[string]*schema.Schema{},
+			DataSourcesMap: map[string]*schema.Resource{
+				"aws_rds_engine_version": resource,
+			},
+		}
+
+		tfdriver := tfcheck.NewTfDriver(t, t.TempDir(), "aws", tfcheck.NewTFDriverOpts{SDKProvider: tfProvider})
+		tfdriver.Write(t, `
+data "aws_rds_engine_version" "test" {
+  engine = "postgres"
+`+tfBody+`
+}
+`)
+		_, err := tfdriver.Plan(t)
+		require.NoError(t, err)
+		require.NotNil(t, tfRd)
+		require.Nil(t, puRd)
+
+		p := shimv2.NewProvider(tfProvider)
+		info := tfbridge.ProviderInfo{
+			P:    p,
+			Name: "aws",
+			DataSources: map[string]*tfbridge.DataSourceInfo{
+				"aws_rds_engine_version": {Tok: "aws:rds/getEngineVersion:getEngineVersion"},
+			},
+		}
+
+		server := tfbridge.NewProvider(context.Background(),
+			nil,      /* hostClient */
+			"aws",    /* module */
+			"",       /* version */
+			p,        /* tf */
+			info,     /* info */
+			[]byte{}, /* pulumiSchema */
+		)
+
+		args, err := structpb.NewStruct(argsMap)
+		require.NoError(t, err)
+
+		resp, err := server.Invoke(context.Background(), &pulumirpc.InvokeRequest{
+			Tok:  "aws:rds/getEngineVersion:getEngineVersion",
+			Args: args,
+		})
+		require.NoError(t, err)
+		require.Empty(t, resp.Failures)
+		require.NotNil(t, puRd)
+		// Data source reads can inspect RawConfig too, so invoke needs the same
+		// omission-preserving behavior as resource CRUD and provider Configure.
+		require.Equal(t, tfRd.GetRawConfig(), puRd.GetRawConfig())
+	}
+
+	t.Run("omitted bool default false", func(t *testing.T) {
+		// Matches the auth0-style reported case, but on the Invoke path.
+		runTest(t,
+			map[string]*schema.Schema{
+				"is_signup_enabled": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+			},
+			"",
+			map[string]interface{}{
+				"engine": "postgres",
+			},
+		)
+	})
+
+	t.Run("omitted string default empty", func(t *testing.T) {
+		// Confirms top-level empty-string defaults are also a real RawConfig parity
+		// gap, not just a replay-test compatibility artifact.
+		runTest(t,
+			map[string]*schema.Schema{
+				"default_location": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Default:  "",
+				},
+			},
+			"",
+			map[string]interface{}{
+				"engine": "postgres",
+			},
+		)
+	})
 }

--- a/pkg/tfbridge/defaults.go
+++ b/pkg/tfbridge/defaults.go
@@ -35,3 +35,34 @@ func deleteDefaultsKey(inputs resource.PropertyMap) {
 func isEmptyDefaults(v resource.PropertyValue) bool {
 	return v.IsArray() && len(v.ArrayValue()) == 0
 }
+
+func normalizeTFDefaultValue(v interface{}) interface{} {
+	// SDKv2 schema defaults surface numerics through several Go integer/float
+	// types, but the suppression logic only cares about semantic zero-ness.
+	switch value := v.(type) {
+	case int:
+		return float64(value)
+	case int8:
+		return float64(value)
+	case int16:
+		return float64(value)
+	case int32:
+		return float64(value)
+	case int64:
+		return float64(value)
+	case uint:
+		return float64(value)
+	case uint8:
+		return float64(value)
+	case uint16:
+		return float64(value)
+	case uint32:
+		return float64(value)
+	case uint64:
+		return float64(value)
+	case float32:
+		return float64(value)
+	default:
+		return value
+	}
+}

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -3226,6 +3226,10 @@ func TestDefaultsAndRequiredWithValidationInteraction(t *testing.T) {
 	}
 
 	t.Run("CheckMissingRequiredPropErrors", func(t *testing.T) {
+		// pulumi/pulumi-terraform-bridge#1546 and PR #1583:
+		// validate before applying TF defaults so RequiredWith behaves like
+		// Terraform. The current #2618 behavior change intentionally also stops
+		// returning omitted empty-string defaults in Check inputs.
 		//nolint:lll
 		testutils.Replay(t, provider, `
 		{
@@ -3238,20 +3242,7 @@ func TestDefaultsAndRequiredWithValidationInteraction(t *testing.T) {
 			},
 			"response": {
 				"inputs": {
-					"__defaults": [
-						"requiredWithNonrequiredProperty",
-						"requiredWithProperty",
-						"requiredWithProperty2",
-						"requiredWithRequiredProperty",
-						"requiredWithRequiredProperty2",
-						"requiredWithRequiredProperty3"
-					],
-					"requiredWithNonrequiredProperty": "",
-					"requiredWithProperty": "",
-					"requiredWithProperty2": "",
-					"requiredWithRequiredProperty": "",
-					"requiredWithRequiredProperty2": "",
-					"requiredWithRequiredProperty3": ""
+					"__defaults": []
 				},
 				"failures": [
 					{"reason": "Missing required argument. The argument \"required_with_required_property\" is required, but no definition was found.. Examine values at 'exres.requiredWithRequiredProperty'."},
@@ -3310,17 +3301,10 @@ func TestDefaultsAndRequiredWithValidationInteraction(t *testing.T) {
 				},
 				"response": {
 					"inputs": {
-						"__defaults": [
-							"requiredWithNonrequiredProperty",
-							"requiredWithProperty2",
-							"requiredWithRequiredProperty3"
-						],
-						"requiredWithNonrequiredProperty": "",
+						"__defaults": [],
 						"requiredWithProperty": "foo",
-						"requiredWithProperty2": "",
 						"requiredWithRequiredProperty": "foo",
-						"requiredWithRequiredProperty2": "foo",
-						"requiredWithRequiredProperty3": ""
+						"requiredWithRequiredProperty2": "foo"
 					},
 					"failures": [
 						{"reason": "Missing required argument. \"required_with_property\": all of $required_with_property,required_with_property2$ must be specified. Examine values at 'exres.requiredWithProperty'."},
@@ -4252,6 +4236,301 @@ func TestMaxItemsOnePropCheckResponseNoNulls(t *testing.T) {
 			}
 		}`)
 	})
+}
+
+func TestCheckSuppressesOmittedFalsyTFDefaults(t *testing.T) {
+	t.Parallel()
+
+	newProvider := func(schema map[string]*schemav2.Schema) *Provider {
+		p := &schemav2.Provider{
+			Schema:       map[string]*schemav2.Schema{},
+			ResourcesMap: map[string]*schemav2.Resource{"res": {Schema: schema}},
+		}
+		shimProv := shimv2.NewProvider(p)
+		return &Provider{
+			tf:     shimProv,
+			config: shimv2.NewSchemaMap(p.Schema),
+			info:   ProviderInfo{P: shimProv},
+			resources: map[tokens.Type]Resource{
+				"Res": {
+					TF:     shimProv.ResourcesMap().Get("res"),
+					TFName: "res",
+					Schema: &ResourceInfo{},
+				},
+			},
+		}
+	}
+
+	checkInputs := func(t *testing.T, provider *Provider, news resource.PropertyMap) resource.PropertyMap {
+		t.Helper()
+
+		mnews, err := plugin.MarshalProperties(news, plugin.MarshalOptions{
+			Label:         "news",
+			KeepUnknowns:  true,
+			KeepSecrets:   true,
+			SkipNulls:     true,
+			KeepResources: true,
+		})
+		require.NoError(t, err)
+
+		resp, err := provider.Check(context.Background(), &pulumirpc.CheckRequest{
+			Urn:  "urn:pulumi:dev::teststack::Res::exres",
+			News: mnews,
+		})
+		require.NoError(t, err)
+		require.Empty(t, resp.Failures)
+
+		inputs, err := plugin.UnmarshalProperties(resp.GetInputs(), plugin.MarshalOptions{})
+		require.NoError(t, err)
+		return inputs
+	}
+
+	t.Run("omitted top-level falsy defaults are suppressed", func(t *testing.T) {
+		t.Parallel()
+
+		provider := newProvider(map[string]*schemav2.Schema{
+			"bool_default": {
+				Type:     schemav2.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"int_default": {
+				Type:     schemav2.TypeInt,
+				Optional: true,
+				Default:  0,
+			},
+		})
+
+		inputs := checkInputs(t, provider, resource.PropertyMap{})
+		assert.Equal(t, resource.NewPropertyMapFromMap(map[string]interface{}{
+			"__defaults": []interface{}{},
+		}), inputs)
+	})
+
+	t.Run("explicit authored falsy defaults are preserved", func(t *testing.T) {
+		t.Parallel()
+
+		provider := newProvider(map[string]*schemav2.Schema{
+			"bool_default": {
+				Type:     schemav2.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"int_default": {
+				Type:     schemav2.TypeInt,
+				Optional: true,
+				Default:  0,
+			},
+		})
+
+		inputs := checkInputs(t, provider, resource.NewPropertyMapFromMap(map[string]interface{}{
+			"boolDefault": false,
+			"intDefault":  0,
+		}))
+		assert.Equal(t, resource.NewPropertyMapFromMap(map[string]interface{}{
+			"__defaults":  []interface{}{},
+			"boolDefault": false,
+			"intDefault":  0,
+		}), inputs)
+	})
+
+	t.Run("azuredevops issue 514 shape", func(t *testing.T) {
+		t.Parallel()
+
+		provider := newProvider(map[string]*schemav2.Schema{
+			"variables": {
+				Type:     schemav2.TypeSet,
+				Required: true,
+				MinItems: 1,
+				Elem: &schemav2.Resource{
+					Schema: map[string]*schemav2.Schema{
+						"name": {
+							Type:     schemav2.TypeString,
+							Required: true,
+						},
+						"value": {
+							Type:     schemav2.TypeString,
+							Optional: true,
+							Default:  "",
+						},
+						"secret_value": {
+							Type:     schemav2.TypeString,
+							Optional: true,
+							Default:  "",
+						},
+						"is_secret": {
+							Type:     schemav2.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+					},
+				},
+			},
+		})
+
+		inputs := checkInputs(t, provider, resource.NewPropertyMapFromMap(map[string]interface{}{
+			"variables": []interface{}{
+				map[string]interface{}{
+					"name":  "key1",
+					"value": "val1",
+				},
+			},
+		}))
+
+		variables := inputs["variables"].ArrayValue()
+		require.Len(t, variables, 1)
+		variable := variables[0].ObjectValue()
+		assert.Equal(t, "key1", variable["name"].StringValue())
+		assert.Equal(t, "val1", variable["value"].StringValue())
+		assert.NotContains(t, variable, "secretValue")
+		assert.NotContains(t, variable, "isSecret")
+	})
+
+	t.Run("docker issue 401 shape", func(t *testing.T) {
+		t.Parallel()
+
+		provider := newProvider(map[string]*schemav2.Schema{
+			"mode": {
+				Type:     schemav2.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schemav2.Resource{
+					Schema: map[string]*schemav2.Schema{
+						"global": {
+							Type:          schemav2.TypeBool,
+							Optional:      true,
+							Default:       false,
+							ConflictsWith: []string{"mode.0.replicated"},
+						},
+						"replicated": {
+							Type:          schemav2.TypeList,
+							Optional:      true,
+							MaxItems:      1,
+							ConflictsWith: []string{"mode.0.global"},
+							Elem: &schemav2.Resource{
+								Schema: map[string]*schemav2.Schema{
+									"replicas": {
+										Type:     schemav2.TypeInt,
+										Required: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+		inputs := checkInputs(t, provider, resource.NewPropertyMapFromMap(map[string]interface{}{
+			"mode": map[string]interface{}{
+				"replicated": map[string]interface{}{
+					"replicas": 1,
+				},
+			},
+		}))
+
+		mode := inputs["mode"].ObjectValue()
+		assert.NotContains(t, mode, resource.PropertyKey("global"))
+		require.Contains(t, mode, resource.PropertyKey("replicated"))
+	})
+}
+
+func TestUpdatePreservesOmittedFalsyTFDefaults(t *testing.T) {
+	t.Parallel()
+
+	var updateData *schemav2.ResourceData
+
+	p := &schemav2.Provider{
+		Schema: map[string]*schemav2.Schema{},
+		ResourcesMap: map[string]*schemav2.Resource{
+			"res": {
+				Schema: map[string]*schemav2.Schema{
+					"name": {
+						Type:     schemav2.TypeString,
+						Required: true,
+					},
+					"is_signup_enabled": {
+						Type:     schemav2.TypeBool,
+						Optional: true,
+						Default:  false,
+					},
+				},
+				CreateContext: func(_ context.Context, rd *schemav2.ResourceData, _ interface{}) diag.Diagnostics {
+					rd.SetId("someid")
+					return nil
+				},
+				UpdateContext: func(_ context.Context, rd *schemav2.ResourceData, _ interface{}) diag.Diagnostics {
+					// pulumi/pulumi-terraform-bridge#2618:
+					// Update must keep omitted falsy defaults omitted too, otherwise
+					// the fix would only cover create-time RawConfig.
+					updateData = rd
+					return nil
+				},
+			},
+		},
+	}
+
+	shimProv := shimv2.NewProvider(p)
+	provider := &Provider{
+		tf:     shimProv,
+		config: shimv2.NewSchemaMap(p.Schema),
+		info:   ProviderInfo{P: shimProv},
+		resources: map[tokens.Type]Resource{
+			"Res": {
+				TF:     shimProv.ResourcesMap().Get("res"),
+				TFName: "res",
+				Schema: &ResourceInfo{},
+			},
+		},
+	}
+
+	urn := "urn:pulumi:dev::teststack::Res::exres"
+	marshal := func(props resource.PropertyMap) *structpb.Struct {
+		t.Helper()
+		m, err := plugin.MarshalProperties(props, plugin.MarshalOptions{
+			Label:         "props",
+			KeepUnknowns:  true,
+			KeepSecrets:   true,
+			SkipNulls:     true,
+			KeepResources: true,
+		})
+		require.NoError(t, err)
+		return m
+	}
+
+	initialCheck, err := provider.Check(context.Background(), &pulumirpc.CheckRequest{
+		Urn:  urn,
+		News: marshal(resource.NewPropertyMapFromMap(map[string]interface{}{"name": "before"})),
+	})
+	require.NoError(t, err)
+	require.Empty(t, initialCheck.Failures)
+
+	createResp, err := provider.Create(context.Background(), &pulumirpc.CreateRequest{
+		Urn:        urn,
+		Properties: initialCheck.GetInputs(),
+	})
+	require.NoError(t, err)
+
+	updateCheck, err := provider.Check(context.Background(), &pulumirpc.CheckRequest{
+		Urn:  urn,
+		Olds: createResp.GetProperties(),
+		News: marshal(resource.NewPropertyMapFromMap(map[string]interface{}{"name": "after"})),
+	})
+	require.NoError(t, err)
+	require.Empty(t, updateCheck.Failures)
+
+	_, err = provider.Update(context.Background(), &pulumirpc.UpdateRequest{
+		Id:   "someid",
+		Urn:  urn,
+		Olds: createResp.GetProperties(),
+		News: updateCheck.GetInputs(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, updateData)
+
+	rawConfig := updateData.GetRawConfig()
+	assert.True(t, rawConfig.GetAttr("is_signup_enabled").IsNull())
+	assert.Equal(t, "after", updateData.Get("name"))
 }
 
 // TODO[pulumi/pulumi#15636] if/when Pulumi supports customizing Read timeouts these could be added here.

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-cty/cty"
+	schemav1 "github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	schemav2 "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hexops/autogold/v2"
@@ -2418,6 +2419,96 @@ func TestSDKv2PreConfigureCallback(t *testing.T) {
 	})
 }
 
+func TestSDKv1CheckConfigSuppressesOmittedFalsyTFDefaults(t *testing.T) {
+	t.Parallel()
+
+	newProvider := func(t *testing.T, expectSet bool, expectVar bool) *Provider {
+		t.Helper()
+
+		tfp := &schemav1.Provider{
+			Schema: map[string]*schemav1.Schema{
+				"config_value": {
+					Type:     schemav1.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+			},
+		}
+
+		return &Provider{
+			tf:     shimv1.NewProvider(tfp),
+			config: shimv1.NewSchemaMap(tfp.Schema),
+			info: ProviderInfo{
+				PreConfigureCallback: func(vars resource.PropertyMap, config shim.ResourceConfig) error {
+					require.Equal(t, expectSet, config.IsSet("config_value"))
+					_, hasVar := vars["config_value"]
+					require.Equal(t, expectVar, hasVar)
+					if expectVar {
+						require.False(t, vars["config_value"].BoolValue())
+					}
+					return nil
+				},
+			},
+		}
+	}
+
+	marshal := func(t *testing.T, props resource.PropertyMap) *structpb.Struct {
+		t.Helper()
+		m, err := plugin.MarshalProperties(props, plugin.MarshalOptions{
+			Label:         "props",
+			KeepUnknowns:  true,
+			KeepSecrets:   true,
+			SkipNulls:     true,
+			KeepResources: true,
+		})
+		require.NoError(t, err)
+		return m
+	}
+
+	unmarshal := func(t *testing.T, m *structpb.Struct) resource.PropertyMap {
+		t.Helper()
+		pm, err := plugin.UnmarshalProperties(m, plugin.MarshalOptions{})
+		require.NoError(t, err)
+		return pm
+	}
+
+	t.Run("omitted default false remains unset", func(t *testing.T) {
+		t.Parallel()
+
+		provider := newProvider(t, false, false)
+		resp, err := provider.CheckConfig(context.Background(), &pulumirpc.CheckRequest{
+			Urn: "urn:pulumi:dev::teststack::pulumi:providers:testprovider::test",
+			News: marshal(t, resource.NewPropertyMapFromMap(map[string]interface{}{
+				"version": "6.54.0",
+			})),
+		})
+		require.NoError(t, err)
+		require.Empty(t, resp.Failures)
+		assert.Equal(t, resource.NewPropertyMapFromMap(map[string]interface{}{
+			"version": "6.54.0",
+		}), unmarshal(t, resp.GetInputs()))
+	})
+
+	t.Run("explicit authored false stays set", func(t *testing.T) {
+		t.Parallel()
+
+		provider := newProvider(t, true, true)
+		resp, err := provider.CheckConfig(context.Background(), &pulumirpc.CheckRequest{
+			Urn: "urn:pulumi:dev::teststack::pulumi:providers:testprovider::test",
+			News: marshal(t, resource.NewPropertyMapFromMap(map[string]interface{}{
+				"config_value": false,
+				"version":      "6.54.0",
+			})),
+		})
+		require.NoError(t, err)
+		require.Empty(t, resp.Failures)
+		assert.Equal(t, resource.NewPropertyMapFromMap(map[string]interface{}{
+			"config_value": false,
+			"version":      "6.54.0",
+		}), unmarshal(t, resp.GetInputs()))
+	})
+}
+
 func TestInvoke(t *testing.T) {
 	t.Parallel()
 	t.Run("preserve_program_secrets", func(t *testing.T) {
@@ -4513,7 +4604,7 @@ func TestUpdatePreservesOmittedFalsyTFDefaults(t *testing.T) {
 
 	updateCheck, err := provider.Check(context.Background(), &pulumirpc.CheckRequest{
 		Urn:  urn,
-		Olds: createResp.GetProperties(),
+		Olds: initialCheck.GetInputs(),
 		News: marshal(resource.NewPropertyMapFromMap(map[string]interface{}{"name": "after"})),
 	})
 	require.NoError(t, err)
@@ -4530,6 +4621,98 @@ func TestUpdatePreservesOmittedFalsyTFDefaults(t *testing.T) {
 
 	rawConfig := updateData.GetRawConfig()
 	assert.True(t, rawConfig.GetAttr("is_signup_enabled").IsNull())
+	assert.Equal(t, "after", updateData.Get("name"))
+}
+
+func TestUpdatePreservesLegacyFalsyTFDefaults(t *testing.T) {
+	t.Parallel()
+
+	var updateData *schemav2.ResourceData
+
+	p := &schemav2.Provider{
+		Schema: map[string]*schemav2.Schema{},
+		ResourcesMap: map[string]*schemav2.Resource{
+			"res": {
+				Schema: map[string]*schemav2.Schema{
+					"name": {
+						Type:     schemav2.TypeString,
+						Required: true,
+					},
+					"is_signup_enabled": {
+						Type:     schemav2.TypeBool,
+						Optional: true,
+						Default:  false,
+					},
+				},
+				UpdateContext: func(_ context.Context, rd *schemav2.ResourceData, _ interface{}) diag.Diagnostics {
+					updateData = rd
+					return nil
+				},
+			},
+		},
+	}
+
+	shimProv := shimv2.NewProvider(p)
+	provider := &Provider{
+		tf:     shimProv,
+		config: shimv2.NewSchemaMap(p.Schema),
+		info:   ProviderInfo{P: shimProv},
+		resources: map[tokens.Type]Resource{
+			"Res": {
+				TF:     shimProv.ResourcesMap().Get("res"),
+				TFName: "res",
+				Schema: &ResourceInfo{},
+			},
+		},
+	}
+
+	urn := "urn:pulumi:dev::teststack::Res::exres"
+	marshal := func(props resource.PropertyMap) *structpb.Struct {
+		t.Helper()
+		m, err := plugin.MarshalProperties(props, plugin.MarshalOptions{
+			Label:         "props",
+			KeepUnknowns:  true,
+			KeepSecrets:   true,
+			SkipNulls:     true,
+			KeepResources: true,
+		})
+		require.NoError(t, err)
+		return m
+	}
+
+	legacyOlds := resource.NewPropertyMapFromMap(map[string]interface{}{
+		"__defaults":      []interface{}{"isSignupEnabled"},
+		"isSignupEnabled": false,
+		"name":            "before",
+	})
+
+	updateCheck, err := provider.Check(context.Background(), &pulumirpc.CheckRequest{
+		Urn:  urn,
+		Olds: marshal(legacyOlds),
+		News: marshal(resource.NewPropertyMapFromMap(map[string]interface{}{"name": "after"})),
+	})
+	require.NoError(t, err)
+	require.Empty(t, updateCheck.Failures)
+
+	inputs, err := plugin.UnmarshalProperties(updateCheck.GetInputs(), plugin.MarshalOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, resource.NewPropertyMapFromMap(map[string]interface{}{
+		"__defaults":      []interface{}{"isSignupEnabled"},
+		"isSignupEnabled": false,
+		"name":            "after",
+	}), inputs)
+
+	_, err = provider.Update(context.Background(), &pulumirpc.UpdateRequest{
+		Id:   "someid",
+		Urn:  urn,
+		Olds: marshal(legacyOlds),
+		News: updateCheck.GetInputs(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, updateData)
+
+	rawConfig := updateData.GetRawConfig()
+	assert.Equal(t, cty.False, rawConfig.GetAttr("is_signup_enabled"))
 	assert.Equal(t, "after", updateData.Get("name"))
 }
 

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -944,6 +944,16 @@ func (ctx *conversionContext) applyDefaults(
 					source = "Terraform schema"
 				}
 
+				// pulumi/pulumi-terraform-bridge#2618:
+				// preserve Terraform raw-config semantics for omitted falsy TF defaults.
+				// Terraform providers can distinguish omitted from explicitly configured
+				// values through GetRawConfig/RawConfig, and materializing false/0/""
+				// here makes later Create/Update/Configure/Invoke calls observe an
+				// authored value that Terraform itself would keep omitted.
+				if shouldSuppressTFSchemaDefaultValue(dv) {
+					return true
+				}
+
 				if dv != nil {
 					glog.V(9).Infof("Created Terraform input: %v = %v (from %s)", name, dv, source)
 					result[name] = dv
@@ -964,6 +974,23 @@ func (ctx *conversionContext) applyDefaults(
 	result[reservedkeys.Defaults] = newDefaults
 
 	return nil
+}
+
+func shouldSuppressTFSchemaDefaultValue(defaultValue interface{}) bool {
+	// pulumi/pulumi-terraform-bridge#2618:
+	// narrow bridge-side suppression to falsy TF schema defaults only. This
+	// keeps omission visible to Terraform while leaving non-falsy defaults on
+	// the existing path until we have broader parity evidence for them.
+	switch normalized := normalizeTFDefaultValue(defaultValue).(type) {
+	case bool:
+		return !normalized
+	case float64:
+		return normalized == 0
+	case string:
+		return normalized == ""
+	default:
+		return false
+	}
 }
 
 // makeTerraformUnknownElement creates an unknown value to be used as an element of a list or set using the given

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -945,12 +945,10 @@ func (ctx *conversionContext) applyDefaults(
 				}
 
 				// pulumi/pulumi-terraform-bridge#2618:
-				// preserve Terraform raw-config semantics for omitted falsy TF defaults.
-				// Terraform providers can distinguish omitted from explicitly configured
-				// values through GetRawConfig/RawConfig, and materializing false/0/""
-				// here makes later Create/Update/Configure/Invoke calls observe an
-				// authored value that Terraform itself would keep omitted.
-				if shouldSuppressTFSchemaDefaultValue(dv) {
+				// preserve Terraform raw-config semantics for freshly synthesized falsy
+				// TF schema defaults. Replayed defaults from prior state still need to
+				// round-trip through unchanged updates for legacy stacks.
+				if source == "Terraform schema" && shouldSuppressTFSchemaDefaultValue(dv) {
 					return true
 				}
 


### PR DESCRIPTION
## Summary

Fix SDKv2 RawConfig parity for omitted falsy Terraform schema defaults.

Today the bridge can materialize omitted Terraform defaults like `false`, `0`, and `\"\"` into the canonical input bag. Later Terraform-facing calls then observe those fields as explicitly configured even when the user omitted them.

That diverges from Terraform and breaks providers that use `GetRawConfig()` / `RawConfig` or otherwise treat field presence as meaningful.

This change suppresses omitted falsy TF-schema defaults at the point where Terraform defaults are applied in the bridge, instead of returning them as authored inputs.

## What issue is this fixing?

This is primarily fixing `pulumi/pulumi-terraform-bridge#2618`.

The concrete bug is:

- user omits an optional Terraform field
- the field has a falsy TF default like `false`, `0`, or `\"\"`
- the bridge materializes that value into the checked/configured input bag
- the Terraform provider later sees the field as explicitly set instead of omitted

That changes provider-visible behavior in places like:
- `Create`
- `Update`
- provider `Configure`
- data source `Invoke`

## Why the narrow falsy-only approach?

I considered broader options, including changing default behavior more generally.

I went narrow here on purpose.

What I have strong evidence for:
- downstream reports and patches cluster around falsy defaults
- focused parity tests show real Pulumi-vs-Terraform divergence for omitted `false`, `0`, and `\"\"`
- the known failures are presence-sensitive: providers treat omitted differently from explicitly-set falsy values

What I do not have strong evidence for yet:
- that non-falsy defaults should all follow the same rule
- that a broader default-materialization change would be safe across the full SDKv2 lifecycle

So this PR is intentionally a reported-cases-first fix:
- restore Terraform parity for omitted falsy defaults
- avoid claiming a full redesign of TF default handling

## Why change `applyDefaults` instead of post-processing `Check`?

I explored a `Check` post-processor first, but ended up moving the logic into the Terraform-default branch of `applyDefaults`.

That ended up being the better seam for three reasons:

1. It is simpler.
   I do not need to re-walk Pulumi-shaped objects after the fact. The suppression happens exactly where TF defaults are being materialized.

2. It fixes the whole affected TF-facing surface.
   The bug is not only `Check -> Create/Update`. The same RawConfig parity issue also exists in:
   - provider `Configure`
   - data source `Invoke`

   Centralizing the change in `applyDefaults` fixed those paths too.

3. The tests supported it.
   I added focused parity coverage for:
   - resource create/update
   - provider configure
   - invoke/data sources

   Those tests showed the broader seam was helping, not hurting.

## Behavior change

After this PR, omitted falsy TF-schema defaults are no longer replayed as authored inputs.

This applies to:
- omitted `false`
- omitted `0`
- omitted `\"\"`

That includes both:
- top-level fields
- nested block / collection element fields

The validation behavior from `#1546` / `#1583` is preserved where it matters:
- validate before applying TF defaults

But the returned/propagated checked inputs now stop echoing omitted falsy defaults back as explicit user inputs.

## Tests

Added / updated focused coverage for:

- resource create parity for omitted falsy defaults
- update regression for omitted falsy defaults
- provider configure RawConfig parity
- invoke/data source RawConfig parity
- existing `ConflictsWith` / `ExactlyOneOf` / `RequiredWith` validation interaction coverage

Notable downstream issue shapes covered by the new tests:
- Azure DevOps-style nested set defaults
- Auth0-style omitted `false`
- Docker-style `ConflictsWith`

## Verification

Ran:

- `go test ./pkg/tfbridge -run 'TestCheckSuppressesOmittedFalsyTFDefaults|TestUpdatePreservesOmittedFalsyTFDefaults|TestDefaultsAndConflictsWithValidationInteraction|TestDefaultsAndExactlyOneOfValidationInteraction|TestDefaultsAndRequiredWithValidationInteraction' -count=1`
- `go test ./pkg/tests -run 'TestCreateFalsyTFDefaultParity|TestConfigureCrossTest/(omitted_bool_default_false|omitted_string_default_empty)|TestInvokeCrossTest' -count=1`