### PR TITLE
Use isolated plugin cache when re-recording golden files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,5 @@ pulumi-hcl-lint
 dynamic/indexfileonly
 dynamic/localdir
 .pulumi
+.pulumi-test
 __pycache__

--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,14 @@ test:: install_plugins
 # Run tests while accepting current output as expected output "golden"
 # tests. In case where system behavior changes intentionally this can
 # be useful to run to review the differences with git diff.
+#
+# For re-recording golden files, we use a local, test-specific plugin
+# cache to ensure parity with CI.
+TEST_PULUMI_HOME := $(PROJECT_DIR)/.pulumi-test
 test_accept::
-	PULUMI_ACCEPT=1 go test -v -count=1 -cover -timeout 2h -parallel ${TESTPARALLELISM} $(value RUN_TEST_CMD)
+	rm -rf $(TEST_PULUMI_HOME)
+	PULUMI_HOME=$(TEST_PULUMI_HOME) $(MAKE) install_plugins
+	PULUMI_HOME=$(TEST_PULUMI_HOME) PULUMI_ACCEPT=1 go test -v -count=1 -cover -timeout 2h -parallel ${TESTPARALLELISM} $(value RUN_TEST_CMD)
 
 generate_builtins_test::
 	if [ ! -d ./scripts/venv ]; then python -m venv ./scripts/venv; fi

--- a/dynamic/Makefile
+++ b/dynamic/Makefile
@@ -18,7 +18,13 @@ test:
 	cd internal/shim && go test -v ./...
 	go test -v ./...
 
+# For re-recording golden files, we use a local, test-specific plugin
+# cache to ensure parity with CI.
+TEST_PULUMI_HOME := $(abspath ../.pulumi-test)
 test_accept:
-	go test -v ./... -update
+	rm -rf $(TEST_PULUMI_HOME)
+	PULUMI_HOME=$(TEST_PULUMI_HOME) $(MAKE) -C .. install_plugins
+	PULUMI_HOME=$(TEST_PULUMI_HOME) PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=true \
+		go test -v . ./parameterize -update
 
 .PHONY: bin/pulumi-resource-terraform-provider install build test_unit test test_acccept


### PR DESCRIPTION
https://github.com/pulumi/pulumi-terraform-bridge/pull/3393 showed us that the docsgen tests which use the real pulumi CLI to convert examples are susceptible to subtle diffs in ambient plugins:

- different converter plugin than the one pinned in Makefile
- different ambient plugins for providers used in conversion

Basically: when re-recording golden files for these conversion tests in a local dev environment, the result was completely different from what CI produced on a test, making it incredibly difficult to update them properly.

PULUMI_DISABLE_AMBIENT_PLUGIN_ACQUISITION only helps somewhat because the CLI will _still_ use whatever you have in your global plugins. This PR introduces a local test plugin directory that gets populated via `plugin install`, which in combination with disabling plugin acquisition, mirrors CI exactly.

I've verified that this process now successfully ignores the developer's global plugin cache.



## Summary

- `make test_accept` (root and `dynamic/`) now installs into and runs against a repo-local `.pulumi-test/` plugin cache instead of the developer's global `~/.pulumi/plugins`.
- Ambient plugins in the global cache (e.g. `pulumi-std` installed for another project) silently change the converter's codegen and cause local output to drift from CI. The isolated cache ensures parity.
- CI is unchanged — this only affects local golden regeneration.

## Bugfix discovered along the way

The previous `dynamic/Makefile` `test_accept` ran `go test -v ./... -update`, but `-update` is only registered as a flag by packages that import `autogold`. Packages like `dynamic/internal/shim/run` don't, so they would see `-update` as an unknown flag, print the test help, and fail. The new target only runs the autogold-using packages (`.` and `./parameterize`).

## Test plan

- [x] `make -C dynamic test_accept` with `pulumi-std` v2.2.0 globally installed → no golden diff
- [x] `make test_accept RUN_TEST_CMD='-run TestConvertViaPulumiCLI ./pkg/tfgen/'` → no golden diff
- [x] Confirmed `.pulumi-test/plugins/` contains only the 9 pinned plugins after each run (no auto-acquired extras)

🤖 Generated with [Claude Code](https://claude.com/claude-code)