### PR TITLE
Fix infinite loop in import fence rewriting for commented terraform import lines

### DIFF
--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -1447,6 +1447,7 @@ func rewriteImportFenceWithHoistedComments(lines []string, indent, typeToken str
 			remaining = remaining[1:]
 		}
 		if len(chunk) == 0 {
+			remaining = remaining[1:]
 			continue
 		}
 		if allBlank(chunk) {

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -26,6 +26,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 	"text/template"
 
 	"github.com/hexops/autogold/v2"
@@ -1997,6 +1998,25 @@ func TestParseImports_ImportOnlyFence(t *testing.T) {
 	expected := readfile(t, "test_data/parse-imports/import-only-expected.md")
 	actual := parseImportsNoOverrides(t, input, "pkg:mod/name:Type")
 	assert.Equal(t, expected, actual)
+}
+
+func TestParseImports_AdvancesPastNonHoistableCommentLines(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skipf("Skippping on windows - tests cases need to be made robust to newline handling")
+	}
+	t.Parallel()
+	input := readfile(t, "test_data/parse-imports/commented-import.md")
+	done := make(chan string, 1)
+	go func() {
+		done <- parseImportsNoOverrides(t, input, "pkg:mod/name:Type")
+	}()
+	select {
+	case actual := <-done:
+		assert.NotEmpty(t, actual)
+	case <-time.After(5 * time.Second):
+		t.Fatal("parseImports appears stuck in an infinite loop " +
+			"(commented-out 'terraform import' inside a code fence with hoistable comments)")
+	}
 }
 
 func TestParseImports_WithOverride(t *testing.T) {

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -26,8 +26,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
-	"time"
 	"text/template"
+	"time"
 
 	"github.com/hexops/autogold/v2"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -2012,7 +2012,12 @@ func TestParseImports_AdvancesPastNonHoistableCommentLines(t *testing.T) {
 	}()
 	select {
 	case actual := <-done:
-		assert.NotEmpty(t, actual)
+		expectedFile := "test_data/parse-imports/commented-import-expected.md"
+		if accept {
+			writefile(t, expectedFile, []byte(actual))
+		}
+		expected := readfile(t, expectedFile)
+		assert.Equal(t, expected, actual)
 	case <-time.After(5 * time.Second):
 		t.Fatal("parseImports appears stuck in an infinite loop " +
 			"(commented-out 'terraform import' inside a code fence with hoistable comments)")

--- a/pkg/tfgen/test_data/parse-imports/commented-import-expected.md
+++ b/pkg/tfgen/test_data/parse-imports/commented-import-expected.md
@@ -1,0 +1,8 @@
+## Import
+
+Replace with your project ID
+
+```sh
+$ pulumi import pkg:mod/name:Type example1 id1
+```
+

--- a/pkg/tfgen/test_data/parse-imports/commented-import.md
+++ b/pkg/tfgen/test_data/parse-imports/commented-import.md
@@ -1,0 +1,5 @@
+```shell
+# Replace with your project ID
+terraform import gitlab_project.example1 id1
+# terraform import gitlab_project.example2 id2
+```


### PR DESCRIPTION
## Summary

Fixes #3399

`rewriteImportFenceWithHoistedComments` could loop forever when a code fence contained a commented-out `terraform import` line (e.g. `# terraform import gitlab_project.example project_id`) alongside hoistable comments. The preamble branch rejected the line (contains "terraform import") and the chunk branch immediately broke on it (starts with `#`), so neither branch advanced `remaining`. The fix advances `remaining` by one line when the chunk is empty.

## Test plan

- [x] New test `TestParseImports_AdvancesPastNonHoistableCommentLines`
- [x] All existing `TestParseImports*` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)